### PR TITLE
Make Cosmos and Container Client Async

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Removed `ContainerClient::patch_item`, `PatchDocument`, and `PatchOperation` temporarily to redesign the PATCH API for safe idempotency. Use a Read/Modify/Replace model with ETag-based optimistic concurrency instead.
 - Changed return type of query methods from `FeedPager<T>` (an alias for `ItemIterator<FeedPage<T>, String>`) to `FeedItemIterator<T>`, which implements `Stream<Item = Result<T>>` and provides `into_pages()` for page-level access. ([#3515](https://github.com/Azure/azure-sdk-for-rust/pull/3515))
 - Introduced `CosmosClientBuilder` for constructing `CosmosClient` instances, replacing constructor-based API. Removed `consistency_level`, `priority`, `throughput_bucket`, `excluded_regions`, `SessionRetryOptions`, triggers, and `IndexingDirective` from options. Simplified `CosmosAccountReference` to take `CosmosAccountEndpoint` directly. Made option struct fields private with getters and `with_*` setters. ([#3744](https://github.com/Azure/azure-sdk-for-rust/pull/3744))
+- Made `CosmosClientBuilder::build()` and `DatabaseClient::container_client()` async to prepare for future cache population (account, collection, partition key range caches).
 - Support for `wasm32-unknown-unknown` has been removed ([#3377](https://github.com/Azure/azure-sdk-for-rust/issues/3377))
 
 ### Bugs Fixed

--- a/sdk/cosmos/azure_data_cosmos/README.md
+++ b/sdk/cosmos/azure_data_cosmos/README.md
@@ -67,7 +67,7 @@ async fn example() -> Result<(), Box<dyn std::error::Error>> {
         .parse()?;
     let account = CosmosAccountReference::with_credential(endpoint, credential);
     let cosmos_client = CosmosClient::builder()
-        .build(account)?;
+        .build(account).await?;
     Ok(())
 }
 ```
@@ -102,7 +102,7 @@ async fn example(cosmos_client: CosmosClient) -> Result<(), Box<dyn std::error::
         value: "2".into(),
     };
 
-    let container = cosmos_client.database_client("myDatabase").container_client("myContainer");
+    let container = cosmos_client.database_client("myDatabase").container_client("myContainer").await;
 
     // Create an item
     container.create_item("partition1", item, None).await?;

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/create.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/create.rs
@@ -80,7 +80,7 @@ impl CreateCommand {
                 show_updated,
             } => {
                 let db_client = client.database_client(&database);
-                let container_client = db_client.container_client(&container);
+                let container_client = db_client.container_client(&container).await;
 
                 let pk = PartitionKey::from(&partition_key);
                 let item: serde_json::Value = serde_json::from_str(&json)?;

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/delete.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/delete.rs
@@ -56,7 +56,7 @@ impl DeleteCommand {
                 partition_key,
             } => {
                 let db_client = client.database_client(&database);
-                let container_client = db_client.container_client(&container);
+                let container_client = db_client.container_client(&container).await;
 
                 let response = container_client
                     .delete_item(partition_key, &item_id, None)
@@ -79,7 +79,7 @@ impl DeleteCommand {
 
             Subcommands::Container { database, id } => {
                 let db_client = client.database_client(&database);
-                let container_client = db_client.container_client(&id);
+                let container_client = db_client.container_client(&id).await;
                 container_client.delete(None).await?;
                 Ok(())
             }

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/main.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/main.rs
@@ -63,7 +63,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         return Ok(());
     };
 
-    let client = create_client(&args.shared_args)?;
+    let client = create_client(&args.shared_args).await?;
 
     match cmd {
         Subcommands::Create(cmd) => cmd.run(client).await,
@@ -76,7 +76,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
-fn create_client(args: &SharedArgs) -> Result<CosmosClient, Box<dyn Error>> {
+async fn create_client(args: &SharedArgs) -> Result<CosmosClient, Box<dyn Error>> {
     let endpoint: CosmosAccountEndpoint = args.endpoint.parse()?;
     if let Some(key) = args.key.as_ref() {
         #[cfg(feature = "key_auth")]
@@ -85,7 +85,7 @@ fn create_client(args: &SharedArgs) -> Result<CosmosClient, Box<dyn Error>> {
                 endpoint,
                 azure_core::credentials::Secret::from(key.clone()),
             );
-            Ok(CosmosClient::builder().build(account)?)
+            Ok(CosmosClient::builder().build(account).await?)
         }
         #[cfg(not(feature = "key_auth"))]
         {
@@ -96,6 +96,6 @@ fn create_client(args: &SharedArgs) -> Result<CosmosClient, Box<dyn Error>> {
         let cred: Arc<dyn azure_core::credentials::TokenCredential> =
             DeveloperToolsCredential::new(None).unwrap();
         let account = CosmosAccountReference::with_credential(endpoint, cred);
-        Ok(CosmosClient::builder().build(account)?)
+        Ok(CosmosClient::builder().build(account).await?)
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/metadata.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/metadata.rs
@@ -21,7 +21,7 @@ impl MetadataCommand {
     pub async fn run(self, client: CosmosClient) -> Result<(), Box<dyn Error>> {
         let db_client = client.database_client(&self.database);
         if let Some(container_name) = &self.container {
-            let container_client = db_client.container_client(container_name);
+            let container_client = db_client.container_client(container_name).await;
             let response = container_client.read(None).await?.into_model()?;
             println!("{:#?}", response);
             return Ok(());

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/query.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/query.rs
@@ -50,7 +50,7 @@ impl QueryCommand {
                 partition_key,
             } => {
                 let db_client = client.database_client(&database);
-                let container_client = db_client.container_client(&container);
+                let container_client = db_client.container_client(&container).await;
 
                 let pk = match partition_key {
                     Some(pk) => PartitionKey::from(pk),

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/read.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/read.rs
@@ -51,7 +51,7 @@ impl ReadCommand {
                 partition_key,
             } => {
                 let db_client = client.database_client(&database);
-                let container_client = db_client.container_client(&container);
+                let container_client = db_client.container_client(&container).await;
 
                 let response = container_client
                     .read_item(&partition_key, &item_id, None)
@@ -91,7 +91,7 @@ impl ReadCommand {
                 container,
             } => {
                 let db_client = client.database_client(&database);
-                let container_client = db_client.container_client(&container);
+                let container_client = db_client.container_client(&container).await;
                 let response = container_client.read(None).await?.into_model()?;
                 println!("Container:");
                 println!("  {:#?}", response);

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/replace.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/replace.rs
@@ -69,7 +69,7 @@ impl ReplaceCommand {
                 show_updated,
             } => {
                 let db_client = client.database_client(&database);
-                let container_client = db_client.container_client(&container);
+                let container_client = db_client.container_client(&container).await;
 
                 let pk = PartitionKey::from(&partition_key);
                 let item: serde_json::Value = serde_json::from_str(&json)?;
@@ -118,7 +118,7 @@ impl ReplaceCommand {
             } => {
                 let throughput_properties = throughput_options.try_into()?;
                 let db_client = client.database_client(&database);
-                let container_client = db_client.container_client(&container);
+                let container_client = db_client.container_client(&container).await;
                 let new_throughput = container_client
                     .replace_throughput(throughput_properties, None)
                     .await?

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/upsert.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/upsert.rs
@@ -28,7 +28,7 @@ pub struct UpsertCommand {
 impl UpsertCommand {
     pub async fn run(self, client: CosmosClient) -> Result<(), Box<dyn Error>> {
         let db_client = client.database_client(&self.database);
-        let container_client = db_client.container_client(&self.container);
+        let container_client = db_client.container_client(&self.container).await;
 
         let pk = PartitionKey::from(&self.partition_key);
         let item: serde_json::Value = serde_json::from_str(&self.json)?;

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -36,7 +36,7 @@ pub struct ContainerClient {
 }
 
 impl ContainerClient {
-    pub(crate) fn new(
+    pub(crate) async fn new(
         pipeline: Arc<GatewayPipeline>,
         database_link: &ResourceLink,
         container_id: &str,

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
@@ -32,6 +32,7 @@ pub use super::cosmos_client_builder::CosmosClientBuilder;
 /// use azure_data_cosmos::{CosmosClient, CosmosAccountReference, CosmosAccountEndpoint};
 /// use std::sync::Arc;
 ///
+/// # async fn doc() -> Result<(), Box<dyn std::error::Error>> {
 /// let credential: Arc<dyn azure_core::credentials::TokenCredential> =
 ///     azure_identity::DeveloperToolsCredential::new(None).unwrap();
 /// let endpoint: CosmosAccountEndpoint = "https://myaccount.documents.azure.com/"
@@ -40,7 +41,9 @@ pub use super::cosmos_client_builder::CosmosClientBuilder;
 /// let account = CosmosAccountReference::with_credential(endpoint, credential);
 /// let client = CosmosClient::builder()
 ///     .build(account)
-///     .unwrap();
+///     .await?;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// Using key authentication (requires `key_auth` feature):
@@ -49,6 +52,7 @@ pub use super::cosmos_client_builder::CosmosClientBuilder;
 /// use azure_data_cosmos::{CosmosClient, CosmosAccountReference, CosmosAccountEndpoint};
 /// use azure_core::credentials::Secret;
 ///
+/// # async fn doc() -> Result<(), Box<dyn std::error::Error>> {
 /// let endpoint: CosmosAccountEndpoint = "https://myaccount.documents.azure.com/"
 ///     .parse()
 ///     .unwrap();
@@ -58,7 +62,9 @@ pub use super::cosmos_client_builder::CosmosClientBuilder;
 /// );
 /// let client = CosmosClient::builder()
 ///     .build(account)
-///     .unwrap();
+///     .await?;
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone)]
 pub struct CosmosClient {
@@ -76,6 +82,7 @@ impl CosmosClient {
     /// ```rust,no_run
     /// use azure_data_cosmos::{CosmosClient, CosmosAccountReference, CosmosAccountEndpoint};
     ///
+    /// # async fn doc() -> Result<(), Box<dyn std::error::Error>> {
     /// let credential: std::sync::Arc<dyn azure_core::credentials::TokenCredential> =
     ///     azure_identity::DeveloperToolsCredential::new(None).unwrap();
     /// let endpoint: CosmosAccountEndpoint = "https://myaccount.documents.azure.com/"
@@ -84,7 +91,9 @@ impl CosmosClient {
     /// let account = CosmosAccountReference::with_credential(endpoint, credential);
     /// let client = CosmosClient::builder()
     ///     .build(account)
-    ///     .unwrap();
+    ///     .await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn builder() -> CosmosClientBuilder {
         CosmosClientBuilder::new()

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client_builder.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client_builder.rs
@@ -38,13 +38,16 @@ use azure_core::http::{ClientOptions, LoggingOptions, RetryOptions};
 /// use azure_data_cosmos::{CosmosClientBuilder, CosmosAccountReference, CosmosAccountEndpoint};
 /// use std::sync::Arc;
 ///
+/// # async fn doc() -> Result<(), Box<dyn std::error::Error>> {
 /// let credential: Arc<dyn azure_core::credentials::TokenCredential> =
 ///     azure_identity::DeveloperToolsCredential::new(None).unwrap();
 /// let endpoint: CosmosAccountEndpoint = "https://myaccount.documents.azure.com/".parse().unwrap();
 /// let account = CosmosAccountReference::with_credential(endpoint, credential);
 /// let client = CosmosClientBuilder::new()
 ///     .build(account)
-///     .unwrap();
+///     .await?;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// Using key authentication (requires `key_auth` feature):
@@ -53,11 +56,14 @@ use azure_core::http::{ClientOptions, LoggingOptions, RetryOptions};
 /// use azure_data_cosmos::{CosmosClientBuilder, CosmosAccountReference, CosmosAccountEndpoint};
 /// use azure_core::credentials::Secret;
 ///
+/// # async fn doc() -> Result<(), Box<dyn std::error::Error>> {
 /// let endpoint: CosmosAccountEndpoint = "https://myaccount.documents.azure.com/".parse().unwrap();
 /// let account = CosmosAccountReference::with_master_key(endpoint, Secret::from("my_account_key"));
 /// let client = CosmosClientBuilder::new()
 ///     .build(account)
-///     .unwrap();
+///     .await?;
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Default)]
 pub struct CosmosClientBuilder {
@@ -163,7 +169,7 @@ impl CosmosClientBuilder {
     /// # Errors
     ///
     /// Returns an error if the client cannot be constructed.
-    pub fn build(
+    pub async fn build(
         self,
         account: impl Into<CosmosAccountReference>,
     ) -> azure_core::Result<CosmosClient> {

--- a/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
@@ -54,7 +54,7 @@ impl DatabaseClient {
     ///
     /// # Arguments
     /// * `name` - The name of the container.
-    pub fn container_client(&self, name: &str) -> ContainerClient {
+    pub async fn container_client(&self, name: &str) -> ContainerClient {
         ContainerClient::new(
             self.pipeline.clone(),
             &self.link,
@@ -62,6 +62,7 @@ impl DatabaseClient {
             self.global_endpoint_manager.clone(),
             self.global_partition_endpoint_manager.clone(),
         )
+        .await
     }
 
     /// Returns the identifier of the Cosmos database.

--- a/sdk/cosmos/azure_data_cosmos/src/fault_injection/client_builder.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/fault_injection/client_builder.rs
@@ -28,6 +28,7 @@ use super::rule::FaultInjectionRule;
 /// use azure_core::credentials::Secret;
 /// use std::sync::Arc;
 ///
+/// # async fn doc() {
 /// let result = FaultInjectionResultBuilder::new()
 ///     .with_error(FaultInjectionErrorType::ServiceUnavailable)
 ///     .build();
@@ -41,7 +42,9 @@ use super::rule::FaultInjectionRule;
 /// let client = CosmosClientBuilder::new()
 ///     .with_fault_injection(fault_builder)
 ///     .build((endpoint, Secret::from("my_account_key")))
+///     .await
 ///     .unwrap();
+/// # }
 /// ```
 pub struct FaultInjectionClientBuilder {
     /// The fault injection rules to apply.

--- a/sdk/cosmos/azure_data_cosmos/src/fault_injection/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/fault_injection/mod.rs
@@ -47,6 +47,7 @@
 //! use std::sync::Arc;
 //! use std::time::{Duration, Instant};
 //!
+//! # async fn doc() {
 //! // 1. Define what error to inject
 //! let result = FaultInjectionResultBuilder::new()
 //!     .with_error(FaultInjectionErrorType::ServiceUnavailable)
@@ -78,7 +79,9 @@
 //!         "https://myaccount.documents.azure.com/".parse().unwrap(),
 //!         Secret::new("my_account_key"),
 //!     ))
+//!     .await
 //!     .unwrap();
+//! # }
 //! ```
 //!
 //! # Rule Evaluation

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_containers.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_containers.rs
@@ -81,7 +81,7 @@ pub async fn container_crud_simple() -> Result<(), Box<dyn Error>> {
             }
             assert_eq!(vec![properties.id.clone()], ids);
 
-            let container_client = db_client.container_client(&properties.id);
+            let container_client = db_client.container_client(&properties.id).await;
             let mut updated_indexing_policy = IndexingPolicy::default();
             updated_indexing_policy.automatic = false;
             updated_indexing_policy.indexing_mode = Some(IndexingMode::None);

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_fault_injection.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_fault_injection.rs
@@ -89,7 +89,7 @@ pub async fn fault_injection_probability_zero_never_fails() -> Result<(), Box<dy
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // With probability 0.0, all reads should succeed
             for i in 1..=5 {
@@ -151,7 +151,7 @@ pub async fn fault_injection_probability_one_always_fails() -> Result<(), Box<dy
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // With probability 1.0, all reads should fail
             for i in 1..=5 {
@@ -216,7 +216,7 @@ pub async fn fault_injection_429_retry_with_hit_limit() -> Result<(), Box<dyn Er
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // First request - should succeed after retries
             let result = fault_container_client
@@ -283,7 +283,7 @@ pub async fn fault_injection_delete_item_fault_crud_succeeds() -> Result<(), Box
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // Read should succeed
             let read_result = fault_container_client
@@ -367,7 +367,7 @@ pub async fn fault_injection_container_specific() -> Result<(), Box<dyn Error>> 
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // Read should succeed since container name doesn't match "FaultyContainer"
             let result = fault_container_client
@@ -392,7 +392,7 @@ pub async fn fault_injection_container_specific() -> Result<(), Box<dyn Error>> 
 
             // Now try to read using the fault client - should fail because container name contains "FaultyContainer"
             let faulty_fault_container_client =
-                fault_db_client.container_client(faulty_container_id);
+                fault_db_client.container_client(faulty_container_id).await;
             let faulty_result = faulty_fault_container_client
                 .read_item::<TestItem>(&pk, &item_id, None)
                 .await;
@@ -463,7 +463,7 @@ pub async fn fault_injection_multiple_rules_priority() -> Result<(), Box<dyn Err
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             let result = fault_container_client
                 .read_item::<TestItem>(&pk, &item_id, None)
@@ -537,7 +537,7 @@ pub async fn fault_injection_first_rule_inactive_due_to_start_time() -> Result<(
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             let result = fault_container_client
                 .read_item::<TestItem>(&pk, &item_id, None)
@@ -611,7 +611,7 @@ pub async fn fault_injection_first_rule_expired_due_to_end_time() -> Result<(), 
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // Small delay to ensure duration has passed
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -675,7 +675,7 @@ pub async fn fault_injection_hit_limit_behavior() -> Result<(), Box<dyn Error>> 
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // First 2 requests should fail with one in region retry
             for i in 1..=2 {
@@ -737,7 +737,7 @@ pub async fn fault_injection_empty_rules() -> Result<(), Box<dyn Error>> {
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // Read should succeed with no fault rules
             let result = fault_container_client
@@ -801,7 +801,7 @@ pub async fn fault_injection_metadata_fault_item_ops_succeed() -> Result<(), Box
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // Cache warmup: read the container with the rule disabled so that
             // ContainerClient::read() populates the internal container cache.
@@ -906,7 +906,7 @@ pub async fn fault_injection_enable_disable_rule() -> Result<(), Box<dyn Error>>
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // Rule is enabled — read should fail
             let result = fault_container_client

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_items.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_items.rs
@@ -79,7 +79,7 @@ async fn create_container(run_context: &TestRunContext) -> azure_core::Result<Co
             None,
         )
         .await?;
-    let container_client = db_client.container_client(&container_id);
+    let container_client = db_client.container_client(&container_id).await;
 
     Ok(container_client)
 }

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/test_data.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/test_data.rs
@@ -62,7 +62,7 @@ pub async fn create_container_with_items(
         }
     }
 
-    let container_client = db.container_client("TestContainer");
+    let container_client = db.container_client("TestContainer").await;
 
     for item in items {
         container_client

--- a/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write_fault_injection.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write_fault_injection.rs
@@ -86,7 +86,7 @@ async fn verify_read_fails_with_injected_error(
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             let result = run_context
                 .read_item::<TestItem>(&fault_container_client, &pk, &item_id, None)
@@ -213,7 +213,7 @@ pub async fn item_read_succeeds_when_fault_targets_create_item() -> Result<(), B
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // Read the item using the fault client - this should succeed because the fault only targets CreateItem
             let result = run_context
@@ -292,7 +292,7 @@ pub async fn fault_injection_read_region_retry_503() -> Result<(), Box<dyn Error
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // Read should succeed on satellite region after primary returns 503
             let result = run_context
@@ -353,7 +353,7 @@ pub async fn fault_injection_write_region_retry_503() -> Result<(), Box<dyn Erro
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             let unique_id = Uuid::new_v4().to_string();
             let item = TestItem {
@@ -447,7 +447,7 @@ pub async fn fault_injection_read_region_retry_404_1002() -> Result<(), Box<dyn 
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // Make sure the write has been replicated on both regions
             let _ = run_context
@@ -521,7 +521,7 @@ pub async fn fault_injection_write_connection_error_failover() -> Result<(), Box
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             let unique_id = Uuid::new_v4().to_string();
             let item = TestItem {
@@ -608,7 +608,7 @@ pub async fn fault_injection_read_connection_error_failover() -> Result<(), Box<
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // Ensure replication to satellite before reading with fault client
             let options = ItemOptions::default().with_excluded_regions(vec![HUB_REGION.into()]);
@@ -673,7 +673,7 @@ pub async fn fault_injection_write_response_timeout_does_not_retry() -> Result<(
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             let unique_id = Uuid::new_v4().to_string();
             let item = TestItem {
@@ -756,7 +756,7 @@ pub async fn fault_injection_read_response_timeout_retries_to_satellite(
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // Ensure replication to satellite
             let options = ItemOptions::default().with_excluded_regions(vec![HUB_REGION.into()]);
@@ -821,7 +821,7 @@ pub async fn fault_injection_connection_error_reverse_failover() -> Result<(), B
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             let unique_id = Uuid::new_v4().to_string();
             let item = TestItem {
@@ -908,7 +908,7 @@ pub async fn fault_injection_connection_error_local_retry_succeeds() -> Result<(
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             let response = run_context
                 .read_item::<TestItem>(&fault_container_client, &pk, &item_id, None)

--- a/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write_retry_policies.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write_retry_policies.rs
@@ -95,7 +95,7 @@ pub async fn read_cross_region_retry_on_408() -> Result<(), Box<dyn Error>> {
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // Read should succeed via cross-region retry after hub returns 408
             let result = run_context
@@ -162,7 +162,7 @@ pub async fn write_no_cross_region_retry_on_408() -> Result<(), Box<dyn Error>> 
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             let unique_id = Uuid::new_v4().to_string();
             let item = TestItem {
@@ -233,7 +233,7 @@ pub async fn upsert_no_cross_region_retry_on_408() -> Result<(), Box<dyn Error>>
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             let unique_id = Uuid::new_v4().to_string();
             let item = TestItem {
@@ -321,7 +321,7 @@ pub async fn query_cross_region_retry_on_408() -> Result<(), Box<dyn Error>> {
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             let query = Query::from(format!("SELECT * FROM c WHERE c.partition_key = '{}'", pk));
 
@@ -400,7 +400,7 @@ pub async fn read_cross_region_retry_on_500() -> Result<(), Box<dyn Error>> {
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // Read should succeed via cross-region retry after hub returns 500
             let result = run_context
@@ -483,7 +483,7 @@ pub async fn replace_no_cross_region_retry_on_408() -> Result<(), Box<dyn Error>
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             let updated_item = TestItem {
                 id: item_id.clone().into(),
@@ -571,7 +571,7 @@ pub async fn delete_no_cross_region_retry_on_408() -> Result<(), Box<dyn Error>>
                 .fault_client()
                 .expect("fault client should be available");
             let fault_db_client = fault_client.database_client(&db_client.id());
-            let fault_container_client = fault_db_client.container_client(&container_id);
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
 
             // Delete should fail with 408 — no cross-region retry for writes
             let result = fault_container_client

--- a/sdk/cosmos/azure_data_cosmos_native/include/azurecosmos.h
+++ b/sdk/cosmos/azure_data_cosmos_native/include/azurecosmos.h
@@ -73,6 +73,7 @@ typedef struct cosmos_container_client cosmos_container_client;
  * use azure_data_cosmos::{CosmosClient, CosmosAccountReference, CosmosAccountEndpoint};
  * use std::sync::Arc;
  *
+ * # async fn doc() -> Result<(), Box<dyn std::error::Error>> {
  * let credential: Arc<dyn azure_core::credentials::TokenCredential> =
  *     azure_identity::DeveloperToolsCredential::new(None).unwrap();
  * let endpoint: CosmosAccountEndpoint = "https://myaccount.documents.azure.com/"
@@ -81,7 +82,9 @@ typedef struct cosmos_container_client cosmos_container_client;
  * let account = CosmosAccountReference::with_credential(endpoint, credential);
  * let client = CosmosClient::builder()
  *     .build(account)
- *     .unwrap();
+ *     .await?;
+ * # Ok(())
+ * # }
  * ```
  *
  * Using key authentication (requires `key_auth` feature):
@@ -90,6 +93,7 @@ typedef struct cosmos_container_client cosmos_container_client;
  * use azure_data_cosmos::{CosmosClient, CosmosAccountReference, CosmosAccountEndpoint};
  * use azure_core::credentials::Secret;
  *
+ * # async fn doc() -> Result<(), Box<dyn std::error::Error>> {
  * let endpoint: CosmosAccountEndpoint = "https://myaccount.documents.azure.com/"
  *     .parse()
  *     .unwrap();
@@ -99,7 +103,9 @@ typedef struct cosmos_container_client cosmos_container_client;
  * );
  * let client = CosmosClient::builder()
  *     .build(account)
- *     .unwrap();
+ *     .await?;
+ * # Ok(())
+ * # }
  * ```
  */
 typedef struct cosmos_client cosmos_client;

--- a/sdk/cosmos/azure_data_cosmos_native/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/azure_data_cosmos_native/src/clients/cosmos_client.rs
@@ -38,7 +38,7 @@ pub extern "C" fn cosmos_client_create_with_key(
     options: *const ClientOptions,
     out_client: *mut *mut CosmosClient,
 ) -> CosmosErrorCode {
-    context!(ctx).run_sync_with_output(out_client, || {
+    context!(ctx).run_async_with_output(out_client, async {
         let endpoint: CosmosAccountEndpoint =
             parse_cstr(endpoint, error::messages::INVALID_ENDPOINT)?.parse()?;
         let key = parse_cstr(key, error::messages::INVALID_KEY)?.to_string();
@@ -54,7 +54,7 @@ pub extern "C" fn cosmos_client_create_with_key(
             }
         }
 
-        let client = builder.build(account)?;
+        let client = builder.build(account).await?;
 
         Ok(Box::new(client))
     })
@@ -82,7 +82,7 @@ pub extern "C" fn cosmos_client_create_with_connection_string(
     options: *const ClientOptions,
     out_client: *mut *mut CosmosClient,
 ) -> CosmosErrorCode {
-    context!(ctx).run_sync_with_output(out_client, || {
+    context!(ctx).run_async_with_output(out_client, async {
         let connection_string_str = parse_cstr(
             connection_string,
             error::messages::INVALID_CONNECTION_STRING,
@@ -101,7 +101,7 @@ pub extern "C" fn cosmos_client_create_with_connection_string(
             }
         }
 
-        let client = builder.build(account)?;
+        let client = builder.build(account).await?;
 
         Ok(Box::new(client))
     })

--- a/sdk/cosmos/azure_data_cosmos_native/src/clients/database_client.rs
+++ b/sdk/cosmos/azure_data_cosmos_native/src/clients/database_client.rs
@@ -42,10 +42,10 @@ pub extern "C" fn cosmos_database_container_client(
     container_id: *const c_char,
     out_container: *mut *mut ContainerClient,
 ) -> CosmosErrorCode {
-    context!(ctx).run_sync_with_output(out_container, || {
+    context!(ctx).run_async_with_output(out_container, async {
         let database = unwrap_required_ptr(database, error::messages::INVALID_DATABASE_POINTER)?;
         let container_id = parse_cstr(container_id, error::messages::INVALID_CONTAINER_ID)?;
-        let container_client = database.container_client(container_id);
+        let container_client = database.container_client(container_id).await;
         Ok(Box::new(container_client))
     })
 }
@@ -136,7 +136,7 @@ pub extern "C" fn cosmos_database_create_container(
 
         database.create_container(properties, None).await?;
 
-        let container_client = database.container_client(&container_id);
+        let container_client = database.container_client(&container_id).await;
 
         Ok(Box::new(container_client))
     })


### PR DESCRIPTION
Make CosmosClientBuilder::build() and DatabaseClient::container_client() async to prepare the public API surface for future cache population (account properties, collection, and partition key range caches). These
  caches will require async I/O during client and container construction, so the API signatures need to change now to avoid a second breaking change later.

  No cache logic is wired in yet — the async methods currently perform the same synchronous work as before. This is purely an API shape change.

  Breaking Changes

   - CosmosClientBuilder::build() is now async — callers must .await the result.
   - DatabaseClient::container_client() is now async — callers must .await the result. Chained calls like .database_client(id).container_client(name).read(None).await become 
  .database_client(id).container_client(name).await.read(None).await.

  Changes by area

   - azure_data_cosmos public API (cosmos_client_builder.rs, database_client.rs, container_client.rs): Changed method signatures from fn to async fn.
   - azure_data_cosmos_native FFI layer (cosmos_client.rs, database_client.rs): Switched client creation and container_client calls from run_sync_with_output to run_async_with_output.
   - Examples (create.rs, delete.rs, main.rs, metadata.rs, query.rs, read.rs, replace.rs, upsert.rs): Added .await at all .build() and .container_client() call sites.
   - Test framework (test_client.rs, test_data.rs): Made from_env*, from_connection_string, and create_client_with_preferred_region async, propagating .await to all callers.
   - Integration tests (cosmos_containers.rs, cosmos_items.rs, cosmos_fault_injection.rs, cosmos_multi_write_*.rs): Added .await to .container_client() calls.
   - Doc examples (fault_injection/mod.rs, fault_injection/client_builder.rs): Wrapped examples in async fn and added .await.
   - README.md: Updated code examples with .await.