### PR TITLE
Ensure azure_core is proper superset of typespec

### DIFF
--- a/sdk/core/azure_core/src/http/mod.rs
+++ b/sdk/core/azure_core/src/http/mod.rs
@@ -18,7 +18,7 @@ pub use pager::{ItemIterator, PageIterator, Pager};
 pub use pipeline::*;
 pub use poller::Poller;
 pub use request::{Body, Request, RequestContent};
-pub use response::{BufResponse, Response};
+pub use response::{BufResponse, RawResponse, Response};
 
 pub use typespec_client_core::http::response;
 pub use typespec_client_core::http::{

--- a/sdk/typespec/CHANGELOG.md
+++ b/sdk/typespec/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Changed `RawResponse::json()` from `async` to synchronous function. The body was already buffered.
 - Changed `RawResponse::xml()` from `async` to synchronous function. The body was already buffered.
 - Removed `ErrorKind::http_response()`. Construct an `ErrorResponse::HttpResponse` variant instead.
+- Moved `AsHeaders`, `FromHeaders`, `Header`, `Headers`, `HeaderName`, and `HeaderValue` to `http::headers` module to align with `typespec_client_core`.
 - Renamed a number of construction functions for `Error` to align with [guidelines](https://azure.github.io/azure-sdk/rust_introduction.html)"
   - Renamed `Error::full()` to `Error::with_error()`.
   - Renamed `Error::with_message()` to `Error::with_message_fn()`.
@@ -24,6 +25,9 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- Made `http::headers` a public module to align with `typespec_client_core`.
+- Made `http::response` a public module to align with `typespec_client_core`.
 
 ## 0.8.0 (2025-09-11)
 

--- a/sdk/typespec/src/http/headers.rs
+++ b/sdk/typespec/src/http/headers.rs
@@ -46,9 +46,6 @@ pub static DEFAULT_ALLOWED_HEADER_NAMES: LazyLock<HashSet<Cow<'static, str>>> =
         .collect()
     });
 
-/// Default pattern for redacted headers or query parameters.
-pub const REDACTED_PATTERN: &str = "REDACTED";
-
 /// A trait for converting a type into request headers.
 pub trait AsHeaders {
     /// The error type which can occur when converting the type into headers.
@@ -282,7 +279,7 @@ impl fmt::Debug for Headers {
                     if DEFAULT_ALLOWED_HEADER_NAMES.contains(k.as_str()) {
                         v.as_str()
                     } else {
-                        REDACTED_PATTERN
+                        super::REDACTED_PATTERN
                     },
                 )
             }))

--- a/sdk/typespec/src/http/mod.rs
+++ b/sdk/typespec/src/http/mod.rs
@@ -3,10 +3,13 @@
 
 //! This module contains types and utilities for working with HTTP status codes.
 
-mod headers;
-mod response;
+pub mod headers;
+pub mod response;
 mod status_code;
 
-pub use headers::*;
-pub use response::*;
+pub use headers::DEFAULT_ALLOWED_HEADER_NAMES;
+pub use response::RawResponse;
 pub use status_code::StatusCode;
+
+/// Default pattern for redacted headers or query parameters.
+pub const REDACTED_PATTERN: &str = "REDACTED";

--- a/sdk/typespec/src/http/response.rs
+++ b/sdk/typespec/src/http/response.rs
@@ -4,7 +4,7 @@
 //! HTTP responses.
 
 use crate::{
-    http::{Headers, StatusCode},
+    http::{headers::Headers, StatusCode},
     Bytes,
 };
 #[cfg(any(feature = "json", feature = "xml"))]

--- a/sdk/typespec/typespec_client_core/CHANGELOG.md
+++ b/sdk/typespec/typespec_client_core/CHANGELOG.md
@@ -9,7 +9,6 @@
 - Changed `ClientOptions::retry` from `Option<RetryOptions>` to `RetryOptions`.
 - Changed `RawResponse::json()` from `async` to synchronous function. The body was already buffered.
 - Changed `RawResponse::xml()` from `async` to synchronous function. The body was already buffered.
