### PR TITLE
Cosmos: Fixes Circuit Breaker Failover Logic for Multi-Master Writes on 403/3

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixes Circuit Breaker Failover Logic for Multi-Master Writes on 403/3. ([#3861](https://github.com/Azure/azure-sdk-for-rust/pull/3861))
+
 ### Other Changes
 
 ## 0.31.0 (2026-02-25)

--- a/sdk/cosmos/azure_data_cosmos/src/retry_policies/client_retry_policy.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/retry_policies/client_retry_policy.rs
@@ -529,7 +529,7 @@ impl ClientRetryPolicy {
         {
             if self.request.is_some()
                 && (self.is_request_eligible_for_per_partition_automatic_failover()
-                    || self.is_request_eligible_for_partition_level_circuit_breaker())
+                    || self.increment_failure_counter_and_check_circuit_breaker_eligibility())
                 && self
                     .partition_key_range_location_cache
                     .try_mark_endpoint_unavailable_for_partition_key_range(
@@ -613,7 +613,7 @@ impl ClientRetryPolicy {
         if let Some(request) = self.request.as_ref() {
             if is_system_resource_unavailable_for_write
                 || self.is_request_eligible_for_per_partition_automatic_failover()
-                || self.is_request_eligible_for_partition_level_circuit_breaker()
+                || self.increment_failure_counter_and_check_circuit_breaker_eligibility()
             {
                 return self
                     .partition_key_range_location_cache
@@ -644,8 +644,8 @@ impl ClientRetryPolicy {
         false
     }
 
-    /// Checks if request is eligible for partition-level circuit breaker.
-    fn is_request_eligible_for_partition_level_circuit_breaker(&self) -> bool {
+    /// Increments failure counter and checks if request is eligible for partition-level circuit breaker.
+    fn increment_failure_counter_and_check_circuit_breaker_eligibility(&self) -> bool {
         if let Some(request) = self.request.as_ref() {
             return self
                 .partition_key_range_location_cache
@@ -739,12 +739,14 @@ impl ClientRetryPolicy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::AccountRegion;
     use crate::operation_context::OperationType;
     use crate::partition_key::PartitionKey;
     use crate::regions;
     use crate::regions::RegionName;
     use crate::resource_context::{ResourceLink, ResourceType};
     use crate::routing::global_endpoint_manager::GlobalEndpointManager;
+    use crate::routing::partition_key_range::PartitionKeyRange;
     use azure_core::http::headers::Headers;
     use azure_core::http::ClientOptions;
     use azure_core::Bytes;
@@ -875,6 +877,63 @@ mod tests {
             },
             "Test error with substatus",
         )
+    }
+
+    /// Creates a multi-master endpoint manager with two regions (West US + East US),
+    /// both configured as write AND read endpoints.
+    fn create_multi_master_endpoint_manager() -> Arc<GlobalEndpointManager> {
+        let pipeline = azure_core::http::Pipeline::new(
+            option_env!("CARGO_PKG_NAME"),
+            option_env!("CARGO_PKG_VERSION"),
+            ClientOptions::default(),
+            Vec::new(),
+            Vec::new(),
+            None,
+        );
+
+        let manager = GlobalEndpointManager::new(
+            "https://test.documents.azure.com".parse().unwrap(),
+            vec![RegionName::from("West US"), RegionName::from("East US")],
+            vec![],
+            pipeline,
+        );
+
+        let west = AccountRegion {
+            name: RegionName::from("West US"),
+            database_account_endpoint: "https://test-westus.documents.azure.com".parse().unwrap(),
+        };
+        let east = AccountRegion {
+            name: RegionName::from("East US"),
+            database_account_endpoint: "https://test-eastus.documents.azure.com".parse().unwrap(),
+        };
+
+        // Both regions as write + read → multi-master account
+        manager.update_location_cache(vec![west.clone(), east.clone()], vec![west, east]);
+        manager
+    }
+
+    /// Creates a policy configured for multi-master with PPCB enabled.
+    fn create_multi_master_ppcb_policy() -> ClientRetryPolicy {
+        let manager = create_multi_master_endpoint_manager();
+        // PPAF = false, PPCB = true
+        let partition_manager = GlobalPartitionEndpointManager::new(manager.clone(), false, true);
+        ClientRetryPolicy::new(manager, partition_manager, None)
+    }
+
+    /// Creates a write request with a PartitionKeyRange and routed endpoint,
+    /// as the PPCB code path requires both to be present.
+    fn create_ppcb_write_request() -> CosmosRequest {
+        let resource_link = ResourceLink::root(ResourceType::Documents);
+        let mut request = CosmosRequest::builder(OperationType::Create, resource_link)
+            .partition_key(PartitionKey::from("test"))
+            .build()
+            .unwrap();
+        request.request_context.resolved_partition_key_range =
+            Some(PartitionKeyRange::new("0".into(), "".into(), "FF".into()));
+        request.request_context.resolved_collection_rid = Some("dbs/db1/colls/coll1".into());
+        request.request_context.location_endpoint_to_route =
+            Some("https://test-westus.documents.azure.com/".parse().unwrap());
+        request
     }
 
     #[tokio::test]
@@ -1552,5 +1611,113 @@ mod tests {
             RetryResult::DoNotRetry,
             "unknown IO errors should not retry write requests"
         );
+    }
+
+    /// **Core bug-fix test.** On a multi-master account with PPCB enabled, a write
+    /// receiving 403/3 must reach `is_request_eligible_for_partition_level_circuit_breaker`,
+    /// which internally calls `increment_request_failure_counter_and_check_if_partition_can_failover`.
+    ///
+    /// Before the fix, the outer `partition_level_failover_enabled()` guard short-circuited
+    /// on multi-master accounts, so the counter was never incremented and partition-level
+    /// failover could never trigger. After the fix, each 403/3 increments the counter.
+    #[tokio::test]
+    async fn write_forbidden_on_multi_master_increments_ppcb_counter() {
+        let mut policy = create_multi_master_ppcb_policy();
+        let request = create_ppcb_write_request();
+
+        policy.operation_type = Some(OperationType::Create);
+        policy.can_use_multiple_write_locations = true;
+        policy.location_endpoint = Some("https://test-westus.documents.azure.com".parse().unwrap());
+        policy.request = Some(request);
+
+        // Call the method that the 403/3 handler now invokes.
+        // Default write threshold = 5, so each of the first 5 calls should return false
+        // (counter not yet exceeded), but still increment the counter.
+        for i in 1..=5 {
+            let result = policy.increment_failure_counter_and_check_circuit_breaker_eligibility();
+            assert!(
+                !result,
+                "Attempt {i}: Expected false (counter {i} <= threshold 5)"
+            );
+        }
+
+        // The 6th call should exceed the threshold (6 > 5) and return true
+        let result = policy.increment_failure_counter_and_check_circuit_breaker_eligibility();
+        assert!(
+            result,
+            "Expected true after exceeding write failure threshold (6 > 5)"
+        );
+    }
+
+    /// On a multi-master account with PPCB enabled, once the write failure count
+    /// exceeds the threshold (default: 5), the next 403/3 should trigger partition-level
+    /// failover: the partition is marked unavailable and the retry is immediate
+    /// (Duration::ZERO) without going through account-level failover.
+    #[tokio::test]
+    async fn write_forbidden_on_multi_master_triggers_partition_failover_after_threshold() {
+        let mut policy = create_multi_master_ppcb_policy();
+        let request = create_ppcb_write_request();
+
+        policy.operation_type = Some(OperationType::Create);
+        policy.can_use_multiple_write_locations = true;
+        policy.location_endpoint = Some("https://test-westus.documents.azure.com".parse().unwrap());
+        policy.request = Some(request);
+
+        // Pre-pump the PPCB counter to just below threshold (5 increments).
+        // Each call to increment_failure_counter_and_check_circuit_breaker_eligibility()
+        // increments the counter via increment_request_failure_counter_and_check_if_partition_can_failover.
+        for _ in 1..=5 {
+            let _ = policy.increment_failure_counter_and_check_circuit_breaker_eligibility();
+        }
+
+        let failover_count_before = policy.failover_retry_count;
+
+        // Now call should_retry_error with a 403/3 error.
+        // The 6th increment will exceed the threshold → the PPCB path returns
+        // Retry { after: ZERO } immediately, without calling should_retry_on_endpoint_failure
+        // (and thus without any HTTP calls).
+        let error = create_error_with_substatus(
+            StatusCode::Forbidden,
+            SubStatusCode::WRITE_FORBIDDEN.value() as u32,
+        );
+
+        let result = policy.should_retry_error(&error).await;
+
+        assert!(
+            result.is_retry(),
+            "Expected retry after PPCB threshold exceeded"
+        );
+
+        // The partition-level path returns Retry { after: ZERO } directly,
+        // WITHOUT going through should_retry_on_endpoint_failure, so
+        // failover_retry_count should NOT have increased.
+        assert_eq!(
+            policy.failover_retry_count, failover_count_before,
+            "failover_retry_count should NOT increment when partition-level failover succeeds \
+             (partition path bypasses account-level retry)"
+        );
+    }
+
+    /// Without PPCB enabled, `is_request_eligible_for_partition_level_circuit_breaker`
+    /// should always return false, meaning partition-level failover never triggers
+    /// for 403/3 on multi-master accounts.
+    #[tokio::test]
+    async fn write_forbidden_on_multi_master_without_ppcb_returns_ineligible() {
+        let manager = create_multi_master_endpoint_manager();
+        // PPAF = false, PPCB = false
+        let partition_manager = GlobalPartitionEndpointManager::new(manager.clone(), false, false);
+        let mut policy = ClientRetryPolicy::new(manager, partition_manager, None);
+
+        let request = create_ppcb_write_request();
+        policy.operation_type = Some(OperationType::Create);
+        policy.can_use_multiple_write_locations = true;
+        policy.location_endpoint = Some("https://test-westus.documents.azure.com".parse().unwrap());
+        policy.request = Some(request);
+
+        // Even after many calls, should always return false (PPCB disabled)
+        for i in 1..=8 {
+            let result = policy.increment_failure_counter_and_check_circuit_breaker_eligibility();
+            assert!(!result, "Attempt {i}: Expected false when PPCB is disabled");
+        }
     }
 }


### PR DESCRIPTION
### Problem

On **multi-master** accounts, when a write request receives a `403/3` (WriteForbidden) response, the Per-Partition Circuit Breaker (PPCB) was not properly tracking failures or applying partition-level failover. This caused the partition override to never take effect, leaving the request stuck retrying via the generic account-level failover path without partition-level awareness.

### Root Cause

In `ClientRetryPolicy::should_retry_on_http_status()`, the 403/3 handler used a broad `partition_level_failover_enabled()` guard and then called `try_mark_endpoint_unavailable_for_partition_key_range()` directly — **without** going through the `ClientRetryPolicy`-level PPAF/PPCB eligibility checks:

```rust
if self
    .partition_key_range_location_cache
    .partition_level_failover_enabled()         // ← broad flag check only
    && self.request.is_some()
    && self
        .partition_key_range_location_cache
        .try_mark_endpoint_unavailable_for_partition_key_range(...)  // ← called directly
{
    return Some(RetryResult::Retry { after: Duration::ZERO });
}
// automatic failover support needed to be plugged in here.
return Some(self.should_retry_on_endpoint_failure(...).await);
```

This had two issues:

1. **PPCB failure counters were never incremented on 403/3.** The `try_mark_endpoint_unavailable_for_partition_key_range()` method moves the partition to the next region but does **not** call `increment_request_failure_counter_and_check_if_partition_can_failover()`. The counter is only incremented when `ClientRetryPolicy::is_request_eligible_for_partition_level_circuit_breaker()` is called — and it was bypassed on this code path.

2. **The PPCB threshold was bypassed on mark, but enforced on override application.** Even though `try_mark_endpoint_unavailable_for_partition_key_range()` would succeed (creating a failover map entry and moving the partition to the next region), the subsequent `try_add_partition_level_location_override()` call in `before_send_request()` checks `can_circuit_breaker_trigger_partition_failover()`, which verifies the failure count exceeds the threshold. Since the counter was never incremented, this check always returned `false`, so the **override was never applied** — the retry went back to the original (failed) endpoint.

**Net effect:** On multi-master accounts, 403/3 responses created phantom failover entries that were never applied, causing requests to repeatedly hit the failed endpoint.

### Fix

Replaced the broad `partition_level_failover_enabled()` check with the specific `ClientRetryPolicy`-level PPAF and PPCB eligibility checks:

```rust
if self.request.is_some()
    && (self.is_request_eligible_for_per_partition_automatic_failover()
        || self.is_request_eligible_for_partition_level_circuit_breaker())
    && self
        .partition_key_range_location_cache
        .try_mark_endpoint_unavailable_for_partition_key_range(...)
{
    return Some(RetryResult::Retry { after: Duration::ZERO });
}
return Some(self.should_retry_on_endpoint_failure(...).await);
```

This ensures:

- **`is_request_eligible_for_partition_level_circuit_breaker()`** (on `ClientRetryPolicy`) calls `increment_request_failure_counter_and_check_if_partition_can_failover()`, which **increments the PPCB failure counter** on every 403/3 and returns `true` only when the threshold is exceeded (default: 5 for writes).
- **Before threshold is reached:** PPCB returns `false`, `try_mark_endpoint_unavailable` is short-circuited via `&&`, and the request falls through to `should_retry_on_endpoint_failure()` (account-level retry) — correct behavior while the circuit breaker is counting.
- **After threshold is exceeded:** PPCB returns `true`, `try_mark_endpoint_unavailable` creates the failover entry and moves the partition to the next region. The override in `before_send_request()` is now also applied because `can_circuit_breaker_trigger_partition_failover()` sees a counter that exceeds the threshold.

Also removed the stale comment `// automatic failover support needed to be plugged in here.` since PPAF/PPCB eligibility checks are now properly integrated.

### Changes

- **`src/retry_policies/client_retry_policy.rs`** (+3 / -5)
  - `should_retry_on_http_status`: Replaced the broad `partition_level_failover_enabled()` guard with specific `is_request_eligible_for_per_partition_automatic_failover()` and `is_request_eligible_for_partition_level_circuit_breaker()` checks. Removed stale TODO comment.
