### PR TITLE
Potential fix for Issue #2901

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,7 @@ dependencies = [
  "criterion",
  "futures",
  "rand 0.9.2",
+ "reqwest",
  "rustc_version",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ dependencies = [
  "hmac",
  "openssl",
  "pin-project",
+ "reqwest",
  "rustc_version",
  "serde",
  "serde_json",

--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -44,6 +44,7 @@ azure_identity.workspace = true
 azure_security_keyvault_certificates.path = "../../keyvault/azure_security_keyvault_certificates"
 azure_security_keyvault_secrets.path = "../../keyvault/azure_security_keyvault_secrets"
 criterion.workspace = true
+reqwest.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
@@ -86,4 +87,8 @@ features = [
 
 [[bench]]
 name = "benchmarks"
+harness = false
+
+[[bench]]
+name = "http_transport_benchmarks"
 harness = false

--- a/sdk/core/azure_core/benches/benchmarks.rs
+++ b/sdk/core/azure_core/benches/benchmarks.rs
@@ -60,10 +60,12 @@ fn http_transport_test(c: &mut Criterion) {
         });
     });
 }
+
 // Main benchmark configuration
 criterion_group! {
     name = benchmarks;
     config = Criterion::default();
     targets = url_parsing_benchmark, http_transport_test
 }
+
 criterion_main!(benchmarks);

