### PR TITLE
[Storage] Generated code causes compiler errors

### DIFF
--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
@@ -873,7 +873,7 @@ impl BlobContainerClient {
                         )
                         .await?;
                     let (status, headers, body) = rsp.deconstruct();
-                    let res: ListBlobsFlatSegmentResponse = xml::from_xml(&body)?;
+                    let res: ListBlobsFlatSegmentResponse = xml::read_xml(&body)?;
                     let rsp = RawResponse::from_bytes(status, headers, body).into();
                     Ok(match res.next_marker {
                         Some(next_marker) if !next_marker.is_empty() => PagerResult::More {
@@ -1000,7 +1000,7 @@ impl BlobContainerClient {
                         )
                         .await?;
                     let (status, headers, body) = rsp.deconstruct();
-                    let res: ListBlobsHierarchySegmentResponse = xml::from_xml(&body)?;
+                    let res: ListBlobsHierarchySegmentResponse = xml::read_xml(&body)?;
                     let rsp = RawResponse::from_bytes(status, headers, body).into();
                     Ok(match res.next_marker {
                         Some(next_marker) if !next_marker.is_empty() => PagerResult::More {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
@@ -481,7 +481,7 @@ impl BlobServiceClient {
                         )
                         .await?;
                     let (status, headers, body) = rsp.deconstruct();
-                    let res: ListContainersSegmentResponse = xml::from_xml(&body)?;
+                    let res: ListContainersSegmentResponse = xml::read_xml(&body)?;
                     let rsp = RawResponse::from_bytes(status, headers, body).into();
                     Ok(match res.next_marker {
                         Some(next_marker) if !next_marker.is_empty() => PagerResult::More {

--- a/sdk/storage/azure_storage_blob/src/generated/models/pub_models.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/pub_models.rs
@@ -14,7 +14,7 @@ use super::{
     QueryRequestType, QueryType, RehydratePriority,
 };
 use azure_core::{
-    base64::option::{deserialize, serialize},
+    base64::{deserialize, serialize},
     fmt::SafeDebug,
     time::OffsetDateTime,
 };


### PR DESCRIPTION
`.tsp`: https://github.com/Azure/azure-rest-api-specs/tree/feature/blob-tsp-rust
3 main class of errors:

1. `read_xml()` issue
```
error[E0425]: cannot find function `read_xml` in module `xml`
   --> sdk\storage\azure_storage_blob\src\generated\clients\blob_container_client.rs:876:66
    |
876 |                     let res: ListBlobsFlatSegmentResponse = xml::read_xml(&body)?;
    |                                                                  ^^^^^^^^ not found in `xml`
```
2. deserialize issue
```
error[E0308]: `?` operator has incompatible types
   --> sdk\storage\azure_storage_blob\src\generated\models\pub_models.rs:374:28
    |
374 |         deserialize_with = "deserialize",
    |                            ^^^^^^^^^^^^^ expected `Option<Vec<u8>>`, found `Vec<u8>`
    |
    = note: `?` operator cannot convert from `Vec<_>` to `std::option::Option<Vec<_>>`
    = note: expected enum `std::option::Option<Vec<_>>`
             found struct `Vec<_>`
help: try wrapping the expression in `Some`
    |
374 |         deserialize_with = Some("deserialize"),
    |                            +++++             +
```
3. serialize issue
```
error[E0277]: the trait bound `std::option::Option<Vec<u8>>: AsRef<[u8]>` is not satisfied
   --> sdk\storage\azure_storage_blob\src\generated\models\pub_models.rs:312:50
    |
312 | #[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
    |                                                  ^^^^^^^^^ the trait `AsRef<[u8]>` is not implemented for `std::option::Option<Vec<u8>>`
...
376 |         serialize_with = "serialize",
    |                          ----------- required by a bound introduced by this call
    |
note: required by a bound in `azure_core::base64::serialize`
   --> C:\azure-sdk-for-rust\sdk\core\typespec_client_core\src\base64.rs:185:8
    |
182 | pub fn serialize<S, T>(to_serialize: &T, serializer: S) -> Result<S::Ok, S::Error>
    |        --------- required by a bound in this function
...
185 |     T: AsRef<[u8]>,
    |        ^^^^^^^^^^^ required by this bound in `serialize`
```

My attempted mitigation steps so far was to:

1. ❌Wait to see if it would resolve now (since this had our flat client refactor merged into main, and should have the latest code)
2. ❌Regenerate against a `emitter-package.json` that more closely matches [package.json](https://github.com/Azure/typespec-rust/blob/main/packages/typespec-rust/package.json)