### PR TITLE
Add Powershell Installation Instructions for Copilot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ You are an expert Rust programmer. You write safe, efficient, maintainable, and 
 
 ## Prerequisites
 
-- To use Azure MCP tool calls, the user must have PowerShell installed. Provide [PowerShell installation instructions](https://learn.microsoft.com/powershell/scripting/install/installing-powershell) if not installed, and recommend restarting the IDE to start the MCP server.
+- To use Azure SDK MCP tool calls, the user must have PowerShell installed. Provide [PowerShell installation instructions](https://learn.microsoft.com/powershell/scripting/install/installing-powershell) if not installed, and recommend restarting the IDE to start the MCP server.
 
 ## Code Generation
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ You are an expert Rust programmer. You write safe, efficient, maintainable, and 
 
 ## Prerequisites
 
--   To use MCP tools, users must have PowerShell installed. Provide [PowerShell installation instructions](https://learn.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-7.5) if not installed, and recommend restarting VSCode to start the MCP server.
+- To use Azure MCP tool calls, the user must have PowerShell installed. Provide [PowerShell installation instructions](https://learn.microsoft.com/powershell/scripting/install/installing-powershell) if not installed, and recommend restarting the IDE to start the MCP server.
 
 ## Code Generation
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ You are an expert Rust programmer. You write safe, efficient, maintainable, and 
 
 ## Prerequisites
 
--   To use MCP tools, user must have PowerShell installed. Provide [PowerShell installation instructions](https://learn.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-7.5) if not installed, and recommend restarting VSCode to start the MCP server.
+-   To use MCP tools, users must have PowerShell installed. Provide [PowerShell installation instructions](https://learn.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-7.5) if not installed, and recommend restarting VSCode to start the MCP server.
 
 ## Code Generation
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,10 @@ You are an expert Rust programmer. You write safe, efficient, maintainable, and 
 -   Do not be overly apologetic and focus on clear guidance.
 -   If you cannot confidently generate code or other content, do not generate anything and ask for clarification.
 
+## Prerequisites
+
+-   To use MCP tools, user must have PowerShell installed. Provide [PowerShell installation instructions](https://learn.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-7.5) if not installed, and recommend restarting VSCode to start the MCP server.
+
 ## Code Generation
 
 Use these instructions for test generation as well.


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-tools/issues/11716

<img width="143" height="136" alt="image" src="https://github.com/user-attachments/assets/6ca7a914-1458-4c0f-b855-63742ce01b29" />

for MCP tool usage, have copilot tell user they need to install Powershell