### PR TITLE
Onboard prepare-pipelines

### DIFF
--- a/eng/pipelines/prepare-pipelines.yml
+++ b/eng/pipelines/prepare-pipelines.yml
@@ -1,0 +1,9 @@
+trigger: none
+
+variables:
+- template: /eng/pipelines/templates/variables/image.yml
+
+extends:
+  template: /eng/common/pipelines/templates/jobs/prepare-pipelines.yml
+  parameters:
+    Repository: Azure/azure-sdk-for-rust


### PR DESCRIPTION
Places pipeline into `main` so it can be used to create the `rust\prepare-pipelines` pipeline that can be invoked via `/azp run prepare-pipelines` to create a pipeline for a given service. 