### PR TITLE
`create_async_runtime`: Make `cfg` checks exhaustive

### DIFF
--- a/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
@@ -187,13 +187,16 @@ pub fn set_async_runtime(runtime: Arc<dyn AsyncRuntime>) -> crate::Result<()> {
 fn create_async_runtime() -> Arc<dyn AsyncRuntime> {
     #[cfg(all(target_arch = "wasm32", feature = "wasm_bindgen"))]
     {
-        Arc::new(web_runtime::WasmBindgenRuntime) as Arc<dyn AsyncRuntime>
+        return Arc::new(web_runtime::WasmBindgenRuntime) as Arc<dyn AsyncRuntime>;
     }
     #[cfg(feature = "tokio")]
     {
-        Arc::new(tokio_runtime::TokioRuntime) as Arc<dyn AsyncRuntime>
+        return Arc::new(tokio_runtime::TokioRuntime) as Arc<dyn AsyncRuntime>;
     }
-    #[cfg(not(any(feature = "tokio", feature = "wasm_bindgen")))]
+    #[cfg(not(any(
+        feature = "tokio",
+        all(target_arch = "wasm32", feature = "wasm_bindgen")
+    )))]
     {
         Arc::new(standard_runtime::StdRuntime) as Arc<dyn AsyncRuntime>
     }


### PR DESCRIPTION
This PR makes the `cfg` checks exhaustive in the `create_async_runtime()`, to avoid a case that a package depending on `typespec_client_core`, enabled `wasm_bindgen` feature, but build for native target (e.g. x86-84). This will hit no check conditions in the `create_async_runtime()`, makes it reutrn `()`.

In fact, mutually exclusive features are not encouraged: https://doc.rust-lang.org/cargo/reference/features.html#mutually-exclusive-features. While I don't have any better idea in this case..

Related to: #2838.