--- a/sdk/core/azure_core/benches/http_transport_benchmarks.rs
+++ b/sdk/core/azure_core/benches/http_transport_benchmarks.rs
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use azure_core::{
+    credentials::TokenCredential,
+    fmt::SafeDebug,
+    http::{
+        policies::{BearerTokenCredentialPolicy, Policy},
+        ClientMethodOptions, ClientOptions, HttpClient, Method, Pipeline, RawResponse, Request,
+        TransportOptions, Url,
+    },
+    Result,
+};
+use azure_identity::DeveloperToolsCredential;
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::sync::Arc;
+
+#[derive(Clone, SafeDebug)]
+pub struct TestServiceClientOptions {
+    pub client_options: ClientOptions,
+    pub api_version: Option<String>,
+}
+
+impl Default for TestServiceClientOptions {
+    fn default() -> Self {
+        Self {
+            client_options: ClientOptions::default(),
+            api_version: Some("2023-10-01".to_string()),
+        }
+    }
+}
+
+pub struct TestServiceClient {
+    endpoint: Url,
+    api_version: String,
+    pipeline: Pipeline,
+}
+
+#[derive(Default, SafeDebug)]
+pub struct TestServiceClientGetMethodOptions<'a> {
+    pub method_options: ClientMethodOptions<'a>,
+}
+
+impl TestServiceClient {
+    pub fn new(
+        endpoint: &str,
+        credential: Arc<dyn TokenCredential>,
+        options: Option<TestServiceClientOptions>,
+    ) -> Result<Self> {
+        let options = options.unwrap_or_default();
+        let mut endpoint = Url::parse(endpoint)?;
+        if !endpoint.scheme().starts_with("http") {
+            return Err(azure_core::Error::message(
+                azure_core::error::ErrorKind::Other,
+                format!("{endpoint} must use http(s)"),
+            ));
+        }
+        endpoint.set_query(None);
+
+        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+            credential,
+            vec!["https://vault.azure.net/.default"],
+        ));
+
+        Ok(Self {
+            endpoint,
+            api_version: options.api_version.unwrap_or_default(),
+            pipeline: Pipeline::new(
+                option_env!("CARGO_PKG_NAME"),
+                option_env!("CARGO_PKG_VERSION"),
+                options.client_options,
+                Vec::default(),
+                vec![auth_policy.clone()],
+            ),
+        })
+    }
+
+    /// Returns the Url associated with this client.
+    pub fn endpoint(&self) -> &Url {
+        &self.endpoint
+    }
+
+    /// Returns the result of a Get verb against the configured endpoint with the specified path.
+    ///
+    /// This method demonstrates a service client which does not have per-method spans but which will create
+    /// HTTP client spans if the `InstrumentationOptions` are configured in the client options.
+    ///
+    pub async fn get(
+        &self,
+        path: &str,
+        options: Option<TestServiceClientGetMethodOptions<'_>>,
+    ) -> Result<RawResponse> {
+        let options = options.unwrap_or_default();
+        let mut url = self.endpoint.clone();
+        url.set_path(path);
+        url.query_pairs_mut()
+            .append_pair("api-version", &self.api_version);
+
+        let mut request = Request::new(url, azure_core::http::Method::Get);
+
+        let response = self
+            .pipeline
+            .send(&options.method_options.context, &mut request)
+            .await?;
+        if !response.status().is_success() {
+            return Err(azure_core::Error::message(
+                azure_core::error::ErrorKind::HttpResponse {
+                    status: response.status(),
+                    error_code: None,
+                },
+                format!("Failed to GET {}: {}", request.url(), response.status()),
+            ));
+        }
+        Ok(response)
+    }
+}
+
+pub fn new_reqwest_client_disable_connection_pool() -> Arc<dyn HttpClient> {
+    let client = ::reqwest::ClientBuilder::new()
+        .pool_max_idle_per_host(0)
+        .build()
+        .expect("failed to build `reqwest` client");
+
+    Arc::new(client)
+}
+
+pub fn new_default_reqwest_client() -> Arc<dyn HttpClient> {
+    let client = ::reqwest::Client::new();
+
+    Arc::new(client)
+}
+
+pub fn simple_http_transport_test(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    let endpoint = "https://azuresdkforcpp.azurewebsites.net";
+    let credential = DeveloperToolsCredential::new(None).unwrap();
+    let options = TestServiceClientOptions::default();
+
+    let client = TestServiceClient::new(endpoint, credential, Some(options)).unwrap();
+
+    // Benchmark GET and POST requests
+    c.bench_function("default_http_pipeline_test", |b| {
+        b.to_async(&rt).iter(|| async {
+            let response = client.get("get", None).await;
+            assert!(response.is_ok());
+            let response = response.unwrap();
+            assert_eq!(response.status(), azure_core::http::StatusCode::Ok);
+        });
+    });
+}
+
+pub fn disable_pooling_http_transport_test(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    let endpoint = "https://azuresdkforcpp.azurewebsites.net";
+    let credential = DeveloperToolsCredential::new(None).unwrap();
+    let transport = new_reqwest_client_disable_connection_pool();
+    let options = TestServiceClientOptions {
+        client_options: ClientOptions {
+            transport: Some(TransportOptions::new(transport)),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let client = TestServiceClient::new(endpoint, credential, Some(options)).unwrap();
+
+    // Benchmark GET and POST requests
+    c.bench_function("disable_pooling_http_pipeline_test", |b| {
+        b.to_async(&rt).iter(|| async {
+            let response = client.get("get", None).await;
+            assert!(response.is_ok());
+            let response = response.unwrap();
+            assert_eq!(response.status(), azure_core::http::StatusCode::Ok);
+        });
+    });
+}
+
+pub fn baseline_http_transport_test(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let endpoint = "https://azuresdkforcpp.azurewebsites.net";
+
+    let http_client = new_default_reqwest_client();
+
+    // Benchmark GET and POST requests
+    c.bench_function("baseline_http_pipeline_test", |b| {
+        b.to_async(&rt).iter(|| async {
+            let request = Request::new(
+                Url::parse(&format!("{}/get", endpoint)).unwrap(),
+                Method::Get,
+            );
+            let response = http_client.execute_request(&request).await;
+            assert!(response.is_ok());
+            let response = response.unwrap();
+            assert_eq!(response.status(), azure_core::http::StatusCode::Ok);
+        });
+    });
+}
+
+// Main benchmark configuration
+criterion_group!(name=http_transport_benchmarks;
+    config=Criterion::default()
+        .sample_size(100)
+        .warm_up_time(std::time::Duration::new(10, 0))
+        .measurement_time(std::time::Duration::new(50, 0));
+    targets=simple_http_transport_test, disable_pooling_http_transport_test, baseline_http_transport_test
+);
+
+criterion_main!(http_transport_benchmarks);

--- a/sdk/keyvault/azure_security_keyvault_keys/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_keys/Cargo.toml
@@ -29,6 +29,7 @@ azure_identity.workspace = true
 azure_security_keyvault_test = { path = "../azure_security_keyvault_test" }
 criterion.workspace = true
 rand.workspace = true
+reqwest.workspace = true
 sha2.workspace = true
 tokio.workspace = true
 

--- a/sdk/keyvault/azure_security_keyvault_keys/benches/benchmarks.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/benches/benchmarks.rs
@@ -1,9 +1,13 @@
+use azure_core::http::{ClientOptions, TransportOptions};
 use azure_core_test::credentials;
 use azure_security_keyvault_keys::{
-    models::{CreateKeyParameters, CurveName, Key, KeyType},
-    KeyClient,
+    models::{
+        CreateKeyParameters, CurveName, EncryptionAlgorithm, Key, KeyOperationParameters, KeyType,
+    },
+    KeyClient, KeyClientOptions,
 };
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::sync::Arc;
 
 fn key_operations_benchmark(c: &mut Criterion) {
     const ENV_NAME: &str = "AZURE_KEYVAULT_URL";
@@ -77,11 +81,171 @@ fn key_operations_benchmark(c: &mut Criterion) {
     });
 }
 
+fn key_2901_benchmark_default(c: &mut Criterion) {
+    const ENV_NAME: &str = "AZURE_KEYVAULT_URL";
+
+    // Check if the environment variable is set thus allowing the benchmarks to run
+    if std::env::var(ENV_NAME).is_err() {
+        println!("Skipping benchmarks. Set {} to run.", ENV_NAME);
+        return;
+    }
+    const KEY_NAME: &str = "key-2901";
+
+    //    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    // Setup the KeyClient and the CreateKeyParameters
+    async fn setup_key_client() -> (KeyClient, CreateKeyParameters) {
+        let keyvault_url: String =
+            std::env::var(ENV_NAME).unwrap_or_else(|e| panic!("{} not set: {}", ENV_NAME, e));
+        let credential = credentials::from_env(None).unwrap();
+        let client: KeyClient = KeyClient::new(&keyvault_url, credential.clone(), None).unwrap();
+        let body = CreateKeyParameters {
+            kty: Some(KeyType::RSA),
+            key_size: Some(2048),
+            ..Default::default()
+        };
+        (client, body)
+    }
+
+    let (client, body) = rt.block_on(async { setup_key_client().await });
+
+    // Create a key with name
+    async fn create_key(
+        name: &str,
+        client: &KeyClient,
+        body: CreateKeyParameters,
+    ) -> Result<Key, azure_core::Error> {
+        // Create a new key version
+        client
+            .create_key(name, body.try_into()?, None)
+            .await?
+            .into_body()
+            .await
+    }
+
+    // prep key in order to run the benchmark in a clean state
+    let _ = rt.block_on(async { create_key(KEY_NAME, &client, body.clone()).await });
+
+    let dek = rand::random::<[u8; 32]>(); // Generate a random 32-byte data encryption key (DEK)
+
+    c.bench_function("key_2901_benchmark_default", |b| {
+        b.to_async(&rt).iter(|| async {
+            let parameters = KeyOperationParameters {
+                algorithm: Some(EncryptionAlgorithm::RsaOAEP256),
+                value: Some(dek.to_vec()),
+                ..Default::default()
+            };
+            let _wrap_key_response = client
+                .wrap_key(KEY_NAME, "", parameters.try_into().unwrap(), None)
+                .await
+                .unwrap()
+                .into_body()
+                .await
+                .unwrap();
+
+            black_box(());
+        });
+    });
+}
+
+fn key_2901_benchmark_slow(c: &mut Criterion) {
+    const ENV_NAME: &str = "AZURE_KEYVAULT_URL";
+
+    // Check if the environment variable is set thus allowing the benchmarks to run
+    if std::env::var(ENV_NAME).is_err() {
+        println!("Skipping benchmarks. Set {} to run.", ENV_NAME);
+        return;
+    }
+    const KEY_NAME: &str = "key-2901";
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    // Setup the KeyClient and the CreateKeyParameters
+    async fn setup_key_client() -> (KeyClient, CreateKeyParameters) {
+        let reqwest = Arc::new(
+            reqwest::Client::builder()
+                .pool_max_idle_per_host(0)
+                .build()
+                .unwrap(),
+        );
+
+        let options = KeyClientOptions {
+            client_options: ClientOptions {
+                transport: Some(TransportOptions::new(reqwest)),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let keyvault_url: String =
+            std::env::var(ENV_NAME).unwrap_or_else(|e| panic!("{} not set: {}", ENV_NAME, e));
+        let credential = credentials::from_env(None).unwrap();
+        let client: KeyClient =
+            KeyClient::new(&keyvault_url, credential.clone(), Some(options)).unwrap();
+        let body = CreateKeyParameters {
+            kty: Some(KeyType::RSA),
+            key_size: Some(2048),
+            ..Default::default()
+        };
+        (client, body)
+    }
+
+    let (client, body) = rt.block_on(async { setup_key_client().await });
+
+    // Create a key with name
+    async fn create_key(
+        name: &str,
+        client: &KeyClient,
+        body: CreateKeyParameters,
+    ) -> Result<Key, azure_core::Error> {
+        // Create a new key version
+        client
+            .create_key(name, body.try_into()?, None)
+            .await?
+            .into_body()
+            .await
+    }
+
+    // prep key in order to run the benchmark in a clean state
+    let _ = rt.block_on(async { create_key(KEY_NAME, &client, body.clone()).await });
+
+    let dek = rand::random::<[u8; 32]>(); // Generate a random 32-byte data encryption key (DEK)
+
+    c.bench_function("key_2901_benchmark_default", |b| {
+        b.to_async(&rt).iter(|| async {
+            let parameters = KeyOperationParameters {
+                algorithm: Some(EncryptionAlgorithm::RsaOAEP256),
+                value: Some(dek.to_vec()),
+                ..Default::default()
+            };
+            let _wrap_key_response = client
+                .wrap_key(KEY_NAME, "", parameters.try_into().unwrap(), None)
+                .await
+                .unwrap()
+                .into_body()
+                .await
+                .unwrap();
+
+            black_box(());
+        });
+    });
+}
+
 // Main benchmark configuration
 criterion_group! {
     name = benchmarks;
-    config = Criterion::default().sample_size(10).warm_up_time(std::time::Duration::new(1, 0));
-    targets = key_operations_benchmark
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(std::time::Duration::new(1, 0))
+        .measurement_time(std::time::Duration::from_secs(30));
+    targets = key_operations_benchmark, key_2901_benchmark_default, key_2901_benchmark_slow
 }
 
 criterion_main!(benchmarks);

--- a/sdk/typespec/typespec_client_core/src/http/clients/reqwest.rs
+++ b/sdk/typespec/typespec_client_core/src/http/clients/reqwest.rs
@@ -17,13 +17,15 @@ use typespec::error::{Error, ErrorKind, Result, ResultExt};
 pub fn new_reqwest_client() -> Arc<dyn HttpClient> {
     debug!("creating an http client using `reqwest`");
 
-    // Set `pool_max_idle_per_host` to `0` to avoid an issue in the underlying
-    // `hyper` library that causes the `reqwest` client to hang in some cases.
+    // Note that customers have reported challenges associated with enabling
+    // connection pooling in reqwest. See <https://github.com/hyperium/hyper/issues/2312>
+    // for more details.
     //
-    // See <https://github.com/hyperium/hyper/issues/2312> for more details.
+    // Due to the significant performance impact associated with disabling connection pooling,
+    // it is enabled here, but instructions on how to disable it are in the troubleshooting
+    // guide.
     #[cfg(not(target_arch = "wasm32"))]
     let client = ::reqwest::ClientBuilder::new()
-        .pool_max_idle_per_host(0)
         .build()
         .expect("failed to build `reqwest` client");
 


### PR DESCRIPTION
Re-enabled HTTP connection pooling. In benchmarks using `criterion`, this results in a 3x performance improvement on repeated HTTP operations against the same server, which is not quite the 10x performance reduction reported in #2901, but is a significant improvement.

