### PR TITLE
Disable proxy by default, add explicit opt-in

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 ### Features Added
 
+- Added `CosmosClientBuilder::with_proxy_allowed(bool)` for explicit opt-in to HTTP proxy usage with documented support limitations. ([#4062](https://github.com/Azure/azure-sdk-for-rust/pull/4062))
 - Added `CustomResponseBuilder` and `FaultInjectionRule::hit_count()` APIs for fault injection, enabling ergonomic construction of synthetic HTTP responses and test verification of rule activation counts. ([#3888](https://github.com/Azure/azure-sdk-for-rust/pull/3888))
 
 ### Breaking Changes
 
+- HTTP proxies (`HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY` environment variables) are now ignored by default. Use `CosmosClientBuilder::with_proxy_allowed(true)` to opt in. ([#4062](https://github.com/Azure/azure-sdk-for-rust/pull/4062))
 - Client methods now return dedicated response types instead of `CosmosResponse<T>`: `ItemResponse<T>` for point operations, `ResourceResponse<T>` for resource management, `BatchResponse` for transactional batch, and `QueryFeedPage<T>` for query pages. `etag()` returns `Option<&Etag>` instead of `Option<&str>`, and `activity_id()` / `server_duration_ms()` are accessed via `response.diagnostics()`. ([#3960](https://github.com/Azure/azure-sdk-for-rust/pull/3960))
 - `FeedPage::deconstruct()` has been removed. Use `into_items()`, `continuation()`, `headers()`, and `diagnostics()` instead. ([#3960](https://github.com/Azure/azure-sdk-for-rust/pull/3960))
 - Replaced `CosmosClientBuilder::with_application_region()` with a mandatory `RoutingStrategy` parameter on `build()`. Use `RoutingStrategy::ProximityTo(region)` to specify the application region. Also removed `CosmosClientOptions::with_application_region()`. ([#3889](https://github.com/Azure/azure-sdk-for-rust/pull/3889))

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client_builder.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client_builder.rs
@@ -79,6 +79,8 @@ use azure_core::http::{ClientOptions, LoggingOptions, RetryOptions};
 #[derive(Default)]
 pub struct CosmosClientBuilder {
     options: CosmosClientOptions,
+    /// Whether to allow proxy usage. When false (default), `HTTPS_PROXY` is ignored.
+    allow_proxy: bool,
     /// Whether to accept invalid TLS certificates when connecting to the emulator.
     #[cfg(feature = "allow_invalid_certificates")]
     allow_emulator_invalid_certificates: bool,
@@ -139,6 +141,27 @@ impl CosmosClientBuilder {
         self
     }
 
+    /// Allows the SDK to use HTTP proxies and respect system proxy settings.
+    ///
+    /// By default, the Cosmos DB SDK ignores the `HTTPS_PROXY`, `HTTP_PROXY`,
+    /// `ALL_PROXY` environment variables and their lowercase variants. Proxies
+    /// can cause issues for Cosmos DB connectivity, availability, and throughput.
+    ///
+    /// When enabled, the SDK will respect system-configured proxy settings
+    /// (such as proxy-related environment variables, including any exclusions).
+    ///
+    /// NOTE: End-to-end latency, availability, and throughput guarantees cannot
+    /// be provided when a proxy is in use. Full backend support is provided,
+    /// but client/proxy interactions are supported on a best-effort basis only.
+    ///
+    /// # Arguments
+    ///
+    /// * `allow` - Whether to allow proxy usage.
+    pub fn with_proxy_allowed(mut self, allow: bool) -> Self {
+        self.allow_proxy = allow;
+        self
+    }
+
     /// Builds the [`CosmosClient`] with the specified account reference and region selection strategy.
     ///
     /// The account reference bundles an endpoint and credential. You can create one using
@@ -190,6 +213,16 @@ impl CosmosClientBuilder {
                 .pool_max_idle_per_host(DEFAULT_MAX_CONNECTION_POOL_SIZE)
                 .connect_timeout(DEFAULT_CONNECTION_TIMEOUT)
                 .timeout(DEFAULT_REQUEST_TIMEOUT);
+
+            if self.allow_proxy {
+                tracing::warn!(
+                    "Proxy usage is enabled. Azure Cosmos DB does not provide end-to-end SLAs \
+                     when a proxy is in use. Full backend support is provided, but client/proxy \
+                     interactions are supported on a best-effort basis only."
+                );
+            } else {
+                builder = builder.no_proxy();
+            }
 
             #[cfg(feature = "allow_invalid_certificates")]
             if self.allow_emulator_invalid_certificates {

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_proxy.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_proxy.rs
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Integration tests verifying proxy configuration behavior.
+//! These tests run against the Cosmos DB emulator.
+
+#![cfg(feature = "key_auth")]
+
+use super::framework;
+
+use framework::{TestClient, CONNECTION_STRING_ENV_VAR, EMULATOR_CONNECTION_STRING};
+use std::error::Error;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use tokio::net::TcpListener;
+
+/// Verifies that a client built with default settings does not route
+/// requests through an HTTP proxy, even when `HTTPS_PROXY` is set.
+#[tokio::test]
+pub async fn proxy_disabled_by_default_ignores_env() -> Result<(), Box<dyn Error>> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    let connect_count = Arc::new(AtomicU32::new(0));
+    let counter = Arc::clone(&connect_count);
+
+    let accept_handle = tokio::spawn(async move {
+        while let Ok((_stream, _addr)) = listener.accept().await {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }
+    });
+
+    let proxy_key = "HTTPS_PROXY";
+    let prev = std::env::var(proxy_key).ok();
+    std::env::set_var(proxy_key, format!("http://127.0.0.1:{port}"));
+
+    // Run a real emulator test with proxy disabled (default).
+    // TestClient::run uses the default CosmosClientBuilder which has no_proxy().
+    let result = TestClient::run(async |run_context| {
+        let client = run_context.client();
+        let _ = client.database_client("nonexistent").read(None).await;
+        Ok(())
+    })
+    .await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    match prev {
+        Some(v) => std::env::set_var(proxy_key, v),
+        None => std::env::remove_var(proxy_key),
+    }
+
+    accept_handle.abort();
+
+    result?;
+    assert_eq!(
+        connect_count.load(Ordering::SeqCst),
+        0,
+        "Default builder should not route through proxy"
+    );
+
+    Ok(())
+}
+
+/// Verifies that a client built with `with_proxy_allowed(true)`
+/// routes requests through the proxy specified by `HTTPS_PROXY`.
+#[tokio::test]
+pub async fn proxy_enabled_routes_through_proxy() -> Result<(), Box<dyn Error>> {
+    // Skip when test mode is "skipped" or no connection string is available.
+    let test_mode = std::env::var("AZURE_COSMOS_TEST_MODE").unwrap_or_default();
+    let conn_string_available = std::env::var(CONNECTION_STRING_ENV_VAR).is_ok();
+    if test_mode == "skipped" || (!conn_string_available && test_mode != "required") {
+        eprintln!("Skipping proxy_enabled test: no emulator connection available.");
+        return Ok(());
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    let connected = Arc::new(tokio::sync::Notify::new());
+    let connected_signal = Arc::clone(&connected);
+
+    let accept_handle = tokio::spawn(async move {
+        if let Ok((_stream, _addr)) = listener.accept().await {
+            connected_signal.notify_one();
+        }
+    });
+
+    let proxy_key = "HTTPS_PROXY";
+    let prev = std::env::var(proxy_key).ok();
+    std::env::set_var(proxy_key, format!("http://127.0.0.1:{port}"));
+
+    // Build a client manually with proxy enabled.
+    let env_val = std::env::var(CONNECTION_STRING_ENV_VAR)
+        .unwrap_or_else(|_| EMULATOR_CONNECTION_STRING.to_string());
+    let conn_str = if env_val == "emulator" {
+        EMULATOR_CONNECTION_STRING.to_string()
+    } else {
+        env_val
+    };
+    let parsed: azure_data_cosmos::ConnectionString = conn_str.parse()?;
+
+    let mut builder = azure_data_cosmos::CosmosClient::builder().with_proxy_allowed(true);
+
+    #[cfg(feature = "allow_invalid_certificates")]
+    {
+        builder = builder.with_allow_emulator_invalid_certificates(true);
+    }
+
+    let endpoint: azure_data_cosmos::CosmosAccountEndpoint = parsed.account_endpoint.parse()?;
+    let client = builder
+        .build(
+            azure_data_cosmos::CosmosAccountReference::with_master_key(
+                endpoint,
+                parsed.account_key,
+            ),
+            azure_data_cosmos::RoutingStrategy::ProximityTo(azure_data_cosmos::Region::EAST_US),
+        )
+        .await?;
+
+    // Spawn the request so we can wait on the proxy signal instead.
+    let request_handle = tokio::spawn(async move {
+        let _ = client.database_client("nonexistent").read(None).await;
+    });
+
+    // Wait for the proxy listener to accept a connection, with a timeout fallback.
+    let proxy_hit = tokio::time::timeout(std::time::Duration::from_secs(5), connected.notified())
+        .await
+        .is_ok();
+
+    match prev {
+        Some(v) => std::env::set_var(proxy_key, v),
+        None => std::env::remove_var(proxy_key),
+    }
+
+    request_handle.abort();
+    accept_handle.abort();
+
+    assert!(
+        proxy_hit,
+        "Proxy-enabled builder should route through proxy, but no connection was received"
+    );
+
+    Ok(())
+}

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/mod.rs
@@ -6,6 +6,7 @@ mod cosmos_databases;
 mod cosmos_fault_injection;
 mod cosmos_items;
 mod cosmos_offers;
+mod cosmos_proxy;
 mod cosmos_query;
 
 #[path = "../framework/mod.rs"]

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
@@ -21,7 +21,8 @@ pub mod test_data;
 
 pub use test_client::{
     get_effective_hub_endpoint, get_global_endpoint, TestClient, TestOptions, TestRunContext,
-    DEFAULT_TEST_TIMEOUT, HUB_REGION, SATELLITE_REGION,
+    CONNECTION_STRING_ENV_VAR, DEFAULT_TEST_TIMEOUT, EMULATOR_CONNECTION_STRING, HUB_REGION,
+    SATELLITE_REGION,
 };
 
 use serde::{Deserialize, Serialize};

--- a/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/mod.rs
@@ -19,6 +19,7 @@
 //! `DiagnosticsContext` which is safe to share via `Arc` without locking.
 
 mod diagnostics_context;
+mod proxy_configuration;
 
 pub(crate) use diagnostics_context::DiagnosticsContextBuilder;
 pub use diagnostics_context::{
@@ -26,3 +27,4 @@ pub use diagnostics_context::{
     RequestDiagnostics, RequestEvent, RequestEventType, RequestHandle, RequestSentStatus,
     TransportHttpVersion, TransportKind, TransportSecurity, TransportShardDiagnostics,
 };
+pub use proxy_configuration::ProxyConfiguration;

--- a/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/proxy_configuration.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/proxy_configuration.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Proxy configuration diagnostics.
+
+/// Captures proxy configuration for diagnostic purposes.
+///
+/// Built once at client creation time and inserted into the request
+/// [`Context`](azure_core::http::Context) so that policies and diagnostic
+/// consumers can identify when a proxy is in use.
+#[derive(Clone, Debug)]
+pub struct ProxyConfiguration {
+    /// Whether proxy usage is allowed.
+    pub proxy_allowed: bool,
+    /// Whether `HTTPS_PROXY` (or `https_proxy`) was set at client creation time.
+    pub https_proxy_set: bool,
+    /// Whether `HTTP_PROXY` (or `http_proxy`) was set at client creation time.
+    pub http_proxy_set: bool,
+}
+
+impl ProxyConfiguration {
+    /// Snapshots the current proxy environment variables.
+    pub fn from_env(proxy_allowed: bool) -> Self {
+        let (https_proxy_set, http_proxy_set) = if proxy_allowed {
+            (
+                std::env::var("HTTPS_PROXY")
+                    .or_else(|_| std::env::var("https_proxy"))
+                    .is_ok(),
+                std::env::var("HTTP_PROXY")
+                    .or_else(|_| std::env::var("http_proxy"))
+                    .is_ok(),
+            )
+        } else {
+            (false, false)
+        };
+
+        Self {
+            proxy_allowed,
+            https_proxy_set,
+            http_proxy_set,
+        }
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/runtime.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/runtime.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 use crate::{
+    diagnostics::ProxyConfiguration,
     models::{AccountReference, ContainerReference, ThroughputControlGroupName, UserAgent},
     options::{
         parse_duration_millis_from_env, ConnectionPoolOptions, CorrelationId, DriverOptions,
@@ -162,6 +163,9 @@ pub struct CosmosDriverRuntime {
 
     /// Whether fault injection is enabled for this runtime.
     fault_injection_enabled: bool,
+
+    /// Proxy configuration snapshot for diagnostics.
+    proxy_configuration: ProxyConfiguration,
 }
 
 impl CosmosDriverRuntime {
@@ -218,6 +222,14 @@ impl CosmosDriverRuntime {
     /// Returns whether fault injection is enabled for this runtime.
     pub(crate) fn fault_injection_enabled(&self) -> bool {
         self.fault_injection_enabled
+    }
+
+    /// Returns the proxy configuration snapshot.
+    ///
+    /// Captures whether proxy is allowed and the proxy environment variable
+    /// values at client creation time, for diagnostic purposes.
+    pub fn proxy_configuration(&self) -> &ProxyConfiguration {
+        &self.proxy_configuration
     }
 
     /// Returns the environment-level operation options (populated from env vars at build time).
@@ -612,6 +624,7 @@ impl CosmosDriverRuntimeBuilder {
         };
 
         let connection_pool = self.connection_pool.unwrap_or_default();
+        let proxy_configuration = ProxyConfiguration::from_env(connection_pool.proxy_allowed());
         #[allow(unused_mut)]
         let mut fault_injection_enabled = false;
         let http_client_factory: Arc<dyn HttpClientFactory> = {
@@ -696,6 +709,7 @@ impl CosmosDriverRuntimeBuilder {
             cpu_monitor,
             machine_id: Arc::new(vm_metadata.machine_id().to_owned()),
             fault_injection_enabled,
+            proxy_configuration,
         }))
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/transport/http_client_factory.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/transport/http_client_factory.rs
@@ -172,7 +172,7 @@ impl HttpClientFactory for DefaultHttpClientFactory {
         builder = builder.connect_timeout(connection_pool.max_connect_timeout());
         builder = builder.timeout(config.request_timeout);
 
-        if !connection_pool.is_proxy_allowed() {
+        if !connection_pool.proxy_allowed() {
             builder = builder.no_proxy();
         }
 

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/connection_pool.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/connection_pool.rs
@@ -34,7 +34,7 @@ use crate::options::EmulatorServerCertValidation;
 #[non_exhaustive]
 #[derive(Clone, Debug)]
 pub struct ConnectionPoolOptions {
-    is_proxy_allowed: bool,
+    proxy_allowed: bool,
 
     min_connect_timeout: Duration,
     max_connect_timeout: Duration,
@@ -88,8 +88,8 @@ impl ConnectionPoolOptions {
     ///
     /// When `true`, the `HTTPS_PROXY` environment variable will be respected.
     /// When using a proxy, no end-to-end SLAs are guaranteed by Azure Cosmos DB.
-    pub fn is_proxy_allowed(&self) -> bool {
-        self.is_proxy_allowed
+    pub fn proxy_allowed(&self) -> bool {
+        self.proxy_allowed
     }
 
     /// Returns the minimum connection timeout.
@@ -274,7 +274,7 @@ impl ConnectionPoolOptions {
 #[non_exhaustive]
 #[derive(Clone, Debug, Default)]
 pub struct ConnectionPoolOptionsBuilder {
-    is_proxy_allowed: Option<bool>,
+    proxy_allowed: Option<bool>,
     min_connect_timeout: Option<Duration>,
     max_connect_timeout: Option<Duration>,
     min_dataplane_request_timeout: Option<Duration>,
@@ -310,8 +310,8 @@ impl ConnectionPoolOptionsBuilder {
     /// Sets whether proxy usage is allowed. If true, the HTTPS_PROXY environment variable will be respected.
     /// When using a proxy, no e2e SLAs are guaranteed by Azure Cosmos DB.
     /// Defaults to `false`.
-    pub fn with_dangerous_is_proxy_allowed(mut self, value: bool) -> Self {
-        self.is_proxy_allowed = Some(value);
+    pub fn with_proxy_allowed(mut self, value: bool) -> Self {
+        self.proxy_allowed = Some(value);
         self
     }
 
@@ -738,8 +738,8 @@ impl ConnectionPoolOptionsBuilder {
         )?;
 
         Ok(ConnectionPoolOptions {
-            is_proxy_allowed: parse_from_env(
-                self.is_proxy_allowed,
+            proxy_allowed: parse_from_env(
+                self.proxy_allowed,
                 "AZURE_COSMOS_CONNECTION_POOL_IS_PROXY_ALLOWED",
                 false,
                 ValidationBounds::none(),
@@ -802,7 +802,7 @@ mod tests {
     fn connection_pool_options_builder_defaults() {
         let options = ConnectionPoolOptionsBuilder::new().build().unwrap();
 
-        assert!(!options.is_proxy_allowed());
+        assert!(!options.proxy_allowed());
         assert_eq!(options.min_connect_timeout(), Duration::from_millis(100));
         assert_eq!(options.max_connect_timeout(), Duration::from_millis(5_000));
         assert_eq!(
@@ -857,7 +857,7 @@ mod tests {
     #[test]
     fn connection_pool_options_builder_custom_values() {
         let options = ConnectionPoolOptionsBuilder::new()
-            .with_dangerous_is_proxy_allowed(true)
+            .with_proxy_allowed(true)
             .with_min_connect_timeout(Duration::from_millis(200))
             .with_max_connect_timeout(Duration::from_millis(3_000))
             .with_min_dataplane_request_timeout(Duration::from_millis(500))
@@ -884,7 +884,7 @@ mod tests {
             .build()
             .unwrap();
 
-        assert!(options.is_proxy_allowed());
+        assert!(options.proxy_allowed());
         assert_eq!(options.min_connect_timeout(), Duration::from_millis(200));
         assert_eq!(options.max_connect_timeout(), Duration::from_millis(3_000));
         assert_eq!(

--- a/sdk/cosmos/eng/scripts/Invoke-CosmosTestSetup.ps1
+++ b/sdk/cosmos/eng/scripts/Invoke-CosmosTestSetup.ps1
@@ -95,6 +95,9 @@ if ($IsWindows) {
     $env:AZURE_COSMOS_CONNECTION_STRING = "emulator"
     $env:RUSTFLAGS = "$($env:RUSTFLAGS) --cfg=test_category=`"emulator`""
     Write-Host "RUSTFLAGS set to: $env:RUSTFLAGS"
+
+    # Run tests single-threaded to avoid env var contamination from proxy tests.
+    $env:RUST_TEST_THREADS = "1"
 } elseif (Get-Command "docker" -ErrorAction SilentlyContinue) {
     Write-Host "Docker detected. Using Cosmos DB Emulator in Docker."
 
@@ -141,6 +144,9 @@ if ($IsWindows) {
     $env:AZURE_COSMOS_CONNECTION_STRING = "emulator"
     $env:RUSTFLAGS = "$($env:RUSTFLAGS) --cfg=test_category=`"emulator`""
     Write-Host "RUSTFLAGS set to: $env:RUSTFLAGS"
+
+    # Run tests single-threaded to avoid env var contamination from proxy tests.
+    $env:RUST_TEST_THREADS = "1"
 
     Write-Host "Cosmos DB Emulator is running in Docker."
 } else {


### PR DESCRIPTION
By default, call `no_proxy()` on the reqwest `ClientBuilder` to prevent
the SDK from silently inheriting `HTTPS_PROXY` from the environment.
Proxies can cause issues for Cosmos DB connectivity and throughput.

Add `with_dangerous_proxy_allowed()` for explicit opt-in with clear
documentation about support limitations. Log a warning when proxy
is enabled so support can identify the scenario in diagnostics.

### Changes

- Call `.no_proxy()` by default on the reqwest builder in `CosmosClientBuilder::build()`
- Add `with_dangerous_proxy_allowed(bool)` builder method for explicit opt-in
- Document support limitations on the new method

Fixes #3911