### PR TITLE
ServiceBus 

### DIFF
--- a/sdk/servicebus/azure_messaging_servicebus/CONTRIBUTING.md
+++ b/sdk/servicebus/azure_messaging_servicebus/CONTRIBUTING.md
@@ -34,19 +34,6 @@ This will automatically create:
 -   RBAC permissions for TokenCredential testing
 -   All required environment variables
 
-The script will output PowerShell commands to set environment variables.
-
-### Environment Variables
-
-After deployment completes successfully, the script will output commands like:
-
-```powershell
-$env:SERVICEBUS_NAMESPACE = "sb-your-deployment-name.servicebus.windows.net"
-$env:SERVICEBUS_QUEUE_NAME = "testqueue"
-$env:SERVICEBUS_TOPIC_NAME = "testtopic"
-$env:SERVICEBUS_SUBSCRIPTION_NAME = "testsubscription"
-```
-
 ## Run Live Tests
 
 Once the environment variables are set, run the tests:

--- a/sdk/servicebus/azure_messaging_servicebus/src/client.rs
+++ b/sdk/servicebus/azure_messaging_servicebus/src/client.rs
@@ -5,7 +5,7 @@ use crate::{
     common::authorizer::Authorizer, ErrorKind, ReceiveMode, Receiver, Result, Sender,
     ServiceBusError,
 };
