### PR TITLE
More efficient deserialization of Entra ID errors

### DIFF
--- a/sdk/identity/azure_identity/Cargo.toml
+++ b/sdk/identity/azure_identity/Cargo.toml
@@ -20,6 +20,7 @@ futures.workspace = true
 openssl = { workspace = true, optional = true }
 pin-project.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 time.workspace = true
 tokio = { workspace = true, optional = true }
 tracing.workspace = true


### PR DESCRIPTION
Change the type of `error_description` from `String` to `&str` so serde can borrow from the input buffer instead of copying. Still have to copy the value before handing it off to `Error::new`, but the deserialization overhead will be smaller. Closes #3322
