### PR TITLE
Fix APIView for Key Vault crates

### DIFF
--- a/sdk/keyvault/azure_security_keyvault_certificates/src/clients.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/clients.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+//! Clients used to communicate with the service.
 pub use crate::generated::clients::*;
 use crate::{
     authorizer::KeyVaultAuthorizer,

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/models.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/models.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+//! Contains all the data structures and types used by the client library.
 pub use crate::generated::models::*;
 use azure_core::{
     fmt::SafeDebug,

--- a/sdk/keyvault/azure_security_keyvault_keys/src/clients.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/clients.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+//! Clients used to communicate with the service.
 use crate::authorizer::KeyVaultAuthorizer;
-pub use crate::generated::KeyClient;
+pub use crate::generated::clients::*;
 use azure_core::{
     credentials::TokenCredential,
     fmt::SafeDebug,

--- a/sdk/keyvault/azure_security_keyvault_keys/src/lib.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/lib.rs
@@ -6,9 +6,13 @@
 
 mod authorizer;
 pub mod clients;
+#[allow(
+    unused_imports,
+    reason = "Publicly exported generated/clients are instead exported from clients"
+)]
 mod generated;
 mod resource;
 
 pub use clients::{KeyClient, KeyClientOptions};
-pub use generated::*;
+pub use generated::models;
 pub use resource::*;

--- a/sdk/keyvault/azure_security_keyvault_secrets/src/clients.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/src/clients.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+//! Clients used to communicate with the service.
 use crate::authorizer::KeyVaultAuthorizer;
-pub use crate::generated::SecretClient;
+pub use crate::generated::clients::*;
 use azure_core::{
     credentials::TokenCredential,
     fmt::SafeDebug,

--- a/sdk/keyvault/azure_security_keyvault_secrets/src/lib.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/src/lib.rs
@@ -6,9 +6,13 @@
 
 mod authorizer;
 pub mod clients;
+#[allow(
+    unused_imports,
+    reason = "Publicly exported generated/clients are instead exported from clients"
+)]
 mod generated;
 mod resource;
 
 pub use clients::{SecretClient, SecretClientOptions};
-pub use generated::*;
+pub use generated::models;
 pub use resource::*;


### PR DESCRIPTION
Other crates were now creating APIViews correctly after my recent changes, but this was still failing for Key Vault.

While the compiler was folding duplicate types, the APIView scripts were not and it's probably not worth trying to handle this case in general. Certificates was actually right already, so I made Keys and Secrets more like Certificates. Fixed up module doc comments while I was at it.

Verified docs look correct for all three crates.
