### PR TITLE
[Storage] Omit constructors `tspconfig.yaml` emitter flag proof-of-concept

### DIFF
--- a/sdk/storage/azure_storage_blob/src/generated/clients/append_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/append_blob_client.rs
@@ -11,18 +11,14 @@ use crate::generated::models::{
 };
 use azure_core::{
     base64::encode,
-    credentials::TokenCredential,
     error::CheckSuccessOptions,
-    fmt::SafeDebug,
     http::{
-        policies::{auth::BearerTokenAuthorizationPolicy, Policy},
-        ClientOptions, Method, NoFormat, Pipeline, PipelineSendOptions, Request, RequestContent,
-        Response, Url, UrlExt,
+        Method, NoFormat, Pipeline, PipelineSendOptions, Request, RequestContent, Response, Url,
+        UrlExt,
     },
     time::to_rfc7231,
     tracing, Bytes, Result,
 };
-use std::sync::Arc;
 
 #[tracing::client]
 pub struct AppendBlobClient {
@@ -31,56 +27,7 @@ pub struct AppendBlobClient {
     pub(crate) version: String,
 }
 
-/// Options used when creating a `AppendBlobClient`
-#[derive(Clone, SafeDebug)]
-pub struct AppendBlobClientOptions {
-    /// Allows customization of the client.
-    pub client_options: ClientOptions,
-    /// Specifies the version of the operation to use for this request.
-    pub version: String,
-}
-
 impl AppendBlobClient {
-    /// Creates a new AppendBlobClient, using Entra ID authentication.
-    ///
-    /// # Arguments
-    ///
-    /// * `endpoint` - Service host
-    /// * `credential` - An implementation of [`TokenCredential`](azure_core::credentials::TokenCredential) that can provide an
-    ///   Entra ID token to use when authenticating.
-    /// * `options` - Optional configuration for the client.
-    #[tracing::new("Storage.Blob.AppendBlob")]
-    pub fn new(
-        endpoint: &str,
-        credential: Arc<dyn TokenCredential>,
-        options: Option<AppendBlobClientOptions>,
-    ) -> Result<Self> {
-        let options = options.unwrap_or_default();
-        let endpoint = Url::parse(endpoint)?;
-        if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::with_message(
-                azure_core::error::ErrorKind::Other,
-                format!("{endpoint} must use http(s)"),
-            ));
-        }
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
-            credential,
-            vec!["https://storage.azure.com/.default"],
-        ));
-        Ok(Self {
-            endpoint,
-            version: options.version,
-            pipeline: Pipeline::new(
-                option_env!("CARGO_PKG_NAME"),
-                option_env!("CARGO_PKG_VERSION"),
-                options.client_options,
-                Vec::default(),
-                vec![auth_policy],
-                None,
-            ),
-        })
-    }
-
     /// Returns the Url associated with this client.
     pub fn endpoint(&self) -> &Url {
         &self.endpoint
@@ -628,14 +575,5 @@ impl AppendBlobClient {
             )
             .await?;
         Ok(rsp.into())
-    }
-}
-
-impl Default for AppendBlobClientOptions {
-    fn default() -> Self {
-        Self {
-            client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
-        }
     }
 }

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_client.rs
@@ -20,18 +20,15 @@ use crate::generated::models::{
 };
 use azure_core::{
     base64::encode,
-    credentials::TokenCredential,
     error::CheckSuccessOptions,
-    fmt::SafeDebug,
     http::{
-        policies::{auth::BearerTokenAuthorizationPolicy, Policy},
-        AsyncResponse, ClientOptions, Method, NoFormat, Pipeline, PipelineSendOptions,
-        PipelineStreamOptions, Request, RequestContent, Response, Url, UrlExt, XmlFormat,
+        AsyncResponse, Method, NoFormat, Pipeline, PipelineSendOptions, PipelineStreamOptions,
+        Request, RequestContent, Response, Url, UrlExt, XmlFormat,
     },
     time::{to_rfc7231, OffsetDateTime},
     tracing, Result,
 };
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 #[tracing::client]
 pub struct BlobClient {
@@ -40,56 +37,7 @@ pub struct BlobClient {
     pub(crate) version: String,
 }
 
-/// Options used when creating a `BlobClient`
-#[derive(Clone, SafeDebug)]
-pub struct BlobClientOptions {
-    /// Allows customization of the client.
-    pub client_options: ClientOptions,
-    /// Specifies the version of the operation to use for this request.
-    pub version: String,
-}
-
 impl BlobClient {
-    /// Creates a new BlobClient, using Entra ID authentication.
-    ///
-    /// # Arguments
-    ///
-    /// * `endpoint` - Service host
-    /// * `credential` - An implementation of [`TokenCredential`](azure_core::credentials::TokenCredential) that can provide an
-    ///   Entra ID token to use when authenticating.
-    /// * `options` - Optional configuration for the client.
-    #[tracing::new("Storage.Blob.Blob")]
-    pub fn new(
-        endpoint: &str,
-        credential: Arc<dyn TokenCredential>,
-        options: Option<BlobClientOptions>,
-    ) -> Result<Self> {
-        let options = options.unwrap_or_default();
-        let endpoint = Url::parse(endpoint)?;
-        if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::with_message(
-                azure_core::error::ErrorKind::Other,
-                format!("{endpoint} must use http(s)"),
-            ));
-        }
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
-            credential,
-            vec!["https://storage.azure.com/.default"],
-        ));
-        Ok(Self {
-            endpoint,
-            version: options.version,
-            pipeline: Pipeline::new(
-                option_env!("CARGO_PKG_NAME"),
-                option_env!("CARGO_PKG_VERSION"),
-                options.client_options,
-                Vec::default(),
-                vec![auth_policy],
-                None,
-            ),
-        })
-    }
-
     /// Returns the Url associated with this client.
     pub fn endpoint(&self) -> &Url {
         &self.endpoint
@@ -2084,14 +2032,5 @@ impl BlobClient {
             )
             .await?;
         Ok(rsp.into())
-    }
-}
-
-impl Default for BlobClientOptions {
-    fn default() -> Self {
-        Self {
-            client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
-        }
     }
 }

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
@@ -12,18 +12,14 @@ use crate::generated::models::{
     StorageServiceStats, UserDelegationKey,
 };
 use azure_core::{
-    credentials::TokenCredential,
     error::CheckSuccessOptions,
-    fmt::SafeDebug,
     http::{
         pager::{PagerResult, PagerState},
-        policies::{auth::BearerTokenAuthorizationPolicy, Policy},
-        ClientOptions, Method, NoFormat, Pager, Pipeline, PipelineSendOptions, RawResponse,
-        Request, RequestContent, Response, Url, UrlExt, XmlFormat,
+        Method, NoFormat, Pager, Pipeline, PipelineSendOptions, RawResponse, Request,
+        RequestContent, Response, Url, UrlExt, XmlFormat,
     },
     tracing, xml, Result,
 };
