### PR TITLE
Remove C type parameter from Poller

### DIFF
--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -16,7 +16,6 @@
 ### Breaking Changes
 
 - Added type parameter `C` to `Pager` declaration, defaulting to `Url` so it can be elided in most existing declarations.
-- Added type parameter `C` to `Poller` declaration, defaulting to `Url` so it can be elided in most existing declarations.
 - Changed `Pager::from_callback` to take a `PagerOptions` as the second parameter rather than a `Context` parameter.
 - Changed `Pager::from_callback` to `Pager::new` which now requires the caller to return a `Pin<Box<dyn Future>>`.
 - Changed `Poller::from_callback` to `Poller::new` which now requires the caller to return a `Pin<Box<dyn Future>>`.


### PR DESCRIPTION
Reverts some of the changes in PR #3506. Basically, many `Poller`s need to track 2 or more data points e.g., a `next_link` and `final_link` because we have many different LRO patterns. The idea was to make `Poller` closer to `Pager`, but `Pager` only ever tracks one continuation token / next link. So because we emitted a `struct Progress` to hold whatever data we needed, that meant we had to leak this private implementation detail - not only exposing it as a public API, but also including it in many client methods.
