### PR TITLE
[Storage] Downgrade core version to point to current released version (0.29.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "0.30.0"
+version = "0.29.1"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ path = "sdk/core/typespec_macros"
 
 [workspace.dependencies.azure_core]
 default-features = false
-version = "0.30.0"
+version = "0.29.1"
 path = "sdk/core/azure_core"
 
 [workspace.dependencies.azure_core_macros]

--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_core"
-version = "0.30.0"
+version = "0.29.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Core crate"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -19,7 +19,7 @@ edition.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-azure_core = { path = "../azure_core", version = "0.30.0", default-features = false }
+azure_core = { path = "../azure_core", version = "0.29.1", default-features = false }
 fe2o3-amqp = { workspace = true, optional = true }
 fe2o3-amqp-cbs = { workspace = true, optional = true }
 fe2o3-amqp-ext = { workspace = true, optional = true }

--- a/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
@@ -20,7 +20,7 @@ edition.workspace = true
 async-lock.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
-azure_core = { path = "../../core/azure_core", version = "0.30.0", default-features = false }
+azure_core = { path = "../../core/azure_core", version = "0.29.1", default-features = false }
 azure_core_amqp.workspace = true
 futures.workspace = true
 rand.workspace = true

--- a/sdk/servicebus/azure_messaging_servicebus/Cargo.toml
+++ b/sdk/servicebus/azure_messaging_servicebus/Cargo.toml
@@ -20,7 +20,7 @@ publish = false
 async-lock.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
-azure_core = { path = "../../core/azure_core", version = "0.30.0", default-features = false }
+azure_core = { path = "../../core/azure_core", version = "0.29.1", default-features = false }
 azure_core_amqp.workspace = true
 futures.workspace = true
 rand.workspace = true


### PR DESCRIPTION
We cannot do a release of queues currently because the core dependency is pointing to an unreleased version. Will need to do the same fix as https://github.com/Azure/azure-sdk-for-rust/pull/3160