### PR TITLE
Clean up azure_core doc examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "futures",
  "hmac",
  "http",
+ "include-file",
  "json-patch",
  "openssl",
  "pin-project",
@@ -1637,9 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "include-file"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b82360a1cfc38a30a967d4e1b58745ff9258c9326772293402d88d6dd201229"
+checksum = "4db0c2483923cdc1a04d371af232e93215bef3d6a761b663870dd2db4ca795a9"
 dependencies = [
  "proc-macro2",
  "syn 2.0.110",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ futures = "0.3"
 getrandom = { version = "0.3" }
 gloo-timers = { version = "0.3" }
 hmac = { version = "0.12" }
-include-file = { version = "0.5.0" }
+include-file = { version = "0.5.1", default-features = false }
 litemap = "0.7.4"
 openssl = { version = "0.10.72" }
 opentelemetry = { version = "0.30", features = ["trace"] }

--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -45,6 +45,7 @@ azure_security_keyvault_certificates.path = "../../keyvault/azure_security_keyva
 azure_security_keyvault_secrets.path = "../../keyvault/azure_security_keyvault_secrets"
 criterion.workspace = true
 http = "1.3.1"
+include-file.workspace = true
 json-patch = "4.1.0"
 reqwest.workspace = true
 thiserror.workspace = true

--- a/sdk/core/azure_core/README.md
+++ b/sdk/core/azure_core/README.md
@@ -109,28 +109,22 @@ These client types can be instantiated by calling a simple `new` function that t
 Various service specific options are usually added to its subclasses, but a set of SDK-wide options are
 available directly on `ClientOptions`.
 
-```rust no_run
-use azure_core::http::ClientOptions;
+```rust ignore new-client
 use azure_identity::DeveloperToolsCredential;
 use azure_security_keyvault_secrets::{SecretClient, SecretClientOptions};
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let credential = DeveloperToolsCredential::new(None)?;
+let credential = DeveloperToolsCredential::new(None)?;
 
-    let options = SecretClientOptions {
-        api_version: "7.5".to_string(),
-        ..Default::default()
-    };
+let options = SecretClientOptions {
+    api_version: "7.5".to_string(),
+    ..Default::default()
+};
 
-    let client = SecretClient::new(
-        "https://<your-key-vault-name>.vault.azure.net/",
-        credential.clone(),
-        Some(options),
-    )?;
-
-    Ok(())
-}
+let client = SecretClient::new(
+    "https://<your-key-vault-name>.vault.azure.net/",
+    credential.clone(),
+    Some(options),
+)?;
 ```
 
 ### Accessing HTTP response details using `Response<T>`
@@ -139,43 +133,28 @@ _Service clients_ have methods that can be used to call Azure services. We refer
 _Service methods_ return a shared `azure_core` type `Response<T>` where `T` is either a `Model` type or a `ResponseBody` representing a raw stream of bytes.
 This type provides access to both the deserialized result of the service call, and to the details of the HTTP response returned from the server.
 
-```rust no_run
-use azure_core::http::Response;
-use azure_identity::DeveloperToolsCredential;
-use azure_security_keyvault_secrets::{models::Secret, SecretClient};
+Using the `client` we instantiated above:
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // create a client
-    let credential = DeveloperToolsCredential::new(None)?;
-    let client = SecretClient::new(
-        "https://<your-key-vault-name>.vault.azure.net/",
-        credential.clone(),
-        None,
-    )?;
+```rust ignore response
+// Call a service method, which returns `Response<T>`.
+let response = client.get_secret("secret-name", None).await?;
 
-    // call a service method, which returns Response<T>
-    let response = client.get_secret("secret-name", None).await?;
+// `Response<T>` has two main accessors:
+// 1. The `into_model()` function consumes self to deserialize into a model type defined by the client library.
+let secret = response.into_model()?;
 
-    // Response<T> has two main accessors:
-    // 1. The `into_model()` function consumes self to deserialize into a model type
-    let secret = response.into_model()?;
+// Get response again because it was moved in above statement.
+let response = client.get_secret("secret-name", None).await?;
 
-    // get response again because it was moved in above statement
-    let response: Response<Secret> = client.get_secret("secret-name", None).await?;
+// 2. The `deconstruct()` method for accessing all the details of the HTTP response.
+let (status, headers, body) = response.deconstruct();
 
-    // 2. The deconstruct() method for accessing all the details of the HTTP response
-    let (status, headers, body) = response.deconstruct();
+// For example, you can access HTTP status.
+println!("Status: {}", status);
 
-    // for example, you can access HTTP status
-    println!("Status: {}", status);
-
-    // or the headers
-    for (header_name, header_value) in headers.iter() {
-        println!("{}: {}", header_name.as_str(), header_value.as_str());
-    }
-
-    Ok(())
+// ...or the headers.
+for (header_name, header_value) in headers.iter() {
+    println!("{}: {}", header_name.as_str(), header_value.as_str());
 }
 ```
 
