### PR TITLE
Update emitter to 0.38.0

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -5,43 +5,43 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-tools/typespec-rust": "0.36.0"
+        "@azure-tools/typespec-rust": "0.38.0"
       },
       "devDependencies": {
-        "@azure-tools/typespec-azure-core": "~0.65.0",
-        "@azure-tools/typespec-azure-resource-manager": "~0.65.0",
-        "@azure-tools/typespec-azure-rulesets": "~0.65.0",
-        "@azure-tools/typespec-client-generator-core": "~0.65.3",
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/events": "~0.79.0",
-        "@typespec/http": "^1.9.0",
-        "@typespec/openapi": "^1.9.0",
-        "@typespec/rest": "~0.79.0",
-        "@typespec/sse": "~0.79.0",
-        "@typespec/streams": "~0.79.0",
-        "@typespec/versioning": "~0.79.0",
-        "@typespec/xml": "~0.79.0"
+        "@azure-tools/typespec-azure-core": "~0.66.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.66.0",
+        "@azure-tools/typespec-azure-rulesets": "~0.66.0",
+        "@azure-tools/typespec-client-generator-core": "~0.66.2",
+        "@typespec/compiler": "^1.10.0",
+        "@typespec/events": "~0.80.0",
+        "@typespec/http": "^1.10.0",
+        "@typespec/openapi": "^1.10.0",
+        "@typespec/rest": "~0.80.0",
+        "@typespec/sse": "~0.80.0",
+        "@typespec/streams": "~0.80.0",
+        "@typespec/versioning": "~0.80.0",
+        "@typespec/xml": "~0.80.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.65.0.tgz",
-      "integrity": "sha512-dYgHtt0CY0Q9AimdIsMV41jHKLmAT4r++TLwyxAHRbxdiRG+Sll1UKJzOIIoq45Bq64wCfEltu5OOnyPA01/sQ==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.66.0.tgz",
+      "integrity": "sha512-OBKxRN7AucK3snh+GtLKSDdcZTz08IgcSZlIO3c4KSlmcR5twT1NMyqf1+V8SAhyOdZimndb+ikzrkkgab+GpA==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/http": "^1.9.0",
-        "@typespec/rest": "^0.79.0"
+        "@typespec/compiler": "^1.10.0",
+        "@typespec/http": "^1.10.0",
+        "@typespec/rest": "^0.80.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.65.0.tgz",
-      "integrity": "sha512-3rvyGDIYSqraZ7jHfq5Bfet8u3ZeERWJWhwWMNvbShnrS/vVR3iuu/1z2M0p5mTRFuwUaSMlL/dbtBp1YqgGAg==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.66.0.tgz",
+      "integrity": "sha512-UbgYUaYTt7prsv+RYxd2kiOWjeEeoH56QOqgXnSOFhYzq/h9fyDaQAm6+CY7cklziED+MYy3uMQd1BG9mNwlfQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -53,34 +53,34 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.65.0",
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/http": "^1.9.0",
-        "@typespec/openapi": "^1.9.0",
-        "@typespec/rest": "^0.79.0",
-        "@typespec/versioning": "^0.79.0"
+        "@azure-tools/typespec-azure-core": "^0.66.0",
+        "@typespec/compiler": "^1.10.0",
+        "@typespec/http": "^1.10.0",
+        "@typespec/openapi": "^1.10.0",
+        "@typespec/rest": "^0.80.0",
+        "@typespec/versioning": "^0.80.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.65.0.tgz",
-      "integrity": "sha512-oGuCw61uU9fUASog/1iD1rGeGhcKgnAuyBWA63wRcMMrcW1ZqUK2xvjV1XJuoYRlMxU8HpQShFcvsj715pNVLQ==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.66.0.tgz",
+      "integrity": "sha512-Wf0SpphmKDDzHgaqpxl68DpP65VUWjpD3mrnZ3Lw4Pdtt8BcZf7+LKgFF06gPRnh15hR0VbjAERCzxI/qGY4ag==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.65.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.65.0",
-        "@azure-tools/typespec-client-generator-core": "^0.65.0",
-        "@typespec/compiler": "^1.9.0"
+        "@azure-tools/typespec-azure-core": "^0.66.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.66.0",
+        "@azure-tools/typespec-client-generator-core": "^0.66.1",
+        "@typespec/compiler": "^1.10.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.65.4",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.65.4.tgz",
-      "integrity": "sha512-p+MZU/nEmU3ciLEuNbqQtAybPxUKo/fKeKT9feh+tZLVpDDFO5DTefYoN4cteZQkPu/xyzxhjeUnKKvyVQxd6A==",
+      "version": "0.66.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.66.2.tgz",
+      "integrity": "sha512-Qr5fstJ0yQiTYNvp/EuY3+mUBue2ri9qNZkT6aC+CsfBt5yjfdjo++3SuEsDQtELyS8pBoDOT3weLiB0N+/fSw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -92,22 +92,22 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.65.0",
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/events": "^0.79.0",
-        "@typespec/http": "^1.9.0",
-        "@typespec/openapi": "^1.9.0",
-        "@typespec/rest": "^0.79.0",
-        "@typespec/sse": "^0.79.0",
-        "@typespec/streams": "^0.79.0",
-        "@typespec/versioning": "^0.79.0",
-        "@typespec/xml": "^0.79.0"
+        "@azure-tools/typespec-azure-core": "^0.66.0",
+        "@typespec/compiler": "^1.10.0",
+        "@typespec/events": "^0.80.0",
+        "@typespec/http": "^1.10.0",
+        "@typespec/openapi": "^1.10.0",
+        "@typespec/rest": "^0.80.0",
+        "@typespec/sse": "^0.80.0",
+        "@typespec/streams": "^0.80.0",
+        "@typespec/versioning": "^0.80.0",
+        "@typespec/xml": "^0.80.0"
       }
     },
     "node_modules/@azure-tools/typespec-rust": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-rust/-/typespec-rust-0.36.0.tgz",
