### PR TITLE
Allow use of other TLS implementations for eventhubs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ cargo_metadata = "0.18.1"
 clap = { version = "4.5.45", features = ["derive"] }
 criterion = { version = "0.5", features = ["async_tokio"] }
 dyn-clone = "1.0"
-fe2o3-amqp = { version = "0.14", features = ["native-tls", "uuid"] }
+fe2o3-amqp = { version = "0.14", features = ["uuid"] }
 fe2o3-amqp-ext = { version = "0.14" }
 fe2o3-amqp-management = { version = "0.14" }
 fe2o3-amqp-cbs = { version = "0.14" }

--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -37,7 +37,7 @@ typespec_macros.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [features]
-default = ["fe2o3_amqp"]
+default = ["fe2o3_amqp", "fe2o3-amqp/native-tls"]
 cplusplus = []
 test = []
 fe2o3_amqp = [

--- a/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
@@ -44,6 +44,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 
 [features]
 in_memory_checkpoint_store = []
+default = ["azure_core_amqp/default"]
 
 [[bench]]
 name = "benchmarks"

--- a/sdk/servicebus/azure_messaging_servicebus/Cargo.toml
+++ b/sdk/servicebus/azure_messaging_servicebus/Cargo.toml
@@ -31,6 +31,9 @@ tracing.workspace = true
 url.workspace = true
 uuid.workspace = true
 
+[features]
+default = ["azure_core_amqp/default"]
+
 [dev-dependencies]
 azure_core_amqp = { workspace = true, features = ["test"] }
 azure_core_test = { workspace = true, features = ["tracing"] }


### PR DESCRIPTION
Fixes #2796 following the model used in #2933

Move `fe2o3-amqp`'s `native-tls` feature to default features for AMQP layer and use that for eventhubs.
