### PR TITLE
[Storage] Attempt other `SignedIdentifiers` approach

### DIFF
--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
@@ -14,7 +14,7 @@ use crate::generated::models::{
     BlobContainerClientListBlobsOptions, BlobContainerClientReleaseLeaseOptions,
     BlobContainerClientReleaseLeaseResult, BlobContainerClientRenewLeaseOptions,
     BlobContainerClientRenewLeaseResult, BlobContainerClientSetAccessPolicyOptions,
-    BlobContainerClientSetMetadataOptions, FilterBlobSegment, ListBlobsResponse, SignedIdentifiers,
+    BlobContainerClientSetMetadataOptions, FilterBlobSegment, ListBlobsResponse, SignedIdentifier,
 };
 use azure_core::{
     error::CheckSuccessOptions,
@@ -471,14 +471,14 @@ impl BlobContainerClient {
     ///
     /// ## Response Headers
     ///
-    /// The returned [`Response`](azure_core::http::Response) implements the [`SignedIdentifiersHeaders`] trait, which provides
+    /// The returned [`Response`](azure_core::http::Response) implements the [`VecSignedIdentifierHeaders`] trait, which provides
     /// access to response headers. For example:
     ///
     /// ```no_run
     /// use azure_core::{Result, http::{Response, XmlFormat}};
-    /// use azure_storage_blob::models::{SignedIdentifiers, SignedIdentifiersHeaders};
+    /// use azure_storage_blob::models::{SignedIdentifier, VecSignedIdentifierHeaders};
     /// async fn example() -> Result<()> {
-    ///     let response: Response<SignedIdentifiers, XmlFormat> = unimplemented!();
+    ///     let response: Response<Vec<SignedIdentifier>, XmlFormat> = unimplemented!();
     ///     // Access response headers
     ///     if let Some(etag) = response.etag()? {
     ///         println!("etag: {:?}", etag);
@@ -494,16 +494,16 @@ impl BlobContainerClient {
     /// ```
     ///
     /// ### Available headers
-    /// * [`etag`()](crate::generated::models::SignedIdentifiersHeaders::etag) - etag
-    /// * [`last_modified`()](crate::generated::models::SignedIdentifiersHeaders::last_modified) - last-modified
-    /// * [`access`()](crate::generated::models::SignedIdentifiersHeaders::access) - x-ms-blob-public-access
+    /// * [`etag`()](crate::generated::models::VecSignedIdentifierHeaders::etag) - etag
+    /// * [`last_modified`()](crate::generated::models::VecSignedIdentifierHeaders::last_modified) - last-modified
+    /// * [`access`()](crate::generated::models::VecSignedIdentifierHeaders::access) - x-ms-blob-public-access
     ///
-    /// [`SignedIdentifiersHeaders`]: crate::generated::models::SignedIdentifiersHeaders
+    /// [`VecSignedIdentifierHeaders`]: crate::generated::models::VecSignedIdentifierHeaders
     #[tracing::function("Storage.Blob.BlobContainerClient.getAccessPolicy")]
     pub async fn get_access_policy(
         &self,
         options: Option<BlobContainerClientGetAccessPolicyOptions<'_>>,
-    ) -> Result<Response<SignedIdentifiers, XmlFormat>> {
+    ) -> Result<Response<Vec<SignedIdentifier>, XmlFormat>> {
         let options = options.unwrap_or_default();
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
@@ -942,7 +942,7 @@ impl BlobContainerClient {
     #[tracing::function("Storage.Blob.BlobContainerClient.setAccessPolicy")]
     pub async fn set_access_policy(
         &self,
-        container_acl: RequestContent<SignedIdentifiers, XmlFormat>,
+        container_acl: RequestContent<Vec<SignedIdentifier>, XmlFormat>,
         options: Option<BlobContainerClientSetAccessPolicyOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/sdk/storage/azure_storage_blob/src/generated/models/header_traits.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/header_traits.rs
@@ -20,7 +20,7 @@ use super::{
     PageBlobClientClearPagesResult, PageBlobClientCreateResult, PageBlobClientResizeResult,
     PageBlobClientSetSequenceNumberResult, PageBlobClientUploadPagesFromUrlResult,
     PageBlobClientUploadPagesResult, PageList, PublicAccessType, RehydratePriority,
-    SignedIdentifiers, SkuName,
+    SignedIdentifier, SkuName,
 };
 use azure_core::{
     base64,
@@ -2724,9 +2724,9 @@ impl PageListHeaders for Response<PageList, XmlFormat> {
 ///
 /// ```no_run
 /// use azure_core::{Result, http::{Response, XmlFormat}};
-/// use azure_storage_blob::models::{SignedIdentifiers, SignedIdentifiersHeaders};
+/// use azure_storage_blob::models::{SignedIdentifier, VecSignedIdentifierHeaders};
 /// async fn example() -> Result<()> {
-///     let response: Response<SignedIdentifiers, XmlFormat> = unimplemented!();
+///     let response: Response<Vec<SignedIdentifier>, XmlFormat> = unimplemented!();
 ///     // Access response headers
 ///     if let Some(etag) = response.etag()? {
 ///         println!("etag: {:?}", etag);
@@ -2740,13 +2740,13 @@ impl PageListHeaders for Response<PageList, XmlFormat> {
 ///     Ok(())
 /// }
 /// ```
-pub trait SignedIdentifiersHeaders: private::Sealed {
+pub trait VecSignedIdentifierHeaders: private::Sealed {
     fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn access(&self) -> Result<Option<PublicAccessType>>;
 }
 
-impl SignedIdentifiersHeaders for Response<SignedIdentifiers, XmlFormat> {
+impl VecSignedIdentifierHeaders for Response<Vec<SignedIdentifier>, XmlFormat> {
     /// The ETag contains a value that you can use to perform operations conditionally.
     fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
@@ -2781,7 +2781,7 @@ mod private {
         BlockBlobClientUploadInternalResult, BlockList, PageBlobClientClearPagesResult,
         PageBlobClientCreateResult, PageBlobClientResizeResult,
         PageBlobClientSetSequenceNumberResult, PageBlobClientUploadPagesFromUrlResult,
-        PageBlobClientUploadPagesResult, PageList, SignedIdentifiers,
+        PageBlobClientUploadPagesResult, PageList, SignedIdentifier,
     };
     use azure_core::http::{AsyncResponse, NoFormat, Response, XmlFormat};
 
@@ -2821,5 +2821,5 @@ mod private {
     impl Sealed for Response<PageBlobClientUploadPagesFromUrlResult, NoFormat> {}
     impl Sealed for Response<PageBlobClientUploadPagesResult, NoFormat> {}
     impl Sealed for Response<PageList, XmlFormat> {}
-    impl Sealed for Response<SignedIdentifiers, XmlFormat> {}
+    impl Sealed for Response<Vec<SignedIdentifier>, XmlFormat> {}
 }

--- a/sdk/storage/azure_storage_blob/src/generated/models/models.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/models.rs
@@ -138,7 +138,7 @@ pub struct BlobFlatListSegment {
 #[serde(rename = "Blob")]
 pub struct BlobItem {
     /// The tags of the blob.
-    #[serde(rename = "BlobTags", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "Tags", skip_serializing_if = "Option::is_none")]
     pub blob_tags: Option<BlobTags>,
 
     /// Whether the blob is deleted.
@@ -672,7 +672,7 @@ pub struct ContainerProperties {
     pub deleted_time: Option<OffsetDateTime>,
 
     /// The ETag of the container.
-    #[serde(rename = "ETag", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "Etag", skip_serializing_if = "Option::is_none")]
     pub etag: Option<String>,
 
     /// Whether it has an immutability policy.
@@ -777,7 +777,7 @@ pub struct FilterBlobItem {
     pub name: Option<String>,
 
     /// The metadata of the blob.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "Tags", skip_serializing_if = "Option::is_none")]
     pub tags: Option<BlobTags>,
 
     /// The version ID of the blob.
@@ -1037,14 +1037,6 @@ pub struct SignedIdentifier {
     /// The unique ID for the signed identifier.
     #[serde(rename = "Id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-}
-
-/// Represents an array of signed identifiers
-#[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
-pub struct SignedIdentifiers {
-    /// The array of signed identifiers.
-    #[serde(rename = "SignedIdentifier", skip_serializing_if = "Option::is_none")]
-    pub items: Option<Vec<SignedIdentifier>>,
 }
 
 /// The properties that enable an account to host a static website

--- a/sdk/storage/azure_storage_blob/src/generated/models/models_impl.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/models_impl.rs
@@ -5,7 +5,7 @@
 
 use super::{
     BlobItem, BlobServiceProperties, BlobTags, BlockLookupList, ContainerItem, ListBlobsResponse,
-    ListContainersSegmentResponse, SignedIdentifiers,
+    ListContainersSegmentResponse,
 };
 use async_trait::async_trait;
 use azure_core::{
@@ -51,13 +51,6 @@ impl TryFrom<BlobTags> for RequestContent<BlobTags, XmlFormat> {
 impl TryFrom<BlockLookupList> for RequestContent<BlockLookupList, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: BlockLookupList) -> Result<Self> {
-        Ok(to_xml(&value)?.into())
-    }
-}
-
-impl TryFrom<SignedIdentifiers> for RequestContent<SignedIdentifiers, XmlFormat> {
-    type Error = azure_core::Error;
-    fn try_from(value: SignedIdentifiers) -> Result<Self> {
         Ok(to_xml(&value)?.into())
     }
 }

--- a/sdk/storage/azure_storage_blob/src/models/extensions.rs
+++ b/sdk/storage/azure_storage_blob/src/models/extensions.rs
@@ -2,9 +2,8 @@
 // Licensed under the MIT License.
 
 use crate::models::{
-    AccessPolicy, AppendBlobClientCreateOptions, BlobTag, BlobTags,
-    BlockBlobClientUploadBlobFromUrlOptions, BlockBlobClientUploadOptions,
-    PageBlobClientCreateOptions, SignedIdentifier, SignedIdentifiers,
+    AppendBlobClientCreateOptions, BlobTag, BlobTags, BlockBlobClientUploadBlobFromUrlOptions,
+    BlockBlobClientUploadOptions, PageBlobClientCreateOptions,
 };
 use std::collections::HashMap;
 
@@ -95,27 +94,6 @@ impl From<HashMap<String, String>> for BlobTags {
             .collect();
         BlobTags {
             blob_tag_set: Some(blob_tags),
-        }
-    }
-}
-
-/// Converts a `HashMap<String, AccessPolicy>` into a `SignedIdentifiers` struct.
-impl From<HashMap<String, AccessPolicy>> for SignedIdentifiers {
-    fn from(policies: HashMap<String, AccessPolicy>) -> Self {
-        if policies.is_empty() {
-            return SignedIdentifiers { items: None };
-        }
-
-        let signed_identifiers: Vec<SignedIdentifier> = policies
-            .into_iter()
-            .map(|(id, access_policy)| SignedIdentifier {
-                id: Some(id),
-                access_policy: Some(access_policy),
-            })
-            .collect();
-
-        SignedIdentifiers {
-            items: Some(signed_identifiers),
         }
     }
 }

--- a/sdk/storage/azure_storage_blob/tsp-location.yaml
+++ b/sdk/storage/azure_storage_blob/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/storage/Microsoft.BlobStorage
-commit: fe6a867f358d3feafd203f53882d60bbe4ef62b0
+commit: f110689289f6725dc6d665cee72ee9bd87e2352d
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 


### PR DESCRIPTION
## Issue: `SignedIdentifiers` array model introduces XML wire-shape mismatch in Rust

### Background
After regenerating from [Azure/azure-rest-api-specs#40822](https://github.com/Azure/azure-rest-api-specs/pull/40822), `SignedIdentifiers` is modeled as an array alias (`Array<SignedIdentifier>`).  
In Rust, this becomes `Vec<SignedIdentifier>`.

### Problem
The Blob ACL wire contract is still **wrapped XML**, not a bare array:

```xml
<SignedIdentifiers>
  <SignedIdentifier>...</SignedIdentifier>
  <SignedIdentifier>...</SignedIdentifier>
</SignedIdentifiers>
```

This causes two concrete issues with the generated `Vec` model:

1. **Set ACL serialization fails for bare `Vec`**
   - Serializing `Vec<SignedIdentifier>` directly to XML fails with:
     - `cannot serialize sequence without defined root tag`
   - XML requires a root element (`SignedIdentifiers`), which a raw `Vec` does not provide.

2. **Get ACL deserialization can under-read wrapped XML**
   - Service returns wrapped XML (`SignedIdentifiers` root with repeated `SignedIdentifier` children).
   - Direct deserialization into bare `Vec<SignedIdentifier>` can under-read wrapped payloads (observed behavior: only one item returned while raw XML had two).

### Evidence from raw HTTP recordings
- **PUT** `?comp=acl&restype=container` request body contains both `SignedIdentifier` entries under `SignedIdentifiers`.
- **GET** `?comp=acl&restype=container` response body also contains both `SignedIdentifier` entries under `SignedIdentifiers`.

```xml
"RequestBody": "
<?xml version=\"1.0\" encoding=\"utf-8\"?>
<SignedIdentifiers>
	<SignedIdentifier>
		<AccessPolicy>
			<Expiry>2026-02-27T01:11:47.0529299Z</Expiry>
			<Permission>rw</Permission>
			<Start>2026-02-27T01:11:37.0529889Z</Start>
		</AccessPolicy>
		<Id>testid_1</Id>
	</SignedIdentifier>
	<SignedIdentifier>
		<AccessPolicy>
			<Expiry>2026-02-27T01:11:47.0529299Z</Expiry>
			<Permission>cd</Permission>
			<Start>2026-02-27T01:11:37.0529889Z</Start>
		</AccessPolicy>
		<Id>testid_2</Id>
	</SignedIdentifier>
</SignedIdentifiers>",
```
Note how both the identifiers are present `testid_1` and `testid_2` yet client-side the assertion was failing when trying to do direct deserialization (only yielding 1 identifier)

So the service payload is correct; the mismatch is in client-side model/wire handling.

### Current workaround in Rust (not real solutions, but what sort of massaging is necessary to force this XML wire-shape to work)
We added handwritten helpers to bridge model-vs-wire shape differences:

- `set_access_policy_items(...)`
  - wraps `Vec<SignedIdentifier>` in a temporary `SignedIdentifiers` XML envelope before sending
- `get_access_policy_items(...)`
  - explicitly parses wrapped XML envelope first, then returns all enclosed items