### PR TITLE
azure_data_cosmos: allow users to override TLS backend

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings"]
 
 [dependencies]
 async-trait.workspace = true
-azure_core.workspace = true
+azure_core = { workspace = true, default-features = false, features = ["reqwest"] }
 futures.workspace = true
 serde_json.workspace = true
 serde.workspace = true
@@ -36,11 +36,12 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 workspace = true
 
 [features]
-default = ["hmac_rust"]
+default = ["hmac_rust", "reqwest_native_tls"]
 key_auth = [] # Enables support for key-based authentication (Primary Keys and Resource Tokens)
 preview_query_engine = ["serde_json/raw_value"] # Enables support for the PREVIEW external query engine
 hmac_rust = ["azure_core/hmac_rust"]
 hmac_openssl = ["azure_core/hmac_openssl"]
+reqwest_native_tls = ["azure_core/reqwest_native_tls"]
 
 [package.metadata.docs.rs]
 features = ["key_auth"]

--- a/sdk/cosmos/azure_data_cosmos/README.md
+++ b/sdk/cosmos/azure_data_cosmos/README.md
@@ -14,6 +14,18 @@ Install the Azure Cosmos DB SDK for Rust with cargo:
 cargo add azure_data_cosmos
 ```
 
+### Using rustls instead of OpenSSL
+
+By default, this crate uses OpenSSL for TLS connections through its dependency on `azure_core`, which enables `reqwest_native_tls` by default. For cross-platform compatibility, you can use rustls instead by configuring your `Cargo.toml`:
+
+```toml
+[dependencies]
+azure_data_cosmos = { version = "0.27", default-features = false, features = ["hmac_rust"] }
+reqwest = { version = "0.12", features = ["rustls-tls"] }
+```
+
+**Important**: When disabling default features, you must include `hmac_rust` for cryptographic operations to work properly. The `hmac_rust` feature provides a pure Rust implementation of HMAC that works well with rustls for a fully Rust-native TLS stack.
+
 ### Prerequisites
 
 * An [Azure subscription] or free Azure Cosmos DB trial account.


### PR DESCRIPTION
## Allow users to override TLS backend for cross-platform compatibility

### Rationale
This change enables users to use rustls instead of OpenSSL for better cross-platform portability. Specifically, this addresses the need to cross-compile to linux musl targets for Azure Functions without dealing with OpenSSL dependencies. Inspired by https://github.com/Azure/azure-sdk-for-rust/issues/2796

### Changes
• Set azure_core dependency to default-features = false with explicit reqwest feature
• Added reqwest_native_tls feature that passes through to azure_core/reqwest_native_tls
• Updated default features to include reqwest_native_tls for backward compatibility

### Usage
• **Default behavior**: Uses native-tls (no change for existing users)
• **For rustls/musl targets**: Use --no-default-features --features "hmac_rust" and specify reqwest with rustls-tls features in user's Cargo.toml

This enables seamless cross-compilation to musl targets while maintaining backward compatibility for existing users.

I'm not very experienced with designing large project dependencies. Please provide any feedback you have and point out my blind spots and I'm happy to fix them to the best of my ability. 
