### PR TITLE
Rename BearerTokenCredentialPolicy -> BearerTokenAuthorizationPolicy

### DIFF
--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Removed `ErrorKind::MockFramework`.
 - Removed `Poller::wait()` function. Call `await` on a `Poller` to wait for it to complete and, upon success, return the final model.
 - Removed `xml::read_xml_str()`.
+- Renamed `BearerTokenCredentialPolicy` to `BearerTokenAuthorizationPolicy`.
 - Renamed `xml::read_xml()` to `xml::from_xml()` congruent with `json::from_json()`.
 
 ### Bugs Fixed

--- a/sdk/core/azure_core/src/http/policies/bearer_token_policy.rs
+++ b/sdk/core/azure_core/src/http/policies/bearer_token_policy.rs
@@ -17,14 +17,14 @@ use typespec_client_core::time::{Duration, OffsetDateTime};
 
 /// Authentication policy for a bearer token.
 #[derive(Debug, Clone)]
-pub struct BearerTokenCredentialPolicy {
+pub struct BearerTokenAuthorizationPolicy {
     credential: Arc<dyn TokenCredential>,
     scopes: Vec<String>,
     access_token: Arc<RwLock<Option<AccessToken>>>,
 }
 
-impl BearerTokenCredentialPolicy {
-    /// Creates a new `BearerTokenCredentialPolicy`.
+impl BearerTokenAuthorizationPolicy {
+    /// Creates a new `BearerTokenAuthorizationPolicy`.
     pub fn new<A, B>(credential: Arc<dyn TokenCredential>, scopes: A) -> Self
     where
         A: IntoIterator<Item = B>,
@@ -52,7 +52,7 @@ impl BearerTokenCredentialPolicy {
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl Policy for BearerTokenCredentialPolicy {
+impl Policy for BearerTokenAuthorizationPolicy {
     async fn send(
         &self,
         ctx: &Context,
@@ -209,7 +209,7 @@ mod tests {
     async fn authn_error() {
         // this mock's get_token() will return an error because it has no tokens
         let credential = MockCredential::new(&[]);
-        let policy = BearerTokenCredentialPolicy::new(Arc::new(credential), ["scope"]);
+        let policy = BearerTokenAuthorizationPolicy::new(Arc::new(credential), ["scope"]);
         let client = MockHttpClient::new(|_| panic!("expected an error from get_token"));
         let transport = Arc::new(TransportPolicy::new(Transport::new(Arc::new(client))));
         let mut req = Request::new("https://localhost".parse().unwrap(), Method::Get);
@@ -228,7 +228,7 @@ mod tests {
 
     async fn run_test(tokens: &[AccessToken]) {
         let credential = Arc::new(MockCredential::new(tokens));
-        let policy = BearerTokenCredentialPolicy::new(credential.clone(), ["scope"]);
+        let policy = BearerTokenAuthorizationPolicy::new(credential.clone(), ["scope"]);
         let client = Arc::new(MockHttpClient::new(move |actual| {
             let credential = credential.clone();
             async move {

--- a/sdk/core/azure_core/src/http/policies/mod.rs
+++ b/sdk/core/azure_core/src/http/policies/mod.rs
@@ -8,7 +8,7 @@ mod client_request_id;
 mod instrumentation;
 mod user_agent;
 
-pub use bearer_token_policy::BearerTokenCredentialPolicy;
+pub use bearer_token_policy::BearerTokenAuthorizationPolicy;
 pub use client_request_id::*;
 pub use instrumentation::*;
 pub use typespec_client_core::http::policies::*;

--- a/sdk/core/azure_core_macros/src/tracing_new.rs
+++ b/sdk/core/azure_core_macros/src/tracing_new.rs
@@ -542,7 +542,7 @@ mod tests {
                     ));
                 }
                 endpoint.set_query(None);
-                let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+                let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
                     credential,
                     vec!["https://vault.azure.net/.default"],
                 ));
@@ -581,7 +581,7 @@ mod tests {
                     ));
                 }
                 endpoint.set_query(None);
-                let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+                let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
                     credential,
                     vec!["https://vault.azure.net/.default"],
                 ));
@@ -635,7 +635,7 @@ mod tests {
                     ));
                 }
                 endpoint.set_query(None);
-                let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+                let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
                     credential,
                     vec!["https://vault.azure.net/.default"],
                 ));
@@ -674,7 +674,7 @@ mod tests {
                     ));
                 }
                 endpoint.set_query(None);
-                let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+                let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
                     credential,
                     vec!["https://vault.azure.net/.default"],
                 ));

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/generated/clients/certificate_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/generated/clients/certificate_client.rs
@@ -32,7 +32,7 @@ use azure_core::{
     fmt::SafeDebug,
     http::{
         pager::{PagerResult, PagerState},
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         ClientOptions, Method, NoFormat, Pager, Pipeline, PipelineSendOptions, RawResponse,
         Request, RequestContent, Response, Url,
     },
@@ -80,7 +80,7 @@ impl CertificateClient {
                 format!("{endpoint} must use http(s)"),
             ));
         }
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
             vec!["https://vault.azure.net/.default"],
         ));

