### PR TITLE
Update Key Vault to use changes to get/update overrides

### DIFF
--- a/sdk/keyvault/azure_security_keyvault_certificates/tsp-location.yaml
+++ b/sdk/keyvault/azure_security_keyvault_certificates/tsp-location.yaml
@@ -1,5 +1,5 @@
 directory: specification/keyvault/Security.KeyVault.Certificates
-commit: fd8fd88708d4a1e2bc3d7f064d295b17fb4fa3f7
+commit: 2daa93270f6743188fe69d301f101d031a624fb2
 repo: Azure/azure-rest-api-specs
 additionalDirectories:
   - specification/keyvault/Security.KeyVault.Common

--- a/sdk/keyvault/azure_security_keyvault_keys/tsp-location.yaml
+++ b/sdk/keyvault/azure_security_keyvault_keys/tsp-location.yaml
@@ -1,5 +1,5 @@
 directory: specification/keyvault/Security.KeyVault.Keys
-commit: fd8fd88708d4a1e2bc3d7f064d295b17fb4fa3f7
+commit: 2daa93270f6743188fe69d301f101d031a624fb2
 repo: Azure/azure-rest-api-specs
 additionalDirectories:
   - specification/keyvault/Security.KeyVault.Common/

--- a/sdk/keyvault/azure_security_keyvault_secrets/tsp-location.yaml
+++ b/sdk/keyvault/azure_security_keyvault_secrets/tsp-location.yaml
@@ -1,5 +1,5 @@
 directory: specification/keyvault/Security.KeyVault.Secrets
-commit: fd8fd88708d4a1e2bc3d7f064d295b17fb4fa3f7
+commit: 2daa93270f6743188fe69d301f101d031a624fb2
 repo: Azure/azure-rest-api-specs
 additionalDirectories:
   - specification/keyvault/Security.KeyVault.Common/


### PR DESCRIPTION
This will break once the emitter is updated, which we're counting on.
The get/update functions won't, but we intentionally want the key version to be promoted to a parameter like other languages have for crypto operations because callers *really* should use versioned keys lest they get crypto-locked.
