### PR TITLE
Change SeekableStream::len to u64

### DIFF
--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Breaking Changes
 
+- `SeekableStream::len()` and `Body::len()` now return `u64` instead of `usize` to align with `std::fs::Metadata::len()` and support large file sizes.
 - Added `tokio` feature to `default` features.
 
 ### Bugs Fixed

--- a/sdk/core/azure_core_test/src/stream.rs
+++ b/sdk/core/azure_core_test/src/stream.rs
@@ -177,8 +177,8 @@ where
         Ok(())
     }
 
-    fn len(&self) -> usize {
-        LENGTH
+    fn len(&self) -> u64 {
+        LENGTH as u64
     }
 }
 

--- a/sdk/core/typespec_client_core/CHANGELOG.md
+++ b/sdk/core/typespec_client_core/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Breaking Changes
 
+- `SeekableStream::len()` and `Body::len()` now return `u64` instead of `usize` to align with `std::fs::Metadata::len()` and support large file sizes.
 - Added `tokio` feature to `default` features.
 
 ### Bugs Fixed

--- a/sdk/core/typespec_client_core/examples/common/fs.rs
+++ b/sdk/core/typespec_client_core/examples/common/fs.rs
@@ -152,12 +152,12 @@ impl SeekableStream for FileStream {
         Ok(())
     }
 
