### PR TITLE
Derive `Clone` for `ManagedIdentityCredential`

### DIFF
--- a/sdk/identity/azure_identity/src/managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/managed_identity_credential.rs
@@ -22,7 +22,7 @@ pub enum UserAssignedId {
 }
 
 /// Authenticates a managed identity from Azure App Service or an Azure Virtual Machine.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ManagedIdentityCredential {
     credential: Arc<dyn TokenCredential>,
 }


### PR DESCRIPTION
Would fix https://github.com/Azure/azure-sdk-for-rust/issues/3816
