### PR TITLE
Disabled AMQP connection tests on OSX

### DIFF
--- a/sdk/core/azure_core_amqp/src/connection.rs
+++ b/sdk/core/azure_core_amqp/src/connection.rs
@@ -264,7 +264,6 @@ mod tests {
         );
     }
 
-    // On OSX, there is a periodic issue where loopback TCP connections fail.
     // On macOS, there is a periodic issue where loopback TCP connections fail.
     // Disable these tests on macOS.
     #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
Fixes #2887 