### PR TITLE
[Storage] Fix flaky live tests in `test_container_access_policy`

### DIFF
--- a/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
@@ -475,7 +475,7 @@ async fn test_container_access_policy(ctx: TestContext) -> Result<(), Box<dyn Er
         let returned_policy = signed_identifier.access_policy.unwrap();
         let expected_policy = expected_policies.get(&id).expect("Unexpected ID returned");
 
-        // Compare start times by truncating to seconds precision
+        // Truncate start and expiry times to seconds precision for assertion
         assert_eq!(
             expected_policy
                 .start
@@ -485,7 +485,6 @@ async fn test_container_access_policy(ctx: TestContext) -> Result<(), Box<dyn Er
                 .map(|dt| dt.replace_nanosecond(0).unwrap()),
             "Start times don't match (truncated to seconds precision)"
         );
-        // Compare expiry times by truncating to seconds precision
         assert_eq!(
             expected_policy
                 .expiry

--- a/sdk/storage/azure_storage_blob_test/src/lib.rs
+++ b/sdk/storage/azure_storage_blob_test/src/lib.rs
@@ -3,7 +3,6 @@
 
 use azure_core::{
     http::{ClientOptions, NoFormat, RequestContent, Response},
-    time::OffsetDateTime,
     Bytes, Result,
 };
 use azure_core_test::Recording;
@@ -12,7 +11,6 @@ use azure_storage_blob::{
     BlobClient, BlobContainerClient, BlobContainerClientOptions, BlobServiceClient,
     BlobServiceClientOptions,
 };
-use std::time::Duration;
 
 /// Takes in a Recording instance and returns an instrumented options bag and endpoint.
 ///
@@ -126,30 +124,5 @@ pub async fn create_test_blob(
                 )
                 .await
         }
-    }
-}
-
-/// Helper function that enables `OffsetDateTime` comparison with a specified margin of error.
-///
-/// # Arguments
-///
-/// * `expected` - The expected `OffsetDateTime`.
-/// * `actual` - The actual (or returned) `OffsetDateTime`.
-/// * `tolerance` - Margin of error in seconds.
-pub fn assert_datetime_within(
-    expected: Option<OffsetDateTime>,
-    actual: Option<OffsetDateTime>,
-    tolerance: Duration,
-) {
-    match (expected, actual) {
-        (Some(exp), Some(act)) => {
-            let diff = (exp - act).abs();
-            assert!(
-                diff <= tolerance,
-                "Datetime difference too large: expected {exp:?}, got {act:?}, difference: {diff:?} (max: {tolerance:?})"
-            );
-        }
-        (None, None) => {}
-        (exp, act) => panic!("Datetime mismatch: expected {exp:?}, got {act:?}"),
     }
 }


### PR DESCRIPTION
This PR updates the offending tests to truncate to account for differing precisions on the `OffsetDateTime` objects on different plaforms vs. what the Service returns.
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5629625&view=results