-      "integrity": "sha512-v69kT0W5byz0MqotLI6svDY9n658RJmc3C9lEZQh8FxF9VgDRM3w3mdD4pOxAS9sVxJGJCEBd3z9YfomRgPx/A==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-rust/-/typespec-rust-0.38.0.tgz",
+      "integrity": "sha512-C8xKtponYRLGu1RNVL4GYHighySryGYDZmxJbzF6L5+ad2qQDLEExS4UvdY86yhiv183LUc3u78PbxRWKXQSRQ==",
       "license": "MIT",
       "dependencies": {
         "@types/turndown": "^5.0.6",
@@ -120,15 +120,15 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-client-generator-core": ">=0.65.3 <1.0.0",
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/http": "^1.9.0"
+        "@azure-tools/typespec-client-generator-core": ">=0.66.1 <1.0.0",
+        "@typespec/compiler": "^1.10.0",
+        "@typespec/http": "^1.10.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
-      "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -149,24 +149,24 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.3.tgz",
-      "integrity": "sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.4.tgz",
+      "integrity": "sha512-DpcZrQObd7S0R/U3bFdkcT5ebRwbTTC4D3tCc1vsJizmgPLxNJBo+AAFmrZwe8zk30P2QzgzGWZ3Q9uJwWuhIg==",
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.0.tgz",
-      "integrity": "sha512-/HjF1LN0a1h4/OFsbGKHNDtWICFU/dqXCdym719HFTyJo9IG7Otr+ziGWc9S0iQuohRZllh+WprSgd5UW5Fw0g==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.2.tgz",
+      "integrity": "sha512-PubpMPO2nJgMufkoB3P2wwxNXEMUXnBIKi/ACzDUYfaoPuM7gSTmuxJeMscoLVEsR4qqrCMf5p0SiYGWnVJ8kw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.3",
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/figures": "^2.0.3",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/figures": "^2.0.4",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -181,13 +181,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.8.tgz",
-      "integrity": "sha512-Di6dgmiZ9xCSUxWUReWTqDtbhXCuG2MQm2xmgSAIruzQzBqNf49b8E07/vbCYY506kDe8BiwJbegXweG8M1klw==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.10.tgz",
+      "integrity": "sha512-tiNyA73pgpQ0FQ7axqtoLUe4GDYjNCDcVsbgcA5anvwg2z6i+suEngLKKJrWKJolT//GFPZHwN30binDIHgSgQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -202,14 +202,14 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.5.tgz",
-      "integrity": "sha512-QQPAX+lka8GyLcZ7u7Nb1h6q72iZ/oy0blilC3IB2nSt1Qqxp7akt94Jqhi/DzARuN3Eo9QwJRvtl4tmVe4T5A==",
+      "version": "11.1.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.7.tgz",
+      "integrity": "sha512-1BiBNDk9btIwYIzNZpkikIHXWeNzNncJePPqwDyVMhXhD1ebqbpn1mKGctpoqAbzywZfdG0O4tvmsGIcOevAPQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.3",
-        "@inquirer/figures": "^2.0.3",
-        "@inquirer/type": "^4.0.3",
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/figures": "^2.0.4",
+        "@inquirer/type": "^4.0.4",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -228,14 +228,14 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.8.tgz",
-      "integrity": "sha512-sLcpbb9B3XqUEGrj1N66KwhDhEckzZ4nI/W6SvLXyBX8Wic3LDLENlWRvkOGpCPoserabe+MxQkpiMoI8irvyA==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.10.tgz",
+      "integrity": "sha512-VJx4XyaKea7t8hEApTw5dxeIyMtWXre2OiyJcICCRZI4hkoHsMoCnl/KbUnJJExLbH9csLLHMVR144ZhFE1CwA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/external-editor": "^2.0.3",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/external-editor": "^2.0.4",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -250,13 +250,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.8.tgz",
-      "integrity": "sha512-QieW3F1prNw3j+hxO7/NKkG1pk3oz7pOB6+5Upwu3OIwADfPX0oZVppsqlL+Vl/uBHHDSOBY0BirLctLnXwGGg==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.10.tgz",
+      "integrity": "sha512-fC0UHJPXsTRvY2fObiwuQYaAnHrp3aDqfwKUJSdfpgv18QUG054ezGbaRNStk/BKD5IPijeMKWej8VV8O5Q/eQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -271,9 +271,9 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-2.0.3.tgz",
-      "integrity": "sha512-LgyI7Agbda74/cL5MvA88iDpvdXI2KuMBCGRkbCl2Dg1vzHeOgs+s0SDcXV7b+WZJrv2+ERpWSM65Fpi9VfY3w==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-2.0.4.tgz",
+      "integrity": "sha512-Prenuv9C1PHj2Itx0BcAOVBTonz02Hc2Nd2DbU67PdGUaqn0nPCnV34oDyyoaZHnmfRxkpuhh/u51ThkrO+RdA==",
       "license": "MIT",
       "dependencies": {
         "chardet": "^2.1.1",
@@ -292,22 +292,22 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.3.tgz",
-      "integrity": "sha512-y09iGt3JKoOCBQ3w4YrSJdokcD8ciSlMIWsD+auPu+OZpfxLuyz+gICAQ6GCBOmJJt4KEQGHuZSVff2jiNOy7g==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.4.tgz",
+      "integrity": "sha512-eLBsjlS7rPS3WEhmOmh1znQ5IsQrxWzxWDxO51e4urv+iVrSnIHbq4zqJIOiyNdYLa+BVjwOtdetcQx1lWPpiQ==",
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.8.tgz",
-      "integrity": "sha512-p0IJslw0AmedLEkOU+yrEX3Aj2RTpQq7ZOf8nc1DIhjzaxRWrrgeuE5Kyh39fVRgtcACaMXx/9WNo8+GjgBOfw==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.10.tgz",
+      "integrity": "sha512-nvZ6qEVeX/zVtZ1dY2hTGDQpVGD3R7MYPLODPgKO8Y+RAqxkrP3i/3NwF3fZpLdaMiNuK0z2NaYIx9tPwiSegQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -322,13 +322,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.8.tgz",
-      "integrity": "sha512-uGLiQah9A0F9UIvJBX52m0CnqtLaym0WpT9V4YZrjZ+YRDKZdwwoEPz06N6w8ChE2lrnsdyhY9sL+Y690Kh9gQ==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.10.tgz",
+      "integrity": "sha512-Ht8OQstxiS3APMGjHV0aYAjRAysidWdwurWEo2i8yI5xbhOBWqizT0+MU1S2GCcuhIBg+3SgWVjEoXgfhY+XaA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -343,14 +343,14 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.8.tgz",
-      "integrity": "sha512-zt1sF4lYLdvPqvmvHdmjOzuUUjuCQ897pdUCO8RbXMUDKXJTTyOQgtn23le+jwcb+MpHl3VAFvzIdxRAf6aPlA==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.10.tgz",
+      "integrity": "sha512-QbNyvIE8q2GTqKLYSsA8ATG+eETo+m31DSR0+AU7x3d2FhaTWzqQek80dj3JGTo743kQc6mhBR0erMjYw5jQ0A==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.3",
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -365,21 +365,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.3.0.tgz",
-      "integrity": "sha512-JAj66kjdH/F1+B7LCigjARbwstt3SNUOSzMdjpsvwJmzunK88gJeXmcm95L9nw1KynvFVuY4SzXh/3Y0lvtgSg==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.3.2.tgz",
+      "integrity": "sha512-yFroiSj2iiBFlm59amdTvAcQFvWS6ph5oKESls/uqPBect7rTU2GbjyZO2DqxMGuIwVA8z0P4K6ViPcd/cp+0w==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.1.0",
-        "@inquirer/confirm": "^6.0.8",
-        "@inquirer/editor": "^5.0.8",
-        "@inquirer/expand": "^5.0.8",
-        "@inquirer/input": "^5.0.8",
-        "@inquirer/number": "^4.0.8",
-        "@inquirer/password": "^5.0.8",
-        "@inquirer/rawlist": "^5.2.4",
-        "@inquirer/search": "^4.1.4",
-        "@inquirer/select": "^5.1.0"
+        "@inquirer/checkbox": "^5.1.2",
+        "@inquirer/confirm": "^6.0.10",
+        "@inquirer/editor": "^5.0.10",
+        "@inquirer/expand": "^5.0.10",
+        "@inquirer/input": "^5.0.10",
+        "@inquirer/number": "^4.0.10",
+        "@inquirer/password": "^5.0.10",
+        "@inquirer/rawlist": "^5.2.6",
+        "@inquirer/search": "^4.1.6",
+        "@inquirer/select": "^5.1.2"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -394,13 +394,13 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.4.tgz",
-      "integrity": "sha512-fTuJ5Cq9W286isLxwj6GGyfTjx1Zdk4qppVEPexFuA6yioCCXS4V1zfKroQqw7QdbDPN73xs2DiIAlo55+kBqg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.6.tgz",
+      "integrity": "sha512-jfw0MLJ5TilNsa9zlJ6nmRM0ZFVZhhTICt4/6CU2Dv1ndY7l3sqqo1gIYZyMMDw0LvE1u1nzJNisfHEhJIxq5w==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -415,14 +415,14 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.4.tgz",
-      "integrity": "sha512-9yPTxq7LPmYjrGn3DRuaPuPbmC6u3fiWcsE9ggfLcdgO/ICHYgxq7mEy1yJ39brVvgXhtOtvDVjDh9slJxE4LQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.6.tgz",
+      "integrity": "sha512-3/6kTRae98hhDevENScy7cdFEuURnSpM3JbBNg8yfXLw88HgTOl+neUuy/l9W0No5NzGsLVydhBzTIxZP7yChQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/figures": "^2.0.3",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/figures": "^2.0.4",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -437,15 +437,15 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.0.tgz",
-      "integrity": "sha512-OyYbKnchS1u+zRe14LpYrN8S0wH1vD0p2yKISvSsJdH2TpI87fh4eZdWnpdbrGauCRWDph3NwxRmM4Pcm/hx1Q==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.2.tgz",
+      "integrity": "sha512-kTK8YIkHV+f02y7bWCh7E0u2/11lul5WepVTclr3UMBtBr05PgcZNWfMa7FY57ihpQFQH/spLMHTcr0rXy50tA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.3",
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/figures": "^2.0.3",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/figures": "^2.0.4",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -460,9 +460,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.3.tgz",
-      "integrity": "sha512-cKZN7qcXOpj1h+1eTTcGDVLaBIHNMT1Rz9JqJP5MnEJ0JhgVWllx7H/tahUp5YEK1qaByH2Itb8wLG/iScD5kw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.4.tgz",
+      "integrity": "sha512-PamArxO3cFJZoOzspzo6cxVlLeIftyBsZw/S9bKY5DzxqJVZgjoj1oP8d0rskKtp7sZxBycsoer1g6UeJV1BBA==",
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -548,17 +548,17 @@
       "license": "MIT"
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.9.0.tgz",
-      "integrity": "sha512-Rz9fFWQSTJSnhBfZvtA/bDIuO82fknYdtyMsL9lZNJE82rquC6JByHPFsnbGH1VXA0HhMj9L7Oqyp3f0m/BTOA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.10.0.tgz",
+      "integrity": "sha512-R6BATDkughntPpaxeESJF+wxma5PEjgmnnKvH0/ByqUH8VyhIckQWE9kkP0Uc/EJ0o0VYhe8qCwWQvV70k5lTw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/code-frame": "~7.28.6",
+        "@babel/code-frame": "~7.29.0",
         "@inquirer/prompts": "^8.0.1",
-        "ajv": "~8.17.1",
+        "ajv": "~8.18.0",
         "change-case": "~5.4.4",
-        "env-paths": "^3.0.0",
+        "env-paths": "^4.0.0",
         "globby": "~16.1.0",
         "is-unicode-supported": "^2.1.0",
         "mustache": "~4.2.0",
@@ -581,30 +581,30 @@
       }
     },
     "node_modules/@typespec/events": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.79.0.tgz",
