### PR TITLE
Fix cargo-semver-checks against new doc version

### DIFF
--- a/eng/pipelines/templates/jobs/pack.yml
+++ b/eng/pipelines/templates/jobs/pack.yml
@@ -49,7 +49,7 @@ jobs:
 
   - template: /eng/pipelines/templates/steps/use-rust.yml@self
     parameters:
-      # 19.3 just came out and bumped the doc version to v57, which cargo-semver-checks does not yet support.
+      # 1.93 just came out and bumped the doc version to v57, which cargo-semver-checks does not yet support.
       Toolchain: '1.92'
 
   - ${{ if eq(parameters.TestPipeline, 'true') }}:


### PR DESCRIPTION
Rust 1.93 bumped the doc version to v57 which cargo-semver-checks 0.45.0 (still latest) does not yet support.
