### PR TITLE
[Storage] Bump `azure_storage_queue` to `v0.2.0` post-release, uncomment hyperlinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ version = "0.1.0"
 
 [[package]]
 name = "azure_storage_queue"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "azure_core",
  "azure_core_test",

--- a/sdk/storage/azure_storage_queue/CHANGELOG.md
+++ b/sdk/storage/azure_storage_queue/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 0.2.0 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 0.1.0 (2025-10-15)
 
 ### Features Added

--- a/sdk/storage/azure_storage_queue/Cargo.toml
+++ b/sdk/storage/azure_storage_queue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_storage_queue"
-version = "0.1.0"
+version = "0.2.0"
 description = "Microsoft Azure Queue client library for Rust"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/storage/azure_storage_queue/README.md
+++ b/sdk/storage/azure_storage_queue/README.md
@@ -81,7 +81,6 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-<!-- TODO: Uncomment the links below when the PR is merged -->
 <!-- LINKS -->
 [Azure subscription]: https://azure.microsoft.com/free/
 [Azure storage account]: https://learn.microsoft.com/azure/storage/common/storage-account-overview
@@ -90,8 +89,8 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 [Azure CLI]: https://learn.microsoft.com/azure/storage/common/storage-quickstart-create-account?tabs=azure-cli
 [cargo]: https://dev-doc.rust-lang.org/stable/cargo/commands/cargo.html
 [Azure Identity]: https://github.com/Azure/azure-sdk-for-rust/tree/main/sdk/identity/azure_identity
-<!--[API reference documentation]: https://docs.rs/crate/azure_storage_queue/latest-->
-<!--[Package (crates.io)]: https://crates.io/crates/azure_storage_queue-->
+[API reference documentation]: https://docs.rs/crate/azure_storage_queue/latest
+[Package (crates.io)]: https://crates.io/crates/azure_storage_queue
 [Source code]: https://github.com/Azure/azure-sdk-for-rust/tree/main/sdk/storage/azure_storage_queue
 [REST API documentation]: https://learn.microsoft.com/rest/api/storageservices/blob-service-rest-api
 [Product documentation]: https://learn.microsoft.com/azure/storage/blobs/storage-blobs-overview


### PR DESCRIPTION
As title states.

- Bump to next version after `v0.1.0` release
- Uncomment hyperlinks now that the package is live 