### PR TITLE
regen 2

### DIFF
--- a/sdk/storage/azure_storage_blob/src/generated/clients/append_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/append_blob_client.rs
@@ -109,14 +109,14 @@ impl AppendBlobClient {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
         request.insert_header("content-type", "application/octet-stream");
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -247,14 +247,14 @@ impl AppendBlobClient {
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -320,8 +320,8 @@ impl AppendBlobClient {
                 source_encryption_key_sha256,
             );
         }
-        if let Some(source_if_match) = options.source_if_match.as_ref() {
-            request.insert_header("x-ms-source-if-match", source_if_match);
+        if let Some(source_if_match) = options.source_if_match {
+            request.insert_header("x-ms-source-if-match", source_if_match.to_string());
         }
         if let Some(source_if_modified_since) = options.source_if_modified_since {
             request.insert_header(
@@ -329,8 +329,11 @@ impl AppendBlobClient {
                 to_rfc7231(&source_if_modified_since),
             );
         }
-        if let Some(source_if_none_match) = options.source_if_none_match.as_ref() {
-            request.insert_header("x-ms-source-if-none-match", source_if_none_match);
+        if let Some(source_if_none_match) = options.source_if_none_match {
+            request.insert_header(
+                "x-ms-source-if-none-match",
+                source_if_none_match.to_string(),
+            );
         }
         if let Some(source_if_unmodified_since) = options.source_if_unmodified_since {
             request.insert_header(
@@ -413,14 +416,14 @@ impl AppendBlobClient {
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-length", "0");
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -557,14 +560,14 @@ impl AppendBlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_client.rs
@@ -27,7 +27,6 @@ use azure_core::{
     time::{to_rfc7231, OffsetDateTime},
     tracing, Result,
 };
-use std::collections::HashMap;
 
 #[tracing::client]
 pub struct BlobClient {
@@ -106,14 +105,14 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -195,14 +194,14 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -287,14 +286,14 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -375,14 +374,14 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -466,14 +465,14 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Delete);
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -825,6 +824,7 @@ impl BlobClient {
     /// * [`content_language`()](crate::generated::models::BlobClientGetPropertiesResultHeaders::content_language) - content-language
     /// * [`content_length`()](crate::generated::models::BlobClientGetPropertiesResultHeaders::content_length) - content-length
     /// * [`content_md5`()](crate::generated::models::BlobClientGetPropertiesResultHeaders::content_md5) - content-md5
+    /// * [`content_type`()](crate::generated::models::BlobClientGetPropertiesResultHeaders::content_type) - content-type
     /// * [`etag`()](crate::generated::models::BlobClientGetPropertiesResultHeaders::etag) - etag
     /// * [`last_modified`()](crate::generated::models::BlobClientGetPropertiesResultHeaders::last_modified) - last-modified
     /// * [`access_tier`()](crate::generated::models::BlobClientGetPropertiesResultHeaders::access_tier) - x-ms-access-tier
@@ -884,14 +884,14 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Head);
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -958,8 +958,8 @@ impl BlobClient {
         query_builder.build();
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("x-ms-blob-if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("x-ms-blob-if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header(
@@ -967,8 +967,8 @@ impl BlobClient {
                 to_rfc7231(&if_modified_since),
             );
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("x-ms-blob-if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("x-ms-blob-if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header(
@@ -1050,14 +1050,14 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -1138,14 +1138,14 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -1277,12 +1277,10 @@ impl BlobClient {
     ///
     /// # Arguments
     ///
-    /// * `metadata` - The metadata headers.
     /// * `options` - Optional parameters for the request.
     #[tracing::function("Storage.Blob.BlobClient.setMetadata")]
     pub async fn set_metadata(
         &self,
-        metadata: &HashMap<String, String>,
         options: Option<BlobClientSetMetadataOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();
@@ -1295,14 +1293,14 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -1328,8 +1326,10 @@ impl BlobClient {
         if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        for (k, v) in metadata {
-            request.insert_header(format!("x-ms-meta-{k}"), v);
+        if let Some(metadata) = options.metadata.as_ref() {
+            for (k, v) in metadata {
+                request.insert_header(format!("x-ms-meta-{k}"), v);
+            }
         }
         request.insert_header("x-ms-version", &self.version);
         let rsp = self
@@ -1368,14 +1368,14 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -1450,8 +1450,8 @@ impl BlobClient {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("x-ms-blob-if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("x-ms-blob-if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header(
@@ -1459,8 +1459,8 @@ impl BlobClient {
                 to_rfc7231(&if_modified_since),
             );
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("x-ms-blob-if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("x-ms-blob-if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header(

--- a/sdk/storage/azure_storage_blob/src/generated/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/block_blob_client.rs
@@ -112,14 +112,14 @@ impl BlockBlobClient {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -529,8 +529,8 @@ impl BlockBlobClient {
                 source_encryption_key_sha256,
             );
         }
-        if let Some(source_if_match) = options.source_if_match.as_ref() {
-            request.insert_header("x-ms-source-if-match", source_if_match);
+        if let Some(source_if_match) = options.source_if_match {
+            request.insert_header("x-ms-source-if-match", source_if_match.to_string());
         }
         if let Some(source_if_modified_since) = options.source_if_modified_since {
             request.insert_header(
@@ -538,8 +538,11 @@ impl BlockBlobClient {
                 to_rfc7231(&source_if_modified_since),
             );
         }
-        if let Some(source_if_none_match) = options.source_if_none_match.as_ref() {
-            request.insert_header("x-ms-source-if-none-match", source_if_none_match);
+        if let Some(source_if_none_match) = options.source_if_none_match {
+            request.insert_header(
+                "x-ms-source-if-none-match",
+                source_if_none_match.to_string(),
+            );
         }
         if let Some(source_if_unmodified_since) = options.source_if_unmodified_since {
             request.insert_header(
@@ -632,14 +635,14 @@ impl BlockBlobClient {
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -729,8 +732,8 @@ impl BlockBlobClient {
                 source_encryption_key_sha256,
             );
         }
-        if let Some(source_if_match) = options.source_if_match.as_ref() {
-            request.insert_header("x-ms-source-if-match", source_if_match);
+        if let Some(source_if_match) = options.source_if_match {
+            request.insert_header("x-ms-source-if-match", source_if_match.to_string());
         }
         if let Some(source_if_modified_since) = options.source_if_modified_since {
             request.insert_header(
@@ -738,8 +741,11 @@ impl BlockBlobClient {
                 to_rfc7231(&source_if_modified_since),
             );
         }
-        if let Some(source_if_none_match) = options.source_if_none_match.as_ref() {
-            request.insert_header("x-ms-source-if-none-match", source_if_none_match);
+        if let Some(source_if_none_match) = options.source_if_none_match {
+            request.insert_header(
+                "x-ms-source-if-none-match",
+                source_if_none_match.to_string(),
+            );
         }
         if let Some(source_if_tags) = options.source_if_tags.as_ref() {
             request.insert_header("x-ms-source-if-tags", source_if_tags);
@@ -836,14 +842,14 @@ impl BlockBlobClient {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
         request.insert_header("content-type", "application/octet-stream");
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));

--- a/sdk/storage/azure_storage_blob/src/generated/clients/page_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/page_blob_client.rs
@@ -101,14 +101,14 @@ impl PageBlobClient {
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-length", "0");
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -231,14 +231,14 @@ impl PageBlobClient {
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-length", "0");
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -394,14 +394,14 @@ impl PageBlobClient {
         query_builder.build();
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -486,14 +486,14 @@ impl PageBlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -592,14 +592,14 @@ impl PageBlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -704,14 +704,14 @@ impl PageBlobClient {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
         request.insert_header("content-type", "application/octet-stream");
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -859,14 +859,14 @@ impl PageBlobClient {
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-length", content_length.to_string());
-        if let Some(if_match) = options.if_match.as_ref() {
-            request.insert_header("if-match", if_match);
+        if let Some(if_match) = options.if_match {
+            request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match.as_ref() {
-            request.insert_header("if-none-match", if_none_match);
+        if let Some(if_none_match) = options.if_none_match {
+            request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
@@ -948,8 +948,8 @@ impl PageBlobClient {
                 source_encryption_key_sha256,
             );
         }
-        if let Some(source_if_match) = options.source_if_match.as_ref() {
-            request.insert_header("x-ms-source-if-match", source_if_match);
+        if let Some(source_if_match) = options.source_if_match {
+            request.insert_header("x-ms-source-if-match", source_if_match.to_string());
         }
         if let Some(source_if_modified_since) = options.source_if_modified_since {
             request.insert_header(
@@ -957,8 +957,11 @@ impl PageBlobClient {
                 to_rfc7231(&source_if_modified_since),
             );
         }
-        if let Some(source_if_none_match) = options.source_if_none_match.as_ref() {
-            request.insert_header("x-ms-source-if-none-match", source_if_none_match);
+        if let Some(source_if_none_match) = options.source_if_none_match {
+            request.insert_header(
+                "x-ms-source-if-none-match",
+                source_if_none_match.to_string(),
+            );
         }
         if let Some(source_if_unmodified_since) = options.source_if_unmodified_since {
             request.insert_header(

--- a/sdk/storage/azure_storage_blob/src/generated/models/header_traits.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/header_traits.rs
@@ -55,6 +55,7 @@ const CONTENT_LANGUAGE: HeaderName = HeaderName::from_static("content-language")
 const CONTENT_LENGTH: HeaderName = HeaderName::from_static("content-length");
 const CONTENT_MD5: HeaderName = HeaderName::from_static("content-md5");
 const CONTENT_RANGE: HeaderName = HeaderName::from_static("content-range");
+const CONTENT_TYPE: HeaderName = HeaderName::from_static("content-type");
 const COPY_COMPLETION_TIME: HeaderName = HeaderName::from_static("x-ms-copy-completion-time");
 const COPY_DESTINATION_SNAPSHOT: HeaderName =
     HeaderName::from_static("x-ms-copy-destination-snapshot");
@@ -1000,6 +1001,7 @@ pub trait BlobClientGetPropertiesResultHeaders: private::Sealed {
     fn content_language(&self) -> Result<Option<String>>;
     fn content_length(&self) -> Result<Option<u64>>;
     fn content_md5(&self) -> Result<Option<Vec<u8>>>;
+    fn content_type(&self) -> Result<Option<String>>;
     fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn access_tier(&self) -> Result<Option<String>>;
@@ -1072,6 +1074,11 @@ impl BlobClientGetPropertiesResultHeaders for Response<BlobClientGetPropertiesRe
     /// client can check for message content integrity.
     fn content_md5(&self) -> Result<Option<Vec<u8>>> {
         Headers::get_optional_with(self.headers(), &CONTENT_MD5, |h| base64::decode(h.as_str()))
+    }
+
+    /// Content-type.
+    fn content_type(&self) -> Result<Option<String>> {
+        Headers::get_optional_as(self.headers(), &CONTENT_TYPE)
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.

--- a/sdk/storage/azure_storage_blob/src/generated/models/method_options.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/method_options.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use azure_core::{
     fmt::SafeDebug,
-    http::{pager::PagerOptions, ClientMethodOptions},
+    http::{pager::PagerOptions, ClientMethodOptions, Etag},
     time::OffsetDateTime,
 };
 use std::collections::HashMap;
@@ -42,13 +42,13 @@ pub struct AppendBlobClientAppendBlockOptions<'a> {
     pub encryption_scope: Option<String>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -117,13 +117,13 @@ pub struct AppendBlobClientAppendBlockFromUrlOptions<'a> {
     pub file_request_intent: Option<FileShareTokenIntent>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -159,13 +159,13 @@ pub struct AppendBlobClientAppendBlockFromUrlOptions<'a> {
     pub source_encryption_key_sha256: Option<String>,
 
     /// Specify an ETag value to operate only on blobs with a matching value.
-    pub source_if_match: Option<String>,
+    pub source_if_match: Option<Etag>,
 
     /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub source_if_modified_since: Option<OffsetDateTime>,
 
     /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
-    pub source_if_none_match: Option<String>,
+    pub source_if_none_match: Option<Etag>,
 
     /// Specify this header value to operate only on a blob if it has not been modified since the specified date/time.
     pub source_if_unmodified_since: Option<OffsetDateTime>,
@@ -228,13 +228,13 @@ pub struct AppendBlobClientCreateOptions<'a> {
     pub encryption_scope: Option<String>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -273,13 +273,13 @@ pub struct AppendBlobClientSealOptions<'a> {
     pub append_position: Option<i64>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has not been modified since the specified date-time.
     pub if_unmodified_since: Option<OffsetDateTime>,
@@ -298,13 +298,13 @@ pub struct AppendBlobClientSealOptions<'a> {
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientAcquireLeaseOptions<'a> {
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -333,13 +333,13 @@ pub struct BlobClientBreakLeaseOptions<'a> {
     pub break_period: Option<i32>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -358,13 +358,13 @@ pub struct BlobClientBreakLeaseOptions<'a> {
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientChangeLeaseOptions<'a> {
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -400,13 +400,13 @@ pub struct BlobClientCreateSnapshotOptions<'a> {
     pub encryption_scope: Option<String>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -444,13 +444,13 @@ pub struct BlobClientDeleteOptions<'a> {
     pub delete_snapshots: Option<DeleteSnapshotsOptionType>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -585,13 +585,13 @@ pub struct BlobClientGetPropertiesOptions<'a> {
     pub encryption_key_sha256: Option<String>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -621,13 +621,13 @@ pub struct BlobClientGetPropertiesOptions<'a> {
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientGetTagsOptions<'a> {
     /// Specify an ETag value to operate only on blobs with a matching value.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// Specify an ETag value to operate only on blobs without a matching value.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -657,13 +657,13 @@ pub struct BlobClientGetTagsOptions<'a> {
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientReleaseLeaseOptions<'a> {
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -682,13 +682,13 @@ pub struct BlobClientReleaseLeaseOptions<'a> {
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientRenewLeaseOptions<'a> {
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -766,13 +766,13 @@ pub struct BlobClientSetMetadataOptions<'a> {
     pub encryption_scope: Option<String>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -782,6 +782,9 @@ pub struct BlobClientSetMetadataOptions<'a> {
 
     /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// The metadata headers.
+    pub metadata: Option<HashMap<String, String>>,
 
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
@@ -817,13 +820,13 @@ pub struct BlobClientSetPropertiesOptions<'a> {
     pub blob_content_type: Option<String>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -845,13 +848,13 @@ pub struct BlobClientSetPropertiesOptions<'a> {
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientSetTagsOptions<'a> {
     /// Specify an ETag value to operate only on blobs with a matching value.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// Specify an ETag value to operate only on blobs without a matching value.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -1349,13 +1352,13 @@ pub struct BlockBlobClientCommitBlockListOptions<'a> {
     pub encryption_scope: Option<String>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -1508,13 +1511,13 @@ pub struct BlockBlobClientStageBlockFromUrlOptions<'a> {
     pub source_encryption_key_sha256: Option<String>,
 
     /// Specify an ETag value to operate only on blobs with a matching value.
-    pub source_if_match: Option<String>,
+    pub source_if_match: Option<Etag>,
 
     /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub source_if_modified_since: Option<OffsetDateTime>,
 
     /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
-    pub source_if_none_match: Option<String>,
+    pub source_if_none_match: Option<Etag>,
 
     /// Specify this header value to operate only on a blob if it has not been modified since the specified date/time.
     pub source_if_unmodified_since: Option<OffsetDateTime>,
@@ -1585,13 +1588,13 @@ pub struct BlockBlobClientUploadBlobFromUrlOptions<'a> {
     pub file_request_intent: Option<FileShareTokenIntent>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -1622,13 +1625,13 @@ pub struct BlockBlobClientUploadBlobFromUrlOptions<'a> {
     pub source_encryption_key_sha256: Option<String>,
 
     /// Specify an ETag value to operate only on blobs with a matching value.
-    pub source_if_match: Option<String>,
+    pub source_if_match: Option<Etag>,
 
     /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub source_if_modified_since: Option<OffsetDateTime>,
 
     /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
-    pub source_if_none_match: Option<String>,
+    pub source_if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub source_if_tags: Option<String>,
@@ -1694,13 +1697,13 @@ pub struct BlockBlobClientUploadInternalOptions<'a> {
     pub encryption_scope: Option<String>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -1768,13 +1771,13 @@ pub struct PageBlobClientClearPagesOptions<'a> {
     pub encryption_scope: Option<String>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify this header value to operate only on a blob if it has the specified sequence number.
     pub if_sequence_number_equal_to: Option<i64>,
@@ -1852,13 +1855,13 @@ pub struct PageBlobClientCreateOptions<'a> {
     pub encryption_scope: Option<String>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -1895,13 +1898,13 @@ pub struct PageBlobClientCreateOptions<'a> {
 #[derive(Clone, Default, SafeDebug)]
 pub struct PageBlobClientGetPageRangesOptions<'a> {
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -1957,13 +1960,13 @@ pub struct PageBlobClientResizeOptions<'a> {
     pub encryption_scope: Option<String>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -1989,13 +1992,13 @@ pub struct PageBlobClientSetSequenceNumberOptions<'a> {
     pub blob_sequence_number: Option<i64>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
@@ -2034,13 +2037,13 @@ pub struct PageBlobClientUploadPagesOptions<'a> {
     pub encryption_scope: Option<String>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify this header value to operate only on a blob if it has the specified sequence number.
     pub if_sequence_number_equal_to: Option<i64>,
@@ -2108,13 +2111,13 @@ pub struct PageBlobClientUploadPagesFromUrlOptions<'a> {
     pub file_request_intent: Option<FileShareTokenIntent>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<String>,
+    pub if_match: Option<Etag>,
 
     /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<OffsetDateTime>,
 
     /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<String>,
+    pub if_none_match: Option<Etag>,
 
     /// Specify this header value to operate only on a blob if it has the specified sequence number.
     pub if_sequence_number_equal_to: Option<i64>,
@@ -2154,13 +2157,13 @@ pub struct PageBlobClientUploadPagesFromUrlOptions<'a> {
     pub source_encryption_key_sha256: Option<String>,
 
     /// Specify an ETag value to operate only on blobs with a matching value.
-    pub source_if_match: Option<String>,
+    pub source_if_match: Option<Etag>,
 
     /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub source_if_modified_since: Option<OffsetDateTime>,
 
     /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
-    pub source_if_none_match: Option<String>,
+    pub source_if_none_match: Option<Etag>,
 
     /// Specify this header value to operate only on a blob if it has not been modified since the specified date/time.
     pub source_if_unmodified_since: Option<OffsetDateTime>,

--- a/sdk/storage/azure_storage_blob/tsp-location.yaml
+++ b/sdk/storage/azure_storage_blob/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/storage/Microsoft.BlobStorage
-commit: 9135fb02c7294430885e9b4f38e939a4a0c12a9f
+commit: a4ffefdcfbe54cc742016a150a751c67efa05436
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 


### PR DESCRIPTION
Regenerating against: https://github.com/Azure/azure-rest-api-specs/pull/40881
This specific file: https://github.com/Azure/azure-rest-api-specs/blob/a4ffefdcfbe54cc742016a150a751c67efa05436/specification/storage/Microsoft.BlobStorage/tspconfig.yaml
Whose commit hash is: `a4ffefdcfbe54cc742016a150a751c67efa05436`

```
(.venv) C:\azure-sdk-for-rust>tsp-client init -c https://github.com/Azure/azure-rest-api-specs/blob/a4ffefdcfbe54cc742016a150a751c67efa05436/specification/storage/Microsoft.BlobStorage/tspconfig.yaml
Using output directory 'C:/azure-sdk-for-rust'

888                                      888 d8b                   888
888                                      888 Y8P                   888
888                                      888                       888
888888 .d8888b  88888b.          .d8888b 888 888  .d88b.  88888b.  888888
888    88K      888 "88b        d88P"    888 888 d8P  Y8b 888 "88b 888
888    "Y8888b. 888  888 888888 888      888 888 88888888 888  888 888
Y88b.       X88 888 d88P        Y88b.    888 888 Y8b.     888  888 Y88b.
 "Y888  88888P' 88888P"          "Y8888P 888 888  "Y8888  888  888  "Y888
                888
                888
                888

0.21.0
Found emitter package @azure-tools/typespec-rust@0.36.0
Found emitter package @azure-tools/typespec-rust@0.36.0
Installing dependencies from npm...
(node:12756) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
(Use `node --trace-deprecation ...` to show where the warning was created)

added 117 packages, and audited 118 packages in 5s

25 packages are looking for funding
  run `npm fund` for details

15 moderate severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
Resolved path: C:/azure-sdk-for-rust/sdk/storage/azure_storage_blob/TempTypeSpecFiles/node_modules/@typespec/compiler
Compiling tsp using @azure-tools/typespec-rust...
Diagnostics were reported during compilation. Use the `--debug` flag to see if there is warning diagnostic output.
generation complete
```

Ran a git clean -nfd and deleted them after:

>(.venv) C:\azure-sdk-for-rust>git clean -nfd
		Would remove sdk/storage/azure_storage_blob/sdk/storage/azure_storage_blob/src/
		Would remove sdk/storage/azure_storage_queue/tests/sdk/
		Would remove test_project/

and checked for a TempTypeSpecFiles dir, none existed.

