### PR TITLE
Add --all-features to cargo test guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,9 +121,11 @@ cargo build --workspace
 
 ### Testing
 
+When running `cargo test`, use `--all-features` to ensure no tests are missed.
+
 ```bash
 # Run tests for a specific crate
-cargo test -p <crate-name>
+cargo test -p <crate-name> --all-features
 
 # Run integration tests with recordings
 cargo test -p <crate-name> --test <test-name>


### PR DESCRIPTION
Update the Test Generation section in copilot-instructions.md to recommend using `--doc` and `--all-features` flags when running `cargo test` to ensure no tests are missed.

This ensures both doc tests and feature-gated tests are included when validating code changes.