-use std::sync::Arc;
 
 #[tracing::client]
 pub struct BlobServiceClient {
@@ -32,56 +28,7 @@ pub struct BlobServiceClient {
     pub(crate) version: String,
 }
 
-/// Options used when creating a `BlobServiceClient`
-#[derive(Clone, SafeDebug)]
-pub struct BlobServiceClientOptions {
-    /// Allows customization of the client.
-    pub client_options: ClientOptions,
-    /// Specifies the version of the operation to use for this request.
-    pub version: String,
-}
-
 impl BlobServiceClient {
-    /// Creates a new BlobServiceClient, using Entra ID authentication.
-    ///
-    /// # Arguments
-    ///
-    /// * `endpoint` - Service host
-    /// * `credential` - An implementation of [`TokenCredential`](azure_core::credentials::TokenCredential) that can provide an
-    ///   Entra ID token to use when authenticating.
-    /// * `options` - Optional configuration for the client.
-    #[tracing::new("Storage.Blob.Service")]
-    pub fn new(
-        endpoint: &str,
-        credential: Arc<dyn TokenCredential>,
-        options: Option<BlobServiceClientOptions>,
-    ) -> Result<Self> {
-        let options = options.unwrap_or_default();
-        let endpoint = Url::parse(endpoint)?;
-        if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::with_message(
-                azure_core::error::ErrorKind::Other,
-                format!("{endpoint} must use http(s)"),
-            ));
-        }
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
-            credential,
-            vec!["https://storage.azure.com/.default"],
-        ));
-        Ok(Self {
-            endpoint,
-            version: options.version,
-            pipeline: Pipeline::new(
-                option_env!("CARGO_PKG_NAME"),
-                option_env!("CARGO_PKG_VERSION"),
-                options.client_options,
-                Vec::default(),
-                vec![auth_policy],
-                None,
-            ),
-        })
-    }
-
     /// Returns the Url associated with this client.
     pub fn endpoint(&self) -> &Url {
         &self.endpoint
@@ -467,14 +414,5 @@ impl BlobServiceClient {
             )
             .await?;
         Ok(rsp.into())
-    }
-}
-
-impl Default for BlobServiceClientOptions {
-    fn default() -> Self {
-        Self {
-            client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
-        }
     }
 }