-      "integrity": "sha512-41R2jA7k21uMArjyUdvnqYzVnPPaSEcGi40dLMiRVP79m6XgnD3INuTdlMblaS1i+5jJ1BtS1o4QhBBuS/5/qg==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.80.0.tgz",
+      "integrity": "sha512-FrWEUwxhDNbE2YN4fyqV5Qrz9qFJbvPoiKrJM7dexkb7eyhepq3dbc5zZgAm/qFBQ+XxGQQVJ4swXxKT+338fw==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0"
+        "@typespec/compiler": "^1.10.0"
       }
     },
     "node_modules/@typespec/http": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.9.1.tgz",
-      "integrity": "sha512-agcwmbB/hK/o9KmM38UB8OGZwLgB17lJ7b4EjqYGpyshqcRMTESMRxnJIH7rRzUq4HJDTqal0tsb8z0K0zXuDg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.10.0.tgz",
+      "integrity": "sha512-/fj55fmUj4m/FmNdfH0V52menVrmS2r5Xj9d1H+pnjQbxvvaxS906RSRcoF8kbg3PvlibP/Py5u82TAk53AyqA==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/streams": "^0.79.0"
+        "@typespec/compiler": "^1.10.0",
+        "@typespec/streams": "^0.80.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -613,92 +613,92 @@
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.9.0.tgz",
-      "integrity": "sha512-5ieXCWRLcyFLv3IFk26ena/RW/NxvT5KiHaoNVFRd79J0XZjFcE0Od6Lxxqj4dWmCo3C8oKtOwFoQuie18G3lQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.10.0.tgz",
+      "integrity": "sha512-tukmyp+c9CFlA2FdF61XfT9eTe5WXWz6J8pOrJ9+IYg0BcBwhJkvDj6BYpDD6SjxbRr1wO5ZL2Whe6MequsyVw==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/http": "^1.9.0"
+        "@typespec/compiler": "^1.10.0",
+        "@typespec/http": "^1.10.0"
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.79.0.tgz",
-      "integrity": "sha512-6QIX7oaUGy/z4rseUrC86LjHxZn8rAAY4fXvGnlPRce6GhEdTb9S9OQPmlPeWngXwCx/07P2+FCR915APqmZxg==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.80.0.tgz",
+      "integrity": "sha512-xczXLoB2akSIDner41gQYTS9CG6TdCN0QHYvXBT6ZrYEnBh+pMvdymW//5CSOTamZLOGo9AOJVJaFfwbFA4vQQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/http": "^1.9.0"
+        "@typespec/compiler": "^1.10.0",
+        "@typespec/http": "^1.10.0"
       }
     },
     "node_modules/@typespec/sse": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.79.0.tgz",
-      "integrity": "sha512-YQYlDWCNBza75S360jc51emwntWXMZfkvqXKng+etKP4iCuogJfTX1J8h1yd8tZwkuUNBcklEPCuz3O/+psopg==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.80.0.tgz",
+      "integrity": "sha512-/lxYgMaxgEcjBVhep9tf/VnFD2wnkZlkmjUHLeZL8Cuf+qip61Ren6Ml91YtNnnIFYsuuymDzRclrA073ZBR6Q==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0",
-        "@typespec/events": "^0.79.0",
-        "@typespec/http": "^1.9.0",
-        "@typespec/streams": "^0.79.0"
+        "@typespec/compiler": "^1.10.0",
+        "@typespec/events": "^0.80.0",
+        "@typespec/http": "^1.10.0",
+        "@typespec/streams": "^0.80.0"
       }
     },
     "node_modules/@typespec/streams": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.79.0.tgz",
-      "integrity": "sha512-nOXpLcEYNdWvLY/6WJ16rD6hGs7bKSmkH+WwgyVwdRON5KJ559quw56pns2DSANw+NaV0lJxJq/8ek5xKCGD6g==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.80.0.tgz",
+      "integrity": "sha512-lNvzrvX/ZRIxRpxIBZu90XNsT+uWsMbLtxHd9edspHAiID3c9WKZbl2fnLcPqdR/60odqKve4yGzB9gF58GUDQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0"
+        "@typespec/compiler": "^1.10.0"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.79.0.tgz",
-      "integrity": "sha512-mk65zpKNm+ARyHASnre/lp3o3FKzb0P8Nj96ji182JUy7ShrVCCF0u+bC+ZXQ8ZTRza1d0xBjRC/Xr4iM+Uwag==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.80.0.tgz",
+      "integrity": "sha512-WQCT0jN2lSRfwOy+Cd1KUYzenpKR5TdoX0uW6zQdvxQ9nQZIXoaSaReh9/ldhmSV4xv3p2dqF9oq1cdbVGfJTg==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0"
+        "@typespec/compiler": "^1.10.0"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.79.0.tgz",
-      "integrity": "sha512-BqbbtkL9xuiAhehHKKUCMtRg0a1vjSvoiAOanvTIuoFq3N8PbKVV3dKTcyI/oS3iCCkJErdu11HQcAoD/VsIsA==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.80.0.tgz",
+      "integrity": "sha512-Qfy5eyCcOF3xYOU/dejhpmmeY75U1Q9C8XBE+GvSZ3lakRfKBIpT+X6Q07qmKSAbGYJZKYLWCIAy/dgCuu/OAA==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.9.0"
+        "@typespec/compiler": "^1.10.0"
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -813,12 +813,15 @@
       "license": "MIT"
     },
     "node_modules/env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-4.0.0.tgz",
+      "integrity": "sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==",
       "license": "MIT",
+      "dependencies": {
+        "is-safe-filename": "^0.1.0"
+      },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1043,6 +1046,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-safe-filename": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-safe-filename/-/is-safe-filename-0.1.1.tgz",
+      "integrity": "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1366,9 +1381,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
+      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -1382,18 +1397,18 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0.tgz",
-      "integrity": "sha512-qNsTkX9K8hi+FHDfHmf22e/OGuXmfBm9RqNismxBrnSmZVJKegQ+HYYXT+R7Ha8F/YSm2Y34vmzD4cxMu2u95g==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
+      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
       "license": "MIT",
       "dependencies": {
-        "temporal-spec": "0.3.0"
+        "temporal-spec": "0.3.1"
       }
     },
     "node_modules/temporal-spec": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.0.tgz",
-      "integrity": "sha512-n+noVpIqz4hYgFSMOSiINNOUOMFtV5cZQNCmmszA6GiVFVRt3G7AqVyhXjhCSmowvQn+NsGn+jMDMKJYHd3bSQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
+      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
       "license": "ISC"
     },
     "node_modules/to-regex-range": {

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,21 +1,21 @@
 {
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-rust": "0.36.0"
+    "@azure-tools/typespec-rust": "0.38.0"
   },
   "devDependencies": {
-    "@azure-tools/typespec-azure-core": "~0.65.0",
-    "@azure-tools/typespec-azure-resource-manager": "~0.65.0",
-    "@azure-tools/typespec-azure-rulesets": "~0.65.0",
-    "@azure-tools/typespec-client-generator-core": "~0.65.4",
-    "@typespec/compiler": "^1.9.0",
-    "@typespec/events": "~0.79.0",
-    "@typespec/http": "^1.9.1",
-    "@typespec/openapi": "^1.9.0",
-    "@typespec/rest": "~0.79.0",
-    "@typespec/sse": "~0.79.0",
-    "@typespec/streams": "~0.79.0",
-    "@typespec/versioning": "~0.79.0",
-    "@typespec/xml": "~0.79.0"
+    "@azure-tools/typespec-azure-core": "~0.66.0",
+    "@azure-tools/typespec-azure-resource-manager": "~0.66.0",
+    "@azure-tools/typespec-azure-rulesets": "~0.66.0",
+    "@azure-tools/typespec-client-generator-core": "~0.66.2",
+    "@typespec/compiler": "^1.10.0",
+    "@typespec/events": "~0.80.0",
+    "@typespec/http": "^1.10.0",
+    "@typespec/openapi": "^1.10.0",
+    "@typespec/rest": "~0.80.0",
+    "@typespec/sse": "~0.80.0",
+    "@typespec/streams": "~0.80.0",
+    "@typespec/versioning": "~0.80.0",
+    "@typespec/xml": "~0.80.0"
   }
 }

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/clients.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/clients.rs
@@ -42,7 +42,7 @@ pub struct CertificateClientOptions {
 impl Default for CertificateClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2025-07-01"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
             verify_challenge_resource: Some(true),
         }

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/generated/clients/certificate_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/generated/clients/certificate_client.rs
@@ -1420,3 +1420,12 @@ impl CertificateClient {
         Ok(rsp.into())
     }
 }
+
+/// Default value for `CertificateClientOptions::api_version`.
+///
+/// This constant is available for SDK authors to use in hand-authored code.
+/// When the options type is suppressed (via `@access(Access.internal)`), the
+/// SDK author provides a custom options type and should reference this constant
+/// in their `Default` implementation rather than hardcoding the value.
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2025-07-01";

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/generated/models/method_options.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/generated/models/method_options.rs
@@ -15,16 +15,16 @@ pub struct CertificateClientBackupCertificateOptions<'a> {
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`CertificateClient::delete_certificate()`](crate::generated::clients::CertificateClient::delete_certificate())
+/// Options to be passed to [`CertificateClient::delete_certificate_operation()`](crate::generated::clients::CertificateClient::delete_certificate_operation())
 #[derive(Clone, Default, SafeDebug)]
