### PR TITLE
Fix recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
   "recommendations": [
     "editorconfig.editorconfig",
-    "GitHub.copilot",
+    "github.copilot-chat",
     "rust-lang.rust-analyzer",
     "streetsidesoftware.code-spell-checker",
     "tamasfe.even-better-toml",


### PR DESCRIPTION
Github.copilot is deprecated; use github.copilot-chat instead.