--- a/sdk/keyvault/azure_security_keyvault_keys/src/generated/clients/key_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/generated/clients/key_client.rs
@@ -26,7 +26,7 @@ use azure_core::{
     fmt::SafeDebug,
     http::{
         pager::{PagerResult, PagerState},
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         ClientOptions, Method, NoFormat, Pager, Pipeline, PipelineSendOptions, RawResponse,
         Request, RequestContent, Response, Url,
     },
@@ -74,7 +74,7 @@ impl KeyClient {
                 format!("{endpoint} must use http(s)"),
             ));
         }
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
             vec!["https://vault.azure.net/.default"],
         ));

--- a/sdk/keyvault/azure_security_keyvault_secrets/src/generated/clients/secret_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/src/generated/clients/secret_client.rs
@@ -20,7 +20,7 @@ use azure_core::{
     fmt::SafeDebug,
     http::{
         pager::{PagerResult, PagerState},
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         ClientOptions, Method, NoFormat, Pager, Pipeline, PipelineSendOptions, RawResponse,
         Request, RequestContent, Response, Url,
     },
@@ -68,7 +68,7 @@ impl SecretClient {
                 format!("{endpoint} must use http(s)"),
             ));
         }
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
             vec!["https://vault.azure.net/.default"],
         ));

--- a/sdk/storage/azure_storage_blob/src/clients/append_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/append_blob_client.rs
@@ -15,7 +15,7 @@ use crate::{
 use azure_core::{
     credentials::TokenCredential,
     http::{
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         NoFormat, Pipeline, RequestContent, Response, Url,
     },
     tracing, Bytes, Result,
@@ -56,7 +56,7 @@ impl GeneratedAppendBlobClient {
                     format!("{blob_url} must use https"),
                 ));
             }
-            let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+            let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
                 token_credential,
                 vec!["https://storage.azure.com/.default"],
             ));

--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -29,7 +29,7 @@ use azure_core::{
     credentials::TokenCredential,
     error::ErrorKind,
     http::{
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         AsyncResponse, JsonFormat, NoFormat, Pipeline, RequestContent, Response, StatusCode, Url,
         XmlFormat,
     },
@@ -72,7 +72,7 @@ impl GeneratedBlobClient {
                     format!("{blob_url} must use https"),
                 ));
             }
-            let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+            let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
                 token_credential,
                 vec!["https://storage.azure.com/.default"],
             ));

--- a/sdk/storage/azure_storage_blob/src/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_container_client.rs
@@ -24,7 +24,7 @@ use azure_core::{
     credentials::TokenCredential,
     error::ErrorKind,
     http::{
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         NoFormat, PageIterator, Pager, Pipeline, Response, StatusCode, Url, XmlFormat,
     },
     tracing, Result,
@@ -65,7 +65,7 @@ impl GeneratedBlobContainerClient {
                     format!("{container_url} must use https"),
                 ));
             }
-            let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+            let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
                 token_credential,
                 vec!["https://storage.azure.com/.default"],
             ));

--- a/sdk/storage/azure_storage_blob/src/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_service_client.rs
@@ -17,7 +17,7 @@ use crate::{
 use azure_core::{
     credentials::TokenCredential,
     http::{
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         NoFormat, PageIterator, Pipeline, RequestContent, Response, Url, XmlFormat,
     },
     tracing, Result,
@@ -58,7 +58,7 @@ impl GeneratedBlobServiceClient {
                     format!("{blob_service_url} must use https"),
                 ));
             }
-            let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+            let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
                 token_credential,
                 vec!["https://storage.azure.com/.default"],
             ));

--- a/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
@@ -21,7 +21,7 @@ use crate::{
 use azure_core::{
     credentials::TokenCredential,
     http::{
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         NoFormat, Pipeline, RequestContent, Response, Url, XmlFormat,
     },
     tracing, Bytes, Result,
@@ -62,7 +62,7 @@ impl GeneratedBlockBlobClient {
                     format!("{blob_url} must use https"),
                 ));
             }
-            let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+            let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
                 token_credential,
                 vec!["https://storage.azure.com/.default"],
             ));

--- a/sdk/storage/azure_storage_blob/src/clients/page_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/page_blob_client.rs
@@ -18,7 +18,7 @@ use crate::{
 use azure_core::{
     credentials::TokenCredential,
     http::{
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         NoFormat, Pipeline, RequestContent, Response, Url, XmlFormat,
     },
     tracing, Bytes, Result,
@@ -59,7 +59,7 @@ impl GeneratedPageBlobClient {
                     format!("{blob_url} must use https"),
                 ));
             }
-            let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+            let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
                 token_credential,
                 vec!["https://storage.azure.com/.default"],
             ));