@@ -183,37 +162,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 When a service call fails, the returned `Result` will contain an `Error`. The `Error` type provides a status property with an HTTP status code and an error_code property with a service-specific error code.
 
-```rust no_run
-use azure_core::{error::ErrorKind, http::{Response, StatusCode}};
-use azure_identity::DeveloperToolsCredential;
-use azure_security_keyvault_secrets::SecretClient;
+Using the `client` we instantiated above:
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // create a client
-    let credential = DeveloperToolsCredential::new(None)?;
-    let client = SecretClient::new(
-        "https://<your-key-vault-name>.vault.azure.net/",
-        credential.clone(),
-        None,
-    )?;
+```rust ignore errors
+use azure_core::{error::ErrorKind, http::StatusCode};
 
-    match client.get_secret("secret-name", None).await {
-        Ok(secret) => println!("Secret: {:?}", secret.into_model()?.value),
-        Err(e) => match e.kind() {
-            ErrorKind::HttpResponse { status, error_code, .. } if *status == StatusCode::NotFound => {
-                // handle not found error
-                if let Some(code) = error_code {
-                    println!("ErrorCode: {}", code);
-                } else {
-                    println!("Secret not found, but no error code provided.");
-                }
-            },
-            _ => println!("An error occurred: {e:?}"),
+match client.get_secret("secret-name", None).await {
+    Ok(secret) => println!("Secret: {:?}", secret.into_model()?.value),
+    Err(e) => match e.kind() {
+        ErrorKind::HttpResponse { status, error_code, .. } if *status == StatusCode::NotFound => {
+            // Handle not found error.
+            if let Some(code) = error_code {
+                println!("ErrorCode: {}", code);
+            } else {
+                println!("Secret not found, but no error code provided.");
+            }
         },
-    }
-
-    Ok(())
+        _ => println!("An error occurred: {e:?}"),
+    },
 }
 ```
 
@@ -223,69 +189,41 @@ and you can [deserialize](https://github.com/Azure/azure-sdk-for-rust/blob/main/
 
 ### Consuming service methods returning `Pager<T>`
 
-If a service call returns multiple values in pages, it should return `Result<Pager<T>>` as a result. You can iterate all items from all pages.
+When a service returns a pageable collection, it will return `Result<Pager<T>>` as a result. You can iterate all items from all pages.
 
-```rust no_run
-use azure_identity::DeveloperToolsCredential;
-use azure_security_keyvault_secrets::{ResourceExt, SecretClient};
-use futures::TryStreamExt;
+Using the `client` we instantiated above:
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // create a client
-    let credential = DeveloperToolsCredential::new(None)?;
-    let client = SecretClient::new(
-        "https://<your-key-vault-name>.vault.azure.net/",
-        credential.clone(),
-        None,
-    )?;
+```rust ignore item-pager
+use azure_security_keyvault_secrets::ResourceExt;
+use futures::TryStreamExt as _;
 
-    // get a stream of items
-    let mut pager = client.list_secret_properties(None)?;
-
-    // poll the pager until there are no more SecretListResults
-    while let Some(secret) = pager.try_next().await? {
-        // get the secret name from the ID
-        let name = secret.resource_id()?.name;
-        println!("Found secret with name: {}", name);
-    }
-
-    Ok(())
+// Get a stream of items.
+let mut pager = client.list_secret_properties(None)?;
+while let Some(secret) = pager.try_next().await? {
+    // Get the secret name from the ID.
+    let name = secret.resource_id()?.name;
+    println!("Found secret with name: {}", name);
 }
 ```
 
 To instead iterate over all pages, call `into_pages()` on the returned `Pager`.
 
-```rust no_run
-use azure_identity::DeveloperToolsCredential;
-use azure_security_keyvault_secrets::{ResourceExt, SecretClient};
-use futures::TryStreamExt;
+```rust ignore page-pager
+use azure_security_keyvault_secrets::ResourceExt;
+use futures::TryStreamExt as _;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // create a client
-    let credential = DeveloperToolsCredential::new(None)?;
-    let client = SecretClient::new(
-        "https://<your-key-vault-name>.vault.azure.net/",
-        credential.clone(),
-        None,
-    )?;
+// Get a stream of pages.
+let mut pager = client.list_secret_properties(None)?.into_pages();
 
-    // get a stream of pages
-    let mut pager = client.list_secret_properties(None)?.into_pages();
-
-    // poll the pager until there are no more SecretListResults
-    while let Some(secrets) = pager.try_next().await? {
-        let secrets = secrets.into_model()?.value;
-        // loop through secrets in SecretsListResults
-        for secret in secrets {
-            // get the secret name from the ID
-            let name = secret.resource_id()?.name;
-            println!("Found secret with name: {}", name);
-        }
+// Poll the pager until there are no more `SecretListResults`.
+while let Some(secrets) = pager.try_next().await? {
+    let secrets = secrets.into_model()?.value;
+    // Loop through secrets in `SecretsListResults`.
+    for secret in secrets {
+        // Get the secret name from the ID.
+        let name = secret.resource_id()?.name;
+        println!("Found secret with name: {}", name);
     }
-
-    Ok(())
 }
 ```
 
@@ -295,102 +233,76 @@ If a service call may take a while to process, it should return `Result<Poller<T
 
 The `Poller<T>` implements `std::future::IntoFuture` so you can `await` it to get the final result:
 
-```rust no_run
-use azure_identity::DeveloperToolsCredential;
+Using a `CertificateClient` created similarly to the `client` we instantiated above:
+
+```rust ignore poller-future
 use azure_security_keyvault_certificates::{
-    CertificateClient,
     models::{CreateCertificateParameters, CertificatePolicy, X509CertificateProperties, IssuerParameters},
 };
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let credential = DeveloperToolsCredential::new(None)?;
-    let client = CertificateClient::new(
-        "https://your-key-vault-name.vault.azure.net/",
-        credential.clone(),
-        None,
-    )?;
-
-    // Create a self-signed certificate.
-    let policy = CertificatePolicy {
-        x509_certificate_properties: Some(X509CertificateProperties {
-            subject: Some("CN=DefaultPolicy".into()),
-            ..Default::default()
-        }),
-        issuer_parameters: Some(IssuerParameters {
-            name: Some("Self".into()),
-            ..Default::default()
-        }),
+// Create a self-signed certificate.
+let policy = CertificatePolicy {
+    x509_certificate_properties: Some(X509CertificateProperties {
+        subject: Some("CN=DefaultPolicy".into()),
         ..Default::default()
-    };
-    let body = CreateCertificateParameters {
-        certificate_policy: Some(policy),
+    }),
+    issuer_parameters: Some(IssuerParameters {
+        name: Some("Self".into()),
         ..Default::default()
-    };
+    }),
+    ..Default::default()
+};
+let body = CreateCertificateParameters {
+    certificate_policy: Some(policy),
+    ..Default::default()
+};
 
-    // Wait for the certificate operation to complete and get the certificate.
-    let certificate = client
-        .create_certificate("certificate-name", body.try_into()?, None)?
-        .await?
-        .into_model()?;
-
-    Ok(())
-}
+// Wait for the certificate operation to complete and get the certificate.
+let certificate = client
+    .create_certificate("certificate-name", body.try_into()?, None)?
+    .await?
+    .into_model()?;
 ```
 
 The `Poller<T>` also implements `futures::Stream` so you can asynchronously iterate over each status monitor update:
 
-```rust no_run
-use azure_identity::DeveloperToolsCredential;
+```rust ignore poller-stream
 use azure_security_keyvault_certificates::{
-    CertificateClient,
     models::{CreateCertificateParameters, CertificatePolicy, X509CertificateProperties, IssuerParameters},
 };
 use futures::stream::TryStreamExt as _;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let credential = DeveloperToolsCredential::new(None)?;
-    let client = CertificateClient::new(
-        "https://your-key-vault-name.vault.azure.net/",
-        credential.clone(),
-        None,
-    )?;
-
-    // Create a self-signed certificate.
-    let policy = CertificatePolicy {
-        x509_certificate_properties: Some(X509CertificateProperties {
-            subject: Some("CN=DefaultPolicy".into()),
-            ..Default::default()
-        }),
-        issuer_parameters: Some(IssuerParameters {
-            name: Some("Self".into()),
-            ..Default::default()
-        }),
+// Create a self-signed certificate.
+let policy = CertificatePolicy {
+    x509_certificate_properties: Some(X509CertificateProperties {
+        subject: Some("CN=DefaultPolicy".into()),
         ..Default::default()
-    };
-    let body = CreateCertificateParameters {
-        certificate_policy: Some(policy),
+    }),
+    issuer_parameters: Some(IssuerParameters {
+        name: Some("Self".into()),
         ..Default::default()
-    };
+    }),
+    ..Default::default()
+};
+let body = CreateCertificateParameters {
+    certificate_policy: Some(policy),
+    ..Default::default()
+};
 
-    // Wait for the certificate operation to complete.
-    // The Poller implements futures::Stream and automatically waits between polls.
-    let mut poller = client.create_certificate("certificate-name", body.try_into()?, None)?;
-    while let Some(operation) = poller.try_next().await? {
-        let operation = operation.into_model()?;
-        match operation.status.as_deref().unwrap_or("unknown") {
-            "inProgress" => continue,
-            "completed" => {
-                let target = operation.target.ok_or("expected target")?;
-                println!("Created certificate {}", target);
-                break;
-            },
-            status => Err(format!("operation terminated with status {status}"))?,
-        }
+// Wait for the certificate operation to complete.
+// The Poller implements futures::Stream and automatically waits between polls.
+let mut poller = client.create_certificate("certificate-name", body.try_into()?, None)?;
+while let Some(operation) = poller.try_next().await? {
+    let operation = operation.into_model()?;
+    match operation.status.as_deref().unwrap_or("unknown") {
+        "inProgress" => continue,
+        "completed" => {
+            let target = operation.target.ok_or("expected target")?;
+            println!("Created certificate {}", target);
+            break;
+        },
+        status => Err(format!("operation terminated with status {status}"))?,
     }
-
-    Ok(())
 }
 ```
 
@@ -399,7 +311,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 You can add custom HTTP policies for each client method (per-call) or request attempt (per-try) by implementing `Policy` and adding it to the appropriate field on `ClientOptions`.
 For example, to remove the `user-agent` header entirely:
 
-```rust no_run
+```rust ignore custom-policy
 use azure_core::http::{
     policies::{Policy, PolicyResult},
     ClientOptions, Context, Request,
@@ -433,13 +345,12 @@ options
     .per_call_policies
     .push(remove_user_agent);
 
-let credential = DeveloperToolsCredential::new(None).unwrap();
+let credential = DeveloperToolsCredential::new(None)?;
 let client = SecretClient::new(
     "https://your-key-vault-name.vault.azure.net/",
     credential.clone(),
     Some(options),
-)
-.unwrap();
+)?;
 ```
 
 See the [example](https://github.com/Azure/azure-sdk-for-rust/blob/main/sdk/core/azure_core/examples/core_remove_user_agent.rs) for a full sample implementation.
@@ -480,13 +391,13 @@ reqwest = { version = "0.12.23", default-features = false, features = [
 In many cases with `reqwest`, importing features may be enough. See their [documentation][`reqwest`] for more information.
 If you do need to write code to customize the `reqwest::Client`, you can pass it in `ClientOptions` to our client libraries:
 
-```rust no_run
+```rust ignore custom-reqwest
 use azure_core::http::{ClientOptions, Transport};
 use azure_identity::DeveloperToolsCredential;
 use azure_security_keyvault_secrets::{SecretClient, SecretClientOptions};
 use std::sync::Arc;
 
-let http_client = Arc::new(reqwest::ClientBuilder::new().gzip(true).build().unwrap());
+let http_client = Arc::new(reqwest::ClientBuilder::new().gzip(true).build()?);
 
 let options = SecretClientOptions {
     client_options: ClientOptions {
@@ -496,13 +407,12 @@ let options = SecretClientOptions {
     ..Default::default()
 };
 
-let credential = DeveloperToolsCredential::new(None).unwrap();
+let credential = DeveloperToolsCredential::new(None)?;
 let client = SecretClient::new(
     "https://your-key-vault-name.vault.azure.net/",
     credential.clone(),
     Some(options),
-)
-.unwrap();
+)?;
 ```
 
 #### Other HTTP client
@@ -587,17 +497,17 @@ struct CustomRuntime;
 
 impl AsyncRuntime for CustomRuntime {
     fn spawn(&self, f: TaskFuture) -> SpawnedTask {
-      unimplemented!("Custom spawn not implemented");
+        unimplemented!("custom spawn not implemented");
     }
     fn sleep(&self, duration: Duration) -> TaskFuture {
-      unimplemented!("Custom sleep not implemented");
+        unimplemented!("custom sleep not implemented");
     }
     fn yield_now(&self) -> TaskFuture {
-        unimplemented!("Custom yield not implemented");
+        unimplemented!("custom yield not implemented");
     }
-  }
+}
 
