### PR TITLE
Make Error constructions consistent

### DIFF
--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -4,12 +4,23 @@
 
 ### Features Added
 
+- Added `Error::with_error_fn()`.
+
 ### Breaking Changes
 
 - Changed `ClientOptions::retry` from `Option<RetryOptions>` to `RetryOptions`.
 - Removed several unreferenced HTTP headers and accessor structures for those headers.
 - Renamed `TransportOptions` to `Transport`.
 - Renamed `TransportOptions::new_custom_policy()` to `Transport::with_policy()`.
+- Renamed a number of construction functions for `Error` to align with [guidelines](https://azure.github.io/azure-sdk/rust_introduction.html)"
+  - Renamed `Error::full()` to `Error::with_error()`.
+  - Renamed `Error::with_message()` to `Error::with_message_fn()`.
+  - Renamed `Error::message()` to `Error::with_message()`.
+  - Renamed `Error::with_context()` to `Error::with_context_fn()`.
+  - Renamed `Error::context()` to `Error::with_context()`.
+  - Renamed `ResultExt::map_kind()` to `ResultExt::with_kind()`.
+  - Renamed `ResultExt::with_context()` to `ResultExt::with_context_fn()`.
+  - Renamed `ResultExt::context()` to `ResultExt::with_context()`.
 
 ### Bugs Fixed
 

--- a/sdk/core/azure_core/README.md
+++ b/sdk/core/azure_core/README.md
@@ -512,7 +512,7 @@ impl HttpClient for Agent {
         let response = self
             .0
             .run(request)
-            .with_context(ErrorKind::Io, || "failed to send request")?;
+            .with_context_fn(ErrorKind::Io, || "failed to send request")?;
 
         Ok(todo!("convert their response into our response"))
     }

--- a/sdk/core/azure_core/benches/http_transport_benchmarks.rs
+++ b/sdk/core/azure_core/benches/http_transport_benchmarks.rs
@@ -50,7 +50,7 @@ impl TestServiceClient {
         let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint)?;
         if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 format!("{endpoint} must use http(s)"),
             ));
@@ -99,7 +99,7 @@ impl TestServiceClient {
             .send(&options.method_options.context, &mut request)
             .await?;
         if !response.status().is_success() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::HttpResponse {
                     status: response.status(),
                     error_code: None,

--- a/sdk/core/azure_core/examples/core_ureq_client.rs
+++ b/sdk/core/azure_core/examples/core_ureq_client.rs
@@ -40,7 +40,7 @@ impl HttpClient for Agent {
         let response = self
             .0
             .run(request)
-            .with_context(ErrorKind::Io, || "failed to send request")?;
+            .with_context_fn(ErrorKind::Io, || "failed to send request")?;
 
         into_response(response)
     }
@@ -81,19 +81,19 @@ fn into_request(request: &Request) -> azure_core::Result<::http::Request<Vec<u8>
         .url()
         .as_str()
         .parse()
-        .with_context(ErrorKind::DataConversion, || "failed to parse url")?;
+        .with_context_fn(ErrorKind::DataConversion, || "failed to parse url")?;
     *req.method_mut() = request
         .method()
         .as_str()
         .parse()
-        .with_context(ErrorKind::DataConversion, || "failed to parse method")?;
+        .with_context_fn(ErrorKind::DataConversion, || "failed to parse method")?;
     let headers = req.headers_mut();
     for (name, value) in request.headers().iter() {
         headers.insert(
             HeaderName::from_bytes(name.as_str().as_bytes())
-                .with_context(ErrorKind::DataConversion, || "failed to parse header name")?,
+                .with_context_fn(ErrorKind::DataConversion, || "failed to parse header name")?,
             HeaderValue::from_bytes(value.as_str().as_bytes())
-                .with_context(ErrorKind::DataConversion, || "failed to parse header value")?,
+                .with_context_fn(ErrorKind::DataConversion, || "failed to parse header value")?,
         );
     }
     let body: Bytes = request.body().into();
@@ -120,13 +120,13 @@ fn into_response(response: ::http::Response<ureq::Body>) -> azure_core::Result<B
             name.as_str().to_ascii_lowercase(),
             value
                 .to_str()
-                .with_context(ErrorKind::DataConversion, || "failed to parse header value")?
+                .with_context_fn(ErrorKind::DataConversion, || "failed to parse header value")?
                 .to_string(),
         );
     }
     let body: Vec<u8> = body
         .read_to_vec()
-        .with_context(ErrorKind::Io, || "failed to read response body")?;
+        .with_context_fn(ErrorKind::Io, || "failed to read response body")?;
 
     Ok(BufResponse::from_bytes(status, response_headers, body))
 }

--- a/sdk/core/azure_core/src/error/error_response.rs
+++ b/sdk/core/azure_core/src/error/error_response.rs
@@ -130,7 +130,7 @@ pub async fn check_success(response: BufResponse) -> crate::Result<BufResponse> 
     if response.body().is_empty() {
         let code = response.headers().get_optional_str(&ERROR_CODE);
         let error_kind = ErrorKind::http_response(status, code.map(str::to_owned));
-        return Err(Error::message(error_kind, status.to_string()));
+        return Err(Error::with_message(error_kind, status.to_string()));
     }
     let internal_response =
         serde_json::de::from_slice::<ErrorResponseInternal>(response.body()).map_err(Error::from);
@@ -144,7 +144,7 @@ pub async fn check_success(response: BufResponse) -> crate::Result<BufResponse> 
                 status,
                 Some(code.map_or_else(|| response.status().to_string(), str::to_owned)),
             );
