### PR TITLE
Separate benchmark tests because JSON output is not supported

### DIFF
--- a/eng/scripts/Test-Packages.ps1
+++ b/eng/scripts/Test-Packages.ps1
@@ -112,7 +112,7 @@ foreach ($package in $packagesToTest) {
     -OutputFile $allTargetsOutput
 
   Invoke-LoggedCommand `
-    "cargo  test --benches --package $($package.Name) --no-fail-fast $featuresArg" `
+    "cargo test --benches --package $($package.Name) --no-fail-fast $featuresArg" `
     -GroupOutput
 
   $cleanupScript = ([System.IO.Path]::Combine($packageDirectory, 'Test-Cleanup.ps1'))


### PR DESCRIPTION
Fixes errors seen in https://dev.azure.com/azure-sdk/public/_build/results?buildId=5728760&view=logs&jobId=4a020b5f-6730-512b-14d3-88437c95abcc&j=4a020b5f-6730-512b-14d3-88437c95abcc&t=87f418d6-79a5-511c-3523-bf0e2d4690b7 

Benchmarks as they're set up don't support JSON output. 