-pub struct CertificateClientDeleteCertificateOptions<'a> {
+pub struct CertificateClientDeleteCertificateOperationOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`CertificateClient::delete_certificate_operation()`](crate::generated::clients::CertificateClient::delete_certificate_operation())
+/// Options to be passed to [`CertificateClient::delete_certificate()`](crate::generated::clients::CertificateClient::delete_certificate())
 #[derive(Clone, Default, SafeDebug)]
-pub struct CertificateClientDeleteCertificateOperationOptions<'a> {
+pub struct CertificateClientDeleteCertificateOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
@@ -43,6 +43,13 @@ pub struct CertificateClientDeleteIssuerOptions<'a> {
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`CertificateClient::get_certificate_operation()`](crate::generated::clients::CertificateClient::get_certificate_operation())
+#[derive(Clone, Default, SafeDebug)]
+pub struct CertificateClientGetCertificateOperationOptions<'a> {
+    /// Allows customization of the method call.
+    pub method_options: ClientMethodOptions<'a>,
+}
+
 /// Options to be passed to [`CertificateClient::get_certificate()`](crate::generated::clients::CertificateClient::get_certificate())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CertificateClientGetCertificateOptions<'a> {
@@ -50,13 +57,6 @@ pub struct CertificateClientGetCertificateOptions<'a> {
     /// is returned.
     pub certificate_version: Option<String>,
 
