### PR TITLE
Use SafeDebug for Cosmos model types

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/src/models/account_properties.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/account_properties.rs
@@ -5,11 +5,12 @@
 //! This is a focused representation for the sample JSON provided; fields not
 //! present in the sample are intentionally omitted for now.
 
+use azure_core::fmt::SafeDebug;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// Represents a single regional endpoint for the Cosmos DB account (readable or writable).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(SafeDebug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountRegion {
     pub name: String,
@@ -17,7 +18,7 @@ pub struct AccountRegion {
 }
 
 /// Describes replica set sizing characteristics for user/system replication policies.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(SafeDebug, Clone, Serialize, Deserialize)]
 // cSpell:disable
 #[serde(rename_all = "camelCase")]
 pub struct ReplicationPolicy {
@@ -29,14 +30,14 @@ pub struct ReplicationPolicy {
 }
 
 /// User-configured default consistency level for the account.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(SafeDebug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConsistencyPolicy {
     pub default_consistency_level: String,
 }
 
 /// Read preference coefficients used by the service when selecting regions.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(SafeDebug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReadPolicy {
     pub primary_read_coefficient: i32,
@@ -49,7 +50,7 @@ pub struct ReadPolicy {
 /// This struct captures a subset of fields surfaced in the account read payload
 /// (not exhaustive). It includes region lists, consistency/replication policies
 /// and a raw `query_engine_configuration` JSON string for optional parsing.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(SafeDebug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountProperties {
     #[serde(rename = "_self")]

--- a/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
@@ -3,6 +3,7 @@
 
 use std::{borrow::Cow, time::Duration};
 
+use azure_core::fmt::SafeDebug;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::models::{IndexingPolicy, PartitionKeyDefinition, SystemProperties};
@@ -47,7 +48,7 @@ where
 /// Also, note that the `id` and `partition_key` values are **required** by the server. You will get an error from the server if you omit them.
 ///
 /// [Struct Update]: https://doc.rust-lang.org/stable/book/ch05-01-defining-structs.html?highlight=Struct#creating-instances-from-other-instances-with-struct-update-syntax
-#[derive(Clone, Default, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Default, SafeDebug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ContainerProperties {
     /// The ID of the container.

--- a/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
@@ -3,7 +3,7 @@
 
 //! Model types sent to and received from the Azure Cosmos DB API.
 
-use azure_core::{http::Etag, time::OffsetDateTime};
+use azure_core::{fmt::SafeDebug, http::Etag, time::OffsetDateTime};
 use serde::{Deserialize, Deserializer, Serialize};
 
 mod account_properties;
@@ -41,7 +41,7 @@ where
 
 /// A page of query results from [`ContainerClient::query_items`](crate::clients::ContainerClient::query_items()) where each item is of type `T`.
 #[non_exhaustive]
-#[derive(Clone, Default, Debug, Deserialize)]
+#[derive(Clone, Default, SafeDebug, Deserialize)]
 pub struct QueryResults<T> {
     #[serde(alias = "Documents")]
     pub items: Vec<T>,
@@ -49,7 +49,7 @@ pub struct QueryResults<T> {
 
 /// A page of results from [`CosmosClient::query_databases`](crate::CosmosClient::query_databases())
 #[non_exhaustive]
-#[derive(Clone, Default, Debug, Deserialize)]
+#[derive(Clone, Default, SafeDebug, Deserialize)]
 pub struct DatabaseQueryResults {
     #[serde(alias = "Databases")]
     pub databases: Vec<DatabaseProperties>,
@@ -57,7 +57,7 @@ pub struct DatabaseQueryResults {
 
 /// A page of results from [`DatabaseClient::query_containers`](crate::clients::DatabaseClient::query_containers())
 #[non_exhaustive]
-#[derive(Clone, Default, Debug, Deserialize)]
+#[derive(Clone, Default, SafeDebug, Deserialize)]
 pub struct ContainerQueryResults {
     #[serde(alias = "DocumentCollections")]
     pub containers: Vec<ContainerProperties>,
@@ -65,7 +65,7 @@ pub struct ContainerQueryResults {
 
 /// Common system properties returned for most Cosmos DB resources.
 #[non_exhaustive]
-#[derive(Clone, Default, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Default, SafeDebug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct SystemProperties {
     /// The entity tag associated with the resource.
     #[serde(default)]
@@ -98,7 +98,7 @@ pub struct SystemProperties {
 ///
 /// Returned by [`DatabaseClient::read()`](crate::clients::DatabaseClient::read()).
 #[non_exhaustive]
-#[derive(Clone, Default, Debug, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Default, SafeDebug, Deserialize, PartialEq, Eq)]
 pub struct DatabaseProperties {
     /// The ID of the database.
     pub id: String,

--- a/sdk/cosmos/azure_data_cosmos/src/models/patch_operations.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/patch_operations.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use azure_core::{error::ErrorKind, Error};
+use azure_core::{error::ErrorKind, fmt::SafeDebug, Error};
 use serde::{Deserialize, Serialize};
 
 // Cosmos' patch operations are _similar_ to JSON Patch (RFC 6902) in structure, but have different operations.
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Default, SafeDebug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PatchDocument {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub condition: Option<Cow<'static, str>>,
@@ -159,7 +159,7 @@ impl PatchDocument {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(SafeDebug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "op")]
 #[serde(rename_all = "camelCase")]
 pub enum PatchOperation {

--- a/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
@@ -3,7 +3,10 @@
 
 use std::borrow::Cow;
 
-use azure_core::http::headers::{AsHeaders, HeaderName, HeaderValue};
+use azure_core::{
+    fmt::SafeDebug,
+    http::headers::{AsHeaders, HeaderName, HeaderValue},
+};
 
 use crate::constants;
 
@@ -74,7 +77,7 @@ use crate::constants;
 /// let partition_key_1 = PartitionKey::from("simple_string");
 /// let partition_key_2 = PartitionKey::from(("parent", "child", 42));
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(SafeDebug, Clone, PartialEq, Eq)]
 pub struct PartitionKey(Vec<PartitionKeyValue>);
 
 impl PartitionKey {
@@ -161,11 +164,11 @@ impl AsHeaders for PartitionKey {
 /// Represents a value for a single partition key.
 ///
 /// You shouldn't need to construct this type directly. The various implementations of [`Into<PartitionKey>`] will handle it for you.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(SafeDebug, Clone, PartialEq, Eq)]
 pub struct PartitionKeyValue(InnerPartitionKeyValue);
 
 // We don't want to expose the implementation details of PartitionKeyValue (specifically the use of serde_json::Number), so we use this inner private enum to store the data.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(SafeDebug, Clone, PartialEq, Eq)]
 enum InnerPartitionKeyValue {
     Null,
     String(Cow<'static, str>),


### PR DESCRIPTION
## Summary
- switch Cosmos DB model types to derive SafeDebug instead of Debug
- add SafeDebug imports for the updated Cosmos modules

## Rationale
- issue #2585 asks Cosmos response models to use SafeDebug to avoid leaking sensitive data while retaining debug output

## Testing
- not run (docs/derive-only change)

Fixes #2585