### PR TITLE
Allow localhost authority for mocking

### DIFF
--- a/sdk/identity/azure_identity/src/lib.rs
+++ b/sdk/identity/azure_identity/src/lib.rs
@@ -154,10 +154,13 @@ fn get_authority_host(env: Option<Env>, cloud: Option<&CloudConfiguration>) -> R
 
     let url = Url::parse(&authority_host)?;
     if url.scheme() != "https" {
-        return Err(Error::with_message(
-            ErrorKind::Other,
-            format!("authority host doesn't use HTTPS scheme: {authority_host}"),
-        ));
+        let localhost_authorities = ["localhost", "127.0.0.1", "[::1]"];
+        if !localhost_authorities.contains(&url.host_str().unwrap_or_default()) {
+            return Err(Error::with_message(
+                ErrorKind::Other,
+                format!("authority host doesn't use HTTPS scheme: {authority_host}"),
+            ));
+        }
     }
     Ok(url)
 }


### PR DESCRIPTION
Since `azure_identity` 0.28, only HTTPS authority endpoints have been allowed. This creates a problem when unit testing, for example, when we want to test our own SpecificAzureCredential implementation.

This PR simply allows HTTP authority endpoints when the host address is localhost.