### PR TITLE
[Storage] Fix failing weekly live test

### DIFF
--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-### Breaking Changesa
+### Breaking Changes
 
 ### Bugs Fixed
 


### PR DESCRIPTION
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5822761&view=ms.vss-test-web.build-test-results-tab&runId=59335785&resultId=100078&paneView=debug
>thread 'managed_upload_large' (234456) panicked at sdk/storage/azure_storage_blob/tests/block_blob_client.rs:374:5:
assertion `left == right` failed
  left: 13
 right: 12
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

Updates the code to not truncate `12.5` and instead round up.