--- a/sdk/storage/azure_storage_blob/src/generated/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/block_blob_client.rs
@@ -14,18 +14,14 @@ use crate::generated::models::{
 };
 use azure_core::{
     base64::encode,
-    credentials::TokenCredential,
     error::CheckSuccessOptions,
-    fmt::SafeDebug,
     http::{
-        policies::{auth::BearerTokenAuthorizationPolicy, Policy},
-        AsyncResponse, ClientOptions, Method, NoFormat, Pipeline, PipelineSendOptions,
-        PipelineStreamOptions, Request, RequestContent, Response, Url, UrlExt, XmlFormat,
+        AsyncResponse, Method, NoFormat, Pipeline, PipelineSendOptions, PipelineStreamOptions,
+        Request, RequestContent, Response, Url, UrlExt, XmlFormat,
     },
     time::to_rfc7231,
     tracing, Bytes, Result,
 };
-use std::sync::Arc;
 
 #[tracing::client]
 pub struct BlockBlobClient {
@@ -34,56 +30,7 @@ pub struct BlockBlobClient {
     pub(crate) version: String,
 }
 
-/// Options used when creating a `BlockBlobClient`
-#[derive(Clone, SafeDebug)]
-pub struct BlockBlobClientOptions {
-    /// Allows customization of the client.
-    pub client_options: ClientOptions,
-    /// Specifies the version of the operation to use for this request.
-    pub version: String,
-}
-
 impl BlockBlobClient {
-    /// Creates a new BlockBlobClient, using Entra ID authentication.
-    ///
-    /// # Arguments
-    ///
-    /// * `endpoint` - Service host
-    /// * `credential` - An implementation of [`TokenCredential`](azure_core::credentials::TokenCredential) that can provide an
-    ///   Entra ID token to use when authenticating.
-    /// * `options` - Optional configuration for the client.
-    #[tracing::new("Storage.Blob.BlockBlob")]
-    pub fn new(
-        endpoint: &str,
-        credential: Arc<dyn TokenCredential>,
-        options: Option<BlockBlobClientOptions>,
-    ) -> Result<Self> {
-        let options = options.unwrap_or_default();
-        let endpoint = Url::parse(endpoint)?;
-        if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::with_message(
-                azure_core::error::ErrorKind::Other,
-                format!("{endpoint} must use http(s)"),
-            ));
-        }
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
-            credential,
-            vec!["https://storage.azure.com/.default"],
-        ));
-        Ok(Self {
-            endpoint,
-            version: options.version,
-            pipeline: Pipeline::new(
-                option_env!("CARGO_PKG_NAME"),
-                option_env!("CARGO_PKG_VERSION"),
-                options.client_options,
-                Vec::default(),
-                vec![auth_policy],
-                None,
-            ),
-        })
-    }
-
     /// Returns the Url associated with this client.
     pub fn endpoint(&self) -> &Url {
         &self.endpoint
@@ -1109,14 +1056,5 @@ impl BlockBlobClient {
             )
             .await?;
         Ok(rsp.into())
-    }
-}
-
-impl Default for BlockBlobClientOptions {
-    fn default() -> Self {
-        Self {
-            client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
-        }
     }
 }