-  set_async_runtime(Arc::new(CustomRuntime)).expect("Failed to set async runtime");
+set_async_runtime(Arc::new(CustomRuntime)).expect("failed to set async runtime");
 ```
 
 There can only be one async runtime set in a given process, so attempts to set the async runtime multiple times will fail.
@@ -608,29 +518,14 @@ There can only be one async runtime set in a given process, so attempts to set t
 
 To help protected end users from accidental Personally-Identifiable Information (PII) from leaking into logs or traces, models' default implementation of `core::fmt::Debug` formats as non-exhaustive structure tuple e.g.,
 
-```rust no_run
-use azure_identity::DeveloperToolsCredential;
-use azure_security_keyvault_secrets::{ResourceExt, SecretClient};
+Using the `client` we instantiated above:
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // create a client
-    let credential = DeveloperToolsCredential::new(None)?;
-    let client = SecretClient::new(
-        "https://<your-key-vault-name>.vault.azure.net/",
-        credential.clone(),
-        None,
-    )?;
+```rust ignore safe-debug
+let secret = client.get_secret("secret-name", None)
+    .await?
+    .into_model()?;
 
-    // get a secret
-    let secret = client.get_secret("secret-name", None)
-        .await?
-        .into_model()?;
-
-    println!("{secret:#?}");
-
-    Ok(())
-}
+println!("{secret:#?}");
 ```
 
 By default this will print:
