### PR TITLE
Tweak Copilot instructions for CHANGELOGs

### DIFF
--- a/.github/instructions/changelog.instructions.md
+++ b/.github/instructions/changelog.instructions.md
@@ -3,7 +3,7 @@ applyTo: "**/CHANGELOG.md"
 ---
 
 - Summarize each change to public APIs in a single line for clarity and brevity.
-- If there are no changes to public APIs, do not make any changes to `CHANGELOG.md` files.
+- If there are no changes to public APIs, do not make any changes to `CHANGELOG.md` files unless a new, unreleased version is being added.
 - Place each change under the appropriate existing category header (e.g., "Features Added", "Breaking Changes", "Bugs Fixed", "Other Changes", etc.) found under the top-level `##` section.
 - Do not create new category headers; use only those already present in the file.
 - Ensure all entries are concise, accurate, and relevant to the release.


### PR DESCRIPTION
GitHub Copilot during a review when these were added said not to change CHANGELOGs,
but we were adding a new, unreleased version so this is appropriate.

See #3572 for context.
