### PR TITLE
Current Core crate authoring incompatible with generated code output

### DIFF
--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
@@ -29,10 +29,9 @@ use azure_core::{
     error::{ErrorKind, HttpError},
     fmt::SafeDebug,
     http::{
-        pager::{PagerResult, PagerState},
         policies::{BearerTokenCredentialPolicy, Policy},
-        ClientOptions, Context, Method, NoFormat, PageIterator, Pipeline, RawResponse, Request,
-        RequestContent, Response, Url, XmlFormat,
+        ClientOptions, Context, Method, NoFormat, PageIterator, PagerResult, PagerState, Pipeline,
+        RawResponse, Request, RequestContent, Response, Url, XmlFormat,
     },
     time::to_rfc7231,
     tracing, xml, Error, Result,

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
@@ -19,10 +19,9 @@ use azure_core::{
     error::{ErrorKind, HttpError},
     fmt::SafeDebug,
     http::{
-        pager::{PagerResult, PagerState},
         policies::{BearerTokenCredentialPolicy, Policy},
-        ClientOptions, Context, Method, NoFormat, PageIterator, Pipeline, RawResponse, Request,
-        RequestContent, Response, Url, XmlFormat,
+        ClientOptions, Context, Method, NoFormat, PageIterator, PagerResult, PagerState, Pipeline,
+        RawResponse, Request, RequestContent, Response, Url, XmlFormat,
     },
     tracing, xml, Error, Result,
 };

--- a/sdk/storage/azure_storage_blob/src/generated/models/models_impl.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/models_impl.rs
@@ -13,34 +13,34 @@ use azure_core::{
 impl TryFrom<BlobServiceProperties> for RequestContent<BlobServiceProperties, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: BlobServiceProperties) -> Result<Self> {
-        Ok(to_xml(&value)?.into())
+        RequestContent::try_from(to_xml(&value)?)
     }
 }
 
 impl TryFrom<BlobTags> for RequestContent<BlobTags, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: BlobTags) -> Result<Self> {
-        Ok(to_xml(&value)?.into())
+        RequestContent::try_from(to_xml(&value)?)
     }
 }
 
 impl TryFrom<BlockLookupList> for RequestContent<BlockLookupList, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: BlockLookupList) -> Result<Self> {
-        Ok(to_xml(&value)?.into())
+        RequestContent::try_from(to_xml(&value)?)
     }
 }
 
 impl TryFrom<KeyInfo> for RequestContent<KeyInfo, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: KeyInfo) -> Result<Self> {
-        Ok(to_xml(&value)?.into())
+        RequestContent::try_from(to_xml(&value)?)
     }
 }
 
 impl TryFrom<QueryRequest> for RequestContent<QueryRequest, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: QueryRequest) -> Result<Self> {
-        Ok(to_xml(&value)?.into())
+        RequestContent::try_from(to_xml(&value)?)
     }
 }


### PR DESCRIPTION
[tspconfig.yaml ](https://github.com/Azure/azure-rest-api-specs/blob/c05b1ba8ec1b4472da48c7000784519f18a40f66/specification/storage/Microsoft.BlobStorage/tspconfig.yaml) from [feature/blob-tsp-rust](https://github.com/Azure/azure-rest-api-specs/tree/feature/blob-tsp-rust)

As a result of the changes made in #2957, the generated code is still building off of the previous version of Core.