### PR TITLE
Update rustls-webpki, tar dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,9 +2642,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/deny.toml
+++ b/deny.toml
@@ -10,8 +10,6 @@ ignore = []
 allow = [
   "Apache-2.0",
   "BSD-3-Clause",
-  "BSL-1.0",
-  "ISC",
   "MIT",
   "MPL-2.0",
   # "OpenSSL",


### PR DESCRIPTION
Fixes RUSTSEC-2026-0049
