### PR TITLE
[Storage] Improve `list_blobs()` API name struct field accessor

### DIFF
--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_client.rs
@@ -930,7 +930,7 @@ impl BlobClient {
     ///
     /// ## Response Headers
     ///
-    /// The returned [`AsyncResponse`](azure_core::http::AsyncResponse) implements the [`BlobClientDownloadResultHeaders`] trait, which provides
+    /// The returned [`Response`](azure_core::http::Response) implements the [`BlobClientDownloadResultHeaders`] trait, which provides
     /// access to response headers. For example:
     ///
     /// ```no_run

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
@@ -25,7 +25,6 @@ use crate::generated::{
     },
 };
 use azure_core::{
-    async_runtime::get_async_runtime,
     credentials::TokenCredential,
     error::CheckSuccessOptions,
     fmt::SafeDebug,
@@ -905,10 +904,8 @@ impl BlobContainerClient {
                             }),
                         )
                         .await?;
-                    // Because serialization can be a CPU intensive operation, yield the CPU before executing it..
-                    get_async_runtime().yield_now().await;
                     let (status, headers, body) = rsp.deconstruct();
-                    let res: ListBlobsFlatSegmentResponse = xml::from_xml(&body)?;
+                    let res: ListBlobsFlatSegmentResponse = xml::read_xml(&body)?;
                     let rsp = RawResponse::from_bytes(status, headers, body).into();
                     Ok(match res.next_marker {
                         Some(next_marker) if !next_marker.is_empty() => PagerResult::More {
@@ -1036,7 +1033,7 @@ impl BlobContainerClient {
                         )
                         .await?;
                     let (status, headers, body) = rsp.deconstruct();
-                    let res: ListBlobsHierarchySegmentResponse = xml::from_xml(&body)?;
+                    let res: ListBlobsHierarchySegmentResponse = xml::read_xml(&body)?;
                     let rsp = RawResponse::from_bytes(status, headers, body).into();
                     Ok(match res.next_marker {
                         Some(next_marker) if !next_marker.is_empty() => PagerResult::More {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
@@ -498,7 +498,7 @@ impl BlobServiceClient {
                         )
                         .await?;
                     let (status, headers, body) = rsp.deconstruct();
-                    let res: ListContainersSegmentResponse = xml::from_xml(&body)?;
+                    let res: ListContainersSegmentResponse = xml::read_xml(&body)?;
                     let rsp = RawResponse::from_bytes(status, headers, body).into();
                     Ok(match res.next_marker {
                         Some(next_marker) if !next_marker.is_empty() => PagerResult::More {

--- a/sdk/storage/azure_storage_blob/src/generated/models/pub_models.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/pub_models.rs
@@ -14,7 +14,7 @@ use super::{
     QueryRequestType, QueryType, RehydratePriority,
 };
 use azure_core::{
-    base64::option::{deserialize, serialize},
+    base64::{deserialize, serialize},
     fmt::SafeDebug,
     time::OffsetDateTime,
 };
@@ -256,7 +256,7 @@ pub struct BlobItemInternal {
 
     /// The name of the blob.
     #[serde(rename = "Name", skip_serializing_if = "Option::is_none")]
-    pub name: Option<BlobName>,
+    pub name: Option<String>,
 
     /// The object replication metadata of the blob.
     #[serde(rename = "OrMetadata", skip_serializing_if = "Option::is_none")]

--- a/sdk/storage/azure_storage_blob/tsp-location.yaml
+++ b/sdk/storage/azure_storage_blob/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/storage/Microsoft.BlobStorage
-commit: cc4322ec468b171e696330258ea59c3b3f657104
+commit: 1227e9ce214ee17f72946fe749bce75666237367
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 


### PR DESCRIPTION
Making this just to illustrate that despite consuming:
```typespec
/** The name of the blob. */
  @Xml.name("Name") name: string;
```

This field is coming back optional? 

Relevant snippet from [branch](https://github.com/Azure/azure-rest-api-specs/blob/1227e9ce214ee17f72946fe749bce75666237367/specification/storage/Microsoft.BlobStorage/models.tsp#L872): 
```typespec
/** An Azure Storage Blob */
@Xml.name("Blob")
model BlobItemInternal {
  /** The name of the blob. */
  @Xml.name("Name") name: string;
```
