### PR TITLE
[Storage] `azure_storage_blob` `v0.10.1` release changelog + `unimplemented!()` for inaccessible codes

### DIFF
--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Release History
 
-## 0.11.0 (2026-03-18)
-
-### Breaking Changes
-
-- Removes previously exported `BlobClient::managed_download()` and associated model type `BlobClientManagedDownloadOptions`. These features were unintentionally included and are not suitable for usage in their previous state.
+## 0.10.1 (2026-03-18)
 
 ### Bugs Fixed
 
+- `BlobClient::managed_download()` and `BlobClientManagedDownloadOptions` were unintentionally exported in 0.10.0. The method now panics unconditionally; this API will be removed in a future release.
 - Updated minimum dependency versions to incorporate a fix for TLS 1.3 data corruption on Windows when uploading large payloads ([schannel-rs#121](https://github.com/steffengy/schannel-rs/pull/121)).
 
 ## 0.10.0 (2026-03-11)

--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -4,30 +4,26 @@
 pub use crate::generated::clients::{BlobClient, BlobClientOptions};
 
 use crate::{
-    generated::clients::BlobClient as GeneratedBlobClient,
     logging::apply_storage_logging_defaults,
     models::{
-        http_ranges::IntoRangeHeader, method_options::BlobClientManagedDownloadOptions,
-        BlobClientDownloadOptions, BlobClientDownloadResult, BlobClientUploadOptions,
-        BlobClientUploadResult, StorageErrorCode,
+        method_options::BlobClientManagedDownloadOptions, BlobClientDownloadOptions,
+        BlobClientDownloadResult, BlobClientUploadOptions, BlobClientUploadResult,
+        StorageErrorCode,
     },
-    partitioned_transfer::{self, PartitionedDownloadBehavior},
     pipeline::StorageHeadersPolicy,
     AppendBlobClient, BlockBlobClient, PageBlobClient,
 };
-use async_trait::async_trait;
 use azure_core::{
     credentials::TokenCredential,
     error::ErrorKind,
     http::{
         policies::{auth::BearerTokenAuthorizationPolicy, Policy},
         response::{AsyncResponse, PinnedStream},
-        AsyncRawResponse, NoFormat, Pipeline, RequestContent, StatusCode, Url, UrlExt,
+        NoFormat, Pipeline, RequestContent, StatusCode, Url, UrlExt,
     },
     tracing, Bytes, Result,
 };
 use std::sync::Arc;
-use std::{num::NonZero, ops::Range};
 
 impl BlobClient {
     /// Creates a new BlobClient, using Entra ID authentication.
@@ -118,45 +114,11 @@ impl BlobClient {
     /// # Arguments
     ///
     /// * `options` - Optional parameters for the request.
-    pub(crate) async fn managed_download(
+    pub async fn managed_download(
         &self,
-        options: Option<BlobClientManagedDownloadOptions<'_>>,
+        _options: Option<BlobClientManagedDownloadOptions<'_>>,
     ) -> Result<PinnedStream> {
-        let options = options.unwrap_or_default();
-        let parallel = options.parallel.unwrap_or(DEFAULT_PARALLEL);
-        let partition_size = options.partition_size.unwrap_or(DEFAULT_PARTITION_SIZE);
-        // construct exhaustively to ensure we catch new options when added
-        let get_range_options = BlobClientDownloadOptions {
-            encryption_algorithm: options.encryption_algorithm,
-            encryption_key: options.encryption_key,
-            encryption_key_sha256: options.encryption_key_sha256,
-            if_match: options.if_match,
-            if_modified_since: options.if_modified_since,
-            if_none_match: options.if_none_match,
-            if_tags: options.if_tags,
-            if_unmodified_since: options.if_unmodified_since,
-            lease_id: options.lease_id,
-            // TODO: method_options: options.method_options,
-            range: None,
-            range_get_content_crc64: options.range_get_content_crc64,
-            range_get_content_md5: options.range_get_content_md5,
-            snapshot: options.snapshot,
-            structured_body_type: options.structured_body_type,
-            timeout: options.timeout,
-            version_id: options.version_id,
-            ..Default::default()
-        };
-
-        let client = GeneratedBlobClient {
-            endpoint: self.endpoint.clone(),
-            pipeline: self.pipeline.clone(),
-            version: self.version.clone(),
-            tracer: self.tracer.clone(),
-        };
-        let client = BlobClientDownloadBehavior::new(client, get_range_options);
-
-        partitioned_transfer::download(options.range, parallel, partition_size, Arc::new(client))
-            .await
+        unimplemented!("BlobClient::managed_download() was unintentionally exported in 0.10.0 and will be removed in a future release.")
     }
 
     /// Returns a new instance of AppendBlobClient.
@@ -283,31 +245,5 @@ impl BlobClient {
             },
             Err(e) => Err(e),
         }
-    }
-}
-
-// unwrap evaluated at compile time
-const DEFAULT_PARALLEL: NonZero<usize> = NonZero::new(4).unwrap();
-const DEFAULT_PARTITION_SIZE: NonZero<usize> = NonZero::new(4 * 1024 * 1024).unwrap();
-
-struct BlobClientDownloadBehavior<'a> {
-    client: GeneratedBlobClient,
-    options: BlobClientDownloadOptions<'a>,
-}
-impl<'a> BlobClientDownloadBehavior<'a> {
-    fn new(client: GeneratedBlobClient, options: BlobClientDownloadOptions<'a>) -> Self {
-        Self { client, options }
-    }
-}
-
-#[async_trait]
-impl PartitionedDownloadBehavior for BlobClientDownloadBehavior<'_> {
-    async fn transfer_range(&self, range: Option<Range<usize>>) -> Result<AsyncRawResponse> {
-        let mut opt = self.options.clone();
-        opt.range = range.map(|r| r.as_range_header());
-        self.client
-            .download_internal(Some(opt))
-            .await
-            .map(AsyncRawResponse::from)
     }
 }

--- a/sdk/storage/azure_storage_blob/src/models/method_options.rs
+++ b/sdk/storage/azure_storage_blob/src/models/method_options.rs
@@ -13,7 +13,7 @@ use crate::models::{AccessTier, EncryptionAlgorithmType, ImmutabilityPolicyMode}
 
 /// Options to be passed to `BlockBlobClient::managed_download()`
 #[derive(Clone, Default, SafeDebug)]
-pub(crate) struct BlobClientManagedDownloadOptions<'a> {
+pub struct BlobClientManagedDownloadOptions<'a> {
     /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
     /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/mod.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/mod.rs
@@ -4,7 +4,6 @@
 mod download;
 mod upload;
 
-pub(crate) use download::*;
 pub(crate) use upload::*;
 
 use std::{cmp::max, future::Future, num::NonZero, pin::Pin};


### PR DESCRIPTION
- Makes `managed_download` have unimplemented and thus panic
- Add changelog entry representing this change