### PR TITLE
Also report live test results to test tab

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -147,14 +147,14 @@ jobs:
 
   - task: Powershell@2
     displayName: Convert Test Results to JUnit XML
-    condition: and(succeededOrFailed(), ne(variables['NoPackagesChanged'],'true'))
+    condition: and(succeededOrFailed(), eq(variables['CI_HAS_DEPLOYED_RESOURCES'], 'true'))
     inputs:
       pwsh: true
       filePath: $(Build.SourcesDirectory)/eng/scripts/Convert-TestResultsToJUnit.ps1
 
   - task: PublishTestResults@2
     displayName: Publish Test Results
-    condition: and(succeededOrFailed(), ne(variables['NoPackagesChanged'],'true'))
+    condition: and(succeededOrFailed(), eq(variables['CI_HAS_DEPLOYED_RESOURCES'], 'true'))
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: '**/test-results/junit/*.xml'


### PR DESCRIPTION
There are some live test failures but nothing in the test tab. This fixes. 

Example failed live tests not reporting results: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5754977&view=results

Fixed: 

<img width="1135" height="1030" alt="image" src="https://github.com/user-attachments/assets/a0dc20fa-a370-49fc-af78-59f52127111b" />

Example successful build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5755140&view=results

Example build with failures: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5755141&view=ms.vss-test-web.build-test-results-tab
