### PR TITLE
Ensure azure_identity docs include ClientCertificateCredential

### DIFF
--- a/sdk/identity/azure_identity/Cargo.toml
+++ b/sdk/identity/azure_identity/Cargo.toml
@@ -44,4 +44,4 @@ client_certificate = ["openssl"]
 workspace = true
 
 [package.metadata.docs.rs]
-features = ["client_certificate"]
+all-features = true

--- a/sdk/identity/azure_identity/Cargo.toml
+++ b/sdk/identity/azure_identity/Cargo.toml
@@ -42,3 +42,6 @@ client_certificate = ["openssl"]
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+features = ["client_certificate"]

--- a/sdk/identity/azure_identity/README.md
+++ b/sdk/identity/azure_identity/README.md
@@ -165,7 +165,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 [Azure CLI]: https://learn.microsoft.com/cli/azure
 [azure_security_keyvault_secrets]: https://github.com/Azure/azure-sdk-for-rust/tree/main/sdk/keyvault/azure_security_keyvault_secrets
 [Azure subscription]: https://azure.microsoft.com/free/
-[cert_cred_ref]: https://docs.rs/azure_identity/latest/azure_identity/struct.ClientCertificateCredential.html
+[cert_cred_ref]: https://aka.ms/azsdk/rust/identity/cert-docs
 [cli_cred_ref]: https://docs.rs/azure_identity/latest/azure_identity/struct.AzureCliCredential.html
 [devtool_cred_ref]: https://aka.ms/azsdk/rust/identity/docs#structs
 [managed_id_cred_ref]: https://docs.rs/azure_identity/latest/azure_identity/struct.ManagedIdentityCredential.html


### PR DESCRIPTION
#2933 removed this metadata on the assumption that docs.rs defaults to building with all features, however it actually defaults to building with none (see [the docs](https://docs.rs/about/metadata)) with the result that ClientCertificateCredential isn't documented for [0.28.0](https://docs.rs/azure_identity/0.28.0/azure_identity/#structs). This PR fudges the now-broken link to that type's docs so our CI runs can succeed and tells docs.rs to build with the client_certificate feature. I'll unfudge the link after the next release.