### PR TITLE
Release patch semver for core crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "azure_core_amqp"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "azure_core",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "azure_core_macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "azure_core_opentelemetry"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "azure_core",
  "azure_core_test",
@@ -3146,7 +3146,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "typespec"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64",
  "bytes",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "typespec_client_core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "typespec_macros"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "cargo_metadata",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,28 +40,28 @@ rust-version = "1.85"
 [workspace.dependencies.typespec]
 default-features = false
 path = "sdk/typespec"
-version = "0.9.0"
+version = "0.9.1"
 
 [workspace.dependencies.typespec_client_core]
 default-features = false
 path = "sdk/typespec/typespec_client_core"
-version = "0.8.0"
+version = "0.8.1"
 
 [workspace.dependencies.typespec_macros]
-version = "0.8.0"
+version = "0.8.1"
 path = "sdk/typespec/typespec_macros"
 
 [workspace.dependencies.azure_core]
 default-features = false
-version = "0.29.0"
+version = "0.29.1"
 path = "sdk/core/azure_core"
 
 [workspace.dependencies.azure_core_macros]
-version = "0.3.0"
+version = "0.3.1"
 path = "sdk/core/azure_core_macros"
 
 [workspace.dependencies.azure_core_amqp]
-version = "0.8.0"
+version = "0.8.1"
 path = "sdk/core/azure_core_amqp"
 
 [workspace.dependencies.azure_messaging_eventhubs]

--- a/eng/pipelines/templates/jobs/analyze.yml
+++ b/eng/pipelines/templates/jobs/analyze.yml
@@ -21,7 +21,7 @@ jobs:
     parameters:
       paths:
       - "/*"
-      
+
   - ${{ if ne(parameters.Toolchain, 'nightly') }}:
       - template: /eng/pipelines/templates/steps/use-rust.yml@self
         parameters:
@@ -40,6 +40,7 @@ jobs:
       filePath: $(Build.SourcesDirectory)/eng/scripts/Analyze-Code.ps1
       arguments: >
         -PackageInfoDirectory '$(Build.ArtifactStagingDirectory)/PackageInfo'
+        -Toolchain '${{ parameters.Toolchain }}'
         -SkipPackageAnalysis:('$(NoPackagesChanged)' -eq 'true')
         -Deny
 

--- a/eng/pipelines/templates/jobs/analyze.yml
+++ b/eng/pipelines/templates/jobs/analyze.yml
@@ -40,7 +40,7 @@ jobs:
       filePath: $(Build.SourcesDirectory)/eng/scripts/Analyze-Code.ps1
       arguments: >
         -PackageInfoDirectory '$(Build.ArtifactStagingDirectory)/PackageInfo'
-        -Toolchain '${{ parameters.Toolchain }}'
+        -Toolchain 'nightly'
         -SkipPackageAnalysis:('$(NoPackagesChanged)' -eq 'true')
         -Deny
 