@@ -656,17 +551,16 @@ The recommended workaround is to disable connection pooling in a custom `reqwest
 If you are encountering this issue, you can construct an `HttpClient` which disables HTTP connection pooling
 and set that as the transport in any `ClientOptions` used to configure your Azure SDK clients:
 
-```rust no_run
+```rust ignore reqwest-hang
 use std::sync::Arc;
-use azure_core::http::{HttpClient, ClientOptions, Transport};
+use azure_core::http::{ClientOptions, Transport};
 use azure_security_keyvault_secrets::SecretClientOptions;
 
 let client = Arc::new(
     ::reqwest::ClientBuilder::new()
         // Note that reqwest does not support `pool_max_idle_per_host` on WASM.
         .pool_max_idle_per_host(0)
-        .build()
-        .expect("failed to build `reqwest` client"),
+        .build()?,
 );
 
 let options = SecretClientOptions {

--- a/sdk/core/azure_core/tests/readme.rs
+++ b/sdk/core/azure_core/tests/readme.rs
@@ -1,0 +1,51 @@
+// Licensed under the MIT License.
+
+#![allow(dead_code)]
+use include_file::include_markdown;
+
+#[ignore = "only compile doc examples"]
+#[tokio::test]
+async fn readme() -> Result<(), Box<dyn std::error::Error>> {
+    include_markdown!("README.md", "new-client");
+    include_markdown!("README.md", "response");
+    include_markdown!("README.md", "errors");
+    include_markdown!("README.md", "item-pager", scope);
+    include_markdown!("README.md", "page-pager", scope);
+    include_markdown!("README.md", "safe-debug");
+
+    {
+        use azure_security_keyvault_certificates::CertificateClient;
+
+        let client =
+            CertificateClient::new("https://my-vault.vault.azure.net", credential.clone(), None)?;
+
+        include_markdown!("README.md", "poller-future", scope);
+        include_markdown!("README.md", "poller-stream", scope);
+    }
+
+    Ok(())
+}
+
+#[ignore = "only compile doc examples"]
+#[tokio::test]
+async fn custom_policy() -> Result<(), Box<dyn std::error::Error>> {
+    include_markdown!("README.md", "custom-policy");
+
+    Ok(())
+}
+
+#[ignore = "only compile doc examples"]
+#[tokio::test]
+async fn custom_reqwest() -> Result<(), Box<dyn std::error::Error>> {
+    include_markdown!("README.md", "custom-reqwest");
+
+    Ok(())
+}
+
+#[ignore = "only compile doc examples"]
+#[tokio::test]
+async fn reqwest_hang() -> Result<(), Box<dyn std::error::Error>> {
+    include_markdown!("README.md", "reqwest-hang");
+
+    Ok(())
+}

--- a/sdk/keyvault/azure_security_keyvault_certificates/README.md
+++ b/sdk/keyvault/azure_security_keyvault_certificates/README.md
@@ -62,7 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a new certificate client
     let credential = DeveloperToolsCredential::new(None)?;
     let client = CertificateClient::new(
-        "https://your-key-vault-name.vault.azure.net/",
+        "https://<your-key-vault-name>.vault.azure.net/",
         credential.clone(),
         None,
     )?;

--- a/sdk/keyvault/azure_security_keyvault_keys/README.md
+++ b/sdk/keyvault/azure_security_keyvault_keys/README.md
@@ -88,7 +88,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a new key client
     let credential = DeveloperToolsCredential::new(None)?;
     let client = KeyClient::new(
-        "https://your-key-vault-name.vault.azure.net/",
+        "https://<your-key-vault-name>.vault.azure.net/",
         credential.clone(),
         None,
     )?;

--- a/sdk/keyvault/azure_security_keyvault_secrets/README.md
+++ b/sdk/keyvault/azure_security_keyvault_secrets/README.md
@@ -61,7 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a new secret client
     let credential = DeveloperToolsCredential::new(None)?;
     let client = SecretClient::new(
-        "https://your-key-vault-name.vault.azure.net/",
+        "https://<your-key-vault-name>.vault.azure.net/",
         credential.clone(),
         None,
     )?;


### PR DESCRIPTION
Also upgraded `include-file` and disables non-markdown features for faster compilation.
