### PR TITLE
[Storage] Prep for `v0.5.0` azure_storage_blob release

### DIFF
--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -4,11 +4,17 @@
 
 ### Features Added
 
+* Added support for `set_properties` to `BlobServiceClient`.
+* Added support for `filter_blobs` to `BlobContainerClient` and `BlobServiceClient`.
+* Added support for `set_tags` and `get_tags` to `BlobClient`.
+* Added support for `get_account_info` to `BlobClient`, `BlobContainerClient`, and `BlobServiceClient`.
+* Added support for `upload_blob_from_url` to `BlockBlobClient`.
+* Added support for `get_page_ranges`, `update_sequence_number`, and `upload_pages_from_url` to `PageBlobClient`.
+* Added support for `find_blobs_by_tags` to `BlobContainerClient` and `BlobServiceClient`.
+
 ### Breaking Changes
 
-### Bugs Fixed
-
-### Other Changes
+* Made `metadata` a required parameter for `set_metadata` for `BlobContainerClient` and `BlobClient`
 
 ## 0.4.0 (2025-08-05)
 

--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Breaking Changes
 
-* Made `metadata` a required parameter for `set_metadata` for `BlobContainerClient` and `BlobClient`
+* Made `metadata` a required parameter for `set_metadata` for `BlobContainerClient` and `BlobClient`.
 
 ## 0.4.0 (2025-08-05)
 

--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -194,12 +194,14 @@ impl BlobClient {
     ///
     /// # Arguments
     ///
+    /// * `metadata` - The metadata headers.
     /// * `options` - Optional configuration for the request.
     pub async fn set_metadata(
         &self,
+        metadata: HashMap<String, String>,
         options: Option<BlobClientSetMetadataOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
-        self.client.set_metadata(options).await
+        self.client.set_metadata(metadata, options).await
     }
 
     /// Deletes the blob.

--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -165,7 +165,7 @@ impl BlobClient {
     /// # Arguments
     ///
     /// * `data` - The blob data to upload.
-    /// * `overwrite` - Whether the blob to be uploaded should overwrite the current data. If True, `upload_blob` will overwrite the existing data.
+    /// * `overwrite` - Whether the blob to be uploaded should overwrite the current data. If True, `upload()` will overwrite the existing data.
     ///   If False, the operation will fail with ResourceExistsError.
     /// * `content_length` - Total length of the blob data to be uploaded.
     /// * `options` - Optional configuration for the request.

--- a/sdk/storage/azure_storage_blob/src/generated/models/method_options.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/method_options.rs
@@ -920,9 +920,6 @@ pub struct BlobClientSetMetadataOptions<'a> {
     /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
 
-    /// The metadata headers.
-    pub metadata: Option<HashMap<String, String>>,
-
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 

--- a/sdk/storage/azure_storage_blob/tests/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client.rs
@@ -238,18 +238,16 @@ async fn test_set_blob_metadata(ctx: TestContext) -> Result<(), Box<dyn Error>> 
 
     // Set Metadata With Values
     let update_metadata = HashMap::from([("updated".to_string(), "values".to_string())]);
-    let set_metadata_options = BlobClientSetMetadataOptions {
-        metadata: Some(update_metadata.clone()),
-        ..Default::default()
-    };
-    blob_client.set_metadata(Some(set_metadata_options)).await?;
+    blob_client
+        .set_metadata(update_metadata.clone(), None)
+        .await?;
     // Assert
     let response = blob_client.get_properties(None).await?;
     let response_metadata = response.metadata()?;
     assert_eq!(update_metadata, response_metadata);
 
     // Set Metadata No Values (Clear Metadata)
-    blob_client.set_metadata(None).await?;
+    blob_client.set_metadata(HashMap::new(), None).await?;
     // Assert
     let response = blob_client.get_properties(None).await?;
     let response_metadata = response.metadata()?;
@@ -361,12 +359,9 @@ async fn test_leased_blob_operations(ctx: TestContext) -> Result<(), Box<dyn Err
         .await?;
 
     let update_metadata = HashMap::from([("updated".to_string(), "values".to_string())]);
-    let set_metadata_options = BlobClientSetMetadataOptions {
-        metadata: Some(update_metadata.clone()),
-        lease_id: Some(lease_id.clone()),
-        ..Default::default()
-    };
-    blob_client.set_metadata(Some(set_metadata_options)).await?;
+    blob_client
+        .set_metadata(update_metadata.clone(), None)
+        .await?;
 
     let set_tier_options = BlobClientSetTierOptions {
         lease_id: Some(lease_id.clone()),

--- a/sdk/storage/azure_storage_blob/tsp-location.yaml
+++ b/sdk/storage/azure_storage_blob/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/storage/Microsoft.BlobStorage
-commit: 2e3571e7b2c729281b6819574cf358fd87ded3ab
+commit: 2151d5a66c7474e5406defa520582645ea720268
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 


### PR DESCRIPTION
`.tsp`: https://github.com/Azure/azure-rest-api-specs/pull/37428

- Authors changelog (will need a follow-up PR to get the correct date in once settled
- Regenerate against `feature/blob-tsp-rust` (which seems to be missing some stuff from latest merged PR, probably bad merge resolution)