-use azure_core::{credentials::TokenCredential, fmt::SafeDebug, http::ClientOptions, http::Url};
+use azure_core::{credentials::TokenCredential, fmt::SafeDebug, http::Url};
 use azure_core_amqp::{
     AmqpConnection, AmqpConnectionApis, AmqpConnectionOptions, AmqpOrderedMap, AmqpSymbol,
     AmqpValue,
@@ -39,9 +39,6 @@ pub struct ServiceBusClientOptions {
     /// The API version to use when communicating with the Service Bus service.
     pub api_version: String,
 
-    /// Core client configuration options.
-    pub client_options: ClientOptions,
-
     /// Application ID that will be passed to the namespace.
     ///
     /// This optional identifier is passed to the Service Bus namespace during connection establishment
@@ -53,7 +50,6 @@ impl Default for ServiceBusClientOptions {
     fn default() -> Self {
         Self {
             api_version: "2017-04".to_string(), // Default Service Bus API version
-            client_options: ClientOptions::default(),
             application_id: None,
         }
     }

--- a/sdk/servicebus/azure_messaging_servicebus/src/client.rs
+++ b/sdk/servicebus/azure_messaging_servicebus/src/client.rs
@@ -25,7 +25,7 @@ pub enum SubQueue {
 
 impl SubQueue {
     /// Returns the path suffix for the sub-queue.
-    pub fn as_path_suffix(&self) -> &'static str {
+    pub(crate) fn as_path_suffix(&self) -> &'static str {
         match self {
             SubQueue::DeadLetter => "/$DeadLetterQueue",
             SubQueue::Transfer => "/$Transfer/$DeadLetterQueue",
@@ -49,7 +49,7 @@ pub struct ServiceBusClientOptions {
 impl Default for ServiceBusClientOptions {
     fn default() -> Self {
         Self {
-            api_version: "2017-04".to_string(), // Default Service Bus API version
+            api_version: "2021-05".to_string(), // Default Service Bus API version
             application_id: None,
         }
     }

--- a/sdk/servicebus/azure_messaging_servicebus/src/receiver.rs
+++ b/sdk/servicebus/azure_messaging_servicebus/src/receiver.rs
@@ -2255,7 +2255,7 @@ mod tests {
         Arc::new(AmqpConnection::new())
     }
 
-    /// Creates a test ClientOptions
+    /// Creates test ServiceBusClientOptions
     fn create_test_options() -> ServiceBusClientOptions {
         Default::default()
     }

--- a/sdk/servicebus/azure_messaging_servicebus/src/sender.rs
+++ b/sdk/servicebus/azure_messaging_servicebus/src/sender.rs
@@ -575,7 +575,7 @@ mod tests {
         Arc::new(AmqpConnection::new())
     }
 
-    /// Creates a test ClientOptions
+    /// Creates test ServiceBusClientOptions
     fn create_test_options() -> ServiceBusClientOptions {
         Default::default()
     }

--- a/sdk/servicebus/azure_messaging_servicebus/test-resources-post.ps1
+++ b/sdk/servicebus/azure_messaging_servicebus/test-resources-post.ps1
@@ -50,44 +50,6 @@ $resourceGroup = $DeploymentOutputs['RESOURCE_GROUP']
 Write-Host "Service Bus Namespace: $namespaceName"
 Write-Host "Resource Group: $resourceGroup"
 
-# Retrieve connection strings (these contain secrets so aren't in Bicep outputs)
-Write-Host "Retrieving Service Bus connection strings..."
-
-try {
-  $connectionString = az servicebus namespace authorization-rule keys list `
-    --resource-group $resourceGroup `
-    --namespace-name $namespaceName `
-    --name RootManageSharedAccessKey `
-    --query primaryConnectionString `
-    --output tsv
-
-  $listenOnlyConnectionString = az servicebus namespace authorization-rule keys list `
-    --resource-group $resourceGroup `
-    --namespace-name $namespaceName `
-    --name ListenOnly `
-    --query primaryConnectionString `
-    --output tsv
-
-  $sendOnlyConnectionString = az servicebus namespace authorization-rule keys list `
-    --resource-group $resourceGroup `
-    --namespace-name $namespaceName `
-    --name SendOnly `
-    --query primaryConnectionString `
-    --output tsv
-
-  Write-Host "✅ Connection strings retrieved successfully"
-
-  # Set additional outputs for the test pipeline
-  if ($CI) {
-    Write-Host "##vso[task.setvariable variable=SERVICEBUS_CONNECTION_STRING;issecret=true]$connectionString"
-    Write-Host "##vso[task.setvariable variable=SERVICEBUS_LISTEN_ONLY_CONNECTION_STRING;issecret=true]$listenOnlyConnectionString"
-    Write-Host "##vso[task.setvariable variable=SERVICEBUS_SEND_ONLY_CONNECTION_STRING;issecret=true]$sendOnlyConnectionString"
-  }
-}
-catch {
-  Write-Warning "Failed to retrieve connection strings: $($_.Exception.Message)"
-}
-
 Write-Host "##[endgroup]"
 
 Write-Host "Service Bus post-deployment setup completed successfully."

--- a/sdk/servicebus/azure_messaging_servicebus/test-resources.bicep
+++ b/sdk/servicebus/azure_messaging_servicebus/test-resources.bicep
@@ -192,9 +192,4 @@ output SERVICEBUS_TOPIC_NAME string = serviceBusNamespace::topic.name
 
 output SERVICEBUS_SUBSCRIPTION_NAME string = serviceBusNamespace::topic::subscription.name
 
-// Connection strings contain secrets and should be retrieved via Azure CLI or portal
-// output SERVICEBUS_CONNECTION_STRING string = serviceBusNamespace::rootSharedAccessKey.listKeys().primaryConnectionString
-// output SERVICEBUS_LISTEN_ONLY_CONNECTION_STRING string = serviceBusNamespace::listenOnlyKey.listKeys().primaryConnectionString
-// output SERVICEBUS_SEND_ONLY_CONNECTION_STRING string = serviceBusNamespace::sendOnlyKey.listKeys().primaryConnectionString
-
 output RESOURCE_GROUP string = resourceGroup().name

--- a/sdk/servicebus/azure_messaging_servicebus/tests/common/mod.rs
+++ b/sdk/servicebus/azure_messaging_servicebus/tests/common/mod.rs
@@ -22,12 +22,6 @@ pub fn setup() {
 }
 
 #[allow(dead_code)]
-pub fn get_connection_string() -> Result<String, Box<dyn Error>> {
-    env::var("SERVICEBUS_CONNECTION_STRING")
-        .map_err(|_| "SERVICEBUS_CONNECTION_STRING environment variable not set".into())
-}
-
-#[allow(dead_code)]
 pub fn get_queue_name() -> Result<String, Box<dyn Error>> {
     env::var("SERVICEBUS_QUEUE_NAME")
         .map_err(|_| "SERVICEBUS_QUEUE_NAME environment variable not set".into())


### PR DESCRIPTION
Remove the ClientOptions from ServiceBusClientOptions.
 - This is not used currently

Fix the default version for the ServiceBus API

Remove code that supported connection_strings in tests.
 - Connection strings are not used in tests