--- a/sdk/storage/azure_storage_blob/src/generated/clients/append_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/append_blob_client.rs
@@ -15,7 +15,7 @@ use azure_core::{
     error::CheckSuccessOptions,
     fmt::SafeDebug,
     http::{
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         ClientOptions, Method, NoFormat, Pipeline, PipelineSendOptions, Request, RequestContent,
         Response, Url,
     },
@@ -63,7 +63,7 @@ impl AppendBlobClient {
                 format!("{endpoint} must use http(s)"),
             ));
         }
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
             vec!["https://storage.azure.com/.default"],
         ));

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_client.rs
@@ -26,7 +26,7 @@ use azure_core::{
     error::CheckSuccessOptions,
     fmt::SafeDebug,
     http::{
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         AsyncResponse, ClientOptions, Method, NoFormat, Pipeline, PipelineSendOptions,
         PipelineStreamOptions, Request, RequestContent, Response, Url, XmlFormat,
     },
@@ -74,7 +74,7 @@ impl BlobClient {
                 format!("{endpoint} must use http(s)"),
             ));
         }
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
             vec!["https://storage.azure.com/.default"],
         ));

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
@@ -27,7 +27,7 @@ use azure_core::{
     fmt::SafeDebug,
     http::{
         pager::{PagerResult, PagerState},
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         ClientOptions, Method, NoFormat, PageIterator, Pipeline, PipelineSendOptions, RawResponse,
         Request, RequestContent, Response, Url, XmlFormat,
     },
@@ -75,7 +75,7 @@ impl BlobContainerClient {
                 format!("{endpoint} must use http(s)"),
             ));
         }
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
             vec!["https://storage.azure.com/.default"],
         ));

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
@@ -17,7 +17,7 @@ use azure_core::{
     fmt::SafeDebug,
     http::{
         pager::{PagerResult, PagerState},
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         ClientOptions, Method, NoFormat, PageIterator, Pipeline, PipelineSendOptions, RawResponse,
         Request, RequestContent, Response, Url, XmlFormat,
     },
@@ -64,7 +64,7 @@ impl BlobServiceClient {
                 format!("{endpoint} must use http(s)"),
             ));
         }
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
             vec!["https://storage.azure.com/.default"],
         ));

--- a/sdk/storage/azure_storage_blob/src/generated/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/block_blob_client.rs
@@ -18,7 +18,7 @@ use azure_core::{
     error::CheckSuccessOptions,
     fmt::SafeDebug,
     http::{
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         AsyncResponse, ClientOptions, Method, NoFormat, Pipeline, PipelineSendOptions,
         PipelineStreamOptions, Request, RequestContent, Response, Url, XmlFormat,
     },
@@ -66,7 +66,7 @@ impl BlockBlobClient {
                 format!("{endpoint} must use http(s)"),
             ));
         }
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
             vec!["https://storage.azure.com/.default"],
         ));

--- a/sdk/storage/azure_storage_blob/src/generated/clients/page_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/page_blob_client.rs
@@ -20,7 +20,7 @@ use azure_core::{
     error::CheckSuccessOptions,
     fmt::SafeDebug,
     http::{
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         ClientOptions, Method, NoFormat, Pipeline, PipelineSendOptions, Request, RequestContent,
         Response, Url, XmlFormat,
     },
@@ -68,7 +68,7 @@ impl PageBlobClient {
                 format!("{endpoint} must use http(s)"),
             ));
         }
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
             vec!["https://storage.azure.com/.default"],
         ));

--- a/sdk/storage/azure_storage_queue/src/generated/clients/queue_client.rs
+++ b/sdk/storage/azure_storage_queue/src/generated/clients/queue_client.rs
@@ -17,7 +17,7 @@ use azure_core::{
     error::CheckSuccessOptions,
     fmt::SafeDebug,
     http::{
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         ClientOptions, Method, NoFormat, Pipeline, PipelineSendOptions, Request, RequestContent,
         Response, Url, XmlFormat,
     },
@@ -67,7 +67,7 @@ impl QueueClient {
                 format!("{endpoint} must use http(s)"),
             ));
         }
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
             vec!["https://storage.azure.com/.default"],
         ));

--- a/sdk/storage/azure_storage_queue/src/generated/clients/queue_service_client.rs
+++ b/sdk/storage/azure_storage_queue/src/generated/clients/queue_service_client.rs
@@ -17,7 +17,7 @@ use azure_core::{
     fmt::SafeDebug,
     http::{
         pager::{PagerResult, PagerState},
-        policies::{BearerTokenCredentialPolicy, Policy},
+        policies::{BearerTokenAuthorizationPolicy, Policy},
         ClientOptions, Method, NoFormat, PageIterator, Pipeline, PipelineSendOptions, RawResponse,
         Request, RequestContent, Response, Url, XmlFormat,
     },
@@ -64,7 +64,7 @@ impl QueueServiceClient {
                 format!("{endpoint} must use http(s)"),
             ));
         }
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
+        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
             vec!["https://storage.azure.com/.default"],
         ));


### PR DESCRIPTION
Two reasons "authorization" is better than "credential" here:
1. the policy authorizes requests with bearer tokens by setting the "Authorization" header
2. a `TokenCredential` could provide other types of token in addition to or instead of bearer tokens