-    /// Allows customization of the method call.
-    pub method_options: ClientMethodOptions<'a>,
-}
-
-/// Options to be passed to [`CertificateClient::get_certificate_operation()`](crate::generated::clients::CertificateClient::get_certificate_operation())
-#[derive(Clone, Default, SafeDebug)]
-pub struct CertificateClientGetCertificateOperationOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/generated/models/models.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/generated/models/models.rs
@@ -35,6 +35,8 @@ pub struct AdministratorContact {
 #[non_exhaustive]
 pub struct BackupCertificateResult {
     /// The backup blob containing the backed up certificate.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         deserialize_with = "base64::option::deserialize_url_safe",
@@ -66,14 +68,20 @@ pub struct Certificate {
     pub content_type: Option<String>,
 
     /// The certificate id.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// The key id.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kid: Option<String>,
 
     /// The management policy.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub policy: Option<CertificatePolicy>,
 
@@ -83,6 +91,8 @@ pub struct Certificate {
     pub preserve_cert_order: Option<bool>,
 
     /// The secret id.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sid: Option<String>,
 
@@ -91,6 +101,8 @@ pub struct Certificate {
     pub tags: Option<HashMap<String, String>>,
 
     /// Thumbprint of the certificate.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         deserialize_with = "base64::option::deserialize_url_safe",
@@ -105,6 +117,8 @@ pub struct Certificate {
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
 pub struct CertificateAttributes {
     /// Creation time in UTC.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -135,16 +149,22 @@ pub struct CertificateAttributes {
     pub not_before: Option<OffsetDateTime>,
 
     /// softDelete data retention days. Value should be >=7 and <=90 when softDelete enabled, otherwise 0.
+    ///
+    /// Operational visibility: Read
     #[serde(rename = "recoverableDays", skip_serializing_if = "Option::is_none")]
     pub recoverable_days: Option<i32>,
 
     /// Reflects the deletion recovery level currently in effect for certificates in the current vault. If it contains 'Purgeable',
     /// the certificate can be permanently deleted by a privileged user; otherwise, only the system can purge the certificate,
     /// at the end of the retention interval.
+    ///
+    /// Operational visibility: Read
     #[serde(rename = "recoveryLevel", skip_serializing_if = "Option::is_none")]
     pub recovery_level: Option<DeletionRecoveryLevel>,
 
     /// Last updated time in UTC.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -175,6 +195,8 @@ pub struct CertificateOperation {
     pub error: Option<KeyVaultErrorError>,
 
     /// The certificate id.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
@@ -212,6 +234,8 @@ pub struct CertificatePolicy {
     pub attributes: Option<CertificateAttributes>,
 
     /// The certificate id.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
@@ -287,6 +311,8 @@ pub struct Contacts {
     pub contact_list: Option<Vec<Contact>>,
 
     /// Identifier for the contacts collection.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 }
@@ -335,6 +361,8 @@ pub struct DeletedCertificate {
     pub content_type: Option<String>,
 
     /// The time when the certificate was deleted, in UTC
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         rename = "deletedDate",
@@ -344,14 +372,20 @@ pub struct DeletedCertificate {
     pub deleted_date: Option<OffsetDateTime>,
 
     /// The certificate id.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// The key id.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kid: Option<String>,
 
     /// The management policy.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub policy: Option<CertificatePolicy>,
 
@@ -365,6 +399,8 @@ pub struct DeletedCertificate {
     pub recovery_id: Option<String>,
 
     /// The time when the certificate is scheduled to be purged, in UTC
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         rename = "scheduledPurgeDate",
@@ -374,6 +410,8 @@ pub struct DeletedCertificate {
     pub scheduled_purge_date: Option<OffsetDateTime>,
 
     /// The secret id.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sid: Option<String>,
 
@@ -382,6 +420,8 @@ pub struct DeletedCertificate {
     pub tags: Option<HashMap<String, String>>,
 
     /// Thumbprint of the certificate.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         deserialize_with = "base64::option::deserialize_url_safe",
@@ -401,6 +441,8 @@ pub struct DeletedCertificateProperties {
     pub attributes: Option<CertificateAttributes>,
 
     /// The time when the certificate was deleted, in UTC
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         rename = "deletedDate",
@@ -418,6 +460,8 @@ pub struct DeletedCertificateProperties {
     pub recovery_id: Option<String>,
 
     /// The time when the certificate is scheduled to be purged, in UTC
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         rename = "scheduledPurgeDate",
@@ -483,6 +527,8 @@ pub struct Issuer {
     pub credentials: Option<IssuerCredentials>,
 
     /// Identifier for the issuer object.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
@@ -499,6 +545,8 @@ pub struct Issuer {
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
 pub struct IssuerAttributes {
     /// Creation time in UTC.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -511,6 +559,8 @@ pub struct IssuerAttributes {
     pub enabled: Option<bool>,
 
     /// Last updated time in UTC.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -585,18 +635,35 @@ pub struct KeyProperties {
     pub reuse_key: Option<bool>,
 }
 
+/// The key vault error exception.
+#[derive(Clone, Deserialize, SafeDebug, Serialize)]
+pub struct KeyVaultError {
+    /// The key vault server error.
+    ///
+    /// Operational visibility: Read
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<KeyVaultErrorError>,
+}
+
+/// The key vault server error.
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
 #[non_exhaustive]
 pub struct KeyVaultErrorError {
     /// The error code.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code: Option<String>,
 
     /// The key vault server error.
+    ///
+    /// Operational visibility: Read
     #[serde(rename = "innererror", skip_serializing_if = "Option::is_none")]
     pub inner_error: Option<Box<KeyVaultErrorError>>,
 
     /// The error message.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }
@@ -639,6 +706,8 @@ pub struct LifetimeActionType {
 #[non_exhaustive]
 pub struct ListCertificatePropertiesResult {
     /// The URL to get the next set of certificates.
+    ///
+    /// Operational visibility: Read
     #[serde(rename = "nextLink", skip_serializing_if = "Option::is_none")]
     pub next_link: Option<String>,
 
@@ -652,11 +721,15 @@ pub struct ListCertificatePropertiesResult {
 #[non_exhaustive]
 pub struct ListDeletedCertificatePropertiesResult {
     /// The URL to get the next set of deleted certificates.
+    ///
+    /// Operational visibility: Read
     #[serde(rename = "nextLink", skip_serializing_if = "Option::is_none")]
     pub next_link: Option<String>,
 
     /// A response message containing a list of deleted certificates in the vault along with a link to the next page of deleted
     /// certificates.
+    ///
+    /// Operational visibility: Read
     #[serde(default)]
     pub value: Vec<DeletedCertificateProperties>,
 }
@@ -666,11 +739,15 @@ pub struct ListDeletedCertificatePropertiesResult {
 #[non_exhaustive]
 pub struct ListIssuerPropertiesResult {
     /// The URL to get the next set of certificate issuers.
+    ///
+    /// Operational visibility: Read
     #[serde(rename = "nextLink", skip_serializing_if = "Option::is_none")]
     pub next_link: Option<String>,
 
     /// A response message containing a list of certificate issuers in the key vault along with a link to the next page of certificate
     /// issuers.
+    ///
+    /// Operational visibility: Read
     #[serde(default)]
     pub value: Vec<IssuerProperties>,
 }

--- a/sdk/keyvault/azure_security_keyvault_keys/src/clients.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/clients.rs
@@ -30,7 +30,7 @@ pub struct KeyClientOptions {
 impl Default for KeyClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2025-07-01"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
             verify_challenge_resource: Some(true),
         }

--- a/sdk/keyvault/azure_security_keyvault_keys/src/generated/clients/key_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/generated/clients/key_client.rs
@@ -1462,3 +1462,12 @@ impl KeyClient {
         Ok(rsp.into())
     }
 }
+
+/// Default value for `KeyClientOptions::api_version`.
+///
+/// This constant is available for SDK authors to use in hand-authored code.
+/// When the options type is suppressed (via `@access(Access.internal)`), the
+/// SDK author provides a custom options type and should reference this constant
+/// in their `Default` implementation rather than hardcoding the value.
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2025-07-01";

--- a/sdk/keyvault/azure_security_keyvault_keys/src/generated/models/method_options.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/generated/models/method_options.rs
@@ -50,22 +50,22 @@ pub struct KeyClientGetDeletedKeyOptions<'a> {
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`KeyClient::get_key()`](crate::generated::clients::KeyClient::get_key())
+/// Options to be passed to [`KeyClient::get_key_attestation()`](crate::generated::clients::KeyClient::get_key_attestation())
 #[derive(Clone, Default, SafeDebug)]
-pub struct KeyClientGetKeyOptions<'a> {
-    /// Adding the version parameter retrieves a specific version of a key. This URI fragment is optional. If not specified, the
-    /// latest version of the key is returned.
+pub struct KeyClientGetKeyAttestationOptions<'a> {
+    /// Adding the version parameter retrieves attestation blob for specific version of a key. This URI fragment is optional.
+    /// If not specified, the latest version of the key attestation blob is returned.
     pub key_version: Option<String>,
 
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`KeyClient::get_key_attestation()`](crate::generated::clients::KeyClient::get_key_attestation())
+/// Options to be passed to [`KeyClient::get_key()`](crate::generated::clients::KeyClient::get_key())
 #[derive(Clone, Default, SafeDebug)]
-pub struct KeyClientGetKeyAttestationOptions<'a> {
-    /// Adding the version parameter retrieves attestation blob for specific version of a key. This URI fragment is optional.
-    /// If not specified, the latest version of the key attestation blob is returned.
+pub struct KeyClientGetKeyOptions<'a> {
+    /// Adding the version parameter retrieves a specific version of a key. This URI fragment is optional. If not specified, the
+    /// latest version of the key is returned.
     pub key_version: Option<String>,
 
     /// Allows customization of the method call.

--- a/sdk/keyvault/azure_security_keyvault_keys/src/generated/models/models.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/generated/models/models.rs
@@ -16,6 +16,8 @@ use std::collections::HashMap;
 #[non_exhaustive]
 pub struct BackupKeyResult {
     /// The backup blob containing the backed up key.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         deserialize_with = "base64::option::deserialize_url_safe",
@@ -70,6 +72,8 @@ pub struct DeletedKey {
     pub attributes: Option<KeyAttributes>,
 
     /// The time when the key was deleted, in UTC
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         rename = "deletedDate",
@@ -83,6 +87,8 @@ pub struct DeletedKey {
     pub key: Option<JsonWebKey>,
 
     /// True if the key's lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub managed: Option<bool>,
 
@@ -95,6 +101,8 @@ pub struct DeletedKey {
     pub release_policy: Option<KeyReleasePolicy>,
 
     /// The time when the key is scheduled to be purged, in UTC
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         rename = "scheduledPurgeDate",
@@ -117,6 +125,8 @@ pub struct DeletedKeyProperties {
     pub attributes: Option<KeyAttributes>,
 
     /// The time when the key was deleted, in UTC
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         rename = "deletedDate",
@@ -130,6 +140,8 @@ pub struct DeletedKeyProperties {
     pub kid: Option<String>,
 
     /// True if the key's lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub managed: Option<bool>,
 
@@ -138,6 +150,8 @@ pub struct DeletedKeyProperties {
     pub recovery_id: Option<String>,
 
     /// The time when the key is scheduled to be purged, in UTC
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         rename = "scheduledPurgeDate",
@@ -325,6 +339,8 @@ pub struct Key {
     pub key: Option<JsonWebKey>,
 
     /// True if the key's lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub managed: Option<bool>,
 
@@ -380,10 +396,14 @@ pub struct KeyAttestation {
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
 pub struct KeyAttributes {
     /// The key or key version attestation information.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attestation: Option<KeyAttestation>,
 
     /// Creation time in UTC.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -410,6 +430,8 @@ pub struct KeyAttributes {
     pub exportable: Option<bool>,
 
     /// The underlying HSM Platform.
+    ///
+    /// Operational visibility: Read
     #[serde(rename = "hsmPlatform", skip_serializing_if = "Option::is_none")]
     pub hsm_platform: Option<String>,
 
@@ -423,16 +445,22 @@ pub struct KeyAttributes {
     pub not_before: Option<OffsetDateTime>,
 
     /// softDelete data retention days. Value should be >=7 and <=90 when softDelete enabled, otherwise 0.
+    ///
+    /// Operational visibility: Read
     #[serde(rename = "recoverableDays", skip_serializing_if = "Option::is_none")]
     pub recoverable_days: Option<i32>,
 
     /// Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the
     /// key can be permanently deleted by a privileged user; otherwise, only the system can purge the key, at the end of the retention
     /// interval.
+    ///
+    /// Operational visibility: Read
     #[serde(rename = "recoveryLevel", skip_serializing_if = "Option::is_none")]
     pub recovery_level: Option<DeletionRecoveryLevel>,
 
     /// Last updated time in UTC.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -492,6 +520,8 @@ pub struct KeyOperationParameters {
 #[non_exhaustive]
 pub struct KeyOperationResult {
     /// Additional data to authenticate but not encrypt/decrypt when using authenticated crypto algorithms.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         deserialize_with = "base64::option::deserialize_url_safe",
@@ -502,6 +532,8 @@ pub struct KeyOperationResult {
     pub additional_authenticated_data: Option<Vec<u8>>,
 
     /// The tag to authenticate when performing decryption with an authenticated algorithm.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         deserialize_with = "base64::option::deserialize_url_safe",
@@ -512,6 +544,8 @@ pub struct KeyOperationResult {
     pub authentication_tag: Option<Vec<u8>>,
 
     /// Cryptographically random, non-repeating initialization vector for symmetric algorithms.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         deserialize_with = "base64::option::deserialize_url_safe",
@@ -521,10 +555,14 @@ pub struct KeyOperationResult {
     pub iv: Option<Vec<u8>>,
 
     /// Key identifier
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kid: Option<String>,
 
     /// The result of the operation.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         deserialize_with = "base64::option::deserialize_url_safe",
@@ -548,6 +586,8 @@ pub struct KeyProperties {
     pub kid: Option<String>,
 
     /// True if the key's lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub managed: Option<bool>,
 
@@ -584,6 +624,8 @@ pub struct KeyReleasePolicy {
 #[non_exhaustive]
 pub struct KeyReleaseResult {
     /// A signed object containing the released key.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
 }
@@ -596,6 +638,8 @@ pub struct KeyRotationPolicy {
     pub attributes: Option<KeyRotationPolicyAttributes>,
 
     /// The key policy id.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
@@ -610,6 +654,8 @@ pub struct KeyRotationPolicy {
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
 pub struct KeyRotationPolicyAttributes {
     /// The key rotation policy created time in UTC.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -623,6 +669,8 @@ pub struct KeyRotationPolicyAttributes {
     pub expiry_time: Option<String>,
 
     /// The key rotation policy's last updated time in UTC.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -631,11 +679,45 @@ pub struct KeyRotationPolicyAttributes {
     pub updated: Option<OffsetDateTime>,
 }
 
+/// The key vault error exception.
+#[derive(Clone, Deserialize, SafeDebug, Serialize)]
+pub struct KeyVaultError {
+    /// The key vault server error.
+    ///
+    /// Operational visibility: Read
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<KeyVaultErrorError>,
+}
+
+/// The key vault server error.
+#[derive(Clone, Deserialize, SafeDebug, Serialize)]
+pub struct KeyVaultErrorError {
+    /// The error code.
+    ///
+    /// Operational visibility: Read
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+
+    /// The key vault server error.
+    ///
+    /// Operational visibility: Read
+    #[serde(rename = "innererror", skip_serializing_if = "Option::is_none")]
+    pub inner_error: Option<Box<KeyVaultErrorError>>,
+
+    /// The error message.
+    ///
+    /// Operational visibility: Read
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
 /// The key verify result.
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
 #[non_exhaustive]
 pub struct KeyVerifyResult {
     /// True if the signature is verified, otherwise false.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<bool>,
 }
@@ -678,10 +760,14 @@ pub struct LifetimeActionType {
 #[non_exhaustive]
 pub struct ListDeletedKeyPropertiesResult {
     /// The URL to get the next set of deleted keys.
+    ///
+    /// Operational visibility: Read
     #[serde(rename = "nextLink", skip_serializing_if = "Option::is_none")]
     pub next_link: Option<String>,
 
     /// A response message containing a list of deleted keys in the key vault along with a link to the next page of deleted keys.
+    ///
+    /// Operational visibility: Read
     #[serde(default)]
     pub value: Vec<DeletedKeyProperties>,
 }
@@ -691,10 +777,14 @@ pub struct ListDeletedKeyPropertiesResult {
 #[non_exhaustive]
 pub struct ListKeyPropertiesResult {
     /// The URL to get the next set of keys.
+    ///
+    /// Operational visibility: Read
     #[serde(rename = "nextLink", skip_serializing_if = "Option::is_none")]
     pub next_link: Option<String>,
 
     /// A response message containing a list of keys in the key vault along with a link to the next page of keys.
+    ///
+    /// Operational visibility: Read
     #[serde(default)]
     pub value: Vec<KeyProperties>,
 }

--- a/sdk/keyvault/azure_security_keyvault_secrets/src/clients.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/src/clients.rs
@@ -30,7 +30,7 @@ pub struct SecretClientOptions {
 impl Default for SecretClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2025-07-01"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
             verify_challenge_resource: Some(true),
         }

--- a/sdk/keyvault/azure_security_keyvault_secrets/src/generated/clients/secret_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/src/generated/clients/secret_client.rs
@@ -711,3 +711,12 @@ impl SecretClient {
         Ok(rsp.into())
     }
 }
+
+/// Default value for `SecretClientOptions::api_version`.
+///
+/// This constant is available for SDK authors to use in hand-authored code.
+/// When the options type is suppressed (via `@access(Access.internal)`), the
+/// SDK author provides a custom options type and should reference this constant
+/// in their `Default` implementation rather than hardcoding the value.
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2025-07-01";

--- a/sdk/keyvault/azure_security_keyvault_secrets/src/generated/models/models.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/src/generated/models/models.rs
@@ -13,6 +13,8 @@ use std::collections::HashMap;
 #[non_exhaustive]
 pub struct BackupSecretResult {
     /// The backup blob containing the backed up secret.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         deserialize_with = "base64::option::deserialize_url_safe",
@@ -35,6 +37,8 @@ pub struct DeletedSecret {
     pub content_type: Option<String>,
 
     /// The time when the secret was deleted, in UTC
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         rename = "deletedDate",
@@ -48,11 +52,15 @@ pub struct DeletedSecret {
     pub id: Option<String>,
 
     /// If this is a secret backing a KV certificate, then this field specifies the corresponding key backing the KV certificate.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kid: Option<String>,
 
     /// True if the secret's lifetime is managed by key vault. If this is a secret backing a certificate, then managed will be
     /// true.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub managed: Option<bool>,
 
@@ -66,6 +74,8 @@ pub struct DeletedSecret {
     pub recovery_id: Option<String>,
 
     /// The time when the secret is scheduled to be purged, in UTC
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         rename = "scheduledPurgeDate",
@@ -96,6 +106,8 @@ pub struct DeletedSecretProperties {
     pub content_type: Option<String>,
 
     /// The time when the secret was deleted, in UTC
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         rename = "deletedDate",
@@ -109,6 +121,8 @@ pub struct DeletedSecretProperties {
     pub id: Option<String>,
 
     /// True if the secret's lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub managed: Option<bool>,
 
@@ -117,6 +131,8 @@ pub struct DeletedSecretProperties {
     pub recovery_id: Option<String>,
 
     /// The time when the secret is scheduled to be purged, in UTC
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         rename = "scheduledPurgeDate",
@@ -130,16 +146,52 @@ pub struct DeletedSecretProperties {
     pub tags: Option<HashMap<String, String>>,
 }
 
+/// The key vault error exception.
+#[derive(Clone, Deserialize, SafeDebug, Serialize)]
+pub struct KeyVaultError {
+    /// The key vault server error.
+    ///
+    /// Operational visibility: Read
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<KeyVaultErrorError>,
+}
+
+/// The key vault server error.
+#[derive(Clone, Deserialize, SafeDebug, Serialize)]
+pub struct KeyVaultErrorError {
+    /// The error code.
+    ///
+    /// Operational visibility: Read
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+
+    /// The key vault server error.
+    ///
+    /// Operational visibility: Read
+    #[serde(rename = "innererror", skip_serializing_if = "Option::is_none")]
+    pub inner_error: Option<Box<KeyVaultErrorError>>,
+
+    /// The error message.
+    ///
+    /// Operational visibility: Read
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
 /// The deleted secret list result
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
 #[non_exhaustive]
 pub struct ListDeletedSecretPropertiesResult {
     /// The URL to get the next set of deleted secrets.
+    ///
+    /// Operational visibility: Read
     #[serde(rename = "nextLink", skip_serializing_if = "Option::is_none")]
     pub next_link: Option<String>,
 
     /// A response message containing a list of deleted secrets in the key vault along with a link to the next page of deleted
     /// secrets.
+    ///
+    /// Operational visibility: Read
     #[serde(default)]
     pub value: Vec<DeletedSecretProperties>,
 }
@@ -149,10 +201,14 @@ pub struct ListDeletedSecretPropertiesResult {
 #[non_exhaustive]
 pub struct ListSecretPropertiesResult {
     /// The URL to get the next set of secrets.
+    ///
+    /// Operational visibility: Read
     #[serde(rename = "nextLink", skip_serializing_if = "Option::is_none")]
     pub next_link: Option<String>,
 
     /// A response message containing a list of secrets in the key vault along with a link to the next page of secrets.
+    ///
+    /// Operational visibility: Read
     #[serde(default)]
     pub value: Vec<SecretProperties>,
 }
@@ -188,11 +244,15 @@ pub struct Secret {
     pub id: Option<String>,
 
     /// If this is a secret backing a KV certificate, then this field specifies the corresponding key backing the KV certificate.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kid: Option<String>,
 
     /// True if the secret's lifetime is managed by key vault. If this is a secret backing a certificate, then managed will be
     /// true.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub managed: Option<bool>,
 
@@ -214,6 +274,8 @@ pub struct Secret {
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
 pub struct SecretAttributes {
     /// Creation time in UTC.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -244,16 +306,22 @@ pub struct SecretAttributes {
     pub not_before: Option<OffsetDateTime>,
 
     /// softDelete data retention days. Value should be >=7 and <=90 when softDelete enabled, otherwise 0.
+    ///
+    /// Operational visibility: Read
     #[serde(rename = "recoverableDays", skip_serializing_if = "Option::is_none")]
     pub recoverable_days: Option<i32>,
 
     /// Reflects the deletion recovery level currently in effect for secrets in the current vault. If it contains 'Purgeable',
     /// the secret can be permanently deleted by a privileged user; otherwise, only the system can purge the secret, at the end
     /// of the retention interval.
+    ///
+    /// Operational visibility: Read
     #[serde(rename = "recoveryLevel", skip_serializing_if = "Option::is_none")]
     pub recovery_level: Option<DeletionRecoveryLevel>,
 
     /// Last updated time in UTC.
+    ///
+    /// Operational visibility: Read
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -279,6 +347,8 @@ pub struct SecretProperties {
     pub id: Option<String>,
 
     /// True if the secret's lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.
+    ///
+    /// Operational visibility: Read
     #[serde(skip_serializing_if = "Option::is_none")]
     pub managed: Option<bool>,
 

--- a/sdk/storage/azure_storage_blob/src/generated/clients/append_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/append_blob_client.rs
@@ -596,11 +596,14 @@ impl AppendBlobClient {
     }
 }
 
+/// Default value for [`AppendBlobClientOptions::version`].
+pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+
 impl Default for AppendBlobClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_client.rs
@@ -1594,11 +1594,14 @@ impl BlobClient {
     }
 }
 
+/// Default value for [`BlobClientOptions::version`].
+pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+
 impl Default for BlobClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
@@ -1039,11 +1039,14 @@ impl BlobContainerClient {
     }
 }
 
+/// Default value for [`BlobContainerClientOptions::version`].
+pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+
 impl Default for BlobContainerClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
@@ -377,11 +377,14 @@ impl BlobServiceClient {
     }
 }
 
+/// Default value for [`BlobServiceClientOptions::version`].
+pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+
 impl Default for BlobServiceClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/sdk/storage/azure_storage_blob/src/generated/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/block_blob_client.rs
@@ -955,11 +955,14 @@ impl BlockBlobClient {
     }
 }
 
+/// Default value for [`BlockBlobClientOptions::version`].
+pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+
 impl Default for BlockBlobClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/sdk/storage/azure_storage_blob/src/generated/clients/page_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/page_blob_client.rs
@@ -988,11 +988,14 @@ impl PageBlobClient {
     }
 }
 
+/// Default value for [`PageBlobClientOptions::version`].
+pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+
 impl Default for PageBlobClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/sdk/storage/azure_storage_blob/src/generated/models/method_options.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/method_options.rs
@@ -16,75 +16,6 @@ use azure_core::{
 };
 use std::collections::HashMap;
 
-/// Options to be passed to `AppendBlobClient::append_block()`
-#[derive(Clone, Default, SafeDebug)]
-pub struct AppendBlobClientAppendBlockOptions<'a> {
-    /// Optional conditional header, used only for the Append Block operation. A number indicating the byte offset to compare.
-    /// Append Block will succeed only if the append position is equal to this number. If it is not, the request will fail with
-    /// the AppendPositionConditionNotMet error (HTTP status code 412 - Precondition Failed).
-    pub append_position: Option<i64>,
-
-    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
-    /// AES256.
-    pub encryption_algorithm: Option<EncryptionAlgorithmType>,
-
-    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
-    /// If not specified, the request will be encrypted with the root account key.
-    pub encryption_key: Option<String>,
-
-    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
-    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
-    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
-    pub encryption_key_sha256: Option<String>,
-
-    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
-    /// If not specified, the request will be encrypted with the root account key.
-    pub encryption_scope: Option<String>,
-
-    /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<Etag>,
-
-    /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
-    pub if_modified_since: Option<OffsetDateTime>,
-
-    /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<Etag>,
-
-    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
-    pub if_tags: Option<String>,
-
-    /// A date-time value. A request is made under the condition that the resource has not been modified since the specified date-time.
-    pub if_unmodified_since: Option<OffsetDateTime>,
-
-    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
-    pub lease_id: Option<String>,
-
-    /// Optional conditional header. The max length in bytes permitted for the append blob. If the Append Block operation would
-    /// cause the blob to exceed that limit or if the blob size is already greater than the value specified in this header, the
-    /// request will fail with MaxBlobSizeConditionNotMet error (HTTP status code 412 - Precondition Failed).
-    pub max_size: Option<i64>,
-
-    /// Allows customization of the method call.
-    pub method_options: ClientMethodOptions<'a>,
-
-    /// Required if the request body is a structured message. Specifies the message schema version and properties.
-    pub structured_body_type: Option<String>,
-
-    /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
-    /// body. Will always be smaller than Content-Length.
-    pub structured_content_length: Option<u64>,
-
-    /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
-    pub timeout: Option<i32>,
-
-    /// Specify the transactional crc64 for the body, to be validated by the service.
-    pub transactional_content_crc64: Option<Vec<u8>>,
-
-    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
-    /// were validated when each was uploaded.
-    pub transactional_content_md5: Option<Vec<u8>>,
-}
-
 /// Options to be passed to `AppendBlobClient::append_block_from_url()`
 #[derive(Clone, Default, SafeDebug)]
 pub struct AppendBlobClientAppendBlockFromUrlOptions<'a> {
@@ -175,6 +106,75 @@ pub struct AppendBlobClientAppendBlockFromUrlOptions<'a> {
 
     /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
     pub timeout: Option<i32>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
+    pub transactional_content_md5: Option<Vec<u8>>,
+}
+
+/// Options to be passed to `AppendBlobClient::append_block()`
+#[derive(Clone, Default, SafeDebug)]
+pub struct AppendBlobClientAppendBlockOptions<'a> {
+    /// Optional conditional header, used only for the Append Block operation. A number indicating the byte offset to compare.
+    /// Append Block will succeed only if the append position is equal to this number. If it is not, the request will fail with
+    /// the AppendPositionConditionNotMet error (HTTP status code 412 - Precondition Failed).
+    pub append_position: Option<i64>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
+    pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
+    pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
+    pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
+    pub encryption_scope: Option<String>,
+
+    /// A condition that must be met in order for the request to be processed.
+    pub if_match: Option<Etag>,
+
+    /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
+    pub if_modified_since: Option<OffsetDateTime>,
+
+    /// A condition that must be met in order for the request to be processed.
+    pub if_none_match: Option<Etag>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
+    pub if_tags: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has not been modified since the specified date-time.
+    pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
+    pub lease_id: Option<String>,
+
+    /// Optional conditional header. The max length in bytes permitted for the append blob. If the Append Block operation would
+    /// cause the blob to exceed that limit or if the blob size is already greater than the value specified in this header, the
+    /// request will fail with MaxBlobSizeConditionNotMet error (HTTP status code 412 - Precondition Failed).
+    pub max_size: Option<i64>,
+
+    /// Allows customization of the method call.
+    pub method_options: ClientMethodOptions<'a>,
+
+    /// Required if the request body is a structured message. Specifies the message schema version and properties.
+    pub structured_body_type: Option<String>,
+
+    /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
+    /// body. Will always be smaller than Content-Length.
+    pub structured_content_length: Option<u64>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
+    pub timeout: Option<i32>,
+
+    /// Specify the transactional crc64 for the body, to be validated by the service.
+    pub transactional_content_crc64: Option<Vec<u8>>,
 
     /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
     /// were validated when each was uploaded.
@@ -427,6 +427,24 @@ pub struct BlobClientCreateSnapshotOptions<'a> {
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to `BlobClient::delete_immutability_policy()`
+#[derive(Clone, Default, SafeDebug)]
+pub struct BlobClientDeleteImmutabilityPolicyOptions<'a> {
+    /// Allows customization of the method call.
+    pub method_options: ClientMethodOptions<'a>,
+
+    /// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+    /// information on working with blob snapshots, see [Creating a Snapshot of a Blob.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob)
+    pub snapshot: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
+    pub timeout: Option<i32>,
+
+    /// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate
+    /// on. It's for service version 2019-10-10 and newer.
+    pub version_id: Option<String>,
+}
+
 /// Options to be passed to `BlobClient::delete()`
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientDeleteOptions<'a> {
@@ -461,24 +479,6 @@ pub struct BlobClientDeleteOptions<'a> {
     /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
 
-    /// Allows customization of the method call.
-    pub method_options: ClientMethodOptions<'a>,
-
-    /// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
-    /// information on working with blob snapshots, see [Creating a Snapshot of a Blob.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob)
-    pub snapshot: Option<String>,
-
-    /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
-    pub timeout: Option<i32>,
-
-    /// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate
-    /// on. It's for service version 2019-10-10 and newer.
-    pub version_id: Option<String>,
-}
-
-/// Options to be passed to `BlobClient::delete_immutability_policy()`
-#[derive(Clone, Default, SafeDebug)]
-pub struct BlobClientDeleteImmutabilityPolicyOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 
@@ -1415,50 +1415,6 @@ pub struct BlockBlobClientGetBlockListOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to `BlockBlobClient::stage_block()`
-#[derive(Clone, Default, SafeDebug)]
-pub struct BlockBlobClientStageBlockOptions<'a> {
-    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
-    /// AES256.
-    pub encryption_algorithm: Option<EncryptionAlgorithmType>,
-
-    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
-    /// If not specified, the request will be encrypted with the root account key.
-    pub encryption_key: Option<String>,
-
-    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
-    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
-    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
-    pub encryption_key_sha256: Option<String>,
-
-    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
-    /// If not specified, the request will be encrypted with the root account key.
-    pub encryption_scope: Option<String>,
-
-    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
-    pub lease_id: Option<String>,
-
-    /// Allows customization of the method call.
-    pub method_options: ClientMethodOptions<'a>,
-
-    /// Required if the request body is a structured message. Specifies the message schema version and properties.
-    pub structured_body_type: Option<String>,
-
-    /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
-    /// body. Will always be smaller than Content-Length.
-    pub structured_content_length: Option<u64>,
-
-    /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
-    pub timeout: Option<i32>,
-
-    /// Specify the transactional crc64 for the body, to be validated by the service.
-    pub transactional_content_crc64: Option<Vec<u8>>,
-
-    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
-    /// were validated when each was uploaded.
-    pub transactional_content_md5: Option<Vec<u8>>,
-}
-
 /// Options to be passed to `BlockBlobClient::stage_block_from_url()`
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlockBlobClientStageBlockFromUrlOptions<'a> {
@@ -1524,6 +1480,50 @@ pub struct BlockBlobClientStageBlockFromUrlOptions<'a> {
 
     /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
     pub timeout: Option<i32>,
+}
+
+/// Options to be passed to `BlockBlobClient::stage_block()`
+#[derive(Clone, Default, SafeDebug)]
+pub struct BlockBlobClientStageBlockOptions<'a> {
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
+    pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
+    pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
+    pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
+    pub encryption_scope: Option<String>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
+    pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
+    pub method_options: ClientMethodOptions<'a>,
+
+    /// Required if the request body is a structured message. Specifies the message schema version and properties.
+    pub structured_body_type: Option<String>,
+
+    /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
+    /// body. Will always be smaller than Content-Length.
+    pub structured_content_length: Option<u64>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
+    pub timeout: Option<i32>,
+
+    /// Specify the transactional crc64 for the body, to be validated by the service.
+    pub transactional_content_crc64: Option<Vec<u8>>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
+    pub transactional_content_md5: Option<Vec<u8>>,
 }
 
 /// Options to be passed to `BlockBlobClient::upload_blob_from_url()`
@@ -2013,74 +2013,6 @@ pub struct PageBlobClientSetSequenceNumberOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to `PageBlobClient::upload_pages()`
-#[derive(Clone, Default, SafeDebug)]
-pub struct PageBlobClientUploadPagesOptions<'a> {
-    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
-    /// AES256.
-    pub encryption_algorithm: Option<EncryptionAlgorithmType>,
-
-    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
-    /// If not specified, the request will be encrypted with the root account key.
-    pub encryption_key: Option<String>,
-
-    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
-    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
-    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
-    pub encryption_key_sha256: Option<String>,
-
-    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
-    /// If not specified, the request will be encrypted with the root account key.
-    pub encryption_scope: Option<String>,
-
-    /// A condition that must be met in order for the request to be processed.
-    pub if_match: Option<Etag>,
-
-    /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
-    pub if_modified_since: Option<OffsetDateTime>,
-
-    /// A condition that must be met in order for the request to be processed.
-    pub if_none_match: Option<Etag>,
-
-    /// Specify this header value to operate only on a blob if it has the specified sequence number.
-    pub if_sequence_number_equal_to: Option<i64>,
-
-    /// Specify this header value to operate only on a blob if it has a sequence number less than the specified.
-    pub if_sequence_number_less_than: Option<i64>,
-
-    /// Specify this header value to operate only on a blob if it has a sequence number less than or equal to the specified.
-    pub if_sequence_number_less_than_or_equal_to: Option<i64>,
-
-    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
-    pub if_tags: Option<String>,
-
-    /// A date-time value. A request is made under the condition that the resource has not been modified since the specified date-time.
-    pub if_unmodified_since: Option<OffsetDateTime>,
-
-    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
-    pub lease_id: Option<String>,
-
-    /// Allows customization of the method call.
-    pub method_options: ClientMethodOptions<'a>,
-
-    /// Required if the request body is a structured message. Specifies the message schema version and properties.
-    pub structured_body_type: Option<String>,
-
-    /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
-    /// body. Will always be smaller than Content-Length.
-    pub structured_content_length: Option<u64>,
-
-    /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
-    pub timeout: Option<i32>,
-
-    /// Specify the transactional crc64 for the body, to be validated by the service.
-    pub transactional_content_crc64: Option<Vec<u8>>,
-
-    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
-    /// were validated when each was uploaded.
-    pub transactional_content_md5: Option<Vec<u8>>,
-}
-
 /// Options to be passed to `PageBlobClient::upload_pages_from_url()`
 #[derive(Clone, Default, SafeDebug)]
 pub struct PageBlobClientUploadPagesFromUrlOptions<'a> {
@@ -2167,4 +2099,72 @@ pub struct PageBlobClientUploadPagesFromUrlOptions<'a> {
 
     /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
     pub timeout: Option<i32>,
+}
+
+/// Options to be passed to `PageBlobClient::upload_pages()`
+#[derive(Clone, Default, SafeDebug)]
+pub struct PageBlobClientUploadPagesOptions<'a> {
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
+    pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
+    pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
+    pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
+    pub encryption_scope: Option<String>,
+
+    /// A condition that must be met in order for the request to be processed.
+    pub if_match: Option<Etag>,
+
+    /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
+    pub if_modified_since: Option<OffsetDateTime>,
+
+    /// A condition that must be met in order for the request to be processed.
+    pub if_none_match: Option<Etag>,
+
+    /// Specify this header value to operate only on a blob if it has the specified sequence number.
+    pub if_sequence_number_equal_to: Option<i64>,
+
+    /// Specify this header value to operate only on a blob if it has a sequence number less than the specified.
+    pub if_sequence_number_less_than: Option<i64>,
+
+    /// Specify this header value to operate only on a blob if it has a sequence number less than or equal to the specified.
+    pub if_sequence_number_less_than_or_equal_to: Option<i64>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
+    pub if_tags: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has not been modified since the specified date-time.
+    pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
+    pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
+    pub method_options: ClientMethodOptions<'a>,
+
+    /// Required if the request body is a structured message. Specifies the message schema version and properties.
+    pub structured_body_type: Option<String>,
+
+    /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
+    /// body. Will always be smaller than Content-Length.
+    pub structured_content_length: Option<u64>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
+    pub timeout: Option<i32>,
+
+    /// Specify the transactional crc64 for the body, to be validated by the service.
+    pub transactional_content_crc64: Option<Vec<u8>>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
+    pub transactional_content_md5: Option<Vec<u8>>,
 }

--- a/sdk/storage/azure_storage_blob/src/generated/models/models.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/models.rs
@@ -11,7 +11,7 @@ use super::{
     },
     AccessTier, ArchiveStatus, BlobType, CopyStatus, GeoReplicationStatusType,
     ImmutabilityPolicyMode, LeaseDuration, LeaseState, LeaseStatus, PublicAccessType,
-    RehydratePriority,
+    RehydratePriority, StorageErrorCode,
 };
 use azure_core::{base64, fmt::SafeDebug, http::Etag, time::OffsetDateTime};
 use serde::{Deserialize, Serialize};
@@ -757,6 +757,59 @@ pub struct CorsRule {
     /// The maximum age in seconds.
     #[serde(rename = "MaxAgeInSeconds", skip_serializing_if = "Option::is_none")]
     pub max_age_in_seconds: Option<i32>,
+}
+
+/// The error response.
+///
+/// This defines the wire format only. Language SDKs wrap this in idiomatic error types.
+#[derive(Clone, Deserialize, SafeDebug, Serialize)]
+pub struct Error {
+    /// The error code.
+    #[serde(rename = "Code", skip_serializing_if = "Option::is_none")]
+    pub code: Option<StorageErrorCode>,
+
+    /// Copy source error code
+    #[serde(
+        rename = "CopySourceErrorCode",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub copy_source_error_code: Option<String>,
+
+    /// Copy source error message
+    #[serde(
+        rename = "CopySourceErrorMessage",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub copy_source_error_message: Option<String>,
+
+    /// Copy source status code
+    #[serde(
+        rename = "CopySourceStatusCode",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub copy_source_status_code: Option<i32>,
+
+    /// The error code.
+    #[serde(rename = "errorCode", skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+
+    /// The error message.
+    #[serde(rename = "Message", skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+
+    /// The error code for the copy source.
+    #[serde(
+        rename = "xMsCopySourceErrorCode",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub x_ms_copy_source_error_code: Option<String>,
+
+    /// The status code for the copy source.
+    #[serde(
+        rename = "xMsCopySourceStatusCode",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub x_ms_copy_source_status_code: Option<i32>,
 }
 
 /// The filter blob item.

--- a/sdk/storage/azure_storage_queue/src/generated/clients/queue_client.rs
+++ b/sdk/storage/azure_storage_queue/src/generated/clients/queue_client.rs
@@ -604,11 +604,14 @@ impl QueueClient {
     }
 }
 
+/// Default value for [`QueueClientOptions::version`].
+pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+
 impl Default for QueueClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/sdk/storage/azure_storage_queue/src/generated/clients/queue_service_client.rs
+++ b/sdk/storage/azure_storage_queue/src/generated/clients/queue_service_client.rs
@@ -248,11 +248,14 @@ impl QueueServiceClient {
     }
 }
 
+/// Default value for [`QueueServiceClientOptions::version`].
+pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+
 impl Default for QueueServiceClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/sdk/storage/azure_storage_queue/src/generated/models/method_options.rs
+++ b/sdk/storage/azure_storage_queue/src/generated/models/method_options.rs
@@ -33,9 +33,9 @@ pub struct QueueClientCreateOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to `QueueClient::delete()`
+/// Options to be passed to `QueueClient::delete_message()`
 #[derive(Clone, Default, SafeDebug)]
-pub struct QueueClientDeleteOptions<'a> {
+pub struct QueueClientDeleteMessageOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 
@@ -43,9 +43,9 @@ pub struct QueueClientDeleteOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to `QueueClient::delete_message()`
+/// Options to be passed to `QueueClient::delete()`
 #[derive(Clone, Default, SafeDebug)]
-pub struct QueueClientDeleteMessageOptions<'a> {
+pub struct QueueClientDeleteOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 

--- a/sdk/storage/azure_storage_queue/src/generated/models/models.rs
+++ b/sdk/storage/azure_storage_queue/src/generated/models/models.rs
@@ -64,6 +64,57 @@ pub struct CorsRule {
     pub max_age_in_seconds: Option<i32>,
 }
 
+/// The error response.
+#[derive(Clone, Deserialize, SafeDebug, Serialize)]
+pub struct Error {
+    /// The error code.
+    #[serde(rename = "Code", skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+
+    /// Copy source error code
+    #[serde(
+        rename = "CopySourceErrorCode",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub copy_source_error_code: Option<String>,
+
+    /// Copy source error message
+    #[serde(
+        rename = "CopySourceErrorMessage",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub copy_source_error_message: Option<String>,
+
+    /// Copy source status code
+    #[serde(
+        rename = "CopySourceStatusCode",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub copy_source_status_code: Option<i32>,
+
+    /// The error code.
+    #[serde(rename = "errorCode", skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+
+    /// The error message.
+    #[serde(rename = "Message", skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+
+    /// The error code for the copy source.
+    #[serde(
+        rename = "xMsCopySourceErrorCode",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub x_ms_copy_source_error_code: Option<String>,
+
+    /// The status code for the copy source.
+    #[serde(
+        rename = "xMsCopySourceStatusCode",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub x_ms_copy_source_status_code: Option<i32>,
+}
+
 /// Geo-Replication information for the Secondary Storage Service
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
 #[non_exhaustive]


### PR DESCRIPTION
Updated KV clients to use the constant for their API versions. No functional changes (sort ordering was fixed for some things).