### PR TITLE
ashleyst/driver options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,7 @@ dependencies = [
  "async-lock",
  "async-trait",
  "azure_core 0.34.0",
+ "azure_data_cosmos_macros",
  "azure_identity 0.34.0",
  "base64 0.22.1",
  "crossbeam-epoch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ async-stream = { version = "0.3.6" }
 async-trait = "0.1"
 base64 = "0.22"
 arc-swap = "1.7"
+azure_data_cosmos_macros = { path = "sdk/cosmos/azure_data_cosmos_macros" }
 bytes = "1.11.1"
 cargo_metadata = "0.23.1"
 clap = { version = "4.5.58", features = ["derive"] }

--- a/sdk/cosmos/azure_data_cosmos/docs/ConfigurationOptions.md
+++ b/sdk/cosmos/azure_data_cosmos/docs/ConfigurationOptions.md
@@ -259,6 +259,7 @@ pub struct CosmosAccountOptions { /* fields below */ }
 | --- | --- | --- | --- |
 | `user_agent_suffix` | `Option<String>` | `AZURE_COSMOS_USER_AGENT_SUFFIX` | Application identifier appended to the User-Agent header for telemetry. |
 | `account_initialization_custom_endpoints` | `Option<HashSet<Url>>` | `AZURE_COSMOS_CUSTOM_ENDPOINTS` | Custom endpoints for initial account discovery (private endpoints, etc.). Env var is comma-separated. |
+| `custom_headers` | `Option<HashMap<HeaderName, HeaderValue>>` | — | **Best-effort only.** Additional HTTP headers injected into outgoing requests. Intended for proxies, gateways, or external telemetry systems — **not** for setting Cosmos DB backend headers. The SDK may use non-standard transports (e.g., custom framing over TCP) where HTTP headers do not apply; in those cases custom headers are silently ignored. The SDK reserves the right to override any header that conflicts with its internal protocol. `None` inherits from a lower layer; `Some(map)` replaces (does not merge) the inherited value. No environment variable — headers are not representable as a single string. |
 
 ---
 
@@ -489,9 +490,11 @@ The `ConsistencyLevel` enum itself is **retained** as a model type for account-l
 
 ### 6.3 Custom HTTP Headers (`custom_headers`)
 
-**Removed from:** `CosmosClientOptions`, `ItemOptions`, `QueryOptions`
+**Moved from:** `CosmosClientOptions`, `ItemOptions`, `QueryOptions` → `CosmosAccountOptions.custom_headers`
 
-The Rust SDK does not expose a custom HTTP header mechanism. Features that other SDKs surface through custom headers (e.g., dedicated gateway cache control) will be modeled as first-class typed options when supported.
+Retained as a **best-effort** mechanism for injecting HTTP headers into outgoing requests. This is intended for proxies, gateways, or external telemetry systems — **not** for setting Cosmos DB backend headers. The Cosmos SDK does not always use standard HTTP or HTTP/2 (e.g., it may use custom framing over TCP); custom headers are silently ignored on transports where they do not apply. The SDK reserves the right to override any header that conflicts with its internal protocol.
+
+Features that other SDKs surface through custom headers (e.g., dedicated gateway cache control) will continue to be modeled as first-class typed options rather than relying on `custom_headers`.
 
 ### 6.4 Indexing Directive (`indexing_directive`)
 
@@ -531,7 +534,7 @@ The Cosmos SDK manages its own transport, retry, and telemetry pipeline internal
 | `throughput_bucket` | `CosmosClientOptions`, `ItemOptions`, `QueryOptions` | — | **Deferred** to throughput control follow-up spec |
 | `session_retry_options` | `CosmosClientOptions` | `RetryOptions.session_retry` | Nested; fields become `Option<T>` |
 | `priority` | `CosmosClientOptions`, `ItemOptions`, `QueryOptions` | — | **Deferred** to throughput control follow-up spec |
-| `custom_headers` | `CosmosClientOptions`, `ItemOptions`, `QueryOptions` | — | **Removed** (§6.3) |
+| `custom_headers` | `CosmosClientOptions`, `ItemOptions`, `QueryOptions` | `CosmosAccountOptions.custom_headers` | Moved to option group; best-effort only (see §6.3) |
 | `pre_triggers` | `ItemOptions` | — | **Removed** (§6.5) |
 | `post_triggers` | `ItemOptions` | — | **Removed** (§6.5) |
 | `session_token` | `ItemOptions`, `QueryOptions` | Operation-only on each type | Duplicated across read/write/query/batch |

--- a/sdk/cosmos/azure_data_cosmos_driver/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_driver/Cargo.toml
@@ -21,6 +21,7 @@ async-trait.workspace = true
 azure_core = { workspace = true, default-features = false, features = [
   "hmac_rust",
 ] }
+azure_data_cosmos_macros.workspace = true
 base64.workspace = true
 crossbeam-epoch = { workspace = true, features = ["std"] }
 futures.workspace = true

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     options::{
         ConnectionPoolOptions, DiagnosticsOptions, DriverOptions, OperationOptions, RuntimeOptions,
-        ThroughputControlGroupSnapshot,
+        RuntimeOptionsView, ThroughputControlGroupSnapshot,
     },
 };
 use arc_swap::ArcSwap;
@@ -56,10 +56,6 @@ pub struct CosmosDriver {
     transport: Arc<ArcSwap<CosmosTransport>>,
     /// Shared operation routing state for multi-region failover.
     location_state_store: Arc<LocationStateStore>,
-    /// Resolved default for max failover retries (from env or hardcoded default).
-    default_max_failover_retries: u32,
-    /// Resolved default for max session retries (from env or None = compute at operation time).
-    default_max_session_retries: Option<u32>,
     /// Set to `true` after [`initialize()`](Self::initialize) completes successfully.
     /// Operations check this flag to fail fast if the driver is used before
     /// initialization. In normal usage `get_or_create_driver` awaits `initialize()`
@@ -556,10 +552,13 @@ impl CosmosDriver {
             fut
         });
 
-        let endpoint_unavailability_ttl = runtime
+        // Resolve endpoint_unavailability_ttl from driver → runtime layers, then
+        // fall back to env var. The env_options layer is skipped because this field
+        // has no #[option(env)] annotation on RuntimeOptions.
+        let endpoint_unavailability_ttl = options
             .runtime_options()
