### PR TITLE
Change typespec_client_core::http::policies::logging Request and Response log level to debug

### DIFF
--- a/sdk/core/typespec_client_core/src/http/policies/logging.rs
+++ b/sdk/core/typespec_client_core/src/http/policies/logging.rs
@@ -8,7 +8,7 @@ use crate::http::{
 };
 use std::sync::Arc;
 use std::{borrow::Cow, collections::HashSet};
-use tracing::info;
+use tracing::{debug, info};
 
 /// [`Policy`] to log a request and response.
 #[derive(Clone, Debug, Default)]
@@ -44,7 +44,7 @@ impl Policy for LoggingPolicy {
         request: &mut Request,
         next: &[Arc<dyn Policy>],
     ) -> PolicyResult {
-        info!(
+        debug!(
             "==> Request: url: {}, method: {}, headers: {{ {} }}",
             request.url.sanitize(&self.allowed_query_params),
             request.method(),
@@ -53,7 +53,7 @@ impl Policy for LoggingPolicy {
         let response = next[0].send(ctx, request, &next[1..]).await;
 
         if let Ok(response) = &response {
-            info!(
+            debug!(
                 "<== Response: {{ url: {}, status: {}, headers: {{ {} }} }}",
                 request.url.sanitize(&self.allowed_query_params),
                 response.status(),


### PR DESCRIPTION
When using `azure_identity`, applications see Request and Response INFO log events as access tokens are refreshed, sometimes hourly(ish):

```
2026-01-30T23:14:25.004300Z  INFO  typespec_client_core::http::policies::logging: ==> Request: url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token, method: POST, headers: { x-ms-client-request-id: 00000000-0000-0000-0000-000000000000 content-type: application/x-www-form-urlencoded user-agent: azsdk-rust-identity/0.30.0 (1.92.0; linux; x86_64)  }
2026-01-30T23:14:25.257778Z  INFO  typespec_client_core::http::policies::logging: <== Response: { url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token, status: 200, headers: { date: Fri, 30 Jan 2026 23:14:25 GMT x-ms-srs: REDACTED content-type: application/json; charset=utf-8 x-content-type-options: REDACTED expires: -1 x-ms-ests-server: REDACTED strict-transport-security: REDACTED p3p: REDACTED x-xss-protection: REDACTED content-length: 1712 cache-control: no-store, no-cache set-cookie: REDACTED pragma: no-cache x-ms-request-id: 00000000-0000-0000-0000-000000000000 content-security-policy-report-only: REDACTED  } }
2026-01-31T00:09:29.955171Z  INFO  typespec_client_core::http::policies::logging: ==> Request: url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token, method: POST, headers: { user-agent: azsdk-rust-identity/0.30.0 (1.92.0; linux; x86_64) content-type: application/x-www-form-urlencoded x-ms-client-request-id: 00000000-0000-0000-0000-000000000000  }
2026-01-31T00:09:30.196806Z  INFO  typespec_client_core::http::policies::logging: <== Response: { url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token, status: 200, headers: { x-ms-request-id: 00000000-0000-0000-0000-000000000000 x-ms-ests-server: REDACTED x-ms-srs: REDACTED date: Sat, 31 Jan 2026 00:09:29 GMT content-type: application/json; charset=utf-8 expires: -1 content-security-policy-report-only: REDACTED set-cookie: REDACTED x-xss-protection: REDACTED pragma: no-cache content-length: 1717 p3p: REDACTED cache-control: no-store, no-cache x-content-type-options: REDACTED strict-transport-security: REDACTED  } }
2026-01-31T01:04:29.990787Z  INFO  typespec_client_core::http::policies::logging: ==> Request: url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token, method: POST, headers: { user-agent: azsdk-rust-identity/0.30.0 (1.92.0; linux; x86_64) content-type: application/x-www-form-urlencoded x-ms-client-request-id: 00000000-0000-0000-0000-000000000000  }
2026-01-31T01:04:30.252971Z  INFO  typespec_client_core::http::policies::logging: <== Response: { url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token, status: 200, headers: { x-ms-ests-server: REDACTED content-type: application/json; charset=utf-8 p3p: REDACTED pragma: no-cache x-content-type-options: REDACTED x-ms-srs: REDACTED expires: -1 date: Sat, 31 Jan 2026 01:04:30 GMT strict-transport-security: REDACTED x-xss-protection: REDACTED set-cookie: REDACTED content-security-policy-report-only: REDACTED x-ms-request-id: 00000000-0000-0000-0000-000000000000 content-length: 1727 cache-control: no-store, no-cache  } }
2026-01-31T01:59:29.956611Z  INFO  typespec_client_core::http::policies::logging: ==> Request: url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token, method: POST, headers: { x-ms-client-request-id: 00000000-0000-0000-0000-000000000000 content-type: application/x-www-form-urlencoded user-agent: azsdk-rust-identity/0.30.0 (1.92.0; linux; x86_64)  }
2026-01-31T01:59:30.259192Z  INFO  typespec_client_core::http::policies::logging: <== Response: { url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token, status: 200, headers: { cache-control: no-store, no-cache x-ms-request-id: 00000000-0000-0000-0000-000000000000 content-type: application/json; charset=utf-8 content-security-policy-report-only: REDACTED expires: -1 date: Sat, 31 Jan 2026 01:59:29 GMT pragma: no-cache x-content-type-options: REDACTED strict-transport-security: REDACTED x-xss-protection: REDACTED x-ms-srs: REDACTED set-cookie: REDACTED x-ms-ests-server: REDACTED content-length: 1717 p3p: REDACTED  } }
2026-01-31T02:54:30.952123Z  INFO  typespec_client_core::http::policies::logging: ==> Request: url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token, method: POST, headers: { content-type: application/x-www-form-urlencoded x-ms-client-request-id: 00000000-0000-0000-0000-000000000000 user-agent: azsdk-rust-identity/0.30.0 (1.92.0; linux; x86_64)  }
2026-01-31T02:54:31.198919Z  INFO  typespec_client_core::http::policies::logging: <== Response: { url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token, status: 200, headers: { set-cookie: REDACTED x-ms-request-id: 00000000-0000-0000-0000-000000000000 strict-transport-security: REDACTED content-type: application/json; charset=utf-8 pragma: no-cache x-ms-ests-server: REDACTED x-ms-srs: REDACTED x-xss-protection: REDACTED content-length: 1717 expires: -1 cache-control: no-store, no-cache date: Sat, 31 Jan 2026 02:54:30 GMT x-content-type-options: REDACTED p3p: REDACTED content-security-policy-report-only: REDACTED  } }
2026-01-31T03:49:30.952551Z  INFO  typespec_client_core::http::policies::logging: ==> Request: url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token, method: POST, headers: { user-agent: azsdk-rust-identity/0.30.0 (1.92.0; linux; x86_64) content-type: application/x-www-form-urlencoded x-ms-client-request-id: 00000000-0000-0000-0000-000000000000  }
2026-01-31T03:49:31.215154Z  INFO  typespec_client_core::http::policies::logging: <== Response: { url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token, status: 200, headers: { x-ms-ests-server: REDACTED x-ms-request-id: 00000000-0000-0000-0000-000000000000 content-length: 1727 x-ms-srs: REDACTED cache-control: no-store, no-cache x-xss-protection: REDACTED x-content-type-options: REDACTED content-security-policy-report-only: REDACTED pragma: no-cache content-type: application/json; charset=utf-8 set-cookie: REDACTED date: Sat, 31 Jan 2026 03:49:31 GMT strict-transport-security: REDACTED expires: -1 p3p: REDACTED  } }
```

Since `azure_identity` doesn't do much logging, these appear out of the blue; and apart from failures, these aren't very useful.

This PR downgrades these logs to `debug`, [consistent with the Python SDK](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/corehttp/corehttp/runtime/policies/_universal.py#L181).

I did consider a more complete PR, and the Failed response case: and either holding off logging the Request (not ideal), or re-log the Request as info... but for every use-case I can think of, the only useful info is the Timestamp and X-MS-Request-ID headers for raising a support case, both which are both in the Response anyway.