### PR TITLE
Refactor Azure Core from Driver Spec

### DIFF
--- a/sdk/cosmos/azure_data_cosmos_driver/doc/refactor-azure-core-dependency-spec.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/doc/refactor-azure-core-dependency-spec.md
@@ -155,9 +155,30 @@ pub mod http {
     }
     pub use typespec_client_core::http::{Transport, Context};
 
-    // Client options (just the struct, not PipelineOptions/LoggingOptions)
-    pub use typespec_client_core::http::ClientOptions;
+    // Client options wrapper (hides RetryOptions/LoggingOptions from public API)
+    ///
+    /// Client configuration for the HTTP pipeline used by this driver.
+    ///
+    /// This wraps `typespec_client_core::http::ClientOptions` but hides
+    /// retry and logging configuration from the public API surface.
+    #[derive(Clone, Debug)]
+    pub struct ClientOptions {
+        inner: typespec_client_core::http::ClientOptions,
+    }
 
+    impl ClientOptions {
+        /// Create client options with default settings.
+        pub fn new() -> Self {
+            Self {
+                inner: typespec_client_core::http::ClientOptions::default(),
+            }
+        }
+
+        /// Internal accessor for the underlying options.
+        pub(crate) fn as_inner(&self) -> &typespec_client_core::http::ClientOptions {
+            &self.inner
+        }
+    }
     // HttpClient trait (needed for Transport construction)
     pub use typespec_client_core::http::HttpClient;
 }


### PR DESCRIPTION
Documents the 149 azure_core references across 4 categories (HTTP pipeline, errors, credentials, utilities) and proposes a 4-phase migration plan using direct ecosystem crates (http, hmac, sha2, time, bytes) plus driver-owned abstractions.

Relates to https://github.com/Azure/azure-sdk-for-rust/issues/3845