-            .snapshot()
             .endpoint_unavailability_ttl
+            .or(runtime.runtime_options().endpoint_unavailability_ttl)
             .unwrap_or_else(|| {
                 std::env::var("AZURE_COSMOS_ENDPOINT_UNAVAILABLE_TTL_MS")
                     .ok()
@@ -577,34 +576,11 @@ impl CosmosDriver {
             endpoint_unavailability_ttl,
         ));
 
-        let default_max_failover_retries = runtime
-            .runtime_options()
-            .snapshot()
-            .max_failover_retry_count
-            .unwrap_or_else(|| {
-                std::env::var("AZURE_COSMOS_FAILOVER_RETRY_COUNT")
-                    .ok()
-                    .and_then(|v| v.parse::<u32>().ok())
-                    .unwrap_or(3)
-            });
-
-        let default_max_session_retries = runtime
-            .runtime_options()
-            .snapshot()
-            .max_session_retry_count
-            .or_else(|| {
-                std::env::var("AZURE_COSMOS_SESSION_RETRY_COUNT")
-                    .ok()
-                    .and_then(|v| v.parse::<u32>().ok())
-            });
-
         Self {
             runtime: runtime.clone(),
             options,
             transport,
             location_state_store,
-            default_max_failover_retries,
-            default_max_session_retries,
             initialized: AtomicBool::new(false),
         }
     }
@@ -692,46 +668,32 @@ impl CosmosDriver {
         Ok(())
     }
 
-    /// Computes the effective runtime options by merging operation, driver, and runtime options.
+    /// Constructs a [`RuntimeOptionsView`] for resolving options across all layers.
     ///
-    /// The merge order is (highest to lowest priority):
+    /// The view resolves options in priority order (highest first):
     /// 1. `OperationOptions` - operation-specific overrides
     /// 2. `DriverOptions` - driver-level defaults
     /// 3. `CosmosDriverRuntime` - global defaults
-    ///
-    /// For each property in `RuntimeOptions`, the first defined value is used.
-    pub fn effective_runtime_options(
+    /// 4. Environment - env vars read at startup
+    pub fn runtime_options_view<'a>(
         &self,
-        operation_options: &OperationOptions,
-    ) -> RuntimeOptions {
-        // Start with operation-level options (highest priority)
-        let operation_runtime = operation_options.runtime();
-
-        // Get driver-level options
-        let driver_runtime = self.options.runtime_options().snapshot();
-
-        // Get runtime-level options (lowest priority)
-        let global_runtime = self.runtime.runtime_options().snapshot();
-
-        // Merge: operation -> driver -> runtime
-        // First merge operation with driver
-        let merged = operation_runtime.merge_with_base(&driver_runtime);
-        // Then merge result with runtime defaults
-        merged.merge_with_base(&global_runtime)
+        operation_options: &'a OperationOptions,
+    ) -> RuntimeOptionsView<'a> {
+        RuntimeOptionsView::new(
+            Some(self.runtime.env_options().clone()),
+            Some(self.runtime.runtime_options().clone()),
+            Some(self.options.runtime_options().clone()),
+            Some(operation_options.runtime()),
+        )
     }
 
     /// Computes the effective throughput control group for an operation.
     ///
     /// Resolution order (first match wins):
-    /// 1. Explicit group name from effective runtime options + operation's container
+    /// 1. Explicit group name from the resolved runtime options + operation's container
     /// 2. Default group for the operation's container
     ///
     /// Returns `None` if no applicable control group is found.
