### PR TITLE
Cosmos: Spec for new Rust SDK options

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/docs/ConfigurationOptions.md
+++ b/sdk/cosmos/azure_data_cosmos/docs/ConfigurationOptions.md
@@ -1,6 +1,6 @@
 # Azure Cosmos DB Rust SDK — Configuration Options Specification
 
-This document specifies the configuration option types for the Rust SDK (`azure_data_cosmos`), aligned with the [Hierarchical Configuration Model](HierarchicalConfigModel.md).
+This document specifies the configuration option types for the Rust SDK (`azure_data_cosmos`), aligned with the Hierarchical Configuration Model.
 
 ## Table of Contents
 


### PR DESCRIPTION
I used Copilot to conduct an analysis of options across the .NET, Java, Python, and Go SDKs (I didn't include JS but I don't see a major difference in options there). I've uploaded [the raw output of that analysis to a gist](https://gist.github.com/analogrelay/8d209ee7aecb6796dea725c29f0f6ca9).

Using that analysis, I built this proposal to migrate all our options towards the hierarchical config group. This document lists out the option groups we want, the layers they apply to, and the types/env vars they use. I covered most of what we've talked about before in terms of making breaking changes (like removing Consistency Level), but this is the place to make sure those are covered before we move forward with applying this change.

You may find it easier to review this [rendered version without diff markers](https://github.com/analogrelay/azure-sdk-for-rust/blob/13ab241b9db59e5b9a5cedc42040fa96e051dfa8/sdk/cosmos/azure_data_cosmos/docs/ConfigurationOptions.md), since it's a brand new file.