### PR TITLE
Refactor pager, poller modules (#2909)

### DIFF
--- a/sdk/core/azure_core/examples/core_poller.rs
+++ b/sdk/core/azure_core/examples/core_poller.rs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use azure_core::{
+    credentials::TokenCredential,
+    http::{
+        headers::{Headers, RETRY_AFTER},
+        HttpClient, Method, RawResponse, StatusCode, TransportOptions,
+    },
+};
+use azure_core_test::{credentials::MockCredential, http::MockHttpClient};
+use azure_security_keyvault_certificates::{
+    models::CreateCertificateParameters, CertificateClient, CertificateClientOptions,
+};
+use futures::FutureExt;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+// This example demonstrates using a Poller to create a certificate with the CertificateClient.
+async fn test_poller() -> Result<(), Box<dyn std::error::Error>> {
+    let mut options = CertificateClientOptions::default();
+
+    // Ignore: this is only set up for testing.
+    // You normally would create credentials from `azure_identity` and
+    // use the default transport in production.
+    let (credential, transport) = setup()?;
+    options.client_options.transport = Some(TransportOptions::new(transport));
+
+    let client = CertificateClient::new(
+        "https://my-vault.vault.azure.net",
+        credential,
+        Some(options),
+    )?;
+
+    // Minimal create parameters (empty policy for mock)
+    let params = CreateCertificateParameters::default();
+
+    // Start a create_certificate long-running operation.
+    let operation = client
+        .begin_create_certificate("my-cert", params.try_into()?, None)?
+        .wait()
+        .await?
+        .into_body()
+        .await?;
+    assert_eq!(operation.status.as_deref(), Some("completed"));
+    assert!(operation.target.is_some());
+
+    Ok(())
+}
+
+// ----- BEGIN TEST SETUP -----
+#[tokio::test]
+async fn test_core_poller() -> Result<(), Box<dyn std::error::Error>> {
+    test_poller().await
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    test_poller().await
+}
+
+#[allow(clippy::type_complexity)]
+fn setup() -> Result<(Arc<dyn TokenCredential>, Arc<dyn HttpClient>), Box<dyn std::error::Error>> {
+    let credential: Arc<dyn TokenCredential> = MockCredential::new()?;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let transport = {
+        let calls = calls.clone();
+        MockHttpClient::new(move |request| {
+            let calls = calls.clone();
+            async move {
+                let idx = calls.fetch_add(1, Ordering::SeqCst);
+                match idx {
+                    0 => {
+                        // Initial POST to start operation
+                        assert_eq!(request.method(), Method::Post);
+                        assert!(request.url().path().starts_with("/certificates/my-cert/create"));
+                        let mut headers = Headers::new();
+                        headers.insert(RETRY_AFTER, "0");
+                        Ok(RawResponse::from_bytes(
+                            StatusCode::Ok,
+                            headers,
+                            r#"{"id":"https://my-vault.vault.azure.net/certificates/my-cert/pending","status":"inProgress"}"#,
+                        ))
+                    }
+                    1 => {
+                        // Polling GET for status
+                        assert_eq!(request.method(), Method::Get);
+                        assert!(request.url().path().starts_with("/certificates/my-cert/pending"));
+                        Ok(RawResponse::from_bytes(
+                            StatusCode::Ok,
+                            Headers::new(),
+                            r#"{"id":"https://my-vault.vault.azure.net/certificates/my-cert/pending","status":"completed","target":"https://my-vault.vault.azure.net/certificates/my-cert"}"#,
+                        ))
+                    }
+                    _ => panic!("unexpected request count {idx}"),
+                }
+            }
+            .boxed()
+        })
+    };
+    Ok((credential, Arc::new(transport)))
+}
+// ----- END TEST SETUP -----

--- a/sdk/core/azure_core/src/http/mod.rs
+++ b/sdk/core/azure_core/src/http/mod.rs
@@ -6,7 +6,7 @@
 pub mod headers;
 mod models;
 mod options;
-mod pager;
+pub mod pager;
 mod pipeline;
 pub mod policies;
 pub mod poller;
@@ -14,9 +14,9 @@ pub mod request;
 
 pub use models::*;
 pub use options::*;
-pub use pager::*;
+pub use pager::{ItemIterator, PageIterator, Pager};
 pub use pipeline::*;
-pub use poller::{Poller, PollerStatus};
+pub use poller::Poller;
 pub use request::{Body, Request, RequestContent};
 pub use response::{RawResponse, Response};
 

--- a/sdk/core/azure_core/src/http/pager.rs
+++ b/sdk/core/azure_core/src/http/pager.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+//! Types and methods for pageable responses.
+
 use crate::http::{headers::HeaderName, response::Response, DeserializeWith, Format, JsonFormat};
 use async_trait::async_trait;
 use futures::{stream::unfold, FutureExt, Stream};
@@ -175,7 +177,7 @@ impl<P: Page> ItemIterator<P> {
     /// To page results using a next link:
     ///
     /// ```rust,no_run
-    /// # use azure_core::{Result, http::{Context, ItemIterator, Page, PagerResult, PagerState, Pipeline, RawResponse, Request, Response, Method, Url}, json};
+    /// # use azure_core::{Result, http::{Context, ItemIterator, pager::{Page, PagerResult, PagerState}, Pipeline, RawResponse, Request, Response, Method, Url}, json};
     /// # let api_version = "2025-06-04".to_string();
     /// # let pipeline: Pipeline = panic!("Not a runnable example");
     /// #[derive(serde::Deserialize)]
@@ -233,7 +235,7 @@ impl<P: Page> ItemIterator<P> {
     /// To page results using headers:
     ///
     /// ```rust,no_run
-    /// # use azure_core::{Result, http::{Context, ItemIterator, Page, PagerResult, PagerState, Pipeline, Request, Response, Method, headers::HeaderName}};
+    /// # use azure_core::{Result, http::{Context, ItemIterator, pager::{Page, PagerResult, PagerState}, Pipeline, Request, Response, Method, headers::HeaderName}};
     /// # let pipeline: Pipeline = panic!("Not a runnable example");
     /// #[derive(serde::Deserialize)]
     /// struct ListItemsResult {
@@ -377,7 +379,7 @@ impl<P> PageIterator<P> {
     /// To page results using a next link:
     ///
     /// ```rust,no_run
-    /// # use azure_core::{Result, http::{Context, PageIterator, PagerResult, PagerState, Pipeline, RawResponse, Request, Response, Method, Url}, json};
+    /// # use azure_core::{Result, http::{Context, pager::{PageIterator, PagerResult, PagerState}, Pipeline, RawResponse, Request, Response, Method, Url}, json};
     /// # let api_version = "2025-06-04".to_string();
     /// # let pipeline: Pipeline = panic!("Not a runnable example");
     /// #[derive(serde::Deserialize)]
@@ -426,7 +428,7 @@ impl<P> PageIterator<P> {
     /// To page results using headers:
     ///
     /// ```rust,no_run
-    /// # use azure_core::{Result, http::{Context, PageIterator, PagerResult, PagerState, Pipeline, Request, Response, Method, headers::HeaderName}};
+    /// # use azure_core::{Result, http::{Context, pager::{PageIterator, PagerResult, PagerState}, Pipeline, Request, Response, Method, headers::HeaderName}};
     /// # let pipeline: Pipeline = panic!("Not a runnable example");
     /// #[derive(serde::Deserialize)]
     /// struct ListItemsResult {
@@ -646,7 +648,8 @@ fn iter_from_callback<
 mod tests {
     use crate::http::{
         headers::{HeaderName, HeaderValue},
-        PageIterator, Pager, PagerResult, PagerState, RawResponse, Response, StatusCode,
+        pager::{PageIterator, Pager, PagerResult, PagerState},
+        RawResponse, Response, StatusCode,
     };
     use async_trait::async_trait;
     use futures::{StreamExt as _, TryStreamExt as _};

--- a/sdk/cosmos/azure_data_cosmos/src/feed.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/feed.rs
@@ -1,5 +1,9 @@
 use async_trait::async_trait;
-use azure_core::http::{headers::Headers, ItemIterator, Page, PagerResult, RawResponse};
+use azure_core::http::{
+    headers::Headers,
+    pager::{Page, PagerResult},
+    ItemIterator, RawResponse,
+};
 use serde::{de::DeserializeOwned, Deserialize};
 
 use crate::constants;

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
@@ -8,9 +8,10 @@ use std::sync::Arc;
 
 pub use authorization_policy::AuthorizationPolicy;
 use azure_core::http::{
+    pager::PagerState,
     request::{options::ContentType, Request},
     response::Response,
-    ClientOptions, Context, Method, PagerState, RawResponse,
+    ClientOptions, Context, Method, RawResponse,
 };
 use futures::TryStreamExt;
 use serde::de::DeserializeOwned;

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/clients.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/clients.rs
@@ -10,7 +10,8 @@ use crate::models::{
 use azure_core::{
     http::{
         poller::{get_retry_after, PollerResult, PollerState, StatusMonitor as _},
-        Body, Method, Poller, PollerStatus, RawResponse, Request, RequestContent, Url,
+        poller::{Poller, PollerStatus},
+        Body, Method, RawResponse, Request, RequestContent, Url,
     },
     json, Result,
 };

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/generated/clients/certificate_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/generated/clients/certificate_client.rs
@@ -32,9 +32,10 @@ use azure_core::{
     error::{ErrorKind, HttpError},
     fmt::SafeDebug,
     http::{
+        pager::{PagerResult, PagerState},
         policies::{BearerTokenCredentialPolicy, Policy},
-        ClientOptions, Context, Method, NoFormat, Pager, PagerResult, PagerState, Pipeline,
-        RawResponse, Request, RequestContent, Response, Url,
+        ClientOptions, Context, Method, NoFormat, Pager, Pipeline, RawResponse, Request,
+        RequestContent, Response, Url,
     },
     json, tracing, Error, Result,
 };

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/generated/models/models_impl.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/generated/models/models_impl.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use async_trait::async_trait;
 use azure_core::{
-    http::{Page, RequestContent},
+    http::{pager::Page, RequestContent},
     json::to_json,
     Result,
 };

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/models.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/models.rs
@@ -5,8 +5,9 @@ pub use crate::generated::models::*;
 use azure_core::{
     fmt::SafeDebug,
     http::{
+        poller::PollerStatus,
         poller::{PollerOptions, StatusMonitor},
-        ClientMethodOptions, PollerStatus,
+        ClientMethodOptions,
     },
 };
 impl StatusMonitor for CertificateOperation {

--- a/sdk/keyvault/azure_security_keyvault_keys/src/generated/clients/key_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/generated/clients/key_client.rs
@@ -25,9 +25,10 @@ use azure_core::{
     error::{ErrorKind, HttpError},
     fmt::SafeDebug,
     http::{
+        pager::{PagerResult, PagerState},
         policies::{BearerTokenCredentialPolicy, Policy},
-        ClientOptions, Context, Method, NoFormat, Pager, PagerResult, PagerState, Pipeline,
-        RawResponse, Request, RequestContent, Response, Url,
+        ClientOptions, Context, Method, NoFormat, Pager, Pipeline, RawResponse, Request,
+        RequestContent, Response, Url,
     },
     json, tracing, Error, Result,
 };

--- a/sdk/keyvault/azure_security_keyvault_keys/src/generated/models/models_impl.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/generated/models/models_impl.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use async_trait::async_trait;
 use azure_core::{
-    http::{Page, RequestContent},
+    http::{pager::Page, RequestContent},
     json::to_json,
     Result,
 };

--- a/sdk/keyvault/azure_security_keyvault_secrets/src/generated/clients/secret_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/src/generated/clients/secret_client.rs
@@ -19,9 +19,10 @@ use azure_core::{
     error::{ErrorKind, HttpError},
     fmt::SafeDebug,
     http::{
+        pager::{PagerResult, PagerState},
         policies::{BearerTokenCredentialPolicy, Policy},
-        ClientOptions, Context, Method, NoFormat, Pager, PagerResult, PagerState, Pipeline,
-        RawResponse, Request, RequestContent, Response, Url,
+        ClientOptions, Context, Method, NoFormat, Pager, Pipeline, RawResponse, Request,
+        RequestContent, Response, Url,
     },
     json, tracing, Error, Result,
 };

--- a/sdk/keyvault/azure_security_keyvault_secrets/src/generated/models/models_impl.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/src/generated/models/models_impl.rs
@@ -10,7 +10,7 @@ use super::{
 };
 use async_trait::async_trait;
 use azure_core::{
-    http::{Page, RequestContent},
+    http::{pager::Page, RequestContent},
     json::to_json,
     Result,
 };

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
@@ -29,9 +29,10 @@ use azure_core::{
     error::{ErrorKind, HttpError},
     fmt::SafeDebug,
     http::{
+        pager::{PagerResult, PagerState},
         policies::{BearerTokenCredentialPolicy, Policy},
-        ClientOptions, Context, Method, NoFormat, PageIterator, PagerResult, PagerState, Pipeline,
-        RawResponse, Request, RequestContent, Response, Url, XmlFormat,
+        ClientOptions, Context, Method, NoFormat, PageIterator, Pipeline, RawResponse, Request,
+        RequestContent, Response, Url, XmlFormat,
     },
     time::to_rfc7231,
     tracing, xml, Error, Result,

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
@@ -19,9 +19,10 @@ use azure_core::{
     error::{ErrorKind, HttpError},
     fmt::SafeDebug,
     http::{
+        pager::{PagerResult, PagerState},
         policies::{BearerTokenCredentialPolicy, Policy},
-        ClientOptions, Context, Method, NoFormat, PageIterator, PagerResult, PagerState, Pipeline,
-        RawResponse, Request, RequestContent, Response, Url, XmlFormat,
+        ClientOptions, Context, Method, NoFormat, PageIterator, Pipeline, RawResponse, Request,
+        RequestContent, Response, Url, XmlFormat,
     },
     tracing, xml, Error, Result,
 };


### PR DESCRIPTION
Resolves #2773 by only re-exporting types that end-user developers would interact with from `http`, leaving types geared more toward emitters and convenience clients in separate `http::pager` and `http:poller` modules.

Also adds simple mocked examples.