--- a/eng/scripts/Analyze-Code.ps1
+++ b/eng/scripts/Analyze-Code.ps1
@@ -3,7 +3,7 @@
 #Requires -Version 7.0
 param(
   [string]$PackageInfoDirectory,
-  [string]$Toolchain = 'stable'
+  [string]$Toolchain = 'stable',
   [switch]$CheckWasm = $true,
   [switch]$Deny,
   [switch]$SkipPackageAnalysis

--- a/eng/scripts/Analyze-Code.ps1
+++ b/eng/scripts/Analyze-Code.ps1
@@ -3,6 +3,7 @@
 #Requires -Version 7.0
 param(
   [string]$PackageInfoDirectory,
+  [string]$Toolchain = 'stable'
   [switch]$CheckWasm = $true,
   [switch]$Deny,
   [switch]$SkipPackageAnalysis
@@ -115,6 +116,16 @@ if (!$SkipPackageAnalysis) {
     return $result
   }
 
+  if ($Toolchain -eq 'nightly') {
+    # Temporary fix to exit immediately on failure. LogError should Write-Error
+    # instead
+    $command = "cargo install --locked cargo-docs-rs"
+    Invoke-LoggedCommand $command
+    if ($LastExitCode) {
+      Write-Error "Failed to execute $command"
+    }
+  }
+
   $packagesToTest = Get-ChildItem $PackageInfoDirectory -Filter "*.json" -Recurse
   | Get-Content -Raw
   | ConvertFrom-Json
@@ -127,6 +138,16 @@ if (!$SkipPackageAnalysis) {
     Invoke-LoggedCommand $command
     if ($LastExitCode) {
       Write-Error "Failed to execute $command"
+    }
+
+    if ($Toolchain -eq 'nightly') {
+      # Temporary fix to exit immediately on failure. LogError should Write-Error
+      # instead
+      $command = "cargo +nightly docs-rs --package "
+      Invoke-LoggedCommand $command
+      if ($LastExitCode) {
+        Write-Error "Failed to execute $command"
+      }
     }
   }
 }

--- a/eng/scripts/Analyze-Code.ps1
+++ b/eng/scripts/Analyze-Code.ps1
@@ -143,7 +143,7 @@ if (!$SkipPackageAnalysis) {
     if ($Toolchain -eq 'nightly') {
       # Temporary fix to exit immediately on failure. LogError should Write-Error
       # instead
-      $command = "cargo +nightly docs-rs --package "
+      $command = "cargo +nightly docs-rs --package $($package.Name)"
       Invoke-LoggedCommand $command
       if ($LastExitCode) {
         Write-Error "Failed to execute $command"

--- a/sdk/canary/azure_canary_core/src/lib.rs
+++ b/sdk/canary/azure_canary_core/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 
 /// Core numeric traits and types

--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.29.1 (2025-10-06)
+
+### Bugs Fixed
+
+- Fix feature documentation ([#3118](https://github.com/Azure/azure-sdk-for-rust/issues/3118))
+
 ## 0.29.0 (2025-10-03)
 
 ### Features Added

--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.29.1 (2025-10-06)
 
+### Breaking Changes
+
+- Removed the `azurite_workaround` feature (unused).
+
 ### Bugs Fixed
 
 - Fix feature documentation ([#3118](https://github.com/Azure/azure-sdk-for-rust/issues/3118))

--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -61,7 +61,6 @@ default = [
   "reqwest_gzip",
   "reqwest_native_tls",
 ]
-azurite_workaround = []
 debug = ["typespec_client_core/debug"]
 decimal = ["typespec_client_core/decimal"]
 hmac_openssl = ["dep:openssl"]

--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_core"
-version = "0.29.0"
+version = "0.29.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Core crate"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/core/azure_core/README.md
+++ b/sdk/core/azure_core/README.md
@@ -55,7 +55,7 @@ We guarantee that all client instance methods are thread-safe and independent of
 - `reqwest` (default): enables and sets `reqwest` as the default `HttpClient`.
 - `reqwest_deflate` (default): enables deflate compression for `reqwest`.
 - `reqwest_gzip` (default): enables gzip compression for `reqwest`.
-- `reqwest_native-tls` (default): enables `reqwest`'s `native-tls` feature, which uses schannel on Windows and openssl elsewhere.
+- `reqwest_native_tls` (default): enables `reqwest`'s `native-tls` feature, which uses schannel on Windows and openssl elsewhere.
 - `tokio`: enables and sets `tokio` as the default async runtime.
 - `wasm_bindgen`: enables the async runtime for WASM.
 - `xml`: enables XML support.

--- a/sdk/core/azure_core/src/lib.rs
+++ b/sdk/core/azure_core/src/lib.rs
@@ -4,7 +4,7 @@
 #![forbid(unsafe_code)]
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 
 #[macro_use]

--- a/sdk/core/azure_core_amqp/CHANGELOG.md
+++ b/sdk/core/azure_core_amqp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.8.1 (2025-10-06)
+
+### Bugs Fixed
+
+- Fix feature documentation ([#3118](https://github.com/Azure/azure-sdk-for-rust/issues/3118))
+
 ## 0.8.0 (2025-10-03)
 
 ### Breaking Changes

--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -3,7 +3,7 @@
 # AMQP Stack for consumption by packages in the Azure SDK.
 [package]
 name = "azure_core_amqp"
-version = "0.8.0"
+version = "0.8.1"
 description = "Rust client library for the AMQP protocol"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/core/azure_core_amqp/src/lib.rs
+++ b/sdk/core/azure_core_amqp/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 
 #[cfg(all(feature = "fe2o3_amqp", not(target_arch = "wasm32")))]

--- a/sdk/core/azure_core_macros/CHANGELOG.md
+++ b/sdk/core/azure_core_macros/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.3.1 (2025-10-06)
+
+### Bugs Fixed
+
+- Fix feature documentation ([#3118](https://github.com/Azure/azure-sdk-for-rust/issues/3118))
+
 ## 0.3.0 (2025-10-03)
 
 ### Other Changes

--- a/sdk/core/azure_core_macros/Cargo.toml
+++ b/sdk/core/azure_core_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_core_macros"
-version = "0.3.0"
+version = "0.3.1"
 description = "Procedural macros for client libraries built on azure_core."
 readme = "README.md"
 authors.workspace = true
@@ -20,8 +20,8 @@ proc-macro = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
-typespec_client_core = { workspace = true, features = ["http", "json"] }
 tracing.workspace = true
+typespec_client_core = { workspace = true, features = ["http", "json"] }
 
 [dev-dependencies]
 tokio.workspace = true

--- a/sdk/core/azure_core_macros/src/lib.rs
+++ b/sdk/core/azure_core_macros/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 
 mod tracing;

--- a/sdk/core/azure_core_opentelemetry/CHANGELOG.md
+++ b/sdk/core/azure_core_opentelemetry/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.3.1 (2025-10-06)
+
+### Bugs Fixed
+
+- Fix feature documentation ([#3118](https://github.com/Azure/azure-sdk-for-rust/issues/3118))
+
 ## 0.3.0 (2025-10-03)
 
 ### Other Changes

--- a/sdk/core/azure_core_opentelemetry/Cargo.toml
+++ b/sdk/core/azure_core_opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_core_opentelemetry"
-version = "0.3.0"
+version = "0.3.1"
 description = "OpenTelemetry integration for the Azure SDK for Rust"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/core/azure_core_opentelemetry/src/lib.rs
+++ b/sdk/core/azure_core_opentelemetry/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 
 mod attributes;

--- a/sdk/cosmos/azure_data_cosmos/src/lib.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/lib.rs
@@ -2,13 +2,7 @@
 // Licensed under the MIT License.
 
 #![doc = include_str!("../README.md")]
-// Docs.rs build is done with the nightly compiler, so we can enable nightly features in that build.
-// In this case we enable two features:
-// - `doc_auto_cfg`: Automatically scans `cfg` attributes and uses them to show those required configurations in the generated documentation.
-// - `doc_cfg_hide`: Ignore the `doc` configuration for `doc_auto_cfg`.
-// See https://doc.rust-lang.org/rustdoc/unstable-features.html#doc_auto_cfg-automatically-generate-doccfg for more details.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![cfg_attr(docsrs, feature(doc_cfg_hide))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod clients;
 mod connection_string;

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/lib.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/lib.rs
@@ -4,7 +4,7 @@
 #![recursion_limit = "128"]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "in_memory_checkpoint_store")]
 mod in_memory_checkpoint_store;

--- a/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/src/lib.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/src/lib.rs
@@ -4,7 +4,7 @@
 #![recursion_limit = "128"]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod checkpoint_store;
 pub use checkpoint_store::BlobCheckpointStore;

--- a/sdk/identity/azure_identity/src/lib.rs
+++ b/sdk/identity/azure_identity/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 
 mod app_service_managed_identity_credential;

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/lib.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod clients;
 #[allow(unused_imports)]

--- a/sdk/keyvault/azure_security_keyvault_keys/src/lib.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod generated;
 mod resource;

--- a/sdk/keyvault/azure_security_keyvault_secrets/src/lib.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod generated;
 mod resource;

--- a/sdk/servicebus/azure_messaging_servicebus/src/lib.rs
+++ b/sdk/servicebus/azure_messaging_servicebus/src/lib.rs
@@ -4,7 +4,7 @@
 #![recursion_limit = "128"]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 /// Service Bus client
 pub mod client;

--- a/sdk/storage/azure_storage_blob/src/lib.rs
+++ b/sdk/storage/azure_storage_blob/src/lib.rs
@@ -6,7 +6,7 @@
 #![doc = include_str!("../README.md")]
 #![allow(dead_code)]
 #![allow(unused_imports)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod clients;
 mod generated;

--- a/sdk/typespec/CHANGELOG.md
+++ b/sdk/typespec/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.9.1 (2025-10-06)
+
+### Bugs Fixed
+
+- Fix feature documentation ([#3118](https://github.com/Azure/azure-sdk-for-rust/issues/3118))
+
 ## 0.9.0 (2025-10-03)
 
 ### Features Added

--- a/sdk/typespec/Cargo.toml
+++ b/sdk/typespec/Cargo.toml
@@ -30,5 +30,8 @@ http = []
 json = ["dep:serde", "dep:serde_json"]
 xml = ["dep:quick-xml"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [lints]
 workspace = true

--- a/sdk/typespec/Cargo.toml
+++ b/sdk/typespec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typespec"
-version = "0.9.0"
+version = "0.9.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/sdk/typespec/README.md
+++ b/sdk/typespec/README.md
@@ -7,3 +7,4 @@ Project [root crate](https://rust-lang.github.io/rfcs/3243-packages-as-optional-
 * `amqp`: enables AMQP support.
 * `http` (default): enables HTTP support.
 * `json` (default): enables JSON support.
+* `xml`: enables XML support.

--- a/sdk/typespec/src/lib.rs
+++ b/sdk/typespec/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 
 pub mod error;

--- a/sdk/typespec/typespec_client_core/CHANGELOG.md
+++ b/sdk/typespec/typespec_client_core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.8.1 (2025-10-06)
+
+### Bugs Fixed
+
+- Fix feature documentation ([#3118](https://github.com/Azure/azure-sdk-for-rust/issues/3118))
+
 ## 0.8.0 (2025-10-03)
 
 ### Features Added

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typespec_client_core"
-version = "0.8.0"
+version = "0.8.1"
 authors.workspace = true
 edition.workspace = true
 description = "Client runtime for TypeSpec-generated libraries."

--- a/sdk/typespec/typespec_client_core/README.md
+++ b/sdk/typespec/typespec_client_core/README.md
@@ -12,7 +12,7 @@ This is the runtime for [TypeSpec](https://typespec.io)-generated clients.
 - `reqwest` (default): enables and sets `reqwest` as the default `HttpClient`. Enables `reqwest`'s `native-tls` feature.
 - `reqwest_deflate` (default): enables deflate compression for `reqwest`.
 - `reqwest_gzip` (default): enables gzip compression for `reqwest`.
-- `reqwest_native-tls` (default): enables `reqwest`'s `native-tls` feature, which uses schannel on Windows and openssl elsewhere.
+- `reqwest_native_tls` (default): enables `reqwest`'s `native-tls` feature, which uses schannel on Windows and openssl elsewhere.
 - `tokio`: enables and sets `tokio` as the default async runtime.
 - `wasm_bindgen`: enables the async runtime for WASM.
 - `xml`: enables XML support.

--- a/sdk/typespec/typespec_client_core/src/lib.rs
+++ b/sdk/typespec/typespec_client_core/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 
 pub mod async_runtime;

--- a/sdk/typespec/typespec_macros/CHANGELOG.md
+++ b/sdk/typespec/typespec_macros/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.8.1 (2025-10-06)
+
+### Bugs Fixed
+
+- Fix feature documentation ([#3118](https://github.com/Azure/azure-sdk-for-rust/issues/3118))
+
 ## 0.8.0 (2025-10-03)
 
 ### Features Added

--- a/sdk/typespec/typespec_macros/Cargo.toml
+++ b/sdk/typespec/typespec_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typespec_macros"
-version = "0.8.0"
+version = "0.8.1"
 authors.workspace = true
 edition.workspace = true
 description = "Procedural macros for client libraries built on typespec."

--- a/sdk/typespec/typespec_macros/src/lib.rs
+++ b/sdk/typespec/typespec_macros/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 
 //! This crate contains procedural macros that are used to generate code for the TypeSpec SDK.


### PR DESCRIPTION
Fixes #3117 and fixes #3118 by renaming `doc_auto_cfg` and `doc_cfg_hide` to just `doc_cfg` after rust-lang/rust#138907 was merged and released in the new nightly toolchain docs.rs uses.