-- Moved `AsHeaders`, `FromHeaders`, `Header`, `Headers`, `HeaderName`, and `HeaderValue` to `http::headers` module to align with `typespec_client_core`.
 - Removed `ErrorKind::http_response()`. Construct an `ErrorResponse::HttpResponse` variant instead.
 - Renamed `TransportOptions` to `Transport`.
 - Renamed `TransportOptions::new_custom_policy()` to `Transport::with_policy()`.
@@ -17,9 +16,6 @@
 ### Bugs Fixed
 
 ### Other Changes
-
-- Made `http::headers` a public module to align with `typespec_client_core`.
-- Made `http::response` a public module to align with `typespec_client_core`.
 
 ## 0.7.0 (2025-09-11)
 

--- a/sdk/typespec/typespec_client_core/CHANGELOG.md
+++ b/sdk/typespec/typespec_client_core/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Changed `ClientOptions::retry` from `Option<RetryOptions>` to `RetryOptions`.
 - Changed `RawResponse::json()` from `async` to synchronous function. The body was already buffered.
 - Changed `RawResponse::xml()` from `async` to synchronous function. The body was already buffered.
+- Moved `AsHeaders`, `FromHeaders`, `Header`, `Headers`, `HeaderName`, and `HeaderValue` to `http::headers` module to align with `typespec_client_core`.
 - Removed `ErrorKind::http_response()`. Construct an `ErrorResponse::HttpResponse` variant instead.
 - Renamed `TransportOptions` to `Transport`.
 - Renamed `TransportOptions::new_custom_policy()` to `Transport::with_policy()`.
@@ -16,6 +17,9 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- Made `http::headers` a public module to align with `typespec_client_core`.
+- Made `http::response` a public module to align with `typespec_client_core`.
 
 ## 0.7.0 (2025-09-11)
 

--- a/sdk/typespec/typespec_client_core/src/http/headers/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/headers/mod.rs
@@ -6,4 +6,4 @@
 mod common;
 
 pub use common::*;
-pub use typespec::http::{AsHeaders, FromHeaders, Header, HeaderName, HeaderValue, Headers};
+pub use typespec::http::headers::*;

--- a/sdk/typespec/typespec_client_core/src/http/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/mod.rs
@@ -24,11 +24,11 @@ pub use models::*;
 pub use options::*;
 pub use pipeline::*;
 pub use request::{Body, Request, RequestContent};
-pub use response::{BufResponse, Response};
+pub use response::{BufResponse, RawResponse, Response};
 pub use sanitizer::*;
 
 // Re-export important types.
-pub use typespec::http::{RawResponse, StatusCode};
+pub use typespec::http::StatusCode;
 pub use url::Url;
 
 /// Add a new query pair into the target [`Url`]'s query string.

--- a/sdk/typespec/typespec_client_core/src/http/request/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/request/mod.rs
@@ -340,6 +340,7 @@ mod decimal {
     use std::convert::Infallible;
 
     #[allow(
+        unknown_lints,
         clippy::infallible_try_from,
         reason = "maintain a consistent pattern of `try_into()`"
     )]
@@ -354,6 +355,7 @@ mod decimal {
     }
 
     #[allow(
+        unknown_lints,
         clippy::infallible_try_from,
         reason = "maintain a consistent pattern of `try_into()`"
     )]

--- a/sdk/typespec/typespec_client_core/src/http/response.rs
+++ b/sdk/typespec/typespec_client_core/src/http/response.rs
@@ -4,13 +4,14 @@
 //! HTTP responses.
 
 use crate::{
-    http::{headers::Headers, DeserializeWith, Format, JsonFormat, RawResponse, StatusCode},
+    http::{headers::Headers, DeserializeWith, Format, JsonFormat, StatusCode},
     Bytes,
 };
 use futures::{Stream, StreamExt};
 use serde::de::DeserializeOwned;
 use std::{fmt, marker::PhantomData, pin::Pin};
 use typespec::error::{ErrorKind, ResultExt};
+pub use typespec::http::response::*;
 
 /// A pinned stream of bytes that can be sent as a response body.
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
Missed a few things in the last release that didn't show up in tests/examples because we don't need to refer to them by name...which we couldn't have imported.
