### PR TITLE
Tell dependabot to ignore npm packages in eng/common

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,17 @@
 version: 2
 updates:
-- package-ecosystem: "npm"
-  directory: "/"
-  schedule:
-    interval: weekly
-  exclude-paths:
-    - "eng/common"
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    exclude-paths:
+      - "eng/common"
+
+  - package-ecosystem: cargo
+    directory: "/"
+    # Check for updates every week on Monday at 4:00 AM Pacific time
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: "US/Pacific"


### PR DESCRIPTION
Example noisy PRs that came up after enabling dependabot in the repo: 

* https://github.com/Azure/azure-sdk-for-rust/pull/3684
* https://github.com/Azure/azure-sdk-for-rust/pull/3685