-            return Err(Error::message(
+            return Err(Error::with_message(
                 error_kind,
                 format!(
                     "{}: {}",
@@ -161,7 +161,7 @@ pub async fn check_success(response: BufResponse) -> crate::Result<BufResponse> 
 
     let error_kind = ErrorKind::http_response(status, code.map(str::to_owned));
 
-    Err(Error::message(
+    Err(Error::with_message(
         error_kind,
         internal_response
             .error

--- a/sdk/core/azure_core/src/hmac.rs
+++ b/sdk/core/azure_core/src/hmac.rs
@@ -27,7 +27,7 @@ pub fn hmac_sha256(data: &str, key: &Secret) -> crate::Result<String> {
     use sha2::Sha256;
     let key = base64::decode(key.secret())?;
     let mut hmac = Hmac::<Sha256>::new_from_slice(&key)
-        .with_context(ErrorKind::DataConversion, || {
+        .with_context_fn(ErrorKind::DataConversion, || {
             "failed to create hmac from key"
         })?;
     hmac.update(data.as_bytes());
@@ -58,7 +58,7 @@ pub fn hmac_sha256(data: &str, key: &Secret) -> crate::Result<String> {
         signer.update(data.as_bytes())?;
         signer.sign_to_vec()
     }()
-    .with_context(ErrorKind::DataConversion, || {
+    .with_context_fn(ErrorKind::DataConversion, || {
         "failed to create hmac from key"
     })?;
     Ok(base64::encode(signature))

--- a/sdk/core/azure_core/src/http/pager.rs
+++ b/sdk/core/azure_core/src/http/pager.rs
@@ -749,7 +749,7 @@ mod tests {
                     .into(),
                     continuation: "1",
                 }),
-                PagerState::More("1") => Err(typespec::Error::message(
+                PagerState::More("1") => Err(typespec::Error::with_message(
                     typespec::error::ErrorKind::Other,
                     "yon request didst fail",
                 )),

--- a/sdk/core/azure_core/src/http/policies/bearer_token_policy.rs
+++ b/sdk/core/azure_core/src/http/policies/bearer_token_policy.rs
@@ -120,7 +120,7 @@ impl Policy for BearerTokenCredentialPolicy {
         }
 
         let access_token = self.access_token().await.ok_or_else(|| {
-            Error::message(
+            Error::with_message(
                 ErrorKind::Credential,
                 "The request failed due to an error while fetching the access token.",
             )
@@ -200,7 +200,7 @@ mod tests {
             let i = self.calls.fetch_add(1, Ordering::SeqCst);
             self.tokens
                 .get(i)
-                .ok_or_else(|| Error::message(ErrorKind::Credential, "no more mock tokens"))
+                .ok_or_else(|| Error::with_message(ErrorKind::Credential, "no more mock tokens"))
                 .cloned()
         }
     }

--- a/sdk/core/azure_core/src/test.rs
+++ b/sdk/core/azure_core/src/test.rs
@@ -63,7 +63,7 @@ impl FromStr for TestMode {
             "playback" => Ok(Self::Playback),
             "record" => Ok(Self::Record),
             "live" => Ok(Self::Live),
-            _ => Err(Error::message(
+            _ => Err(Error::with_message(
                 ErrorKind::DataConversion,
                 "expected 'playback', 'record', or 'live'",
             )),
@@ -106,7 +106,7 @@ impl FromStr for RecordingMode {
         match s.to_ascii_lowercase().as_str() {
             "playback" => Ok(Self::Playback),
             "record" => Ok(Self::Record),
-            _ => Err(Error::message(
+            _ => Err(Error::with_message(
                 ErrorKind::DataConversion,
                 "expected 'playback' or 'record'",
             )),

--- a/sdk/core/azure_core_amqp/src/fe2o3/cbs.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/cbs.rs
@@ -25,19 +25,19 @@ impl Fe2o3ClaimsBasedSecurity {
     }
 
     fn cbs_already_attached() -> azure_core::Error {
-        azure_core::Error::message(
+        azure_core::Error::with_message(
             azure_core::error::ErrorKind::Amqp,
             "Claims Based Security is already attached",
         )
     }
     fn cbs_not_set() -> azure_core::Error {
-        azure_core::Error::message(
+        azure_core::Error::with_message(
             azure_core::error::ErrorKind::Amqp,
             "Claims Based Security is not set",
         )
     }
     fn cbs_not_attached() -> azure_core::Error {
-        azure_core::Error::message(
+        azure_core::Error::with_message(
             azure_core::error::ErrorKind::Amqp,
             "Claims Based Security is not attached",
         )
@@ -97,7 +97,7 @@ impl AmqpClaimsBasedSecurityApis for Fe2o3ClaimsBasedSecurity {
                     .unix_timestamp()
                     .checked_mul(1_000)
                     .ok_or_else(|| {
-                        azure_core::Error::message(
+                        azure_core::Error::with_message(
                             azure_core::error::ErrorKind::Amqp,
                             "Unable to convert time to unix timestamp.",
                         )
@@ -116,7 +116,7 @@ impl AmqpClaimsBasedSecurityApis for Fe2o3ClaimsBasedSecurity {
                 Ok(amqp_error) => amqp_error.into(),
                 Err(e) => {
                     debug!("Failed to convert management error to azure error: {:?}", e);
-                    azure_core::Error::full(
+                    azure_core::Error::with_error(
                         azure_core::error::ErrorKind::Amqp,
                         e,
                         "Failed to convert management error to azure error.",

--- a/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
@@ -28,10 +28,10 @@ impl Fe2o3AmqpConnection {
     }
 
     fn connection_not_set() -> azure_core::Error {
-        azure_core::Error::message(azure_core::error::ErrorKind::Amqp, "Connection is not set")
+        azure_core::Error::with_message(azure_core::error::ErrorKind::Amqp, "Connection is not set")
     }
     fn connection_already_set() -> azure_core::Error {
-        azure_core::Error::message(
+        azure_core::Error::with_message(
             azure_core::error::ErrorKind::Amqp,
             "Connection is already set",
         )

--- a/sdk/core/azure_core_amqp/src/fe2o3/management.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/management.rs
@@ -49,13 +49,13 @@ impl Fe2o3AmqpManagement {
     }
 
     fn amqp_management_already_attached() -> azure_core::Error {
-        azure_core::Error::message(
+        azure_core::Error::with_message(
             azure_core::error::ErrorKind::Amqp,
             "AMQP Management is already attached",
         )
     }
     fn amqp_management_not_attached() -> azure_core::Error {
-        azure_core::Error::message(
+        azure_core::Error::with_message(
             azure_core::error::ErrorKind::Amqp,
             "AMQP Management is not attached",
         )

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
@@ -346,7 +346,7 @@ impl
             let data = body
                 .try_as_data()
                 .map_err(|_| {
-                    Error::message(
+                    Error::with_message(
                         ErrorKind::DataConversion,
                         "Could not convert AMQP Message Body to data.",
                     )

--- a/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
@@ -194,21 +194,21 @@ impl Fe2o3AmqpReceiver {
     }
 
     fn receiver_already_attached() -> azure_core::Error {
-        azure_core::Error::message(
+        azure_core::Error::with_message(
             azure_core::error::ErrorKind::Amqp,
             "AMQP Receiver is already attached",
         )
     }
 
     fn could_not_set_message_receiver() -> azure_core::Error {
-        azure_core::Error::message(
+        azure_core::Error::with_message(
             azure_core::error::ErrorKind::Amqp,
             "Could not set message receiver",
         )
     }
 
     fn receiver_not_set() -> azure_core::Error {
-        azure_core::Error::message(
+        azure_core::Error::with_message(
             azure_core::error::ErrorKind::Amqp,
             "AMQP Receiver is not set",
         )

--- a/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
@@ -23,13 +23,13 @@ pub(crate) struct Fe2o3AmqpSender {
 
 impl Fe2o3AmqpSender {
     fn could_not_set_message_sender() -> azure_core::Error {
-        azure_core::Error::message(
+        azure_core::Error::with_message(
             azure_core::error::ErrorKind::Amqp,
             "Could not set message sender",
         )
     }
     fn could_not_get_message_sender() -> azure_core::Error {
-        azure_core::Error::message(
+        azure_core::Error::with_message(
             azure_core::error::ErrorKind::Amqp,
             "Could not get message sender",
         )

--- a/sdk/core/azure_core_amqp/src/fe2o3/session.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/session.rs
@@ -43,19 +43,19 @@ impl Fe2o3AmqpSession {
     }
 
     fn session_already_attached() -> azure_core::Error {
-        azure_core::Error::message(
+        azure_core::Error::with_message(
             azure_core::error::ErrorKind::Amqp,
             "AMQP Session is already attached",
         )
     }
     fn session_not_set() -> azure_core::Error {
-        azure_core::Error::message(
+        azure_core::Error::with_message(
             azure_core::error::ErrorKind::Amqp,
             "AMQP Session is not set",
         )
     }
     fn could_not_set_session() -> azure_core::Error {
-        azure_core::Error::message(
+        azure_core::Error::with_message(
             azure_core::error::ErrorKind::Amqp,
             "Could not set AMQP Session",
         )

--- a/sdk/core/azure_core_amqp/src/fe2o3/value.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/value.rs
@@ -817,7 +817,7 @@ impl From<&fe2o3_amqp_types::definitions::ReceiverSettleMode> for crate::Receive
 impl From<Fe2o3SerializationError> for azure_core::Error {
     fn from(err: Fe2o3SerializationError) -> Self {
         match err.0 {
-            serde_amqp::Error::Message(m) => azure_core::Error::message(ErrorKind::Amqp, m),
+            serde_amqp::Error::Message(m) => azure_core::Error::with_message(ErrorKind::Amqp, m),
             serde_amqp::Error::Io(error) => azure_core::Error::new(ErrorKind::Io, error),
             serde_amqp::Error::InvalidFormatCode
             | serde_amqp::Error::InvalidUtf8Encoding

--- a/sdk/core/azure_core_opentelemetry/tests/telemetry_service_implementation.rs
+++ b/sdk/core/azure_core_opentelemetry/tests/telemetry_service_implementation.rs
@@ -71,7 +71,7 @@ impl TestServiceClient {
 
         let mut endpoint = Url::parse(endpoint)?;
         if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 format!("{endpoint} must use http(s)"),
             ));
@@ -134,7 +134,7 @@ impl TestServiceClient {
             .send(&options.method_options.context, &mut request)
             .await?;
         if !response.status().is_success() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::HttpResponse {
                     status: response.status(),
                     error_code: None,

--- a/sdk/core/azure_core_opentelemetry/tests/telemetry_service_macros.rs
+++ b/sdk/core/azure_core_opentelemetry/tests/telemetry_service_macros.rs
@@ -65,7 +65,7 @@ impl TestServiceClientWithMacros {
         let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint)?;
         if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 format!("{endpoint} must use http(s)"),
             ));
@@ -109,7 +109,7 @@ impl TestServiceClientWithMacros {
             .send(&options.method_options.context, &mut request)
             .await?;
         if !response.status().is_success() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::HttpResponse {
                     status: response.status(),
                     error_code: None,
@@ -160,7 +160,7 @@ impl TestServiceClientWithMacros {
             .send(&options.method_options.context, &mut request)
             .await?;
         if !response.status().is_success() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::HttpResponse {
                     status: response.status(),
                     error_code: None,

--- a/sdk/core/azure_core_test/src/credentials.rs
+++ b/sdk/core/azure_core_test/src/credentials.rs
@@ -77,7 +77,7 @@ pub fn from_env(options: Option<ClientOptions>) -> azure_core::Result<Arc<dyn To
     }
     #[cfg(target_arch = "wasm32")]
     {
-        Err(Error::message(
+        Err(Error::with_message(
             ErrorKind::Other,
             "No local development credential for WASM.",
         ))

--- a/sdk/core/azure_core_test/src/lib.rs
+++ b/sdk/core/azure_core_test/src/lib.rs
@@ -44,13 +44,14 @@ impl TestContext {
         module_dir: &'static str,
         name: &'static str,
     ) -> azure_core::Result<Self> {
-        let service_dir = parent_of(crate_dir, "sdk")
-            .ok_or_else(|| Error::message(ErrorKind::Other, "not under 'sdk' folder in repo"))?;
+        let service_dir = parent_of(crate_dir, "sdk").ok_or_else(|| {
+            Error::with_message(ErrorKind::Other, "not under 'sdk' folder in repo")
+        })?;
         let test_module = Path::new(module_dir)
             .file_stem()
-            .ok_or_else(|| Error::message(ErrorKind::Other, "invalid test module"))?
+            .ok_or_else(|| Error::with_message(ErrorKind::Other, "invalid test module"))?
             .to_str()
-            .ok_or_else(|| Error::message(ErrorKind::Other, "invalid test module"))?;
+            .ok_or_else(|| Error::with_message(ErrorKind::Other, "invalid test module"))?;
         Ok(Self {
             repo_dir: find_ancestor_of(crate_dir, ".git")?,
             crate_dir: Path::new(crate_dir),
@@ -183,7 +184,7 @@ pub fn load_dotenv_file(cargo_dir: impl AsRef<Path>) -> azure_core::Result<()> {
         ::tracing::debug!("loading environment variables from {}", path.display());
 
         use azure_core::error::ResultExt as _;
-        dotenvy::from_filename(&path).with_context(azure_core::error::ErrorKind::Io, || {
+        dotenvy::from_filename(&path).with_context_fn(azure_core::error::ErrorKind::Io, || {
             format!(
                 "failed to load environment variables from {}",
                 path.display()
@@ -223,7 +224,7 @@ fn find_ancestor_file(dir: impl AsRef<Path>, name: &str) -> azure_core::Result<P
         // Keep looking until we get to the repo root where `.git` is either a directory (primary repo) or file (worktree).
         let path = dir.join(".git");
         if path.exists() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 ErrorKind::Io,
                 format!("{name} not found under repo {}", dir.display()),
             ));

--- a/sdk/core/azure_core_test/src/proxy/bootstrap.rs
+++ b/sdk/core/azure_core_test/src/proxy/bootstrap.rs
@@ -91,7 +91,7 @@ pub async fn start(
         }
         _ = tokio::time::sleep(max_seconds) => {
             proxy.stop().await?;
-            return Err(azure_core::Error::message(ErrorKind::Other, "timed out waiting for test-proxy to start"));
+            return Err(azure_core::Error::with_message(ErrorKind::Other, "timed out waiting for test-proxy to start"));
         },
     };
 
@@ -116,7 +116,7 @@ async fn ensure_assets_file(
             .and_then(Path::file_name)
             .map(|dir| dir.to_ascii_lowercase())
             .ok_or_else(|| {
-                azure_core::Error::message(
+                azure_core::Error::with_message(
                     ErrorKind::Io,
                     "failed to get assets.json parent directory name",
                 )
@@ -214,7 +214,7 @@ async fn download_test_proxy(
     output_dir: &Path,
 ) -> Result<()> {
     let download_file_name = download_file_name().ok_or_else(|| {
-        azure_core::Error::message(
+        azure_core::Error::with_message(
             ErrorKind::Other,
             "test-proxy not supported on current platform",
         )
@@ -224,7 +224,7 @@ async fn download_test_proxy(
 
     let map_reqwest_err = |err: reqwest::Error| {
         let url = err.url().cloned().unwrap();
-        azure_core::Error::full(ErrorKind::Other, err, format!("failed to download {url}"))
+        azure_core::Error::with_error(ErrorKind::Other, err, format!("failed to download {url}"))
     };
     let archive = reqwest::get(url)
         .await
@@ -273,7 +273,7 @@ fn extract_test_proxy(
         Some(ext) if ext == "gz" => untar(archive_file, output_dir),
         Some(ext) if ext == "zip" => unzip(archive_file, output_dir),
         _ => {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 ErrorKind::Io,
                 format!("unsupported archive {}", archive_file_path.display()),
             ))
@@ -285,7 +285,7 @@ fn extract_test_proxy(
             archive_file_path.display(),
             &err
         );
-        azure_core::Error::full(ErrorKind::Io, err, message)
+        azure_core::Error::with_error(ErrorKind::Io, err, message)
     })
 }
 

--- a/sdk/core/azure_core_test/src/proxy/mod.rs
+++ b/sdk/core/azure_core_test/src/proxy/mod.rs
@@ -69,7 +69,7 @@ impl Proxy {
             .stderr(Stdio::piped())
             .spawn()
             .map_err(|err| {
-                azure_core::Error::full(
+                azure_core::Error::with_error(
                     ErrorKind::Io,
                     err,
                     format!("{} failed to start", executable_file_path.display()),
@@ -80,7 +80,7 @@ impl Proxy {
             command
                 .stdout
                 .take()
-                .ok_or_else(|| azure_core::Error::message(ErrorKind::Io, "no stdout pipe"))?,
+                .ok_or_else(|| azure_core::Error::with_message(ErrorKind::Io, "no stdout pipe"))?,
         )
         .lines();
         self.command = Some(command);
@@ -162,7 +162,7 @@ impl Proxy {
 
                 // Need to check version since `test-proxy start` does not fail with unknown parameters.
                 if version < MIN_VERSION {
-                    return Err(azure_core::Error::message(
+                    return Err(azure_core::Error::with_message(
                         ErrorKind::Io,
                         format!("test-proxy older than required version {MIN_VERSION}"),
                     ));
@@ -334,7 +334,7 @@ impl FromStr for Version {
         if let Some(major) = cur.next() {
             v.major = major.parse()?;
         } else {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 ErrorKind::DataConversion,
                 "major version required",
             ));

--- a/sdk/core/azure_core_test/src/proxy/policy.rs
+++ b/sdk/core/azure_core_test/src/proxy/policy.rs
@@ -49,13 +49,22 @@ impl Policy for RecordingPolicy {
             origin = Some(url.origin());
 
             url.set_scheme(host.scheme()).map_err(|_| {
-                azure_core::Error::message(ErrorKind::Other, "failed to set recording url scheme")
+                azure_core::Error::with_message(
+                    ErrorKind::Other,
+                    "failed to set recording url scheme",
+                )
             })?;
             url.set_host(host.host_str()).map_err(|_| {
-                azure_core::Error::message(ErrorKind::Other, "failed to set recording url host")
+                azure_core::Error::with_message(
+                    ErrorKind::Other,
+                    "failed to set recording url host",
+                )
             })?;
             url.set_port(host.port()).map_err(|_| {
-                azure_core::Error::message(ErrorKind::Other, "failed to set recording url port")
+                azure_core::Error::with_message(
+                    ErrorKind::Other,
+                    "failed to set recording url port",
+                )
             })?;
         }
 
@@ -80,16 +89,22 @@ impl Policy for RecordingPolicy {
                 let url = request.url_mut();
 
                 url.set_scheme(scheme.as_ref()).map_err(|_| {
-                    azure_core::Error::message(
+                    azure_core::Error::with_message(
                         ErrorKind::Other,
                         "failed to set recording url scheme",
                     )
                 })?;
                 url.set_host(Some(host.to_string().as_ref())).map_err(|_| {
-                    azure_core::Error::message(ErrorKind::Other, "failed to set recording url host")
+                    azure_core::Error::with_message(
+                        ErrorKind::Other,
+                        "failed to set recording url host",
+                    )
                 })?;
                 url.set_port(Some(port)).map_err(|_| {
-                    azure_core::Error::message(ErrorKind::Other, "failed to set recording url port")
+                    azure_core::Error::with_message(
+                        ErrorKind::Other,
+                        "failed to set recording url port",
+                    )
                 })?;
             }
 

--- a/sdk/core/azure_core_test/src/recording.rs
+++ b/sdk/core/azure_core_test/src/recording.rs
@@ -453,7 +453,7 @@ impl Recording {
         let mut options = policy
             .options
             .write()
-            .map_err(|err| azure_core::Error::message(ErrorKind::Other, err.to_string()))?;
+            .map_err(|err| azure_core::Error::with_message(ErrorKind::Other, err.to_string()))?;
         options.skip = skip;
 
         Ok(())
@@ -537,11 +537,11 @@ impl Drop for Recording {
 }
 
 fn read_lock_error(_: impl std::error::Error) -> azure_core::Error {
-    azure_core::Error::message(ErrorKind::Other, "failed to lock variables for read")
+    azure_core::Error::with_message(ErrorKind::Other, "failed to lock variables for read")
 }
 
 fn write_lock_error(_: impl std::error::Error) -> azure_core::Error {
-    azure_core::Error::message(ErrorKind::Other, "failed to lock variables for write")
+    azure_core::Error::with_message(ErrorKind::Other, "failed to lock variables for write")
 }
 
 /// What to skip when recording to a file.

--- a/sdk/cosmos/azure_data_cosmos/src/models/patch_operations.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/patch_operations.rs
@@ -200,7 +200,7 @@ pub trait ToJsonNumber {
 impl ToJsonNumber for f64 {
     fn to_json_number(self) -> azure_core::Result<serde_json::Number> {
         serde_json::Number::from_f64(self).ok_or_else(|| {
-            Error::with_message(ErrorKind::DataConversion, || {
+            Error::with_message_fn(ErrorKind::DataConversion, || {
                 format!("{} is not a valid JSON number", self)
             })
         })

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/query_engine.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/query_engine.rs
@@ -233,7 +233,7 @@ impl QueryPipeline for MockQueryPipeline {
     ) -> azure_core::Result<()> {
         let payload: DocumentPayload<MockItem> =
             serde_json::from_slice(data.result).map_err(|_| {
-                azure_core::Error::message(
+                azure_core::Error::with_message(
                     azure_core::error::ErrorKind::Other,
                     "Failed to deserialize payload",
                 )
@@ -247,7 +247,7 @@ impl QueryPipeline for MockQueryPipeline {
             partition_state.provide_data(payload.documents, data.next_continuation);
             Ok(())
         } else {
-            Err(azure_core::Error::message(
+            Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 format!(
                     "Partition key range {} not found",

--- a/sdk/cosmos/azure_data_cosmos/tests/query_engine.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/query_engine.rs
@@ -25,7 +25,7 @@ pub async fn create_errors_in_query_engine_appear_in_first_result(
     )
     .await?;
 
-    let query_engine = Arc::new(MockQueryEngine::with_error(Error::message(
+    let query_engine = Arc::new(MockQueryEngine::with_error(Error::with_message(
         ErrorKind::Other,
         "Mock error",
     )));

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
@@ -84,7 +84,7 @@ impl Authorizer {
     #[cfg(test)]
     fn disable_authorization(&self) -> Result<()> {
         let mut disable_authorization = self.disable_authorization.lock().map_err(|e| {
-            azure_core::Error::message(azure_core::error::ErrorKind::Other, e.to_string())
+            azure_core::Error::with_message(azure_core::error::ErrorKind::Other, e.to_string())
         })?;
         *disable_authorization = true;
         Ok(())
@@ -154,7 +154,7 @@ impl Authorizer {
         #[cfg(test)]
         {
             let disable_authorization = self.disable_authorization.lock().map_err(|e| {
-                azure_core::Error::message(
+                azure_core::Error::with_message(
                     azure_core::error::ErrorKind::Other,
                     format!("Unable to grab disable mutex: {}", e),
                 )
@@ -233,7 +233,7 @@ impl Authorizer {
             let mut now = OffsetDateTime::now_utc();
             trace!("refresh_tokens: Start pass for: {now}");
             let most_recent_refresh = expiration_times.first().ok_or_else(|| {
-                azure_core::Error::message(AzureErrorKind::Other, "No tokens to refresh?")
+                azure_core::Error::with_message(AzureErrorKind::Other, "No tokens to refresh?")
             })?;
 
             debug!(
@@ -245,7 +245,7 @@ impl Authorizer {
             let token_refresh_bias: Duration;
             {
                 let token_refresh_times = self.token_refresh_bias.lock().map_err(|e| {
-                    azure_core::Error::message(
+                    azure_core::Error::with_message(
                         azure_core::error::ErrorKind::Other,
                         format!("Unable to grab token refresh bias mutex: {}", e),
                     )
@@ -263,7 +263,7 @@ impl Authorizer {
                     .before_expiration_refresh_time
                     .checked_add(expiration_jitter)
                     .ok_or_else(|| {
-                        azure_core::Error::message(
+                        azure_core::Error::with_message(
                             AzureErrorKind::Other,
                             "Unable to calculate token refresh bias - overflow",
                         )
@@ -273,7 +273,7 @@ impl Authorizer {
                 refresh_time = most_recent_refresh
                     .checked_sub(token_refresh_bias)
                     .ok_or_else(|| {
-                        azure_core::Error::message(
+                        azure_core::Error::with_message(
                             AzureErrorKind::Other,
                             "Unable to calculate token refresh bias - underflow",
                         )
@@ -328,7 +328,7 @@ impl Authorizer {
 
                 // Create an ephemeral connection to host the authentication.
                 let connection = self.recoverable_connection.upgrade().ok_or_else(|| {
-                    azure_core::Error::message(
+                    azure_core::Error::with_message(
                         AzureErrorKind::Other,
                         "Recoverable connection has been dropped",
                     )
@@ -357,7 +357,7 @@ impl Authorizer {
     #[cfg(test)]
     fn set_token_refresh_times(&self, refresh_times: TokenRefreshTimes) -> Result<()> {
         let mut token_refresh_bias = self.token_refresh_bias.lock().map_err(|e| {
-            azure_core::Error::message(azure_core::error::ErrorKind::Other, e.to_string())
+            azure_core::Error::with_message(azure_core::error::ErrorKind::Other, e.to_string())
         })?;
         *token_refresh_bias = refresh_times;
         Ok(())

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -134,7 +134,7 @@ impl RecoverableConnection {
     #[cfg(test)]
     pub(crate) fn force_error(&self, error: azure_core::Error) -> Result<()> {
         let mut err = self.forced_error.lock().map_err(|e| {
-            azure_core::Error::message(azure_core::error::ErrorKind::Other, e.to_string())
+            azure_core::Error::with_message(azure_core::error::ErrorKind::Other, e.to_string())
         })?;
         *err = Some(error);
         Ok(())
@@ -451,7 +451,7 @@ impl RecoverableConnection {
             }
             _ => {
                 warn!("Recover action {reason:?} should already have been handled.");
-                return Err(azure_core::Error::message(
+                return Err(azure_core::Error::with_message(
                     azure_core::error::ErrorKind::Other,
                     "Unknown error recovery action",
                 ));

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -168,7 +168,7 @@ impl ConsumerClient {
                 .endpoint
                 .host()
                 .ok_or_else(|| {
-                    Error::message(
+                    Error::with_message(
                         AzureErrorKind::Other,
                         "Could not find host in consumer client",
                     )

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/load_balancer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/load_balancer.rs
@@ -149,6 +149,7 @@ impl LoadBalancer {
 
         let minimum_required = partition_ids.len() / grouped_by_owner.len();
         let mut maximum_allowed = minimum_required;
+        #[allow(unknown_lints, clippy::manual_is_multiple_of)]
         let allow_extra_partition = partition_ids.len() % grouped_by_owner.len() > 0;
         if allow_extra_partition
             && grouped_by_owner[&self.consumer_client_details.client_id].len() >= minimum_required
@@ -416,6 +417,7 @@ pub(crate) mod tests {
 
         let minimum = partition_count / number_of_consumers;
         let mut maximum = minimum;
+        #[allow(unknown_lints, clippy::manual_is_multiple_of)]
         if partition_count % number_of_consumers > 0 {
             info!("Adding one to maximum because of remainder");
             maximum += 1;

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/load_balancer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/load_balancer.rs
@@ -70,7 +70,7 @@ impl LoadBalancer {
     fn rng(&self) -> Result<MutexGuard<'_, Box<dyn RngCore + Send + Sync>>> {
         self.rng
             .lock()
-            .map_err(|_| Error::message(AzureErrorKind::Other, "Failed to lock RNG mutex"))
+            .map_err(|_| Error::with_message(AzureErrorKind::Other, "Failed to lock RNG mutex"))
     }
 
     async fn get_available_partitions(&self, partition_ids: &[&str]) -> Result<LoadBalancerInfo> {

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/models.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/models.rs
@@ -32,7 +32,7 @@ pub struct Checkpoint {
 macro_rules! check_non_empty_parameter(
     ($field:expr) => {
         if $field.is_empty() {
-            return Err(Error::message(
+            return Err(Error::with_message(
                 AzureErrorKind::Other,
                 String::from("Required field ") + stringify!($field) + " is empty",
             ));
@@ -66,7 +66,7 @@ impl Checkpoint {
         partition_id: &str,
     ) -> Result<String> {
         if partition_id.is_empty() {
-            return Err(Error::message(
+            return Err(Error::with_message(
                 AzureErrorKind::Other,
                 "Partition ID is empty",
             ));

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/partition_client.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/partition_client.rs
@@ -68,7 +68,7 @@ impl PartitionClient {
         } else {
             // Return a stream with a single error indicating that the event receiver is not available.
             Box::pin(futures::stream::once(async {
-                Err(azure_core::error::Error::message(
+                Err(azure_core::error::Error::with_message(
                     azure_core::error::ErrorKind::Other,
                     "Event receiver is not set for this partition.",
                 ))
@@ -143,7 +143,7 @@ impl PartitionClient {
                             sequence_number = Some(*value as i64);
                         }
                         _ => {
-                            return Err(azure_core::error::Error::message(
+                            return Err(azure_core::error::Error::with_message(
                                 azure_core::error::ErrorKind::Other,
                                 "Invalid sequence number",
                             ));
@@ -155,7 +155,7 @@ impl PartitionClient {
                             offset = Some(value.to_string());
                         }
                         _ => {
-                            return Err(azure_core::error::Error::message(
+                            return Err(azure_core::error::Error::with_message(
                                 azure_core::error::ErrorKind::Other,
                                 "Invalid offset",
                             ));
@@ -184,7 +184,7 @@ impl PartitionClient {
                 self.partition_id
             );
             // If the event receiver is already set, return an error
-            azure_core::error::Error::message(
+            azure_core::error::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 format!(
                     "Event receiver already set for partition {}",

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/processor.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/processor.rs
@@ -98,7 +98,10 @@ impl ProcessorConsumersMap {
     ) -> Result<bool> {
         info!("Adding partition client for partition: {}", partition_id);
         let mut consumers = self.consumers.lock().map_err(|_| {
-            azure_core::Error::message(AzureErrorKind::Other, "Could not lock consumers mutex.")
+            azure_core::Error::with_message(
+                AzureErrorKind::Other,
+                "Could not lock consumers mutex.",
+            )
         })?;
         if consumers.contains_key(partition_id) {
             info!(
@@ -115,7 +118,10 @@ impl ProcessorConsumersMap {
     pub fn remove_partition_client(&self, partition_id: &str) -> Result<()> {
         info!("Removing partition client for partition: {}", partition_id);
         let mut consumers = self.consumers.lock().map_err(|_| {
-            azure_core::Error::message(AzureErrorKind::Other, "Could not lock consumers mutex.")
+            azure_core::Error::with_message(
+                AzureErrorKind::Other,
+                "Could not lock consumers mutex.",
+            )
         })?;
         consumers.remove(partition_id);
         info!("Consumers for partition now: {:?}", consumers.keys());
@@ -257,7 +263,7 @@ impl EventProcessor {
         // Implement shutdown logic if needed
 
         let mut is_running = self.is_running.lock().map_err(|_| {
-            Error::message(
+            Error::with_message(
                 AzureErrorKind::Other,
                 "Failed to acquire lock on is_running for shutdown",
             )
@@ -270,7 +276,7 @@ impl EventProcessor {
     fn is_shutdown(&self) -> Result<bool> {
         // Implement shutdown logic if needed
         let is_running = self.is_running.lock().map_err(|_| {
-            Error::message(
+            Error::with_message(
                 AzureErrorKind::Other,
                 "Failed to acquire lock on is_running",
             )
@@ -351,7 +357,7 @@ impl EventProcessor {
             }
         } else {
             error!("Consumers map is no longer valid.");
-            return Err(Error::message(
+            return Err(Error::with_message(
                 AzureErrorKind::Other,
                 "Consumers map is no longer valid.",
             ));
@@ -388,14 +394,14 @@ impl EventProcessor {
         {
             let mut sender = self.next_partition_client_sender.clone();
             let r = sender.send(partition_client).await.map_err(|e| {
-                azure_core::Error::message(
+                azure_core::Error::with_message(
                     AzureErrorKind::Other,
                     format!("Failed to send partition client: {:?}", e),
                 )
             });
             if let Err(e) = r {
                 info!("Failed to send partition client: {:?}", e);
-                return Err(Error::message(
+                return Err(Error::with_message(
                     AzureErrorKind::Other,
                     "Failed to send partition client",
                 ));
@@ -420,7 +426,7 @@ impl EventProcessor {
             // Wait for the next partition client to be available
             let mut clients = self.next_partition_clients.lock().await;
             let next_client = clients.next().await.ok_or_else(|| {
-                azure_core::Error::message(
+                azure_core::Error::with_message(
                     AzureErrorKind::Other,
                     "No next partition client available: ",
                 )

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/in_memory_checkpoint_store.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/in_memory_checkpoint_store.rs
@@ -28,7 +28,7 @@ impl Default for InMemoryCheckpointStore {
 macro_rules! check_non_empty_parameter(
     ($field:expr) => {
         if $field.is_empty() {
-            return Err(Error::message(
+            return Err(Error::with_message(
                 AzureErrorKind::Other,
                 String::from("Required field ") + stringify!($field) + " is empty",
             ));
@@ -65,7 +65,7 @@ impl InMemoryCheckpointStore {
         if store.contains_key(&key) {
             if ownership.etag != store.get(&key).unwrap().etag {
                 warn!("ETag mismatch {}", key);
-                return Err(Error::message(
+                return Err(Error::with_message(
                     AzureErrorKind::Other,
                     format!("ETag mismatch for partition {key}"),
                 ));
@@ -150,7 +150,7 @@ impl CheckpointStore for InMemoryCheckpointStore {
             checkpoint.partition_id
         );
         let mut checkpoints = self.checkpoints.lock().map_err(|e| {
-            Error::message(
+            Error::with_message(
                 AzureErrorKind::Other,
                 format!("Failed to lock checkpoint store: {}", e),
             )

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
@@ -78,7 +78,7 @@ impl<'a> EventDataBatch<'a> {
     pub(crate) async fn attach(&mut self) -> Result<()> {
         let sender = self.producer.ensure_sender(self.get_batch_path()?).await?;
         self.max_size_in_bytes = sender.max_message_size().await?.ok_or_else(|| {
-            Error::message(
+            Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "No message size available.",
             )
@@ -118,7 +118,7 @@ impl<'a> EventDataBatch<'a> {
     }
 
     fn arithmetic_error() -> azure_core::Error {
-        azure_core::Error::message(
+        azure_core::Error::with_message(
             azure_core::error::ErrorKind::DataConversion,
             "Arithmetic error calculating Batch size.",
         )

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
@@ -210,7 +210,7 @@ impl ProducerClient {
                         AmqpError::from(AmqpErrorKind::AmqpDescribedError(reason)),
                     ));
                 }
-                Err(azure_core::Error::message(
+                Err(azure_core::Error::with_message(
                     azure_core::error::ErrorKind::Amqp,
                     "Send was rejected by the Event Hub.",
                 ))
@@ -327,7 +327,7 @@ impl ProducerClient {
                         AmqpError::from(AmqpErrorKind::AmqpDescribedError(reason)),
                     ));
                 }
-                Err(azure_core::Error::message(
+                Err(azure_core::Error::with_message(
                     azure_core::error::ErrorKind::Amqp,
                     "Batch was rejected by the Event Hub.",
                 ))

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs
@@ -237,7 +237,7 @@ async fn get_all_partition_clients(ctx: TestContext) -> azure_core::Result<()> {
         }
         _ = tokio::time::sleep(std::time::Duration::from_secs(15)) => {
             info!("Timeout reached - event processor has no more partitions.");
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "Timeout waiting for next partition client"
             ));

--- a/sdk/identity/azure_identity/examples/specific_credential.rs
+++ b/sdk/identity/azure_identity/examples/specific_credential.rs
@@ -98,7 +98,7 @@ impl SpecificAzureCredential {
                 azure_credential_kinds::MANAGED_IDENTITY => {
                     ManagedIdentityCredential::new(None)
                         .map(SpecificAzureCredentialKind::ManagedIdentity)
-                        .with_context(ErrorKind::Credential, || {
+                        .with_context_fn(ErrorKind::Credential, || {
                             format!(
                                 "unable to create AZURE_CREDENTIAL_KIND of {}",
                                 azure_credential_kinds::MANAGED_IDENTITY
@@ -108,7 +108,7 @@ impl SpecificAzureCredential {
                 #[cfg(not(target_arch = "wasm32"))]
                 azure_credential_kinds::AZURE_CLI => AzureCliCredential::new(None)
                     .map(SpecificAzureCredentialKind::AzureCli)
-                    .with_context(ErrorKind::Credential, || {
+                    .with_context_fn(ErrorKind::Credential, || {
                         format!(
                             "unable to create AZURE_CREDENTIAL_KIND of {}",
                             azure_credential_kinds::AZURE_CLI
@@ -117,7 +117,7 @@ impl SpecificAzureCredential {
                 azure_credential_kinds::WORKLOAD_IDENTITY => {
                     WorkloadIdentityCredential::new(None)
                         .map(SpecificAzureCredentialKind::WorkloadIdentity)
-                        .with_context(ErrorKind::Credential, || {
+                        .with_context_fn(ErrorKind::Credential, || {
                             format!(
                                 "unable to create AZURE_CREDENTIAL_KIND of {}",
                                 azure_credential_kinds::WORKLOAD_IDENTITY
@@ -125,7 +125,7 @@ impl SpecificAzureCredential {
                         })?
                 }
                 _ => {
-                    return Err(Error::with_message(ErrorKind::Credential, || {
+                    return Err(Error::with_message_fn(ErrorKind::Credential, || {
                         format!("unknown AZURE_CREDENTIAL_KIND of {}", credential_type)
                     }))
                 }

--- a/sdk/identity/azure_identity/src/app_service_managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/app_service_managed_identity_credential.rs
@@ -28,13 +28,13 @@ impl AppServiceManagedIdentityCredential {
     ) -> azure_core::Result<Arc<Self>> {
         let endpoint = &env
             .var(ENDPOINT_ENV)
-            .with_context(ErrorKind::Credential, || {
+            .with_context_fn(ErrorKind::Credential, || {
                 format!(
                     "app service credential requires {} environment variable",
                     ENDPOINT_ENV
                 )
             })?;
-        let endpoint = Url::parse(endpoint).with_context(ErrorKind::Credential, || {
+        let endpoint = Url::parse(endpoint).with_context_fn(ErrorKind::Credential, || {
             format!(
                 "app service credential {} environment variable must be a valid URL, but is '{endpoint}'",
                 ENDPOINT_ENV

--- a/sdk/identity/azure_identity/src/azure_cli_credential.rs
+++ b/sdk/identity/azure_identity/src/azure_cli_credential.rs
@@ -34,10 +34,10 @@ impl CliTokenResponse {
     pub fn expires_on(&self) -> azure_core::Result<OffsetDateTime> {
         match self.expires_on {
             Some(timestamp) => Ok(OffsetDateTime::from_unix_timestamp(timestamp)
-                .with_context(ErrorKind::DataConversion, || {
+                .with_context_fn(ErrorKind::DataConversion, || {
                     format!("unable to parse expires_on '{timestamp}'")
                 })?),
-            None => Err(Error::message(
+            None => Err(Error::with_message(
                 ErrorKind::DataConversion,
                 "expires_on field not found. Please use Azure CLI 2.54.0 or newer.",
             )),

--- a/sdk/identity/azure_identity/src/azure_pipelines_credential.rs
+++ b/sdk/identity/azure_identity/src/azure_pipelines_credential.rs
@@ -67,13 +67,13 @@ impl AzurePipelinesCredential {
         let env = Env::default();
         let endpoint = env
             .var(OIDC_VARIABLE_NAME)
-            .map_err(|err| azure_core::Error::full(
+            .map_err(|err| azure_core::Error::with_error(
                 ErrorKind::Credential,
                 err,
                 format!("no value for environment variable {OIDC_VARIABLE_NAME}. This should be set by Azure Pipelines"),
             ))?;
         let mut endpoint: Url = endpoint.parse().map_err(|err| {
-            azure_core::Error::full(
+            azure_core::Error::with_error(
                 ErrorKind::Credential,
                 err,
                 format!("invalid URL for environment variable {OIDC_VARIABLE_NAME}"),
@@ -146,7 +146,7 @@ impl ClientAssertion for Client {
             let err_headers: ErrorHeaders = resp.headers().get()?;
 
             return Err(
-                azure_core::Error::message(
+                azure_core::Error::with_message(
                     ErrorKind::http_response(status_code, Some(status_code.canonical_reason().to_string())),
                      format!("{status_code} response from the OIDC endpoint. Check service connection ID and pipeline configuration. {err_headers}"),
                 )

--- a/sdk/identity/azure_identity/src/client_assertion_credential.rs
+++ b/sdk/identity/azure_identity/src/client_assertion_credential.rs
@@ -91,7 +91,7 @@ impl<C: ClientAssertion> ClientAssertionCredential<C> {
         let authority_host = get_authority_host(None, options.authority_host)?;
         let endpoint = authority_host
             .join(&format!("/{tenant_id}/oauth2/v2.0/token"))
-            .with_context(ErrorKind::DataConversion, || {
+            .with_context_fn(ErrorKind::DataConversion, || {
                 format!("tenant_id {tenant_id} could not be URL encoded")
             })?;
         let pipeline = Pipeline::new(
@@ -158,7 +158,7 @@ impl<C: ClientAssertion> ClientAssertionCredential<C> {
                         CLIENT_ASSERTION_CREDENTIAL, error_response.error_description
                     )
                 };
-                Err(Error::message(ErrorKind::Credential, message))
+                Err(Error::with_message(ErrorKind::Credential, message))
             }
         }
     }

--- a/sdk/identity/azure_identity/src/client_secret_credential.rs
+++ b/sdk/identity/azure_identity/src/client_secret_credential.rs
@@ -67,7 +67,7 @@ impl ClientSecretCredential {
         let authority_host = get_authority_host(None, options.authority_host)?;
         let endpoint = authority_host
             .join(&format!("/{tenant_id}/oauth2/v2.0/token"))
-            .with_context(ErrorKind::DataConversion, || {
+            .with_context_fn(ErrorKind::DataConversion, || {
                 format!("tenant_id '{tenant_id}' could not be URL encoded")
             })?;
 
@@ -131,7 +131,7 @@ impl ClientSecretCredential {
                         CLIENT_SECRET_CREDENTIAL, error_response.error_description
                     )
                 };
-                Err(Error::message(ErrorKind::Credential, message))
+                Err(Error::with_message(ErrorKind::Credential, message))
             }
         }
     }
@@ -146,7 +146,10 @@ impl TokenCredential for ClientSecretCredential {
         options: Option<TokenRequestOptions<'_>>,
     ) -> Result<AccessToken> {
         if scopes.is_empty() {
-            return Err(Error::message(ErrorKind::Credential, "no scopes specified"));
+            return Err(Error::with_message(
+                ErrorKind::Credential,
+                "no scopes specified",
+            ));
         }
         self.cache
             .get_token(scopes, options, |s, o| self.get_token_impl(s, o))

--- a/sdk/identity/azure_identity/src/developer_tools_credential.rs
+++ b/sdk/identity/azure_identity/src/developer_tools_credential.rs
@@ -106,7 +106,7 @@ impl TokenCredential for DeveloperToolsCredential {
                 Err(error) => errors.push(error),
             }
         }
-        Err(Error::with_message(ErrorKind::Credential, || {
+        Err(Error::with_message_fn(ErrorKind::Credential, || {
             format!(
                 "Multiple errors were encountered while attempting to authenticate:\n{}",
                 format_aggregate_error(&errors)
@@ -175,7 +175,7 @@ mod tests {
                     expires_on: (SystemTime::now() + Duration::from_secs(3600)).into(),
                 })
             } else {
-                Err(Error::with_message(ErrorKind::Credential, || {
+                Err(Error::with_message_fn(ErrorKind::Credential, || {
                     format!("{} failed", self.id)
                 }))
             }

--- a/sdk/identity/azure_identity/src/env.rs
+++ b/sdk/identity/azure_identity/src/env.rs
@@ -57,14 +57,14 @@ pub(crate) struct ProcessEnv;
 
 impl ProcessEnv {
     fn var(&self, key: &str) -> azure_core::Result<String> {
-        std::env::var(key).with_context(ErrorKind::Io, || {
+        std::env::var(key).with_context_fn(ErrorKind::Io, || {
             format!("environment variable {} not set", key)
         })
     }
 
     fn var_os(&self, key: &str) -> Result<OsString, Error> {
         std::env::var_os(key).ok_or_else(|| {
-            Error::with_message(ErrorKind::Io, || {
+            Error::with_message_fn(ErrorKind::Io, || {
                 format!("environment variable {key} not set")
             })
         })
@@ -80,7 +80,7 @@ pub(crate) struct MemEnv {
 impl MemEnv {
     fn var(&self, key: &str) -> azure_core::Result<String> {
         self.vars.get(key).cloned().ok_or_else(|| {
-            Error::message(
+            Error::with_message(
                 ErrorKind::Io,
                 format!("environment variable {} not set", key),
             )

--- a/sdk/identity/azure_identity/src/imds_managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/imds_managed_identity_credential.rs
@@ -127,19 +127,19 @@ impl ImdsManagedIdentityCredential {
         if !rsp.status().is_success() {
             match rsp.status() {
                 StatusCode::BadRequest => {
-                    return Err(Error::message(
+                    return Err(Error::with_message(
                         ErrorKind::Credential,
                         "the requested identity has not been assigned to this resource",
                     ))
                 }
                 StatusCode::BadGateway | StatusCode::GatewayTimeout => {
-                    return Err(Error::message(
+                    return Err(Error::with_message(
                         ErrorKind::Credential,
                         "the request failed due to a gateway error",
                     ))
                 }
                 _ => {
-                    return Err(Error::message(
+                    return Err(Error::with_message(
                         ErrorKind::Credential,
                         format!("the request failed: {:?}", rsp.into_body().collect().await?),
                     ));
@@ -184,14 +184,14 @@ where
 /// ref: <https://github.com/Azure/azure-sdk-for-python/blob/d6aeefef46c94b056419613f1a5cc9eaa3af0d22/sdk/identity/azure-identity/azure/identity/_internal/__init__.py#L22>
 fn scopes_to_resource<'a>(scopes: &'a [&'a str]) -> azure_core::Result<&'a str> {
     if scopes.len() != 1 {
-        return Err(Error::message(
+        return Err(Error::with_message(
             ErrorKind::Credential,
             "only one scope is supported for IMDS authentication",
         ));
     }
 
     let Some(scope) = scopes.first() else {
-        return Err(Error::message(
+        return Err(Error::with_message(
             ErrorKind::Credential,
             "no scopes were provided",
         ));

--- a/sdk/identity/azure_identity/src/lib.rs
+++ b/sdk/identity/azure_identity/src/lib.rs
@@ -81,7 +81,7 @@ where
         .into_body()
         .json()
         .await
-        .with_context(ErrorKind::Credential, || {
+        .with_context_fn(ErrorKind::Credential, || {
             format!(
                 "{} authentication failed: invalid response",
                 credential_name
@@ -95,7 +95,7 @@ where
     C: Into<Cow<'static, str>>,
 {
     if value.is_empty() {
-        return Err(Error::message(ErrorKind::Credential, message));
+        return Err(Error::with_message(ErrorKind::Credential, message));
     }
 
     Ok(())
@@ -127,7 +127,7 @@ fn validate_scope(scope: &str) -> Result<()> {
             c.is_alphanumeric() || c == '.' || c == '-' || c == '_' || c == ':' || c == '/'
         })
     {
-        return Err(Error::message(
+        return Err(Error::with_message(
             ErrorKind::Credential,
             format!("invalid scope {scope}"),
         ));
@@ -151,7 +151,7 @@ fn validate_subscription(subscription: &str) -> Result<()> {
             .chars()
             .all(|c| c.is_alphanumeric() || c == '.' || c == '-' || c == '_' || c == ' ')
     {
-        return Err(Error::message(
+        return Err(Error::with_message(
             ErrorKind::Credential,
             format!("invalid subscription {subscription}. If this is the name of a subscription, use its ID instead"),
         ));
@@ -174,7 +174,7 @@ fn validate_tenant_id(tenant_id: &str) -> Result<()> {
             .chars()
             .all(|c| c.is_alphanumeric() || c == '.' || c == '-')
     {
-        return Err(Error::message(
+        return Err(Error::with_message(
             ErrorKind::Credential,
             format!("invalid tenant ID {tenant_id}. You can locate your tenantID by following the instructions listed here: https://learn.microsoft.com/partner-center/find-ids-and-domain-names"),
         ));
@@ -321,7 +321,10 @@ mod tests {
             self.on_request.as_ref().map_or(Ok(()), |f| f(request))?;
             let mut responses = self.responses.lock().unwrap();
             if responses.is_empty() {
-                Err(Error::message(ErrorKind::Other, "No more mock responses"))
+                Err(Error::with_message(
+                    ErrorKind::Other,
+                    "No more mock responses",
+                ))
             } else {
                 Ok(responses.remove(0)) // Use remove(0) to return responses in the correct order
             }

--- a/sdk/identity/azure_identity/src/managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/managed_identity_credential.rs
@@ -64,7 +64,7 @@ impl ManagedIdentityCredential {
                 // App Service does accept resource IDs, however this crate's current implementation sends
                 // them in the wrong query parameter: https://github.com/Azure/azure-sdk-for-rust/issues/2407
                 if let ImdsId::MsiResId(_) = id {
-                    return Err(azure_core::Error::with_message(
+                    return Err(azure_core::Error::with_message_fn(
                         azure_core::error::ErrorKind::Credential,
                         || {
                             "User-assigned resource IDs aren't supported for App Service. Use a client or object ID instead.".to_string()
@@ -77,7 +77,7 @@ impl ManagedIdentityCredential {
                 VirtualMachineManagedIdentityCredential::new(id, options.client_options, env)?
             }
             _ => {
-                return Err(azure_core::Error::with_message(
+                return Err(azure_core::Error::with_message_fn(
                     azure_core::error::ErrorKind::Credential,
                     || format!("{} managed identity isn't supported", source.as_str()),
                 ));
@@ -99,7 +99,7 @@ impl TokenCredential for ManagedIdentityCredential {
         options: Option<TokenRequestOptions<'_>>,
     ) -> azure_core::Result<AccessToken> {
         if scopes.len() != 1 {
-            return Err(azure_core::Error::with_message(
+            return Err(azure_core::Error::with_message_fn(
                 azure_core::error::ErrorKind::Credential,
                 || "ManagedIdentityCredential requires exactly one scope".to_string(),
             ));

--- a/sdk/identity/azure_identity/src/process/mod.rs
+++ b/sdk/identity/azure_identity/src/process/mod.rs
@@ -60,7 +60,7 @@ pub(crate) async fn shell_exec<T: OutputProcessor>(
         #[cfg(windows)]
         {
             let system_root = env.var_os("SYSTEMROOT").map_err(|_| {
-                Error::message(
+                Error::with_message(
                     ErrorKind::Credential,
                     "SYSTEMROOT environment variable not set",
                 )
@@ -98,7 +98,7 @@ pub(crate) async fn shell_exec<T: OutputProcessor>(
             } else {
                 stderr.to_string()
             };
-            Err(Error::with_message(ErrorKind::Credential, || {
+            Err(Error::with_message_fn(ErrorKind::Credential, || {
                 format!("{} authentication failed: {message}", T::credential_name())
             }))
         }
@@ -107,7 +107,7 @@ pub(crate) async fn shell_exec<T: OutputProcessor>(
                 "{} authentication failed: {program:?} wasn't found on PATH",
                 T::credential_name(),
             );
-            Err(Error::full(ErrorKind::Credential, e, message))
+            Err(Error::with_error(ErrorKind::Credential, e, message))
         }
         Err(e) => {
             let message = format!(
@@ -115,7 +115,7 @@ pub(crate) async fn shell_exec<T: OutputProcessor>(
                 T::credential_name(),
                 e.kind()
             );
-            Err(Error::full(ErrorKind::Credential, e, message))
+            Err(Error::with_error(ErrorKind::Credential, e, message))
         }
     }
 }

--- a/sdk/identity/azure_identity/src/workload_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/workload_identity_credential.rs
@@ -64,20 +64,20 @@ impl WorkloadIdentityCredential {
         let env = Env::default();
         let tenant_id = match options.tenant_id {
             Some(id) => id,
-            None => env.var(AZURE_TENANT_ID).with_context(ErrorKind::Credential, || {
+            None => env.var(AZURE_TENANT_ID).with_context_fn(ErrorKind::Credential, || {
                 "no tenant ID specified. Check pod configuration or set tenant_id in the options"
             })?
         };
         crate::validate_tenant_id(&tenant_id)?;
         let path = match options.token_file_path {
             Some(path) => path,
-            None => env.var(AZURE_FEDERATED_TOKEN_FILE).map(PathBuf::from).with_context(ErrorKind::Credential, || {
+            None => env.var(AZURE_FEDERATED_TOKEN_FILE).map(PathBuf::from).with_context_fn(ErrorKind::Credential, || {
                 "no token file specified. Check pod configuration or set token_file_path in the options"
             })?
         };
         let client_id = match options.client_id {
             Some(id) => id,
-            None => env.var(AZURE_CLIENT_ID).with_context(ErrorKind::Credential, || {
+            None => env.var(AZURE_CLIENT_ID).with_context_fn(ErrorKind::Credential, || {
                 "no client id specified. Check pod configuration or set client_id in the options"
             })?
         };
@@ -101,7 +101,10 @@ impl TokenCredential for WorkloadIdentityCredential {
         options: Option<TokenRequestOptions<'_>>,
     ) -> azure_core::Result<AccessToken> {
         if scopes.is_empty() {
-            return Err(Error::message(ErrorKind::Credential, "no scopes specified"));
+            return Err(Error::with_message(
+                ErrorKind::Credential,
+                "no scopes specified",
+            ));
         }
         self.0.get_token(scopes, options).await
     }
@@ -122,12 +125,13 @@ struct FileCache {
 impl Token {
     fn new(path: PathBuf) -> azure_core::Result<Self> {
         let last_read = Instant::now();
-        let token = std::fs::read_to_string(&path).with_context(ErrorKind::Credential, || {
-            format!(
-                "failed to read federated token from file {}",
-                path.display()
-            )
-        })?;
+        let token =
+            std::fs::read_to_string(&path).with_context_fn(ErrorKind::Credential, || {
+                format!(
+                    "failed to read federated token from file {}",
+                    path.display()
+                )
+            })?;
 
         Ok(Self {
             path,
@@ -152,18 +156,19 @@ impl ClientAssertion for Token {
             let path = self.path.clone();
             let (tx, rx) = oneshot::channel();
             thread::spawn(move || {
-                let token = fs::read_to_string(&path).with_context(ErrorKind::Credential, || {
-                    format!(
-                        "failed to read federated token from file {}",
-                        path.display()
-                    )
-                });
+                let token =
+                    fs::read_to_string(&path).with_context_fn(ErrorKind::Credential, || {
+                        format!(
+                            "failed to read federated token from file {}",
+                            path.display()
+                        )
+                    });
                 tx.send(token)
             });
 
             let mut write_cache = RwLockUpgradableReadGuard::upgrade(cache).await;
             let token = rx.await.map_err(|err| {
-                azure_core::Error::full(ErrorKind::Io, err, "canceled reading certificate")
+                azure_core::Error::with_error(ErrorKind::Io, err, "canceled reading certificate")
             })??;
 
             write_cache.token = Secret::new(token);

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/generated/clients/certificate_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/generated/clients/certificate_client.rs
@@ -76,7 +76,7 @@ impl CertificateClient {
         let options = options.unwrap_or_default();
         let endpoint = Url::parse(endpoint)?;
         if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 format!("{endpoint} must use http(s)"),
             ));
@@ -120,7 +120,7 @@ impl CertificateClient {
         options: Option<CertificateClientBackupCertificateOptions<'_>>,
     ) -> Result<Response<BackupCertificateResult>> {
         if certificate_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter certificate_name cannot be empty",
             ));
@@ -158,7 +158,7 @@ impl CertificateClient {
         options: Option<CertificateClientCreateCertificateOptions<'_>>,
     ) -> Result<Response<CertificateOperation>> {
         if certificate_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter certificate_name cannot be empty",
             ));
@@ -196,7 +196,7 @@ impl CertificateClient {
         options: Option<CertificateClientDeleteCertificateOptions<'_>>,
     ) -> Result<Response<DeletedCertificate>> {
         if certificate_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter certificate_name cannot be empty",
             ));
@@ -232,7 +232,7 @@ impl CertificateClient {
         options: Option<CertificateClientDeleteCertificateOperationOptions<'_>>,
     ) -> Result<Response<CertificateOperation>> {
         if certificate_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter certificate_name cannot be empty",
             ));
@@ -294,7 +294,7 @@ impl CertificateClient {
         options: Option<CertificateClientDeleteIssuerOptions<'_>>,
     ) -> Result<Response<Issuer>> {
         if issuer_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter issuer_name cannot be empty",
             ));
@@ -329,7 +329,7 @@ impl CertificateClient {
         options: Option<CertificateClientGetCertificateOptions<'_>>,
     ) -> Result<Response<Certificate>> {
         if certificate_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter certificate_name cannot be empty",
             ));
@@ -370,7 +370,7 @@ impl CertificateClient {
         options: Option<CertificateClientGetCertificateOperationOptions<'_>>,
     ) -> Result<Response<CertificateOperation>> {
         if certificate_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter certificate_name cannot be empty",
             ));
@@ -406,7 +406,7 @@ impl CertificateClient {
         options: Option<CertificateClientGetCertificatePolicyOptions<'_>>,
     ) -> Result<Response<CertificatePolicy>> {
         if certificate_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter certificate_name cannot be empty",
             ));
@@ -469,7 +469,7 @@ impl CertificateClient {
         options: Option<CertificateClientGetDeletedCertificateOptions<'_>>,
     ) -> Result<Response<DeletedCertificate>> {
         if certificate_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter certificate_name cannot be empty",
             ));
@@ -505,7 +505,7 @@ impl CertificateClient {
         options: Option<CertificateClientGetIssuerOptions<'_>>,
     ) -> Result<Response<Issuer>> {
         if issuer_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter issuer_name cannot be empty",
             ));
@@ -545,7 +545,7 @@ impl CertificateClient {
         options: Option<CertificateClientImportCertificateOptions<'_>>,
     ) -> Result<Response<Certificate>> {
         if certificate_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter certificate_name cannot be empty",
             ));
@@ -652,7 +652,7 @@ impl CertificateClient {
         options: Option<CertificateClientListCertificatePropertiesVersionsOptions<'_>>,
     ) -> Result<Pager<ListCertificatePropertiesResult>> {
         if certificate_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter certificate_name cannot be empty",
             ));
@@ -862,7 +862,7 @@ impl CertificateClient {
         options: Option<CertificateClientMergeCertificateOptions<'_>>,
     ) -> Result<Response<Certificate>> {
         if certificate_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter certificate_name cannot be empty",
             ));
@@ -901,7 +901,7 @@ impl CertificateClient {
         options: Option<CertificateClientPurgeDeletedCertificateOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         if certificate_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter certificate_name cannot be empty",
             ));
@@ -937,7 +937,7 @@ impl CertificateClient {
         options: Option<CertificateClientRecoverDeletedCertificateOptions<'_>>,
     ) -> Result<Response<Certificate>> {
         if certificate_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter certificate_name cannot be empty",
             ));
@@ -1034,7 +1034,7 @@ impl CertificateClient {
         options: Option<CertificateClientSetIssuerOptions<'_>>,
     ) -> Result<Response<Issuer>> {
         if issuer_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter issuer_name cannot be empty",
             ));
@@ -1074,7 +1074,7 @@ impl CertificateClient {
         options: Option<CertificateClientUpdateCertificateOperationOptions<'_>>,
     ) -> Result<Response<CertificateOperation>> {
         if certificate_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter certificate_name cannot be empty",
             ));
@@ -1114,7 +1114,7 @@ impl CertificateClient {
         options: Option<CertificateClientUpdateCertificatePolicyOptions<'_>>,
     ) -> Result<Response<CertificatePolicy>> {
         if certificate_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter certificate_name cannot be empty",
             ));
@@ -1154,7 +1154,7 @@ impl CertificateClient {
         options: Option<CertificateClientUpdateCertificatePropertiesOptions<'_>>,
     ) -> Result<Response<Certificate>> {
         if certificate_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter certificate_name cannot be empty",
             ));
@@ -1200,7 +1200,7 @@ impl CertificateClient {
         options: Option<CertificateClientUpdateIssuerOptions<'_>>,
     ) -> Result<Response<Issuer>> {
         if issuer_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter issuer_name cannot be empty",
             ));

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/resource.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/resource.rs
@@ -76,7 +76,7 @@ where
 {
     fn resource_id(&self) -> Result<ResourceId> {
         let Some(id) = self.as_id() else {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 ErrorKind::DataConversion,
                 "missing resource id",
             ));
@@ -90,7 +90,7 @@ where
 impl ResourceExt for CertificateOperation {
     fn resource_id(&self) -> Result<ResourceId> {
         let Some(id) = self.id.as_ref() else {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 ErrorKind::DataConversion,
                 "missing resource id",
             ));
@@ -105,14 +105,16 @@ fn deconstruct(url: &Url, version: bool) -> Result<ResourceId> {
     let vault_url = format!("{}://{}", url.scheme(), url.authority(),);
     let mut segments = url
         .path_segments()
-        .ok_or_else(|| azure_core::Error::message(ErrorKind::DataConversion, "invalid url"))?
+        .ok_or_else(|| azure_core::Error::with_message(ErrorKind::DataConversion, "invalid url"))?
         .filter(|s| !s.is_empty());
     segments
         .next()
-        .ok_or_else(|| azure_core::Error::message(ErrorKind::DataConversion, "missing collection"))
+        .ok_or_else(|| {
+            azure_core::Error::with_message(ErrorKind::DataConversion, "missing collection")
+        })
         .and_then(|col| {
             if col != "certificates" {
-                return Err(azure_core::Error::message(
+                return Err(azure_core::Error::with_message(
                     ErrorKind::DataConversion,
                     "not in certificates collection",
                 ));
@@ -121,7 +123,7 @@ fn deconstruct(url: &Url, version: bool) -> Result<ResourceId> {
         })?;
     let name = segments
         .next()
-        .ok_or_else(|| azure_core::Error::message(ErrorKind::DataConversion, "missing name"))
+        .ok_or_else(|| azure_core::Error::with_message(ErrorKind::DataConversion, "missing name"))
         .map(String::from)?;
 
     let mut resource_id = ResourceId {

--- a/sdk/keyvault/azure_security_keyvault_keys/src/generated/clients/key_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/generated/clients/key_client.rs
@@ -69,7 +69,7 @@ impl KeyClient {
         let options = options.unwrap_or_default();
         let endpoint = Url::parse(endpoint)?;
         if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 format!("{endpoint} must use http(s)"),
             ));
@@ -119,7 +119,7 @@ impl KeyClient {
         options: Option<KeyClientBackupKeyOptions<'_>>,
     ) -> Result<Response<BackupKeyResult>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -159,7 +159,7 @@ impl KeyClient {
         options: Option<KeyClientCreateKeyOptions<'_>>,
     ) -> Result<Response<Key>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -204,7 +204,7 @@ impl KeyClient {
         options: Option<KeyClientDecryptOptions<'_>>,
     ) -> Result<Response<KeyOperationResult>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -247,7 +247,7 @@ impl KeyClient {
         options: Option<KeyClientDeleteKeyOptions<'_>>,
     ) -> Result<Response<DeletedKey>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -289,7 +289,7 @@ impl KeyClient {
         options: Option<KeyClientEncryptOptions<'_>>,
     ) -> Result<Response<KeyOperationResult>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -331,7 +331,7 @@ impl KeyClient {
         options: Option<KeyClientGetDeletedKeyOptions<'_>>,
     ) -> Result<Response<DeletedKey>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -367,7 +367,7 @@ impl KeyClient {
         options: Option<KeyClientGetKeyOptions<'_>>,
     ) -> Result<Response<Key>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -407,7 +407,7 @@ impl KeyClient {
         options: Option<KeyClientGetKeyAttestationOptions<'_>>,
     ) -> Result<Response<Key>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -447,7 +447,7 @@ impl KeyClient {
         options: Option<KeyClientGetKeyRotationPolicyOptions<'_>>,
     ) -> Result<Response<KeyRotationPolicy>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -515,7 +515,7 @@ impl KeyClient {
         options: Option<KeyClientImportKeyOptions<'_>>,
     ) -> Result<Response<Key>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -683,7 +683,7 @@ impl KeyClient {
         options: Option<KeyClientListKeyPropertiesVersionsOptions<'_>>,
     ) -> Result<Pager<ListKeyPropertiesResult>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -757,7 +757,7 @@ impl KeyClient {
         options: Option<KeyClientPurgeDeletedKeyOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -793,7 +793,7 @@ impl KeyClient {
         options: Option<KeyClientRecoverDeletedKeyOptions<'_>>,
     ) -> Result<Response<Key>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -831,7 +831,7 @@ impl KeyClient {
         options: Option<KeyClientReleaseOptions<'_>>,
     ) -> Result<Response<KeyReleaseResult>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -908,7 +908,7 @@ impl KeyClient {
         options: Option<KeyClientRotateKeyOptions<'_>>,
     ) -> Result<Response<Key>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -946,7 +946,7 @@ impl KeyClient {
         options: Option<KeyClientSignOptions<'_>>,
     ) -> Result<Response<KeyOperationResult>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -991,7 +991,7 @@ impl KeyClient {
         options: Option<KeyClientUnwrapKeyOptions<'_>>,
     ) -> Result<Response<KeyOperationResult>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -1036,7 +1036,7 @@ impl KeyClient {
         options: Option<KeyClientUpdateKeyPropertiesOptions<'_>>,
     ) -> Result<Response<Key>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -1079,7 +1079,7 @@ impl KeyClient {
         options: Option<KeyClientUpdateKeyRotationPolicyOptions<'_>>,
     ) -> Result<Response<KeyRotationPolicy>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -1121,7 +1121,7 @@ impl KeyClient {
         options: Option<KeyClientVerifyOptions<'_>>,
     ) -> Result<Response<KeyVerifyResult>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));
@@ -1168,7 +1168,7 @@ impl KeyClient {
         options: Option<KeyClientWrapKeyOptions<'_>>,
     ) -> Result<Response<KeyOperationResult>> {
         if key_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter key_name cannot be empty",
             ));

--- a/sdk/keyvault/azure_security_keyvault_keys/src/resource.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/resource.rs
@@ -77,7 +77,7 @@ where
 {
     fn resource_id(&self) -> Result<ResourceId> {
         let Some(id) = self.as_id() else {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 ErrorKind::DataConversion,
                 "missing resource id",
             ));
@@ -92,14 +92,16 @@ fn deconstruct(url: &Url) -> Result<ResourceId> {
     let vault_url = format!("{}://{}", url.scheme(), url.authority(),);
     let mut segments = url
         .path_segments()
-        .ok_or_else(|| azure_core::Error::message(ErrorKind::DataConversion, "invalid url"))?
+        .ok_or_else(|| azure_core::Error::with_message(ErrorKind::DataConversion, "invalid url"))?
         .filter(|s| !s.is_empty());
     segments
         .next()
-        .ok_or_else(|| azure_core::Error::message(ErrorKind::DataConversion, "missing collection"))
+        .ok_or_else(|| {
+            azure_core::Error::with_message(ErrorKind::DataConversion, "missing collection")
+        })
         .and_then(|col| {
             if col != "keys" {
-                return Err(azure_core::Error::message(
+                return Err(azure_core::Error::with_message(
                     ErrorKind::DataConversion,
                     "not in keys collection",
                 ));
@@ -108,7 +110,7 @@ fn deconstruct(url: &Url) -> Result<ResourceId> {
         })?;
     let name = segments
         .next()
-        .ok_or_else(|| azure_core::Error::message(ErrorKind::DataConversion, "missing name"))
+        .ok_or_else(|| azure_core::Error::with_message(ErrorKind::DataConversion, "missing name"))
         .map(String::from)?;
     let version = segments.next().map(String::from);
 

--- a/sdk/keyvault/azure_security_keyvault_secrets/src/generated/clients/secret_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/src/generated/clients/secret_client.rs
@@ -63,7 +63,7 @@ impl SecretClient {
         let options = options.unwrap_or_default();
         let endpoint = Url::parse(endpoint)?;
         if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 format!("{endpoint} must use http(s)"),
             ));
@@ -107,7 +107,7 @@ impl SecretClient {
         options: Option<SecretClientBackupSecretOptions<'_>>,
     ) -> Result<Response<BackupSecretResult>> {
         if secret_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter secret_name cannot be empty",
             ));
@@ -143,7 +143,7 @@ impl SecretClient {
         options: Option<SecretClientDeleteSecretOptions<'_>>,
     ) -> Result<Response<DeletedSecret>> {
         if secret_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter secret_name cannot be empty",
             ));
@@ -179,7 +179,7 @@ impl SecretClient {
         options: Option<SecretClientGetDeletedSecretOptions<'_>>,
     ) -> Result<Response<DeletedSecret>> {
         if secret_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter secret_name cannot be empty",
             ));
@@ -214,7 +214,7 @@ impl SecretClient {
         options: Option<SecretClientGetSecretOptions<'_>>,
     ) -> Result<Response<Secret>> {
         if secret_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter secret_name cannot be empty",
             ));
@@ -383,7 +383,7 @@ impl SecretClient {
         options: Option<SecretClientListSecretPropertiesVersionsOptions<'_>>,
     ) -> Result<Pager<ListSecretPropertiesResult>> {
         if secret_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter secret_name cannot be empty",
             ));
@@ -457,7 +457,7 @@ impl SecretClient {
         options: Option<SecretClientPurgeDeletedSecretOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         if secret_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter secret_name cannot be empty",
             ));
@@ -492,7 +492,7 @@ impl SecretClient {
         options: Option<SecretClientRecoverDeletedSecretOptions<'_>>,
     ) -> Result<Response<Secret>> {
         if secret_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter secret_name cannot be empty",
             ));
@@ -560,7 +560,7 @@ impl SecretClient {
         options: Option<SecretClientSetSecretOptions<'_>>,
     ) -> Result<Response<Secret>> {
         if secret_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter secret_name cannot be empty",
             ));
@@ -600,7 +600,7 @@ impl SecretClient {
         options: Option<SecretClientUpdateSecretPropertiesOptions<'_>>,
     ) -> Result<Response<Secret>> {
         if secret_name.is_empty() {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 "parameter secret_name cannot be empty",
             ));

--- a/sdk/keyvault/azure_security_keyvault_secrets/src/resource.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/src/resource.rs
@@ -75,7 +75,7 @@ where
 {
     fn resource_id(&self) -> Result<ResourceId> {
         let Some(id) = self.as_id() else {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 ErrorKind::DataConversion,
                 "missing resource id",
             ));
@@ -90,14 +90,16 @@ fn deconstruct(url: &Url) -> Result<ResourceId> {
     let vault_url = format!("{}://{}", url.scheme(), url.authority(),);
     let mut segments = url
         .path_segments()
-        .ok_or_else(|| azure_core::Error::message(ErrorKind::DataConversion, "invalid url"))?
+        .ok_or_else(|| azure_core::Error::with_message(ErrorKind::DataConversion, "invalid url"))?
         .filter(|s| !s.is_empty());
     segments
         .next()
-        .ok_or_else(|| azure_core::Error::message(ErrorKind::DataConversion, "missing collection"))
+        .ok_or_else(|| {
+            azure_core::Error::with_message(ErrorKind::DataConversion, "missing collection")
+        })
         .and_then(|col| {
             if col != "secrets" {
-                return Err(azure_core::Error::message(
+                return Err(azure_core::Error::with_message(
                     ErrorKind::DataConversion,
                     "not in secrets collection",
                 ));
@@ -106,7 +108,7 @@ fn deconstruct(url: &Url) -> Result<ResourceId> {
         })?;
     let name = segments
         .next()
-        .ok_or_else(|| azure_core::Error::message(ErrorKind::DataConversion, "missing name"))
+        .ok_or_else(|| azure_core::Error::with_message(ErrorKind::DataConversion, "missing name"))
         .map(String::from)?;
     let version = segments.next().map(String::from);
 

--- a/sdk/storage/azure_storage_blob/src/generated/clients/append_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/append_blob_client.rs
@@ -63,7 +63,7 @@ impl AppendBlobClient {
         let options = options.unwrap_or_default();
         let endpoint = Url::parse(endpoint)?;
         if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 format!("{endpoint} must use http(s)"),
             ));

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_client.rs
@@ -79,7 +79,7 @@ impl BlobClient {
         let options = options.unwrap_or_default();
         let endpoint = Url::parse(endpoint)?;
         if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 format!("{endpoint} must use http(s)"),
             ));

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
@@ -76,7 +76,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let endpoint = Url::parse(endpoint)?;
         if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 format!("{endpoint} must use http(s)"),
             ));

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
@@ -62,7 +62,7 @@ impl BlobServiceClient {
         let options = options.unwrap_or_default();
         let endpoint = Url::parse(endpoint)?;
         if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 format!("{endpoint} must use http(s)"),
             ));

--- a/sdk/storage/azure_storage_blob/src/generated/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/block_blob_client.rs
@@ -67,7 +67,7 @@ impl BlockBlobClient {
         let options = options.unwrap_or_default();
         let endpoint = Url::parse(endpoint)?;
         if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 format!("{endpoint} must use http(s)"),
             ));

--- a/sdk/storage/azure_storage_blob/src/generated/clients/page_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/page_blob_client.rs
@@ -69,7 +69,7 @@ impl PageBlobClient {
         let options = options.unwrap_or_default();
         let endpoint = Url::parse(endpoint)?;
         if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::message(
+            return Err(azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
                 format!("{endpoint} must use http(s)"),
             ));

--- a/sdk/storage/azure_storage_blob/src/models/extensions.rs
+++ b/sdk/storage/azure_storage_blob/src/models/extensions.rs
@@ -81,7 +81,7 @@ impl TryFrom<BlobTags> for HashMap<String, String> {
                         map.insert(k, v);
                     }
                     _ => {
-                        return Err(azure_core::Error::message(
+                        return Err(azure_core::Error::with_message(
                             azure_core::error::ErrorKind::DataConversion,
                             "BlobTag missing key or value",
                         ));

--- a/sdk/typespec/CHANGELOG.md
+++ b/sdk/typespec/CHANGELOG.md
@@ -4,7 +4,19 @@
 
 ### Features Added
 
+- Added `Error::with_error_fn()`.
+
 ### Breaking Changes
+
+- Renamed a number of construction functions for `Error` to align with [guidelines](https://azure.github.io/azure-sdk/rust_introduction.html)"
+  - Renamed `Error::full()` to `Error::with_error()`.
+  - Renamed `Error::with_message()` to `Error::with_message_fn()`.
+  - Renamed `Error::message()` to `Error::with_message()`.
+  - Renamed `Error::with_context()` to `Error::with_context_fn()`.
+  - Renamed `Error::context()` to `Error::with_context()`.
+  - Renamed `ResultExt::map_kind()` to `ResultExt::with_kind()`.
+  - Renamed `ResultExt::with_context()` to `ResultExt::with_context_fn()`.
+  - Renamed `ResultExt::context()` to `ResultExt::with_context()`.
 
 ### Bugs Fixed
 

--- a/sdk/typespec/src/http/headers.rs
+++ b/sdk/typespec/src/http/headers.rs
@@ -141,7 +141,7 @@ impl Headers {
     pub fn get<H: FromHeaders>(&self) -> crate::Result<H> {
         match H::from_headers(self) {
             Ok(Some(x)) => Ok(x),
-            Ok(None) => Err(crate::Error::with_message(
+            Ok(None) => Err(crate::Error::with_message_fn(
                 ErrorKind::DataConversion,
                 || {
                     let required_headers = H::header_names();
@@ -205,7 +205,7 @@ impl Headers {
         E: std::error::Error + Send + Sync + 'static,
     {
         self.get_optional_with(key, parser)?.ok_or_else(|| {
-            Error::with_message(ErrorKind::DataConversion, || {
+            Error::with_message_fn(ErrorKind::DataConversion, || {
                 format!("header not found {}", key.as_str())
             })
         })
@@ -224,7 +224,7 @@ impl Headers {
         self.0
             .get(key)
             .map(|v: &HeaderValue| {
-                parser(v).with_context(ErrorKind::DataConversion, || {
+                parser(v).with_context_fn(ErrorKind::DataConversion, || {
                     let ty = std::any::type_name::<V>();
                     format!("unable to parse header '{key:?}: {v:?}' into {ty}",)
                 })

--- a/sdk/typespec/src/xml.rs
+++ b/sdk/typespec/src/xml.rs
@@ -22,7 +22,7 @@ pub fn read_xml_str<T>(body: &str) -> Result<T>
 where
     T: DeserializeOwned,
 {
-    from_str(body).with_context(ErrorKind::DataConversion, || {
+    from_str(body).with_context_fn(ErrorKind::DataConversion, || {
         let t = core::any::type_name::<T>();
         format!("failed to deserialize the following xml into a {t}\n{body}")
     })
@@ -33,7 +33,7 @@ pub fn read_xml<T>(body: &[u8]) -> Result<T>
 where
     T: DeserializeOwned,
 {
-    from_reader(slice_bom(body)).with_context(ErrorKind::DataConversion, || {
+    from_reader(slice_bom(body)).with_context_fn(ErrorKind::DataConversion, || {
         let t = core::any::type_name::<T>();
         let xml = std::str::from_utf8(body).unwrap_or("(XML is not UTF8-encoded)");
         format!("failed to deserialize the following xml into a {t}\n{xml}")
@@ -47,7 +47,7 @@ pub fn to_xml<T>(value: &T) -> Result<Bytes>
 where
     T: serde::Serialize,
 {
-    let value = to_string(value).with_context(ErrorKind::DataConversion, || {
+    let value = to_string(value).with_context_fn(ErrorKind::DataConversion, || {
         let t = core::any::type_name::<T>();
         format!("failed to serialize {t} into xml")
     })?;
@@ -65,7 +65,7 @@ where
     T: serde::Serialize,
 {
     let value =
-        to_string_with_root(root_tag, value).with_context(ErrorKind::DataConversion, || {
+        to_string_with_root(root_tag, value).with_context_fn(ErrorKind::DataConversion, || {
             let t = core::any::type_name::<T>();
             format!("failed to serialize {t} into xml")
         })?;

--- a/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
@@ -184,7 +184,7 @@ pub fn get_async_runtime() -> Arc<dyn AsyncRuntime> {
 pub fn set_async_runtime(runtime: Arc<dyn AsyncRuntime>) -> crate::Result<()> {
     let result = ASYNC_RUNTIME_IMPLEMENTATION.set(runtime);
     if result.is_err() {
-        Err(crate::Error::message(
+        Err(crate::Error::with_message(
             crate::error::ErrorKind::Other,
             "Async runtime has already been set.",
         ))

--- a/sdk/typespec/typespec_client_core/src/http/clients/reqwest.rs
+++ b/sdk/typespec/typespec_client_core/src/http/clients/reqwest.rs
@@ -52,7 +52,7 @@ impl HttpClient for ::reqwest::Client {
                 .body(::reqwest::Body::wrap_stream(seekable_stream))
                 .build(),
         }
-        .context(ErrorKind::Other, "failed to build `reqwest` request")?;
+        .with_context(ErrorKind::Other, "failed to build `reqwest` request")?;
 
         debug!(
             "performing request {method} '{}' with `reqwest`",
@@ -61,13 +61,13 @@ impl HttpClient for ::reqwest::Client {
         let rsp = self
             .execute(reqwest_request)
             .await
-            .context(ErrorKind::Io, "failed to execute `reqwest` request")?;
+            .with_context(ErrorKind::Io, "failed to execute `reqwest` request")?;
 
         let status = rsp.status();
         let headers = to_headers(rsp.headers());
 
         let body: PinnedStream = Box::pin(rsp.bytes_stream().map_err(|error| {
-            Error::full(
+            Error::with_error(
                 ErrorKind::Io,
                 error,
                 "error converting `reqwest` request into a byte stream",

--- a/sdk/typespec/typespec_client_core/src/http/policies/logging.rs
+++ b/sdk/typespec/typespec_client_core/src/http/policies/logging.rs
@@ -181,7 +181,7 @@ mod tests {
             _request: &mut Request,
             _next: &[Arc<dyn Policy>],
         ) -> PolicyResult {
-            Err(crate::Error::message(
+            Err(crate::Error::with_message(
                 crate::error::ErrorKind::Other,
                 "Test error",
             ))

--- a/sdk/typespec/typespec_client_core/src/http/policies/retry/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/policies/retry/mod.rs
@@ -156,7 +156,7 @@ where
 
         loop {
             if retry_count > 0 {
-                request.body.reset().await.context(
+                request.body.reset().await.with_context(
                     ErrorKind::Other,
                     "failed to reset body stream before retrying request",
                 )?;
@@ -214,7 +214,7 @@ where
                         (Err(error), retry_after)
                     } else {
                         return Err(
-                            error.context("non-io error occurred which will not be retried")
+                            error.with_context("non-io error occurred which will not be retried")
                         );
                     }
                 }
@@ -224,8 +224,9 @@ where
             if self.is_expired(time_since_start, retry_count) {
                 return match last_result {
                     Ok(result) => Ok(result),
-                    Err(last_error) => Err(last_error
-                        .context("retry policy expired and the request will no longer be retried")),
+                    Err(last_error) => Err(last_error.with_context(
+                        "retry policy expired and the request will no longer be retried",
+                    )),
                 };
             }
             retry_count += 1;

--- a/sdk/typespec/typespec_client_core/src/http/response.rs
+++ b/sdk/typespec/typespec_client_core/src/http/response.rs
@@ -211,7 +211,7 @@ impl ResponseBody {
     /// Collect the stream into a [`String`].
     pub async fn collect_string(self) -> crate::Result<String> {
         std::str::from_utf8(&self.collect().await?)
-            .context(
+            .with_context(
                 ErrorKind::DataConversion,
                 "response body was not utf-8 like expected",
             )

--- a/sdk/typespec/typespec_client_core/src/macros.rs
+++ b/sdk/typespec/typespec_client_core/src/macros.rs
@@ -53,7 +53,7 @@ macro_rules! create_enum {
                     $(
                         $value => Ok($name::$variant),
                     )*
-                    _ => Err($crate::error::Error::with_message($crate::error::ErrorKind::DataConversion, || format!("unknown variant of {} found: \"{}\"",
+                    _ => Err($crate::error::Error::with_message_fn($crate::error::ErrorKind::DataConversion, || format!("unknown variant of {} found: \"{}\"",
                         stringify!($name),
                          s
                     )))

--- a/sdk/typespec/typespec_client_core/src/stream/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/stream/mod.rs
@@ -53,7 +53,7 @@ impl Stream for dyn SeekableStream {
                 let bytes = bytes.slice(0..bytes_read);
                 Poll::Ready(Some(Ok(bytes)))
             }
-            Poll::Ready(Err(err)) => Poll::Ready(Some(Err(Error::full(
+            Poll::Ready(Err(err)) => Poll::Ready(Some(Err(Error::with_error(
                 ErrorKind::Io,
                 err,
                 "an error was encountered when trying to read from a stream",

--- a/sdk/typespec/typespec_client_core/src/time/iso8601.rs
+++ b/sdk/typespec/typespec_client_core/src/time/iso8601.rs
@@ -22,7 +22,7 @@ const SERDE_CONFIG: EncodedConfig = Config::DEFAULT
 /// Parse an ISO 8601 date and time string into an [`OffsetDateTime`].
 pub fn parse_iso8601(s: &str) -> crate::Result<OffsetDateTime> {
     OffsetDateTime::parse(s, &Iso8601::<SERDE_CONFIG>)
-        .with_context(ErrorKind::DataConversion, || {
+        .with_context_fn(ErrorKind::DataConversion, || {
             format!("unable to parse iso8601 date '{s}")
         })
 }
@@ -30,7 +30,7 @@ pub fn parse_iso8601(s: &str) -> crate::Result<OffsetDateTime> {
 /// Convert an [`OffsetDateTime`] to an ISO 8601 string.
 pub fn to_iso8601(date: &OffsetDateTime) -> crate::Result<String> {
     date.format(&Iso8601::<SERDE_CONFIG>)
-        .with_context(ErrorKind::DataConversion, || {
+        .with_context_fn(ErrorKind::DataConversion, || {
             format!("unable to format date '{date:?}")
         })
 }

--- a/sdk/typespec/typespec_client_core/src/time/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/time/mod.rs
@@ -31,7 +31,7 @@ pub use unix_time::parse_unix_time;
 ///
 /// Example string: `1985-04-12T23:20:50.52Z`.
 pub fn parse_rfc3339(s: &str) -> crate::Result<OffsetDateTime> {
-    OffsetDateTime::parse(s, &Rfc3339).with_context(ErrorKind::DataConversion, || {
+    OffsetDateTime::parse(s, &Rfc3339).with_context_fn(ErrorKind::DataConversion, || {
         format!("unable to parse rfc3339 date '{s}")
     })
 }
@@ -63,7 +63,7 @@ pub fn to_rfc3339(date: &OffsetDateTime) -> String {
 /// Example string: `Sun, 06 Nov 1994 08:49:37 GMT`.
 pub fn parse_rfc7231(s: &str) -> crate::Result<OffsetDateTime> {
     Ok(PrimitiveDateTime::parse(s, RFC7231_FORMAT)
-        .with_context(ErrorKind::DataConversion, || {
+        .with_context_fn(ErrorKind::DataConversion, || {
             format!("unable to parse rfc7231 date '{s}")
         })?
         .assume_utc())
@@ -97,7 +97,7 @@ pub fn to_rfc7231(date: &OffsetDateTime) -> String {
 /// x-ms-last-state-change-utc: Fri, 25 Mar 2016 21:27:20.035 GMT
 pub fn parse_last_state_change(s: &str) -> crate::Result<OffsetDateTime> {
     Ok(PrimitiveDateTime::parse(s, LAST_STATE_CHANGE_FORMAT)
-        .with_context(ErrorKind::DataConversion, || {
+        .with_context_fn(ErrorKind::DataConversion, || {
             format!("unable to parse last state change date '{s}")
         })?
         .assume_utc())

--- a/sdk/typespec/typespec_macros/CHANGELOG.md
+++ b/sdk/typespec/typespec_macros/CHANGELOG.md
@@ -4,7 +4,19 @@
 
 ### Features Added
 
+- Added `Error::with_error_fn()`.
+
 ### Breaking Changes
+
+- Renamed a number of construction functions for `Error` to align with [guidelines](https://azure.github.io/azure-sdk/rust_introduction.html)"
+  - Renamed `Error::full()` to `Error::with_error()`.
+  - Renamed `Error::with_message()` to `Error::with_message_fn()`.
+  - Renamed `Error::message()` to `Error::with_message()`.
+  - Renamed `Error::with_context()` to `Error::with_context_fn()`.
+  - Renamed `Error::context()` to `Error::with_context()`.
+  - Renamed `ResultExt::map_kind()` to `ResultExt::with_kind()`.
+  - Renamed `ResultExt::with_context()` to `ResultExt::with_context_fn()`.
+  - Renamed `ResultExt::context()` to `ResultExt::with_context()`.
 
 ### Bugs Fixed
 


### PR DESCRIPTION
We had some inconsistency in construction functions, and many didn't align to our guidelines. This essentially migrates a pattern I evolved for my own Rust crates' template based more or less on what we had.