--- a/sdk/storage/azure_storage_blob/src/generated/clients/page_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/page_blob_client.rs
@@ -16,18 +16,14 @@ use crate::generated::models::{
 };
 use azure_core::{
     base64::encode,
-    credentials::TokenCredential,
     error::CheckSuccessOptions,
-    fmt::SafeDebug,
     http::{
-        policies::{auth::BearerTokenAuthorizationPolicy, Policy},
-        ClientOptions, Method, NoFormat, Pipeline, PipelineSendOptions, Request, RequestContent,
-        Response, Url, UrlExt, XmlFormat,
+        Method, NoFormat, Pipeline, PipelineSendOptions, Request, RequestContent, Response, Url,
+        UrlExt, XmlFormat,
     },
     time::to_rfc7231,
     tracing, Bytes, Result,
 };
-use std::sync::Arc;
 
 #[tracing::client]
 pub struct PageBlobClient {
@@ -36,56 +32,7 @@ pub struct PageBlobClient {
     pub(crate) version: String,
 }
 
-/// Options used when creating a `PageBlobClient`
-#[derive(Clone, SafeDebug)]
-pub struct PageBlobClientOptions {
-    /// Allows customization of the client.
-    pub client_options: ClientOptions,
-    /// Specifies the version of the operation to use for this request.
-    pub version: String,
-}
-
 impl PageBlobClient {
-    /// Creates a new PageBlobClient, using Entra ID authentication.
-    ///
-    /// # Arguments
-    ///
-    /// * `endpoint` - Service host
-    /// * `credential` - An implementation of [`TokenCredential`](azure_core::credentials::TokenCredential) that can provide an
-    ///   Entra ID token to use when authenticating.
-    /// * `options` - Optional configuration for the client.
-    #[tracing::new("Storage.Blob.PageBlob")]
-    pub fn new(
-        endpoint: &str,
-        credential: Arc<dyn TokenCredential>,
-        options: Option<PageBlobClientOptions>,
-    ) -> Result<Self> {
-        let options = options.unwrap_or_default();
-        let endpoint = Url::parse(endpoint)?;
-        if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::with_message(
-                azure_core::error::ErrorKind::Other,
-                format!("{endpoint} must use http(s)"),
-            ));
-        }
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
-            credential,
-            vec!["https://storage.azure.com/.default"],
-        ));
-        Ok(Self {
-            endpoint,
-            version: options.version,
-            pipeline: Pipeline::new(
-                option_env!("CARGO_PKG_NAME"),
-                option_env!("CARGO_PKG_VERSION"),
-                options.client_options,
-                Vec::default(),
-                vec![auth_policy],
-                None,
-            ),
-        })
-    }
-
     /// Returns the Url associated with this client.
     pub fn endpoint(&self) -> &Url {
         &self.endpoint
@@ -1234,14 +1181,5 @@ impl PageBlobClient {
             )
             .await?;
         Ok(rsp.into())
-    }
-}
-
-impl Default for PageBlobClientOptions {
-    fn default() -> Self {
-        Self {
-            client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
-        }
     }
 }

--- a/sdk/storage/azure_storage_blob/src/generated/mod.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/mod.rs
@@ -8,7 +8,6 @@ pub mod clients;
 /// Contains all the data structures and types used by the client library.
 pub mod models;
 pub use clients::{
-    AppendBlobClient, AppendBlobClientOptions, BlobClient, BlobClientOptions, BlobContainerClient,
-    BlobContainerClientOptions, BlobServiceClient, BlobServiceClientOptions, BlockBlobClient,
-    BlockBlobClientOptions, PageBlobClient, PageBlobClientOptions,
+    AppendBlobClient, BlobClient, BlobContainerClient, BlobServiceClient, BlockBlobClient,
+    PageBlobClient,
 };

--- a/sdk/storage/azure_storage_blob/tsp-location.yaml
+++ b/sdk/storage/azure_storage_blob/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/storage/Microsoft.BlobStorage
-commit: d45e11b864f6fc895123dc42573f506f10ed81f9
+commit: b621b54fc8cae5c02bfb432ee83760492fe871c1
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 


### PR DESCRIPTION
Generated off: https://github.com/Azure/azure-rest-api-specs/tree/vincenttran/omit_ctors

Ideally we still would like to be able to encapsulate this functionality in TypeSpec, but this is a usable workaround.