-    fn len(&self) -> usize {
+    fn len(&self) -> u64 {
         debug!(
             "stream len:  {} - {} ... {}",
             self.stream_size, self.offset, self.block_size
         );
-        min(self.stream_size - self.offset, self.block_size) as usize
+        min(self.stream_size - self.offset, self.block_size)
     }
 
     fn buffer_size(&self) -> usize {

--- a/sdk/core/typespec_client_core/src/http/request/mod.rs
+++ b/sdk/core/typespec_client_core/src/http/request/mod.rs
@@ -37,9 +37,9 @@ pub enum Body {
 
 impl Body {
     /// Returns the length of the body in bytes.
-    pub fn len(&self) -> usize {
+    pub fn len(&self) -> u64 {
         match self {
-            Body::Bytes(bytes) => bytes.len(),
+            Body::Bytes(bytes) => bytes.len() as u64,
             Body::SeekableStream(stream) => stream.len(),
         }
     }

--- a/sdk/core/typespec_client_core/src/stream/bytes_stream.rs
+++ b/sdk/core/typespec_client_core/src/stream/bytes_stream.rs
@@ -79,8 +79,8 @@ impl SeekableStream for BytesStream {
         Ok(())
     }
 
-    fn len(&self) -> usize {
-        self.bytes.len()
+    fn len(&self) -> u64 {
+        self.bytes.len() as u64
     }
 }
 

--- a/sdk/core/typespec_client_core/src/stream/mod.rs
+++ b/sdk/core/typespec_client_core/src/stream/mod.rs
@@ -24,7 +24,7 @@ pub trait SeekableStream: AsyncRead + Unpin + std::fmt::Debug + Send + Sync + Dy
     async fn reset(&mut self) -> Result<()>;
 
     /// Returns the total length of the stream in bytes.
-    fn len(&self) -> usize;
+    fn len(&self) -> u64;
 
     /// Returns `true` if the stream is empty.
     fn is_empty(&self) -> bool {

--- a/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
@@ -262,7 +262,7 @@ impl<'c, 'opt> BlockBlobClientUploadBehavior<'c, 'opt> {
 #[async_trait]
 impl PartitionedUploadBehavior for BlockBlobClientUploadBehavior<'_, '_> {
     async fn transfer_oneshot(&self, content: Body) -> Result<()> {
-        let content_len = content.len() as u64;
+        let content_len = content.len();
         let rsp = self
             .client
             .upload_internal(
@@ -287,7 +287,7 @@ impl PartitionedUploadBehavior for BlockBlobClientUploadBehavior<'_, '_> {
 
     async fn transfer_partition(&self, offset: usize, content: Body) -> Result<()> {
         let block_id = Uuid::new_v4();
-        let content_len = content.len().try_into().unwrap();
+        let content_len = content.len();
         {
             self.blocks.lock().await.push(BlockInfo {
                 offset: offset as u64,
@@ -305,7 +305,7 @@ impl PartitionedUploadBehavior for BlockBlobClientUploadBehavior<'_, '_> {
         Ok(())
     }
 
-    async fn initialize(&self, _content_len: usize) -> Result<()> {
+    async fn initialize(&self, _content_len: u64) -> Result<()> {
         Ok(())
     }
 

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/upload.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/upload.rs
@@ -16,7 +16,7 @@ use super::*;
 pub(crate) trait PartitionedUploadBehavior {
     async fn transfer_oneshot(&self, content: Body) -> AzureResult<()>;
     async fn transfer_partition(&self, offset: usize, content: Body) -> AzureResult<()>;
-    async fn initialize(&self, content_len: usize) -> AzureResult<()>;
+    async fn initialize(&self, content_len: u64) -> AzureResult<()>;
     async fn finalize(&self) -> AzureResult<()>;
 }
 
@@ -26,7 +26,7 @@ pub(crate) async fn upload(
     partition_size: NonZero<usize>,
     client: &impl PartitionedUploadBehavior,
 ) -> AzureResult<()> {
-    if content.len() <= partition_size.get() {
+    if content.len() <= partition_size.get() as u64 {
         client.transfer_oneshot(content).await?;
         return Ok(());
     }
@@ -111,7 +111,7 @@ mod tests {
     /// Record of a call made to a PartitionedUploadBehavior
     #[derive(Debug)]
     enum MockPartitionedUploadBehaviorInvocation {
-        Initialize(usize),
+        Initialize(u64),
         TransferOneshot(Bytes, BodyType),
         TransferPartition(usize, Bytes, BodyType),
         Finalize(),
@@ -158,7 +158,7 @@ mod tests {
             Ok(())
         }
 
-        async fn initialize(&self, content_len: usize) -> AzureResult<()> {
+        async fn initialize(&self, content_len: u64) -> AzureResult<()> {
             self.invocations.lock().await.push(
                 MockPartitionedUploadBehaviorInvocation::Initialize(content_len),
             );
@@ -300,7 +300,7 @@ mod tests {
         assert_eq!(invocations.len(), expected_partitions + 2);
         assert!(matches!(
             &invocations[0],
-            MockPartitionedUploadBehaviorInvocation::Initialize(size) if *size == original_data.len()
+            MockPartitionedUploadBehaviorInvocation::Initialize(size) if *size == original_data.len() as u64
         ));
         assert!(matches!(
             &invocations[invocations.len() - 1],

--- a/sdk/storage/azure_storage_blob/src/streams/partitioned_stream.rs
+++ b/sdk/storage/azure_storage_blob/src/streams/partitioned_stream.rs
@@ -21,7 +21,7 @@ impl PartitionedStream {
     pub(crate) fn new(inner: Box<dyn SeekableStream>, partition_len: NonZero<usize>) -> Self {
         let partition_len = partition_len.get();
         Self {
-            buf: BytesMut::with_capacity(std::cmp::min(partition_len, inner.len())),
+            buf: BytesMut::with_capacity(std::cmp::min(partition_len as u64, inner.len()) as usize),
             inner,
             partition_len,
             total_read: 0,
@@ -44,9 +44,9 @@ impl Stream for PartitionedStream {
                 let ret = mem::replace(
                     this.buf,
                     BytesMut::with_capacity(std::cmp::min(
-                        *this.partition_len,
-                        this.inner.len() - *this.total_read,
-                    )),
+                        *this.partition_len as u64,
+                        this.inner.len() - *this.total_read as u64,
+                    ) as usize),
                 );
                 return if ret.is_empty() {
                     Poll::Ready(None)

--- a/sdk/storage/azure_storage_blob_test/src/lib.rs
+++ b/sdk/storage/azure_storage_blob_test/src/lib.rs
@@ -305,7 +305,7 @@ impl BodyTestExt for Body {
             Body::Bytes(bytes) => Ok(bytes.clone()),
             Body::SeekableStream(seekable_stream) => {
                 seekable_stream.reset().await?;
-                let mut bytes = BytesMut::with_capacity(seekable_stream.len());
+                let mut bytes = BytesMut::with_capacity(seekable_stream.len() as usize);
                 while seekable_stream.read_into_spare_capacity(&mut bytes).await? != 0 {}
                 seekable_stream.reset().await?;
                 Ok(bytes.freeze())


### PR DESCRIPTION
Aligns with file size and will not overflow on 32-bit architectures.
