### PR TITLE
add SAS token support to eventhubs

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -22,6 +22,7 @@
     "deny.toml",
     "eng/",
     "**/.dict.txt",
+    "**/cspell.yaml",
     "rust-toolchain.toml"
   ],
   "words": [
@@ -80,6 +81,7 @@
     "rustfmt",
     "rustup",
     "schannel",
+    "sastoken",
     "seekable",
     "servicebus",
     "spector",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/sdk/core/azure_core/src/hmac.rs
+++ b/sdk/core/azure_core/src/hmac.rs
@@ -3,17 +3,30 @@
 
 //! HMAC encoding and decoding functions.
 
-use crate::credentials::Secret;
 #[cfg(any(feature = "hmac_rust", feature = "hmac_openssl"))]
-use crate::{
-    base64,
-    error::{ErrorKind, ResultExt},
-};
+use crate::error::{ErrorKind, ResultExt};
+use crate::{base64, credentials::Secret};
 
 /// Tries to create an HMAC SHA256 signature from the given `data` and `key`.
 ///
 /// The `key` is expected to be a base64 encoded string and will be decoded
 /// before using it for signing. The returned signature is also base64 encoded.
+///
+/// If both `hmac_rust` and `hmac_openssl` are enabled, use `hmac_openssl`.
+///
+/// # Errors
+///
+/// - If the `key` is not a valid base64 encoded string.
+/// - If it fails to create the HMAC from the `key`.
+/// - If `hmac_rust` and/or `hmac_openssl` are not enabled.
+pub fn hmac_sha256(data: &str, key: &Secret) -> crate::Result<String> {
+    let key = base64::decode(key.secret())?;
+    hmac_sha256_bytes(data.as_bytes(), &key)
+}
+
+/// Tries to create an HMAC SHA256 signature from the given `data` and `key`.
+///
+/// The returned signature is also base64 encoded.
 ///
 /// If both `hmac_rust` and `hmac_openssl` are enabled, use `hmac_openssl`.
 ///
@@ -22,23 +35,21 @@ use crate::{
 /// - If the `key` is not a valid base64 encoded string.
 /// - If it fails to create the HMAC from the `key`.
 #[cfg(all(feature = "hmac_rust", not(feature = "hmac_openssl")))]
-pub fn hmac_sha256(data: &str, key: &Secret) -> crate::Result<String> {
+pub fn hmac_sha256_bytes(data: &[u8], key: &[u8]) -> crate::Result<String> {
     use hmac::{Hmac, Mac};
     use sha2::Sha256;
-    let key = base64::decode(key.secret())?;
-    let mut hmac = Hmac::<Sha256>::new_from_slice(&key)
+    let mut hmac = Hmac::<Sha256>::new_from_slice(key)
         .with_context_fn(ErrorKind::DataConversion, || {
             "failed to create hmac from key"
         })?;
-    hmac.update(data.as_bytes());
+    hmac.update(data);
     let signature = hmac.finalize().into_bytes();
     Ok(base64::encode(signature))
 }
 
 /// Tries to create an HMAC SHA256 signature from the given `data` and `key`.
 ///
-/// The `key` is expected to be a base64 encoded string and will be decoded
-/// before using it for signing. The returned signature is also base64 encoded.
+/// The returned signature is also base64 encoded.
 ///
 /// If both `hmac_rust` and `hmac_openssl` are enabled, use `hmac_openssl`.
 ///
@@ -47,15 +58,14 @@ pub fn hmac_sha256(data: &str, key: &Secret) -> crate::Result<String> {
 /// - If the `key` is not a valid base64 encoded string.
 /// - If it fails to create the HMAC from the `key`.
 #[cfg(feature = "hmac_openssl")]
-pub fn hmac_sha256(data: &str, key: &Secret) -> crate::Result<String> {
+pub fn hmac_sha256_bytes(data: &[u8], key: &[u8]) -> crate::Result<String> {
     // cspell:ignore pkey
     use openssl::{error::ErrorStack, hash::MessageDigest, pkey::PKey, sign::Signer};
 
-    let decoded = base64::decode(key.secret())?;
     let signature = || -> Result<Vec<u8>, ErrorStack> {
-        let pkey = PKey::hmac(&decoded)?;
+        let pkey = PKey::hmac(key)?;
         let mut signer = Signer::new(MessageDigest::sha256(), &pkey)?;
-        signer.update(data.as_bytes())?;
+        signer.update(data)?;
         signer.sign_to_vec()
     }()
     .with_context_fn(ErrorKind::DataConversion, || {
@@ -70,7 +80,7 @@ pub fn hmac_sha256(data: &str, key: &Secret) -> crate::Result<String> {
 ///
 /// This implementation always returns an error. Enable `hmac_rust` and/or `hmac_openssl`.
 #[cfg(not(any(feature = "hmac_rust", feature = "hmac_openssl")))]
-pub fn hmac_sha256(_data: &str, _key: &Secret) -> crate::Result<String> {
+pub fn hmac_sha256_bytes(_data: &[u8], _key: &[u8]) -> crate::Result<String> {
     unimplemented!("An HMAC signing request was called without an hmac implementation. Make sure to enable either the `hmac_rust` or `hmac_openssl` feature");
 }
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
@@ -26,6 +26,7 @@ futures.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
 tracing.workspace = true
+url.workspace = true
 
 [build-dependencies]
 rustc_version.workspace = true
@@ -44,7 +45,9 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 
 [features]
 in_memory_checkpoint_store = []
-default = ["azure_core_amqp/default"]
+default = ["azure_core_amqp/default", "hmac_rust"]
+hmac_rust = ["azure_core/hmac_rust"]
+hmac_openssl = ["azure_core/hmac_openssl"]
 
 [[bench]]
 name = "benchmarks"

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_events_sas.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_events_sas.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! This sample demonstrates how to consume events from an Event Hub partition using the [`ConsumerClient`] using a SAS token.
+
+use azure_core::time::Duration;
+use azure_messaging_eventhubs::{
+    ConsumerClient, OpenReceiverOptions, StartLocation, StartPosition,
+};
+use futures::StreamExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Set up the Event Hub client
+    let eventhub_namespace = std::env::var("EVENTHUBS_HOST")?;
+    let eventhub_name = std::env::var("EVENTHUB_NAME")?;
+    let sas_key_name = std::env::var("EVENTHUBS_SAS_KEY_NAME")?;
+    let sas_key = std::env::var("EVENTHUBS_SAS_KEY")?;
+
+    let consumer = ConsumerClient::builder()
+        .open_sas(
+            eventhub_namespace.as_str(),
+            eventhub_name,
+            sas_key_name,
+            sas_key,
+        )
+        .await?;
+
+    println!("Opened consumer client");
+
+    // Get the partition IDs
+    let properties = consumer.get_eventhub_properties().await?;
+    println!("EventHub Properties: {:?}", properties);
+
+    // The default is to receive messages from the end of the partition, so specify a start position at the start of the partition.
+    let receiver = consumer
+        .open_receiver_on_partition(
+            properties.partition_ids[0].clone(),
+            Some(OpenReceiverOptions {
+                start_position: Some(StartPosition {
+                    location: StartLocation::Earliest,
+                    ..Default::default()
+                }),
+                receive_timeout: Some(Duration::seconds(5)),
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+    println!("Created receiver");
+
+    // Create a stream of events from the receiver
+    let mut receive_stream = receiver.stream_events();
+
+    println!("Created receive stream");
+
+    // Receive events until the receive_timeout has been reached.
+    while let Some(event) = receive_stream.next().await {
+        let event = event?;
+        println!("Received: {:?}", event);
+
+        println!("Partition ID: {:?}", event.partition_key());
+        println!("Event offset: {:?}", event.offset());
+    }
+
+    consumer.close().await?;
+
+    Ok(())
+}

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_produce_events_sas.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_produce_events_sas.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! This sample demonstrates how to send events to an Event Hub partition using the `ProducerClient` using a SAS token.
+
+use azure_core::Uuid;
+use azure_messaging_eventhubs::{models::EventData, ProducerClient, SendEventOptions};
+use core::f32;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Set up the Event Hub client
+    let eventhub_namespace = std::env::var("EVENTHUBS_HOST")?;
+    let eventhub_name = std::env::var("EVENTHUB_NAME")?;
+    let sas_key_name = std::env::var("EVENTHUBS_SAS_KEY_NAME")?;
+    let sas_key = std::env::var("EVENTHUBS_SAS_KEY")?;
+
+    let client = ProducerClient::builder()
+        .open_sas(
+            eventhub_namespace.as_str(),
+            eventhub_name.as_str(),
+            sas_key_name,
+            sas_key,
+        )
+        .await?;
+
+    println!("Created producer client.");
+
+    // Send an event to an eventhub instance directly. The message will be sent to a random partition.
+    // Note that this uses an implicit builder to create the EventData being sent to the service.
+    client.send_event("Hello, Event Hub!", None).await?;
+
+    // Send an array of bytes to partition 0 of the Event Hubs instance.
+    // Note that this uses an implicit builder to create the EventData being sent to the service.
+    client
+        .send_event(
+            vec![2, 4, 8, 16],
+            Some(SendEventOptions {
+                partition_id: Some("0".to_string()),
+            }),
+        )
+        .await?;
+
+    // Send an event built using the `EventData` builder which allows for more control over the event.
+    // This message will be sent to a random partition.
+    client
+        .send_event(
+            EventData::builder()
+                .with_content_type("text/plain".to_string())
+                .with_correlation_id(Uuid::new_v4())
+                .with_body("This is some text")
+                .add_property("Event Property".to_string(), "Property Value")
+                .add_property("Pi".to_string(), f32::consts::PI)
+                .add_property("Binary".to_string(), vec![0x08, 0x09, 0x0A])
+                .build(),
+            None,
+        )
+        .await?;
+
+    println!("Sent messages. Closing client.");
+
+    client.close().await?;
+    Ok(())
+}

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
@@ -5,7 +5,8 @@ use crate::{common::recoverable::RecoverableConnection, error::Result};
 use async_lock::Mutex as AsyncMutex;
 use azure_core::{
     async_runtime::{get_async_runtime, SpawnedTask},
-    credentials::{AccessToken, TokenCredential},
+    credentials::{AccessToken, Secret, TokenCredential},
+    hmac::hmac_sha256_bytes,
     http::Url,
     time::{Duration, OffsetDateTime},
 };
@@ -41,12 +42,22 @@ impl Default for TokenRefreshTimes {
     }
 }
 
+pub(crate) enum AuthorizerCredential {
+    TokenCredential {
+        credential: Arc<dyn TokenCredential>,
+    },
+    SasToken {
+        key_name: String,
+        key_value: Secret,
+    },
+}
+
 pub(crate) struct Authorizer {
-    authorization_scopes: AsyncMutex<HashMap<Url, AccessToken>>,
+    credential: AuthorizerCredential,
     authorization_refresher: OnceLock<SpawnedTask>,
+    authorization_scopes: AsyncMutex<HashMap<Url, AccessToken>>,
     /// Bias to apply to token refresh time. This determines how much time we will refresh the token before it expires.
     token_refresh_bias: SyncMutex<TokenRefreshTimes>,
-    credential: Arc<dyn TokenCredential>,
     recoverable_connection: Weak<RecoverableConnection>,
     /// This is used to disable authorization for testing purposes.
     #[cfg(test)]
@@ -59,13 +70,13 @@ unsafe impl Sync for Authorizer {}
 impl Authorizer {
     pub(crate) fn new(
         recoverable_connection: Weak<RecoverableConnection>,
-        credential: Arc<dyn TokenCredential>,
+        credential: AuthorizerCredential,
     ) -> Self {
         Self {
-            authorization_refresher: OnceLock::new(),
-            authorization_scopes: AsyncMutex::new(HashMap::new()),
-            token_refresh_bias: SyncMutex::new(TokenRefreshTimes::default()),
             credential,
+            authorization_scopes: AsyncMutex::new(HashMap::new()),
+            authorization_refresher: OnceLock::new(),
+            token_refresh_bias: SyncMutex::new(TokenRefreshTimes::default()),
             recoverable_connection,
             #[cfg(test)]
             disable_authorization: SyncMutex::new(false),
@@ -100,17 +111,7 @@ impl Authorizer {
 
         if !scopes.contains_key(path) {
             debug!("Creating new authorization scope for path: {path}");
-
-            debug!("Get Token.");
-            let token = self
-                .credential
-                .get_token(&[EVENTHUBS_AUTHORIZATION_SCOPE], None)
-                .await
-                .map_err(AmqpError::from)?;
-
-            debug!("Token for path {path} expires at {}", token.expires_on);
-
-            self.perform_authorization(connection, path, &token).await?;
+            let token = self.perform_authentication(connection, path).await?;
 
             // insert returns some if it *fails* to insert, None if it succeeded.
             let present = scopes.insert(path.clone(), token);
@@ -136,6 +137,45 @@ impl Authorizer {
             .clone())
     }
 
+    // Selects the appropriate authentication method based on the credential type.
+    async fn perform_authentication(
+        self: &Arc<Self>,
+        connection: &Arc<RecoverableConnection>,
+        url: &Url,
+    ) -> azure_core_amqp::Result<AccessToken> {
+        match &self.credential {
+            AuthorizerCredential::TokenCredential { credential } => {
+                let new_token = credential
+                    .get_token(&[EVENTHUBS_AUTHORIZATION_SCOPE], None)
+                    .await?;
+                debug!("Token for path {url} expires at {}", new_token.expires_on);
+                self.perform_token_authorization(connection, url, None, &new_token)
+                    .await?;
+                Ok(new_token)
+            }
+            AuthorizerCredential::SasToken {
+                key_name,
+                key_value,
+            } => {
+                const TOKEN_TYPE: &str = "servicebus.windows.net:sastoken";
+                let new_token =
+                    create_sas_token(OffsetDateTime::now_utc(), key_name, key_value, url.as_str())?;
+                debug!(
+                    "SAS token for path {url} expires at {}",
+                    new_token.expires_on
+                );
+                self.perform_token_authorization(
+                    connection,
+                    url,
+                    Some(TOKEN_TYPE.to_string()),
+                    &new_token,
+                )
+                .await?;
+                Ok(new_token)
+            }
+        }
+    }
+
     /// Actually perform an authorization against the Event Hubs service.
     ///
     /// This method establishes a connection to the Event Hubs service and
@@ -147,10 +187,11 @@ impl Authorizer {
     /// * `url` - The URL of the resource being authorized.
     /// * `new_token` - The new access token to use for authorization.
     ///
-    async fn perform_authorization(
+    async fn perform_token_authorization(
         self: &Arc<Self>,
         connection: &Arc<RecoverableConnection>,
         url: &Url,
+        token_type: Option<String>,
         new_token: &AccessToken,
     ) -> azure_core_amqp::Result<()> {
         // Test Hook: Disable interacting with Event Hubs service if the test doesn't want it.
@@ -171,7 +212,7 @@ impl Authorizer {
             .get_cbs_client()
             .authorize_path(
                 url.to_string(),
-                None,
+                token_type,
                 &new_token.token,
                 new_token.expires_on,
             )
@@ -316,22 +357,11 @@ impl Authorizer {
             // Now refresh tokens without holding the lock to avoid deadlocks
             let mut updated_tokens = HashMap::new();
             for url in tokens_to_refresh {
-                let new_token = self
-                    .credential
-                    .get_token(&[EVENTHUBS_AUTHORIZATION_SCOPE], None)
-                    .await?;
-
-                // Create an ephemeral connection to host the authentication.
+                debug!("Refreshing token for {url}");
                 let connection = self.recoverable_connection.upgrade().ok_or_else(|| {
                     AmqpError::with_message("Recoverable connection has been dropped")
                 })?;
-                self.perform_authorization(&connection, &url, &new_token)
-                    .await?;
-
-                debug!(
-                    "Token refreshed for {url}, new expiration time: {}",
-                    new_token.expires_on
-                );
+                let new_token = self.perform_authentication(&connection, &url).await?;
                 updated_tokens.insert(url.clone(), new_token);
             }
 
@@ -356,10 +386,51 @@ impl Authorizer {
     }
 }
 
+fn url_encode(url: &str) -> String {
+    url::form_urlencoded::byte_serialize(url.as_bytes()).collect::<String>()
+}
+
+fn create_sas_token(
+    now: OffsetDateTime,
+    key_name: &str,
+    key_value: &Secret,
+    url: &str,
+) -> azure_core_amqp::Result<AccessToken> {
+    // Remove anything after the topic name.
+    // amqps://../..[/]
+    let url = if let Some((index, _)) = url.char_indices().filter(|&(_, c)| c == '/').nth(3) {
+        // Make sure we are using a amqp URL.
+        if url.starts_with("amqps://") || url.starts_with("amqp://") {
+            &url[..index]
+        } else {
+            url
+        }
+    } else {
+        url
+    };
+
+    let url = url_encode(url);
+    let expires_on = now + Duration::hours(24);
+    let expiry_timestamp = expires_on.unix_timestamp();
+    let string_to_sign = format!("{url}\n{expiry_timestamp}");
+    let signature = hmac_sha256_bytes(string_to_sign.as_bytes(), key_value.secret().as_bytes())?;
+    let signature = url_encode(&signature);
+    let token_value = format!(
+        "SharedAccessSignature sr={url}&sig={signature}&se={expiry_timestamp}&skn={key_name}"
+    );
+
+    Ok(AccessToken {
+        token: token_value.into(),
+        expires_on,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use azure_core::{credentials::TokenRequestOptions, http::Url, time::OffsetDateTime, Result};
+    use azure_core::{
+        base64, credentials::TokenRequestOptions, http::Url, time::OffsetDateTime, Result,
+    };
     use azure_core_test::{recorded, TestContext};
     use std::sync::Arc;
     use tracing::info;
@@ -444,13 +515,17 @@ mod tests {
             url,
             None,
             None,
-            mock_credential.clone(),
+            AuthorizerCredential::TokenCredential {
+                credential: mock_credential.clone(),
+            },
             Default::default(),
         );
 
         let authorizer = Arc::new(Authorizer::new(
             Arc::downgrade(&connection_manager),
-            mock_credential.clone(),
+            AuthorizerCredential::TokenCredential {
+                credential: mock_credential.clone(),
+            },
         ));
 
         // Disable actual authorization for testing
@@ -507,7 +582,9 @@ mod tests {
             url,
             None,
             None,
-            mock_credential.clone(),
+            AuthorizerCredential::TokenCredential {
+                credential: mock_credential.clone(),
+            },
             Default::default(),
         );
 
@@ -519,7 +596,9 @@ mod tests {
 
         let authorizer = Arc::new(Authorizer::new(
             Arc::downgrade(&connection_manager),
-            mock_credential.clone(),
+            AuthorizerCredential::TokenCredential {
+                credential: mock_credential.clone(),
+            },
         ));
 
         // Disable actual authorization for testing
@@ -575,12 +654,16 @@ mod tests {
             host.clone(),
             None,
             None,
-            mock_credential.clone(),
+            AuthorizerCredential::TokenCredential {
+                credential: mock_credential.clone(),
+            },
             Default::default(),
         ));
         let authorizer = Arc::new(Authorizer::new(
             Arc::downgrade(&recoverable_connection),
-            mock_credential.clone(),
+            AuthorizerCredential::TokenCredential {
+                credential: mock_credential.clone(),
+            },
         ));
 
         // Get initial token get count
@@ -660,6 +743,44 @@ mod tests {
             "Expected second get token count to be 4, but got {final_count}"
         );
         info!("Second token expiration get count: {}", final_count);
+
+        Ok(())
+    }
+
+    #[test]
+    fn sas_token_creation() -> azure_core_amqp::Result<()> {
+        let hardcoded_date = OffsetDateTime::from_unix_timestamp(1737504000).unwrap();
+
+        let url = "amqps://example.com/eventhub";
+        let key_name = "test_key";
+        let key_value = Secret::new(base64::encode("test_key_value"));
+
+        let token = create_sas_token(hardcoded_date, key_name, &key_value, url)?;
+
+        let token_str = token.token.secret();
+        let token_str = token_str
+            .strip_prefix("SharedAccessSignature ")
+            .expect("Has SAS prefix");
+
+        let parts: Vec<&str> = token_str.split('&').collect();
+        assert_eq!(parts.len(), 4);
+
+        let params: HashMap<_, _> = parts.iter().filter_map(|p| p.split_once('=')).collect();
+
+        assert_eq!(
+            params.get("sr"),
+            Some(&"amqps%3A%2F%2Fexample.com%2Feventhub")
+        );
+        assert_eq!(params.get("skn"), Some(&"test_key"));
+
+        let expires_on = hardcoded_date + Duration::hours(24);
+        let expected_expiry = expires_on.unix_timestamp().to_string();
+        assert_eq!(params.get("se"), Some(&expected_expiry.as_str()));
+
+        assert_eq!(
+            params.get("sig"),
+            Some(&"xpqBEOqlRsPRuBqlJGGlp4xCpS%2BK9INXIq%2B0vXa6Z4M%3D")
+        );
 
         Ok(())
     }

--- a/sdk/eventhubs/cspell.yaml
+++ b/sdk/eventhubs/cspell.yaml
@@ -1,0 +1,9 @@
+import:
+  - ../../.vscode/cspell.json
+
+overrides:
+  - filename: "**/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs"
+    words:
+      # URL encoding in unit tests
+      - Fexample
+      - Feventhub


### PR DESCRIPTION
Adds SAS token support to eventhubs.

## Changes

* Add AuthorizerCredential that may be a SAS token and flow support up the call stack, ending with open_sas on the producer and consumer.
* Needed `hmac_sha256_bytes` to avoid a pointless base64 roundtrip.

## Use case

Support for SAS tokens, which was previously impossible.