### PR TITLE
Remove redundant content from Azure[Developer]CliCredential errors

### DIFF
--- a/sdk/identity/azure_identity/CHANGELOG.md
+++ b/sdk/identity/azure_identity/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Removed redundant content from `Azure[Developer]CliCredential` error messages
+
 ### Other Changes
 
 ## 0.31.0 (2026-01-21)

--- a/sdk/identity/azure_identity/src/azure_cli_credential.rs
+++ b/sdk/identity/azure_identity/src/azure_cli_credential.rs
@@ -47,10 +47,6 @@ impl CliTokenResponse {
 }
 
 impl OutputProcessor for CliTokenResponse {
-    fn credential_name() -> &'static str {
-        "AzureCliCredential"
-    }
-
     fn get_error_message(_stderr: &str) -> Option<&str> {
         // Azure CLI's errors are generally clear and more helpful than anything we'd write here
         None
@@ -225,12 +221,14 @@ mod tests {
 
     #[tokio::test]
     async fn error_includes_stderr() {
-        let stderr = "something went wrong";
-        let err = run_test(1, "stdout", stderr, None, None)
+        let err = run_test(1, "stdout", "something went wrong", None, None)
             .await
             .expect_err("expected error");
         assert!(matches!(err.kind(), ErrorKind::Credential));
-        assert!(err.to_string().contains(stderr));
+        assert_eq!(
+            "AzureCliCredential authentication failed. something went wrong\nTo troubleshoot, visit https://aka.ms/azsdk/rust/identity/troubleshoot#azure-cli",
+            err.to_string()
+        );
     }
 
     #[tokio::test]
@@ -259,7 +257,10 @@ mod tests {
             .await
             .expect_err("error");
         assert!(matches!(err.kind(), ErrorKind::Credential));
-        assert!(err.to_string().contains("az login"));
+        assert_eq!(
+            "AzureCliCredential authentication failed. Please run 'az login' to setup account.\nTo troubleshoot, visit https://aka.ms/azsdk/rust/identity/troubleshoot#azure-cli",
+            err.to_string()
+        );
     }
 
     #[tokio::test]

--- a/sdk/identity/azure_identity/src/developer_tools_credential.rs
+++ b/sdk/identity/azure_identity/src/developer_tools_credential.rs
@@ -228,9 +228,10 @@ mod tests {
         assert_eq!(mock1.call_count(), 1);
         assert_eq!(mock2.call_count(), 1);
         assert_eq!(mock3.call_count(), 1);
-        assert!(error_msg.contains("mock1 failed"));
-        assert!(error_msg.contains("mock2 failed"));
-        assert!(error_msg.contains("mock3 failed"));
+        assert_eq!(
+            "Multiple errors were encountered while attempting to authenticate:\nmock1 failed\nmock2 failed\nmock3 failed",
+            error_msg
+        );
     }
 
     #[tokio::test]
@@ -245,7 +246,14 @@ mod tests {
             .get_token(&["scope"], None)
             .await
             .expect_err("expected error");
-        assert!(err.to_string().contains("something went wrong"));
+        assert_eq!(
+            "Multiple errors were encountered while attempting to authenticate:\n\
+             AzureCliCredential authentication failed. other error error: something went wrong\n\
+             To troubleshoot, visit https://aka.ms/azsdk/rust/identity/troubleshoot#azure-cli - other error error: something went wrong - something went wrong\n\
+             AzureDeveloperCliCredential authentication failed. other error error: something went wrong\n\
+             To troubleshoot, visit https://aka.ms/azsdk/rust/identity/troubleshoot#azd - other error error: something went wrong - something went wrong",
+            err.to_string()
+        );
         assert_eq!(
             2,
             executor.call_count(),

--- a/sdk/identity/azure_identity/src/process/mod.rs
+++ b/sdk/identity/azure_identity/src/process/mod.rs
@@ -98,32 +98,20 @@ pub(crate) async fn shell_exec<T: OutputProcessor>(
             } else {
                 stderr.to_string()
             };
-            Err(Error::with_message_fn(ErrorKind::Credential, || {
-                format!("{} authentication failed: {message}", T::credential_name())
-            }))
+            Err(Error::with_message(ErrorKind::Credential, message))
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            let message = format!(
-                "{} authentication failed: {program:?} wasn't found on PATH",
-                T::credential_name(),
-            );
+            let message = format!("{program:?} wasn't found on PATH");
             Err(Error::with_error(ErrorKind::Credential, e, message))
         }
         Err(e) => {
-            let message = format!(
-                "{} failed due to {} error: {e}",
-                T::credential_name(),
-                e.kind()
-            );
+            let message = format!("{} error: {e}", e.kind());
             Err(Error::with_error(ErrorKind::Credential, e, message))
         }
     }
 }
 
 pub(crate) trait OutputProcessor: Send + Sized + Sync + 'static {
-    /// The credential name to include in error messages
-    fn credential_name() -> &'static str;
-
     /// Deserialize an AccessToken from stdout
     fn deserialize_token(stdout: &str) -> Result<AccessToken>;
 


### PR DESCRIPTION
#3302 overlooked `shell_exec()` when consolidating responsibility for error message formatting with the result that a prefix is now repeated in these credentials' errors e.g. `AzureCliCredential authentication failed. AzureCliCredential authentication failed: ...`. This PR removes this prefix from `shell_exec()` errors and updates tests to catch this kind of thing.