### PR TITLE
fix core/ci.yml

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -10,16 +10,16 @@ trigger:
     include:
     - sdk/core/
 
-parameters: 
-- name: typespec
+parameters:
+- name: release_typespec
   displayName: typespec
   type: boolean
   default: false
-- name: typespec_macros
+- name: release_typespec_macros
   displayName: typespec_macros
   type: boolean
   default: false
-- name: typespec_client_core
+- name: release_typespec_client_core
   displayName: typespec_client_core
   type: boolean
   default: false
@@ -46,16 +46,16 @@ extends:
     ServiceDirectory: core
     Artifacts:
     - name: typespec
-      releaseInBatch: ${{ parameters.typespec }}
+      releaseInBatch: ${{ parameters.release_typespec }}
     - name: typespec_macros
-      releaseInBatch: ${{ parameters.typespec_macros }}
+      releaseInBatch: ${{ parameters.release_typespec_macros }}
     - name: typespec_client_core
-      releaseInBatch: ${{ parameters.typespec_client_core }}
+      releaseInBatch: ${{ parameters.release_typespec_client_core }}
     - name: azure_core
-      releaseInBatch: ${{ parameters.azure_core }}
+      releaseInBatch: ${{ parameters.release_azure_core }}
     - name: azure_core_macros
-      releaseInBatch: ${{ parameters.azure_core_macros }}
+      releaseInBatch: ${{ parameters.release_azure_core_macros }}
     - name: azure_core_amqp
-      releaseInBatch: ${{ parameters.azure_core_amqp }}
+      releaseInBatch: ${{ parameters.release_azure_core_amqp }}
     - name: azure_core_opentelemetry
-      releaseInBatch: ${{ parameters.azure_core_opentelemetry }}
+      releaseInBatch: ${{ parameters.release_azure_core_opentelemetry }}


### PR DESCRIPTION
Match param format of ci.yml files

Example run that doesn't fail: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5534719&view=results