### PR TITLE
Upgrade locked rkyv version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.45"
+version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -2444,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.45"
+version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Addresses the [RustSec advisory](https://rustsec.org/advisories/RUSTSEC-2026-0001) causing the `cargo audit` warning that breaks our CI. I upgraded the locked version because we don't have a direct dependency on `rkyv`, and chose the latest `0.7` instead of `0.8.x` because the latter is incompatible with `rust_decimal`.