### PR TITLE
Make sure markdownlint-cli2 only lints modified files

### DIFF
--- a/.github/skills/lint-markdown/SKILL.md
+++ b/.github/skills/lint-markdown/SKILL.md
@@ -19,11 +19,11 @@ For markdownlint rules configuration, nest it under the `config` property follow
 
 ## Check Markdown
 
-Run `npm exec --prefix .github/skills/lint-markdown -- markdownlint-cli2` from the repository root to lint Markdown files according to the configuration.
+Run `npm exec --prefix .github/skills/lint-markdown -- markdownlint-cli2` from the repository root with a list of modified markdown files to lint.
 
 ## Fix issues
 
-Run with the `--fix` flag to automatically fix supported issues:
+Run with the `--fix` flag with a list of modified markdown files to automatically fix supported issues:
 
 ```bash
 npm exec --prefix .github/skills/lint-markdown -- markdownlint-cli2 --fix

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,7 +1,5 @@
 $schema: https://raw.githubusercontent.com/DavidAnson/markdownlint-cli2/v0.21.0/schema/markdownlint-cli2-config-schema.json
 gitignore: true
-globs:
-  - "**/*.md"
 ignores:
   - eng/common/
 config:


### PR DESCRIPTION
The `globs` was being appended instead of overridden by the file paths. It was documented, but unexpected. Could override with `--no-globs` but this makes more sense, IMO.
