### PR TITLE
Converted perf tests to benches so they don't conflict with cargo tests

### DIFF
--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -105,7 +105,7 @@ required-features = ["xml"]
 name = "http_transport_benchmarks"
 harness = false
 
-[[test]]
+[[bench]]
 name = "perf"
 path = "perf/perf.rs"
 harness = false

--- a/sdk/core/azure_core_test/src/perf/README.md
+++ b/sdk/core/azure_core_test/src/perf/README.md
@@ -7,7 +7,7 @@ Performance tests are defined in a "perf" directory under the package root.
 By convention, all performance tests are named "perf" and are invoked via:
 
 ```bash
-cargo test --package <package name> --test perf -- {perf test name} {perf test arguments}
+cargo bench --package <package name> --bench perf -- {perf test name} {perf test arguments}
 ```
 
 where `package name` is the name of the rust package, `perf test name` is the name of the test you want to run, and `perf test arguments` is the arguments to that test.
@@ -70,7 +70,7 @@ The process of authoring tests starts with the cargo.toml file for your package.
 Add the following to the `cargo.toml` file:
 
 ```toml
-[[test]]
+[[bench]]
 name = "perf"
 path = "perf/get_secret.rs"
 harness = false
@@ -81,13 +81,13 @@ This declares a test named `perf` (which is required for the perf automation tes
 After this, to invoke your perf test, you simply use:
 
 ```bash
-cargo test --package azure_storage_blob --test perf -- {performance test command line}
+cargo bench --package azure_storage_blob --bench perf -- {performance test command line}
 ```
 
 For example,
 
 ```bash
-cargo test --package azure_storage_blob --test perf -- list_blob --help
+cargo bench --package azure_storage_blob --bench perf -- list_blob --help
 ```
 
 returns the help text for the `list_blob`test:

--- a/sdk/core/azure_core_test/src/perf/mod.rs
+++ b/sdk/core/azure_core_test/src/perf/mod.rs
@@ -509,6 +509,8 @@ impl PerfRunner {
                     .value_parser(clap::value_parser!(i64))
                     .global(true),
             )
+            // Cargo bench passes --bench to the test binary to instruct it to run benchmarks only.
+            .arg(clap::arg!(--bench).required(false).global(true))
             .arg(
                 clap::arg!(--"test-results" <FILE> "The file to write test results to")
                     .required(false)

--- a/sdk/core/typespec_macros/tests/data/safe-debug-tests/Cargo.toml
+++ b/sdk/core/typespec_macros/tests/data/safe-debug-tests/Cargo.toml
@@ -21,7 +21,7 @@ zerofrom = "0.1.5"
 [dev-dependencies]
 rustc_version = "0.4.1"
 
-[[test]]
+[[bench]]
 name = "debug"
 path = "tests/debug.rs"
 required-features = ["debug"]

--- a/sdk/keyvault/azure_security_keyvault_keys/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_keys/Cargo.toml
@@ -42,7 +42,7 @@ rustc_version.workspace = true
 [lints]
 workspace = true
 
-[[test]]
+[[bench]]
 name = "perf"
 path = "perf/perf_tests.rs"
 harness = false

--- a/sdk/keyvault/azure_security_keyvault_keys/perf/perf_tests.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/perf/perf_tests.rs
@@ -10,7 +10,7 @@
 //!
 //! To run the test, use the following command line arguments:
 //!
-//! cargo test --package azure_security_keyvault_keys --test perf -- --duration 10 --parallel 20 get_key -u https://<my_vault>.vault.azure.net/
+//! cargo bench --package azure_security_keyvault_keys --bench perf -- --duration 10 --parallel 20 get_key -u https://<my_vault>.vault.azure.net/
 //!
 
 mod create_key;

--- a/sdk/keyvault/azure_security_keyvault_secrets/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_secrets/Cargo.toml
@@ -41,7 +41,7 @@ rustc_version.workspace = true
 [lints]
 workspace = true
 
-[[test]]
+[[bench]]
 name = "perf"
 path = "perf/get_secret.rs"
 harness = false

--- a/sdk/keyvault/azure_security_keyvault_secrets/perf/get_secret.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/perf/get_secret.rs
@@ -10,7 +10,7 @@
 //!
 //! To run the test, use the following command line arguments:
 //!
-//! cargo test --package azure_security_keyvault_secrets --test perf -- --duration 10 --parallel 20 get_secret -u https://<my_vault>.vault.azure.net/
+//! cargo bench --package azure_security_keyvault_secrets --bench perf -- --duration 10 --parallel 20 get_secret -u https://<my_vault>.vault.azure.net/
 //!
 
 use std::sync::{Arc, OnceLock};

--- a/sdk/storage/azure_storage_blob/Cargo.toml
+++ b/sdk/storage/azure_storage_blob/Cargo.toml
@@ -38,7 +38,7 @@ futures.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tracing.workspace = true
 
-[[test]]
+[[bench]]
 name = "perf"
 path = "perf/perf_tests.rs"
 harness = false


### PR DESCRIPTION
The command line for cargo test is passed to all tests if you're not specific, but clap based tests (like perf tests) get upset when they encounter command line parameters that are unknown.

To avoid this, instead of using `[[test]]` to declare perf tests, use `[[bench]]`.

