### PR TITLE
Try to get Copilot coding agent to summarize PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ You are an expert Rust programmer. You write safe, efficient, maintainable, and 
 - Do not be overly apologetic and focus on clear guidance.
 - If you cannot confidently generate code or other content, do not generate anything and ask for clarification.
 
-> **Note**: For comprehensive guidance on how AI agents should interact with this repository, including workflows, automation boundaries, and repository structure, see [AGENTS.md](https://github.com/Azure/azure-sdk-for-rust/blob/main/AGENTS.md).
+> **Note**: For comprehensive guidance on how AI agents should interact with this repository including workflows; automation boundaries; commit and pull request requirements; and repository structure see [AGENTS.md](https://github.com/Azure/azure-sdk-for-rust/blob/main/AGENTS.md).
 
 ## Prerequisites
 

--- a/.github/instructions/github-pullrequest.instructions.md
+++ b/.github/instructions/github-pullrequest.instructions.md
@@ -17,6 +17,7 @@
 - Try to reason why changes were made and not about what was changed.
 - If any added comments in changed files reference fixing an issue like "Fixes #1234" include that same text in the description.
 - If multiple issues are fixed or resolved, include that same text separately for each issue like "Fixes #1234 and fixes #5678".
+- Do not leave coding agent plans in the description: always summarize changes before the PR is ready to review.
 
 ## Code Requirements
 


### PR DESCRIPTION
It's hit or miss whether the Copilot coding agent will summarize pull request descriptions instead of leaving a plan in there, which is not useful when you're looking at `git log` long after the PR was merged. Hopefully these instructions work better.