-    ///
-    /// # Parameters
-    ///
-    /// - `effective_options`: The merged runtime options (use `effective_runtime_options()`)
-    /// - `container`: The container reference for the operation
     pub(crate) fn effective_throughput_control_group(
         &self,
         effective_options: &RuntimeOptions,
@@ -822,16 +784,21 @@ impl CosmosDriver {
         }
         tracing::debug!("operation started");
 
-        // Step 1: Derive effective runtime options
-        let mut effective_options = self.effective_runtime_options(&options);
-
-        // Fill in resolved defaults for retry counts (env vars read once at construction).
-        if effective_options.max_failover_retry_count.is_none() {
-            effective_options.max_failover_retry_count = Some(self.default_max_failover_retries);
-        }
-        if effective_options.max_session_retry_count.is_none() {
-            effective_options.max_session_retry_count = self.default_max_session_retries;
-        }
+        // Step 1: Build the runtime options view for layered resolution and
+        // materialize a resolved snapshot for the pipeline.
+        let view = self.runtime_options_view(&options);
+        let effective_options = RuntimeOptions {
+            throughput_control_group_name: view.throughput_control_group_name().cloned(),
+            dedicated_gateway_options: view.dedicated_gateway_options().cloned(),
+            diagnostics_thresholds: view.diagnostics_thresholds().cloned(),
+            end_to_end_latency_policy: view.end_to_end_latency_policy().cloned(),
+            excluded_regions: view.excluded_regions().cloned(),
+            read_consistency_strategy: view.read_consistency_strategy().copied(),
+            content_response_on_write: view.content_response_on_write().copied(),
+            max_failover_retry_count: view.max_failover_retry_count().copied(),
+            max_session_retry_count: view.max_session_retry_count().copied(),
+            endpoint_unavailability_ttl: view.endpoint_unavailability_ttl().copied(),
+        };
 
         // Step 2: Resolve effective throughput control group (if any).
         // Step 1 transport pipeline does not consume this yet.
@@ -1033,7 +1000,8 @@ mod tests {
         driver::CosmosDriverRuntimeBuilder,
         models::AccountReference,
         options::{
-            ContentResponseOnWrite, CorrelationId, RuntimeOptions, UserAgentSuffix, WorkloadId,
+            ContentResponseOnWrite, CorrelationId, RuntimeOptionsBuilder, UserAgentSuffix,
+            WorkloadId,
         },
     };
 
@@ -1154,9 +1122,14 @@ mod tests {
     #[tokio::test]
     async fn default_runtime_options() {
         let runtime = CosmosDriverRuntimeBuilder::new().build().await.unwrap();
-        let snapshot = runtime.runtime_options().snapshot();
-        assert!(snapshot.throughput_control_group_name.is_none());
-        assert!(snapshot.content_response_on_write.is_none());
+        assert!(runtime
+            .runtime_options()
+            .throughput_control_group_name
+            .is_none());
+        assert!(runtime
+            .runtime_options()
+            .content_response_on_write
+            .is_none());
         // user_agent is always available with base prefix
         assert!(runtime
             .user_agent()
@@ -1170,7 +1143,7 @@ mod tests {
 
     #[tokio::test]
     async fn builder_sets_runtime_options() {
-        let opts = RuntimeOptions::builder()
+        let opts = RuntimeOptionsBuilder::new()
             .with_content_response_on_write(ContentResponseOnWrite::Disabled)
             .build();
 
@@ -1180,9 +1153,8 @@ mod tests {
             .await
             .unwrap();
 
-        let snapshot = runtime.runtime_options().snapshot();
         assert_eq!(
-            snapshot.content_response_on_write,
+            runtime.runtime_options().content_response_on_write,
             Some(ContentResponseOnWrite::Disabled)
         );
     }
@@ -1318,26 +1290,23 @@ mod tests {
 
     #[tokio::test]
     async fn runtime_modification() {
-        let runtime = CosmosDriverRuntimeBuilder::new().build().await.unwrap();
+        let mut runtime = CosmosDriverRuntimeBuilder::new().build().await.unwrap();
 
         // Initially none
         assert!(runtime
             .runtime_options()
-            .snapshot()
             .content_response_on_write
             .is_none());
 
-        // Modify at runtime
-        runtime
-            .runtime_options()
-            .set_content_response_on_write(Some(ContentResponseOnWrite::Enabled));
+        // Replace runtime options atomically
+        let new_opts = RuntimeOptionsBuilder::new()
+            .with_content_response_on_write(ContentResponseOnWrite::Enabled)
+            .build();
+        runtime.set_runtime_options(new_opts);
 
         // Now set
         assert_eq!(
-            runtime
-                .runtime_options()
-                .snapshot()
-                .content_response_on_write,
+            runtime.runtime_options().content_response_on_write,
             Some(ContentResponseOnWrite::Enabled)
         );
     }
@@ -1347,7 +1316,7 @@ mod tests {
         // Runtime has ENABLED
         let cosmos_runtime = CosmosDriverRuntimeBuilder::new()
             .with_runtime_options(
-                RuntimeOptions::builder()
+                RuntimeOptionsBuilder::new()
                     .with_content_response_on_write(ContentResponseOnWrite::Enabled)
                     .build(),
             )
@@ -1358,7 +1327,7 @@ mod tests {
         // Driver has DISABLED
         let driver_options = DriverOptions::builder(test_account())
             .with_runtime_options(
-                RuntimeOptions::builder()
+                RuntimeOptionsBuilder::new()
                     .with_content_response_on_write(ContentResponseOnWrite::Disabled)
                     .build(),
             )
@@ -1368,19 +1337,19 @@ mod tests {
 
         // Operation has no override - should get driver's DISABLED
         let op_options = OperationOptions::new();
-        let effective = driver.effective_runtime_options(&op_options);
+        let view = driver.runtime_options_view(&op_options);
         assert_eq!(
-            effective.content_response_on_write,
-            Some(ContentResponseOnWrite::Disabled)
+            view.content_response_on_write(),
+            Some(&ContentResponseOnWrite::Disabled)
         );
 
         // Operation overrides to ENABLED - should get ENABLED
         let op_options =
             OperationOptions::new().with_content_response_on_write(ContentResponseOnWrite::Enabled);
-        let effective = driver.effective_runtime_options(&op_options);
+        let view = driver.runtime_options_view(&op_options);
         assert_eq!(
-            effective.content_response_on_write,
-            Some(ContentResponseOnWrite::Enabled)
+            view.content_response_on_write(),
+            Some(&ContentResponseOnWrite::Enabled)
         );
     }
 
@@ -1389,7 +1358,7 @@ mod tests {
         // Runtime has ENABLED
         let cosmos_runtime = CosmosDriverRuntimeBuilder::new()
             .with_runtime_options(
-                RuntimeOptions::builder()
+                RuntimeOptionsBuilder::new()
                     .with_content_response_on_write(ContentResponseOnWrite::Enabled)
                     .build(),
             )
@@ -1404,10 +1373,10 @@ mod tests {
 
         // Operation has no override - should fall back to runtime's ENABLED
         let op_options = OperationOptions::new();
-        let effective = driver.effective_runtime_options(&op_options);
+        let view = driver.runtime_options_view(&op_options);
         assert_eq!(
-            effective.content_response_on_write,
-            Some(ContentResponseOnWrite::Enabled)
+            view.content_response_on_write(),
+            Some(&ContentResponseOnWrite::Enabled)
         );
     }
 

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/runtime.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/runtime.rs
@@ -17,9 +17,8 @@ use crate::{
     models::{AccountReference, ContainerReference, ThroughputControlGroupName, UserAgent},
     options::{
         parse_duration_millis_from_env, ConnectionPoolOptions, CorrelationId, DriverOptions,
-        RuntimeOptions, SharedRuntimeOptions, ThroughputControlGroupOptions,
-        ThroughputControlGroupRegistrationError, ThroughputControlGroupRegistry, UserAgentSuffix,
-        WorkloadId,
+        RuntimeOptions, ThroughputControlGroupOptions, ThroughputControlGroupRegistrationError,
+        ThroughputControlGroupRegistry, UserAgentSuffix, WorkloadId,
     },
     system::{CpuMemoryMonitor, VmMetadataService},
 };
@@ -50,12 +49,12 @@ use super::{
 /// use azure_data_cosmos_driver::driver::{
 ///     CosmosDriverRuntime, CosmosDriverRuntimeBuilder,
 /// };
-/// use azure_data_cosmos_driver::options::{RuntimeOptions, ContentResponseOnWrite};
+/// use azure_data_cosmos_driver::options::{RuntimeOptions, RuntimeOptionsBuilder, ContentResponseOnWrite};
 /// use azure_data_cosmos_driver::models::AccountReference;
 /// use url::Url;
 ///
 /// # async fn example() -> azure_core::Result<()> {
-/// let runtime = RuntimeOptions::builder()
+/// let runtime = RuntimeOptionsBuilder::new()
 ///     .with_content_response_on_write(ContentResponseOnWrite::Disabled)
 ///     .build();
 ///
@@ -72,8 +71,8 @@ use super::{
 ///
 /// let driver = cosmos_runtime.get_or_create_driver(account, None).await?;
 ///
-/// // Later, modify defaults at runtime
-/// cosmos_runtime.runtime_options().set_content_response_on_write(Some(ContentResponseOnWrite::Enabled));
+/// // Later, replace runtime defaults atomically
+/// // cosmos_runtime.set_runtime_options(new_options);
 /// # Ok(())
 /// # }
 /// ```
@@ -99,8 +98,11 @@ pub struct CosmosDriverRuntime {
     /// Factory for creating HTTP clients, shared across per-account transports.
     http_client_factory: Arc<dyn HttpClientFactory>,
 
-    /// Thread-safe runtime options for operation options.
-    runtime_options: SharedRuntimeOptions,
+    /// Environment-level runtime options, populated once from env vars at build time.
+    env_options: Arc<RuntimeOptions>,
+
+    /// User-provided runtime-level default options, atomically swappable.
+    runtime_options: Arc<RuntimeOptions>,
 
     /// Computed user agent string for HTTP requests.
     ///
@@ -199,11 +201,21 @@ impl CosmosDriverRuntime {
         &self.machine_id
     }
 
-    /// Returns the thread-safe runtime options.
-    ///
-    /// Use this to modify default operation options at runtime.
-    pub fn runtime_options(&self) -> &SharedRuntimeOptions {
+    /// Returns the environment-level runtime options (populated from env vars at build time).
+    pub fn env_options(&self) -> &Arc<RuntimeOptions> {
+        &self.env_options
+    }
+
+    /// Returns the runtime-level default options.
+    pub fn runtime_options(&self) -> &Arc<RuntimeOptions> {
         &self.runtime_options
+    }
+
+    /// Replaces the runtime-level default options atomically.
+    ///
+    /// In-flight operations that already cloned the previous Arc are unaffected.
+    pub fn set_runtime_options(&mut self, options: RuntimeOptions) {
+        self.runtime_options = Arc::new(options);
     }
 
     /// Returns the computed user agent string.
@@ -600,9 +612,8 @@ impl CosmosDriverRuntimeBuilder {
             connection_pool,
             bootstrap_transport,
             http_client_factory,
-            runtime_options: SharedRuntimeOptions::from_options(
-                self.runtime_options.unwrap_or_default(),
-            ),
+            env_options: Arc::new(RuntimeOptions::from_env()),
+            runtime_options: Arc::new(self.runtime_options.unwrap_or_default()),
             user_agent,
             workload_id: self.workload_id,
             correlation_id: self.correlation_id,

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/driver_options.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/driver_options.rs
@@ -3,27 +3,21 @@
 
 //! Driver-level configuration options.
 
-use crate::{
-    models::AccountReference,
-    options::{RuntimeOptions, SharedRuntimeOptions},
-};
+use std::sync::Arc;
+
+use crate::{models::AccountReference, options::RuntimeOptions};
 
 /// Configuration options for a Cosmos DB driver instance.
 ///
 /// A driver represents a connection to a specific Cosmos DB account. It inherits
-/// environment-level defaults but can override them with driver-specific settings.
-///
-/// # Thread Safety
-///
-/// The runtime options can be modified at runtime via the `runtime_options()` accessor.
-/// Changes are thread-safe and will be applied to subsequent operations.
+/// runtime-level defaults but can override them with driver-specific settings.
 ///
 /// # Example
 ///
 /// ```
 /// use azure_data_cosmos_driver::models::AccountReference;
 /// use azure_data_cosmos_driver::options::{
-///     DriverOptions, DriverOptionsBuilder, RuntimeOptions, ContentResponseOnWrite,
+///     DriverOptions, DriverOptionsBuilder, RuntimeOptions, RuntimeOptionsBuilder, ContentResponseOnWrite,
 /// };
 /// use url::Url;
 ///
@@ -32,24 +26,21 @@ use crate::{
 ///     "my-master-key",
 /// );
 ///
-/// let runtime = RuntimeOptions::builder()
+/// let runtime = RuntimeOptionsBuilder::new()
 ///     .with_content_response_on_write(ContentResponseOnWrite::Disabled)
 ///     .build();
 ///
 /// let options = DriverOptionsBuilder::new(account)
 ///     .with_runtime_options(runtime)
 ///     .build();
-///
-/// // Later, modify defaults at runtime
-/// options.runtime_options().set_content_response_on_write(Some(ContentResponseOnWrite::Enabled));
 /// ```
 #[non_exhaustive]
 #[derive(Clone, Debug)]
 pub struct DriverOptions {
     /// The Cosmos DB account reference (required).
     account: AccountReference,
-    /// Thread-safe runtime options for operation options at the driver level.
-    runtime_options: SharedRuntimeOptions,
+    /// Driver-level runtime options, wrapped in Arc for cheap cloning and snapshot sharing.
+    runtime_options: Arc<RuntimeOptions>,
 }
 
 impl DriverOptions {
@@ -65,18 +56,16 @@ impl DriverOptions {
         &self.account
     }
 
-    /// Returns the thread-safe runtime options.
-    ///
-    /// Use this to modify default operation options at runtime.
-    pub fn runtime_options(&self) -> &SharedRuntimeOptions {
+    /// Returns the driver-level runtime options.
+    pub fn runtime_options(&self) -> &Arc<RuntimeOptions> {
         &self.runtime_options
     }
 }
 
 /// Builder for creating [`DriverOptions`].
 ///
-/// Use [`RuntimeOptions::builder()`] to create runtime options, then pass them
-/// to this builder via [`with_runtime_options()`](Self::with_runtime_options).
+/// Use [`RuntimeOptionsBuilder`](super::RuntimeOptionsBuilder) to create runtime options,
+/// then pass them to this builder via [`with_runtime_options()`](Self::with_runtime_options).
 #[non_exhaustive]
 #[derive(Clone, Debug)]
 pub struct DriverOptionsBuilder {
@@ -94,8 +83,6 @@ impl DriverOptionsBuilder {
     }
 
     /// Sets the runtime options (defaults for operations).
-    ///
-    /// Use [`RuntimeOptions::builder()`] to create the runtime options.
     pub fn with_runtime_options(mut self, options: RuntimeOptions) -> Self {
         self.runtime_options = Some(options);
         self
@@ -105,9 +92,7 @@ impl DriverOptionsBuilder {
     pub fn build(self) -> DriverOptions {
         DriverOptions {
             account: self.account,
-            runtime_options: SharedRuntimeOptions::from_options(
-                self.runtime_options.unwrap_or_default(),
-            ),
+            runtime_options: Arc::new(self.runtime_options.unwrap_or_default()),
         }
     }
 }
@@ -115,7 +100,7 @@ impl DriverOptionsBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::options::ContentResponseOnWrite;
+    use crate::options::{ContentResponseOnWrite, RuntimeOptionsBuilder};
     use url::Url;
 
     fn test_account() -> AccountReference {
@@ -133,14 +118,13 @@ mod tests {
         assert_eq!(options.account(), &account);
         assert!(options
             .runtime_options()
-            .snapshot()
             .content_response_on_write
             .is_none());
     }
 
     #[test]
     fn builder_sets_runtime_options() {
-        let runtime = RuntimeOptions::builder()
+        let runtime = RuntimeOptionsBuilder::new()
             .with_content_response_on_write(ContentResponseOnWrite::Disabled)
             .build();
 
@@ -148,36 +132,9 @@ mod tests {
             .with_runtime_options(runtime)
             .build();
 
-        let snapshot = options.runtime_options().snapshot();
         assert_eq!(
-            snapshot.content_response_on_write,
+            options.runtime_options().content_response_on_write,
             Some(ContentResponseOnWrite::Disabled)
-        );
-    }
-
-    #[test]
-    fn runtime_modification() {
-        let options = DriverOptionsBuilder::new(test_account()).build();
-
-        // Initially none
-        assert!(options
-            .runtime_options()
-            .snapshot()
-            .content_response_on_write
-            .is_none());
-
-        // Modify at runtime
-        options
-            .runtime_options()
-            .set_content_response_on_write(Some(ContentResponseOnWrite::Enabled));
-
-        // Now set
-        assert_eq!(
-            options
-                .runtime_options()
-                .snapshot()
-                .content_response_on_write,
-            Some(ContentResponseOnWrite::Enabled)
         );
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/mod.rs
@@ -4,7 +4,18 @@
 //! Configuration options for the Cosmos DB driver.
 //!
 //! This module contains types for configuring driver instances and individual operations.
-//! Options follow a three-level hierarchy: Runtime → Driver → Operation.
+//! Options follow a four-level hierarchy with layered resolution:
+//!
+//! **Environment → Runtime → Account (Driver) → Operation** (lowest to highest priority)
+//!
+//! [`RuntimeOptions`] is the central option group that participates in all layers.
+//! It uses `#[derive(CosmosOptions)]` to generate:
+//! - [`RuntimeOptionsView`] — snapshot view for resolving options across layers
+//! - [`RuntimeOptionsBuilder`] — fluent builder for constructing options
+//! - `from_env()` — environment variable loading
+//!
+//! [`ConnectionPoolOptions`] and [`DiagnosticsOptions`] are captured once at
+//! initialization time and do not participate in per-operation layered resolution.
 
 mod connection_pool;
 mod dedicated_gateway;
@@ -38,7 +49,7 @@ pub use policies::{
 pub use priority::PriorityLevel;
 pub use read_consistency::ReadConsistencyStrategy;
 pub use region::Region;
-pub use runtime_options::{RuntimeOptions, RuntimeOptionsBuilder, SharedRuntimeOptions};
+pub use runtime_options::{RuntimeOptions, RuntimeOptionsBuilder, RuntimeOptionsView};
 pub use throughput_control::{
     ThroughputControlGroupKey, ThroughputControlGroupOptions,
     ThroughputControlGroupRegistrationError, ThroughputControlGroupRegistry,

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/operation_options.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/operation_options.rs
@@ -74,13 +74,6 @@ impl OperationOptions {
         &mut self.runtime
     }
 
-    /// Creates effective runtime options by merging with a base.
-    ///
-    /// Operation-level settings take precedence over the base settings.
-    pub fn effective_runtime(&self, base: &RuntimeOptions) -> RuntimeOptions {
-        self.runtime.merge_with_base(base)
-    }
-
     /// Sets the trigger options for this operation.
     pub fn with_triggers(mut self, triggers: TriggerOptions) -> Self {
         self.triggers = Some(triggers);

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/policies.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/policies.rs
@@ -37,6 +37,33 @@ impl From<ContentResponseOnWrite> for bool {
     }
 }
 
+impl std::str::FromStr for ContentResponseOnWrite {
+    type Err = azure_core::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "true" | "enabled" => Ok(Self::Enabled),
+            "false" | "disabled" => Ok(Self::Disabled),
+            _ => Err(azure_core::Error::with_message(
+                azure_core::error::ErrorKind::DataConversion,
+                format!(
+                    "Unknown content response on write value: '{}'. Expected 'true'/'false' or 'enabled'/'disabled'",
+                    s
+                ),
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for ContentResponseOnWrite {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Enabled => f.write_str("Enabled"),
+            Self::Disabled => f.write_str("Disabled"),
+        }
+    }
+}
+
 /// Configuration for end-to-end operation latency policy.
 ///
 /// Specifies the maximum time an operation can take, including all retries.

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/runtime_options.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/runtime_options.rs
@@ -3,15 +3,9 @@
 
 //! Runtime-configurable options shared across environment, driver, and operation levels.
 
-// Note: `std::sync::RwLock` is used intentionally here instead of `tokio::sync::RwLock`
-// because `RuntimeOptions` may be read from synchronous contexts (e.g., builder construction,
-// configuration merging). The lock is held only briefly for reads/writes of option values,
-// so contention is minimal. Using `std::sync::RwLock` also avoids coupling the crate to a
-// specific async runtime (tokio), which is important for runtime-agnostic design.
-use std::{
-    sync::{Arc, RwLock},
-    time::Duration,
-};
+use std::time::Duration;
+
+use azure_data_cosmos_macros::CosmosOptions;
 
 use crate::{
     models::ThroughputControlGroupName,
@@ -24,9 +18,16 @@ use crate::{
 /// Runtime-configurable options that can be set at environment, driver, or operation level.
 ///
 /// These options follow a hierarchy where operation-level settings override driver-level,
-/// which in turn override environment-level defaults.
+/// which in turn override runtime-level, which override environment-level defaults.
+///
+/// The `#[derive(CosmosOptions)]` macro generates:
+/// - [`RuntimeOptionsView`] — snapshot view for resolving across layers
+/// - [`RuntimeOptionsBuilder`] — fluent builder for constructing options
+/// - `Default` — all fields `None`
+/// - `from_env()` / `from_env_vars()` — environment variable loading
+#[derive(CosmosOptions, Clone, Debug)]
+#[options(layers(runtime, account, operation))]
 #[non_exhaustive]
-#[derive(Clone, Debug, Default)]
 pub struct RuntimeOptions {
     /// Throughput control group name for rate limiting.
     pub throughput_control_group_name: Option<ThroughputControlGroupName>,
@@ -39,269 +40,19 @@ pub struct RuntimeOptions {
     /// Regions to exclude from routing.
     pub excluded_regions: Option<ExcludedRegions>,
     /// Read consistency strategy for read operations.
+    #[option(env = "AZURE_COSMOS_READ_CONSISTENCY_STRATEGY")]
     pub read_consistency_strategy: Option<ReadConsistencyStrategy>,
     /// Content response on write setting.
+    #[option(env = "AZURE_COSMOS_CONTENT_RESPONSE_ON_WRITE")]
     pub content_response_on_write: Option<ContentResponseOnWrite>,
     /// Maximum operation-level failover retries.
+    #[option(env = "AZURE_COSMOS_MAX_FAILOVER_RETRY_COUNT")]
     pub max_failover_retry_count: Option<u32>,
     /// Maximum operation-level session retries.
+    #[option(env = "AZURE_COSMOS_MAX_SESSION_RETRY_COUNT")]
     pub max_session_retry_count: Option<u32>,
     /// Endpoint unavailability TTL used by routing state.
     pub endpoint_unavailability_ttl: Option<Duration>,
-}
-
-impl RuntimeOptions {
-    /// Creates a new empty runtime options.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Returns a builder for creating runtime options.
-    ///
-    /// Use this to construct a new `RuntimeOptions` with specific values.
-    pub fn builder() -> RuntimeOptionsBuilder {
-        RuntimeOptionsBuilder::default()
-    }
-
-    /// Returns a builder initialized with this instance's values.
-    ///
-    /// Use this to create a modified copy of the current options.
-    pub fn to_builder(&self) -> RuntimeOptionsBuilder {
-        RuntimeOptionsBuilder::from_options(self.clone())
-    }
-
-    /// Merges this options with a base, returning a new options where
-    /// `self` values take precedence over `base` values.
-    pub fn merge_with_base(&self, base: &RuntimeOptions) -> RuntimeOptions {
-        RuntimeOptions {
-            throughput_control_group_name: self
-                .throughput_control_group_name
-                .clone()
-                .or_else(|| base.throughput_control_group_name.clone()),
-            dedicated_gateway_options: self
-                .dedicated_gateway_options
-                .clone()
-                .or_else(|| base.dedicated_gateway_options.clone()),
-            diagnostics_thresholds: self
-                .diagnostics_thresholds
-                .clone()
-                .or_else(|| base.diagnostics_thresholds.clone()),
-            end_to_end_latency_policy: self
-                .end_to_end_latency_policy
-                .clone()
-                .or_else(|| base.end_to_end_latency_policy.clone()),
-            excluded_regions: self
-                .excluded_regions
-                .clone()
-                .or_else(|| base.excluded_regions.clone()),
-            read_consistency_strategy: self
-                .read_consistency_strategy
-                .or(base.read_consistency_strategy),
-            content_response_on_write: self
-                .content_response_on_write
-                .or(base.content_response_on_write),
-            max_failover_retry_count: self
-                .max_failover_retry_count
-                .or(base.max_failover_retry_count),
-            max_session_retry_count: self
-                .max_session_retry_count
-                .or(base.max_session_retry_count),
-            endpoint_unavailability_ttl: self
-                .endpoint_unavailability_ttl
-                .or(base.endpoint_unavailability_ttl),
-        }
-    }
-}
-
-/// Builder for creating [`RuntimeOptions`].
-///
-/// # Example
-///
-/// ```
-/// use azure_data_cosmos_driver::options::{RuntimeOptions, RuntimeOptionsBuilder, ContentResponseOnWrite};
-///
-/// let options = RuntimeOptionsBuilder::new()
-///     .with_content_response_on_write(ContentResponseOnWrite::Disabled)
-///     .build();
-///
-/// // Or modify an existing instance
-/// let modified = options.to_builder()
-///     .with_content_response_on_write(ContentResponseOnWrite::Enabled)
-///     .build();
-/// ```
-#[non_exhaustive]
-#[derive(Clone, Debug, Default)]
-pub struct RuntimeOptionsBuilder {
-    options: RuntimeOptions,
-}
-
-impl RuntimeOptionsBuilder {
-    /// Creates a new builder with default values.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Creates a builder from existing runtime options.
-    pub fn from_options(options: RuntimeOptions) -> Self {
-        Self { options }
-    }
-
-    /// Sets the throughput control group name.
-    pub fn with_throughput_control_group_name(mut self, name: ThroughputControlGroupName) -> Self {
-        self.options.throughput_control_group_name = Some(name);
-        self
-    }
-
-    /// Sets the dedicated gateway options.
-    pub fn with_dedicated_gateway_options(mut self, options: DedicatedGatewayOptions) -> Self {
-        self.options.dedicated_gateway_options = Some(options);
-        self
-    }
-
-    /// Sets the diagnostics thresholds.
-    pub fn with_diagnostics_thresholds(mut self, thresholds: DiagnosticsThresholds) -> Self {
-        self.options.diagnostics_thresholds = Some(thresholds);
-        self
-    }
-
-    /// Sets the end-to-end latency policy.
-    pub fn with_end_to_end_latency_policy(
-        mut self,
-        policy: EndToEndOperationLatencyPolicy,
-    ) -> Self {
-        self.options.end_to_end_latency_policy = Some(policy);
-        self
-    }
-
-    /// Sets the excluded regions.
-    pub fn with_excluded_regions(mut self, regions: ExcludedRegions) -> Self {
-        self.options.excluded_regions = Some(regions);
-        self
-    }
-
-    /// Sets the read consistency strategy.
-    pub fn with_read_consistency_strategy(mut self, strategy: ReadConsistencyStrategy) -> Self {
-        self.options.read_consistency_strategy = Some(strategy);
-        self
-    }
-
-    /// Sets the content response on write setting.
-    pub fn with_content_response_on_write(mut self, value: ContentResponseOnWrite) -> Self {
-        self.options.content_response_on_write = Some(value);
-        self
-    }
-
-    /// Sets max operation-level failover retries.
-    pub fn with_max_failover_retry_count(mut self, value: u32) -> Self {
-        self.options.max_failover_retry_count = Some(value);
-        self
-    }
-
-    /// Sets max operation-level session retries.
-    pub fn with_max_session_retry_count(mut self, value: u32) -> Self {
-        self.options.max_session_retry_count = Some(value);
-        self
-    }
-
-    /// Sets endpoint unavailability TTL.
-    pub fn with_endpoint_unavailability_ttl(mut self, value: Duration) -> Self {
-        self.options.endpoint_unavailability_ttl = Some(value);
-        self
-    }
-
-    /// Builds the [`RuntimeOptions`].
-    pub fn build(self) -> RuntimeOptions {
-        self.options
-    }
-}
-
-/// Thread-safe wrapper for runtime options.
-///
-/// Provides interior mutability for runtime configuration changes.
-/// Used by `EnvironmentOptions` and `DriverOptions` to allow runtime modification
-/// of default settings.
-#[derive(Clone, Debug, Default)]
-pub struct SharedRuntimeOptions(Arc<RwLock<RuntimeOptions>>);
-
-impl SharedRuntimeOptions {
-    /// Creates a new empty shared runtime options.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Creates shared runtime options from existing runtime options.
-    pub fn from_options(options: RuntimeOptions) -> Self {
-        Self(Arc::new(RwLock::new(options)))
-    }
-
-    /// Returns a snapshot of the current runtime options.
-    ///
-    /// If the lock is poisoned (a thread panicked while holding it), this
-    /// recovers the inner data via [`std::sync::PoisonError::into_inner`] rather than
-    /// propagating the panic.
-    pub fn snapshot(&self) -> RuntimeOptions {
-        self.0
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .clone()
-    }
-
-    /// Acquires a write guard, recovering from a poisoned lock if necessary.
-    fn write_guard(&self) -> std::sync::RwLockWriteGuard<'_, RuntimeOptions> {
-        self.0
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
-
-    /// Sets the throughput control group name.
-    pub fn set_throughput_control_group_name(&self, name: Option<ThroughputControlGroupName>) {
-        self.write_guard().throughput_control_group_name = name;
-    }
-
-    /// Sets the dedicated gateway options.
-    pub fn set_dedicated_gateway_options(&self, options: Option<DedicatedGatewayOptions>) {
-        self.write_guard().dedicated_gateway_options = options;
-    }
-
-    /// Sets the diagnostics thresholds.
-    pub fn set_diagnostics_thresholds(&self, thresholds: Option<DiagnosticsThresholds>) {
-        self.write_guard().diagnostics_thresholds = thresholds;
-    }
-
-    /// Sets the end-to-end latency policy.
-    pub fn set_end_to_end_latency_policy(&self, policy: Option<EndToEndOperationLatencyPolicy>) {
-        self.write_guard().end_to_end_latency_policy = policy;
-    }
-
-    /// Sets the excluded regions.
-    pub fn set_excluded_regions(&self, regions: Option<ExcludedRegions>) {
-        self.write_guard().excluded_regions = regions;
-    }
-
-    /// Sets the read consistency strategy.
-    pub fn set_read_consistency_strategy(&self, strategy: Option<ReadConsistencyStrategy>) {
-        self.write_guard().read_consistency_strategy = strategy;
-    }
-
-    /// Sets the content response on write setting.
-    pub fn set_content_response_on_write(&self, value: Option<ContentResponseOnWrite>) {
-        self.write_guard().content_response_on_write = value;
-    }
-
-    /// Sets maximum failover retries.
-    pub fn set_max_failover_retry_count(&self, value: Option<u32>) {
-        self.write_guard().max_failover_retry_count = value;
-    }
-
-    /// Sets maximum session retries.
-    pub fn set_max_session_retry_count(&self, value: Option<u32>) {
-        self.write_guard().max_session_retry_count = value;
-    }
-
-    /// Sets endpoint unavailability TTL.
-    pub fn set_endpoint_unavailability_ttl(&self, value: Option<Duration>) {
-        self.write_guard().endpoint_unavailability_ttl = value;
-    }
 }
 
 #[cfg(test)]
@@ -317,7 +68,7 @@ mod tests {
 
     #[test]
     fn builder_creates_options() {
-        let options = RuntimeOptions::builder()
+        let options = RuntimeOptionsBuilder::new()
             .with_content_response_on_write(ContentResponseOnWrite::Disabled)
             .build();
 
@@ -328,75 +79,80 @@ mod tests {
     }
 
     #[test]
-    fn to_builder_creates_modified_copy() {
-        let original = RuntimeOptions::builder()
-            .with_content_response_on_write(ContentResponseOnWrite::Enabled)
-            .with_read_consistency_strategy(ReadConsistencyStrategy::Eventual)
-            .build();
+    fn view_resolves_across_layers() {
+        use std::sync::Arc;
 
-        let modified = original
-            .to_builder()
-            .with_content_response_on_write(ContentResponseOnWrite::Disabled)
-            .build();
-
-        // Modified value changed
-        assert_eq!(
-            modified.content_response_on_write,
-            Some(ContentResponseOnWrite::Disabled)
-        );
-        // Unmodified value preserved
-        assert_eq!(
-            modified.read_consistency_strategy,
-            Some(ReadConsistencyStrategy::Eventual)
-        );
-        // Original unchanged
-        assert_eq!(
-            original.content_response_on_write,
-            Some(ContentResponseOnWrite::Enabled)
-        );
-    }
-
-    #[test]
-    fn merge_with_base() {
-        let base = RuntimeOptions {
-            content_response_on_write: Some(ContentResponseOnWrite::Enabled),
+        let env = Arc::new(RuntimeOptions {
             read_consistency_strategy: Some(ReadConsistencyStrategy::Eventual),
+            max_failover_retry_count: Some(3),
             ..Default::default()
-        };
+        });
 
-        let override_opts = RuntimeOptions {
+        let runtime = Arc::new(RuntimeOptions {
+            content_response_on_write: Some(ContentResponseOnWrite::Enabled),
+            ..Default::default()
+        });
+
+        let account = Arc::new(RuntimeOptions {
+            max_failover_retry_count: Some(5),
+            ..Default::default()
+        });
+
+        let operation = RuntimeOptions {
             content_response_on_write: Some(ContentResponseOnWrite::Disabled),
             ..Default::default()
         };
 
-        let merged = override_opts.merge_with_base(&base);
+        let view =
+            RuntimeOptionsView::new(Some(env), Some(runtime), Some(account), Some(&operation));
 
-        // Override takes precedence
+        // Operation overrides runtime
         assert_eq!(
-            merged.content_response_on_write,
-            Some(ContentResponseOnWrite::Disabled)
+            view.content_response_on_write(),
+            Some(&ContentResponseOnWrite::Disabled)
         );
-        // Base value used when override is None
+        // Account overrides env
+        assert_eq!(view.max_failover_retry_count(), Some(&5));
+        // Falls through to env
         assert_eq!(
-            merged.read_consistency_strategy,
-            Some(ReadConsistencyStrategy::Eventual)
+            view.read_consistency_strategy(),
+            Some(&ReadConsistencyStrategy::Eventual)
         );
+        // Not set anywhere
+        assert!(view.excluded_regions().is_none());
     }
 
     #[test]
-    fn shared_runtime_options_snapshot() {
-        let shared = SharedRuntimeOptions::new();
+    fn from_env_vars_parses_known_vars() {
+        let options = RuntimeOptions::from_env_vars(|key| match key {
+            "AZURE_COSMOS_READ_CONSISTENCY_STRATEGY" => Ok("Session".to_string()),
+            "AZURE_COSMOS_CONTENT_RESPONSE_ON_WRITE" => Ok("true".to_string()),
+            "AZURE_COSMOS_MAX_FAILOVER_RETRY_COUNT" => Ok("7".to_string()),
+            "AZURE_COSMOS_MAX_SESSION_RETRY_COUNT" => Ok("3".to_string()),
+            _ => Err(std::env::VarError::NotPresent),
+        });
 
-        // Initially empty
-        assert!(shared.snapshot().content_response_on_write.is_none());
-
-        // Modify
-        shared.set_content_response_on_write(Some(ContentResponseOnWrite::Enabled));
-
-        // Verify change
         assert_eq!(
-            shared.snapshot().content_response_on_write,
+            options.read_consistency_strategy,
+            Some(ReadConsistencyStrategy::Session)
+        );
+        assert_eq!(
+            options.content_response_on_write,
             Some(ContentResponseOnWrite::Enabled)
         );
+        assert_eq!(options.max_failover_retry_count, Some(7));
+        assert_eq!(options.max_session_retry_count, Some(3));
+        // Fields without env annotation remain None
+        assert!(options.excluded_regions.is_none());
+    }
+
+    #[test]
+    fn from_env_vars_returns_none_for_missing_vars() {
+        let options = RuntimeOptions::from_env_vars(|_| Err(std::env::VarError::NotPresent));
+
+        assert!(options.read_consistency_strategy.is_none());
+        assert!(options.content_response_on_write.is_none());
+        assert!(options.max_failover_retry_count.is_none());
+        assert!(options.max_session_retry_count.is_none());
     }
 }


### PR DESCRIPTION
- **cosmos: reference azure_core 0.32 for mid-band release (#3813)**
- **Increment versions for cosmos releases (#3820)**
- **Driver-03: DiagnosticsContext and AsyncCache (#3592)**
- **Cosmos: Adds PPAF Dynamic Enablement Support (#3831)**
- **Add Azure Cosmos DB performance testing tool with CLI support (#3715)**
- **Driver: Transport spec (#3829)**
- **Updated StatusCode/SubStatusCode tuples in cosmos_status.rs form mative files (#3844)**
- **Use ISO 8601 timestamps for Kusto compatibility and Poll Branches (#3842)**
- **Driver-Transport-Spec - add crossbeam dependency (#3848)**
- **Cosmos: Fixes Circuit Breaker Failover Logic for Multi-Master Writes on 403/3 (#3861)**
- **driver-transport - step 01 (#3875)**
- **Cosmos: Add required `RoutingStrategy` enum to `CosmosClientBuilder::build()` (#3889)**
- **Driver Transport - step 02 (#3887)**
- **Driver Step 5: HTTP/2 support and adaptive transport (no sharding yet) (#3912)**
- **[Cosmos] Driver: prime metadata caches (#3864)**
- **Cosmos: Layered Options Proc-Macro (#3868)**
- **Fixes #3926 by simplifying regional routing state and moving Gateway20 handling into a single `CosmosEndpoint` model. (#3942)**
- **Cosmos: react to ttl change**
- **Cosmos: Introduce `BackgroundTaskManager` To Spawn Background Tasks Using Tokio Runtime (#3945)**
- **Cosmos: Adds Per Partition Automatic Failover and Circuit Breaker Specs (#3880)**
- **Get cosmos driver integration tests running again (#3951)**
- **Cosmos: Add CustomResponseBuilder and hit_count API for fault injection (#3888)**
- **Cosmos Driver: Step 6 - Sharded Transport (#3957)**
- **Cosmos: Spec for new Rust SDK options (#3803)**
- **Cosmos: rework driver options to use new macro and model**
