### PR TITLE
Sanitize query parameters in url.full telemetry

### DIFF
--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Other Changes
 
+- The `url.full` span attribute in distributed traces now has query parameter values sanitized. Only parameters in `LoggingOptions::additional_allowed_query_params` and the default allow list (e.g., `api-version`) retain their values; all others are replaced with `REDACTED`.
+
 ## 0.33.0 (2026-03-05)
 
 ### Features Added

--- a/sdk/core/azure_core/src/http/options/instrumentation.rs
+++ b/sdk/core/azure_core/src/http/options/instrumentation.rs
@@ -4,6 +4,13 @@
 use std::sync::Arc;
 
 /// Policy options to enable distributed tracing.
+///
+/// # Notes
+///
+/// [`LoggingOptions::additional_allowed_query_params`](super::LoggingOptions::additional_allowed_query_params)
+/// is used to sanitize query parameters in traced URLs as well.
+/// Query parameters not in the default or additional allow list will have their values
+/// replaced with `REDACTED` in the `url.full` span attribute.
 #[derive(Clone, Debug, Default)]
 pub struct InstrumentationOptions {
     /// Set the tracer provider for distributed tracing.

--- a/sdk/core/azure_core/src/http/options/mod.rs
+++ b/sdk/core/azure_core/src/http/options/mod.rs
@@ -5,8 +5,8 @@ mod instrumentation;
 mod user_agent;
 
 pub use instrumentation::*;
-use std::sync::Arc;
-use typespec_client_core::http::policies::Policy;
+use std::{borrow::Cow, collections::HashSet, sync::Arc};
+use typespec_client_core::http::{policies::Policy, DEFAULT_ALLOWED_QUERY_PARAMETERS};
 pub use typespec_client_core::http::{
     ClientMethodOptions, ExponentialRetryOptions, FixedRetryOptions, LoggingOptions,
     PipelineOptions, RetryOptions, Transport,
@@ -51,6 +51,7 @@ pub struct ClientOptions {
 pub(crate) struct CoreClientOptions {
     pub(crate) user_agent: UserAgentOptions,
     pub(crate) instrumentation: InstrumentationOptions,
+    pub(crate) allowed_query_params: HashSet<Cow<'static, str>>,
 }
 
 impl ClientOptions {
@@ -60,6 +61,12 @@ impl ClientOptions {
     pub(in crate::http) fn deconstruct(
         self,
     ) -> (CoreClientOptions, typespec_client_core::http::ClientOptions) {
+        // Merge the default allowed query parameters with any additional ones from logging options.
+        // This merged set is shared by both the logging policy and the request instrumentation policy
+        // to sanitize query parameters in logs and traced URLs.
+        let mut allowed_query_params = (*DEFAULT_ALLOWED_QUERY_PARAMETERS).clone();
+        allowed_query_params.extend(self.logging.additional_allowed_query_params.iter().cloned());
+
         let options = typespec_client_core::http::ClientOptions {
             per_call_policies: self.per_call_policies,
             per_try_policies: self.per_try_policies,
@@ -72,6 +79,7 @@ impl ClientOptions {
             CoreClientOptions {
                 user_agent: self.user_agent,
                 instrumentation: self.instrumentation,
+                allowed_query_params,
             },
             options,
         )

--- a/sdk/core/azure_core/src/http/pipeline.rs
+++ b/sdk/core/azure_core/src/http/pipeline.rs
@@ -165,8 +165,10 @@ impl Pipeline {
 
         let mut per_try_policies = per_try_policies.clone();
         if let Some(ref tracer) = tracer {
-            let request_instrumentation_policy =
-                RequestInstrumentationPolicy::new(Some(tracer.clone()));
+            let request_instrumentation_policy = RequestInstrumentationPolicy::new(
+                Some(tracer.clone()),
+                core_client_options.allowed_query_params.clone(),
+            );
             push_unique(&mut per_try_policies, request_instrumentation_policy);
         }
 

--- a/sdk/core/azure_core/src/http/policies/instrumentation/public_api_instrumentation.rs
+++ b/sdk/core/azure_core/src/http/policies/instrumentation/public_api_instrumentation.rs
@@ -246,6 +246,7 @@ mod tests {
     };
     use futures::future::BoxFuture;
     use std::sync::Arc;
+    use typespec_client_core::http::DEFAULT_ALLOWED_QUERY_PARAMETERS;
 
     // Test just the public API instrumentation policy without request instrumentation.
     async fn run_public_api_instrumentation_test<C>(
@@ -320,8 +321,10 @@ mod tests {
         let transport =
             TransportPolicy::new(Transport::new(Arc::new(MockHttpClient::new(callback))));
 
-        let request_instrumentation_policy =
-            RequestInstrumentationPolicy::new(Some(mock_tracer.clone()));
+        let request_instrumentation_policy = RequestInstrumentationPolicy::new(
+            Some(mock_tracer.clone()),
+            (*DEFAULT_ALLOWED_QUERY_PARAMETERS).clone(),
+        );
 
         let next: Vec<Arc<dyn Policy>> = vec![
             Arc::new(request_instrumentation_policy),

--- a/sdk/core/azure_core/src/http/policies/instrumentation/request_instrumentation.rs
+++ b/sdk/core/azure_core/src/http/policies/instrumentation/request_instrumentation.rs
@@ -11,9 +11,12 @@ use crate::{
     http::{headers, Context, Request},
     tracing::{Span, SpanKind},
 };
-use std::sync::Arc;
+use std::{borrow::Cow, collections::HashSet, sync::Arc};
 use typespec_client_core::{
-    http::policies::{Policy, PolicyResult, RetryPolicyCount},
+    http::{
+        policies::{Policy, PolicyResult, RetryPolicyCount},
+        Sanitizer,
+    },
     tracing::Attribute,
 };
 
@@ -21,24 +24,35 @@ use typespec_client_core::{
 #[derive(Clone, Debug)]
 pub(crate) struct RequestInstrumentationPolicy {
     tracer: Option<Arc<dyn crate::tracing::Tracer>>,
+    allowed_query_params: HashSet<Cow<'static, str>>,
 }
 
 impl RequestInstrumentationPolicy {
     /// Creates a new `RequestInstrumentationPolicy`.
     ///
     /// # Arguments
+    ///
     /// - `tracer`: Pre-configured tracer to use for instrumentation.
+    /// - `allowed_query_params`: Set of query parameter names whose values are safe to include
+    ///   in the `url.full` span attribute. All other query parameter values will be redacted.
     ///
     /// # Returns
+    ///
     /// A new instance of `RequestInstrumentationPolicy`.
     ///
-    /// # Note
+    /// # Notes
     ///
     /// The tracer provided is a "fallback" tracer which is used if the `ctx` parameter
     /// to the `send` method does not contain a tracer.
     ///
-    pub fn new(tracer: Option<Arc<dyn crate::tracing::Tracer>>) -> Self {
-        Self { tracer }
+    pub fn new(
+        tracer: Option<Arc<dyn crate::tracing::Tracer>>,
+        allowed_query_params: HashSet<Cow<'static, str>>,
+    ) -> Self {
+        Self {
+            tracer,
+            allowed_query_params,
+        }
     }
 }
 
@@ -85,7 +99,7 @@ impl Policy for RequestInstrumentationPolicy {
         if request.url().username().is_empty() && request.url().password().is_none() {
             span_attributes.push(Attribute {
                 key: URL_FULL_ATTRIBUTE.into(),
-                value: request.url().into(),
+                value: request.url().sanitize(&self.allowed_query_params).into(),
             });
         }
 
@@ -200,11 +214,34 @@ pub(crate) mod tests {
         atomic::{AtomicBool, Ordering},
         Arc,
     };
+    use typespec_client_core::http::DEFAULT_ALLOWED_QUERY_PARAMETERS;
 
     async fn run_instrumentation_test<C>(
         test_namespace: Option<&'static str>,
         crate_name: Option<&'static str>,
         version: Option<&'static str>,
+        request: &mut Request,
+        callback: C,
+    ) -> Arc<MockTracingProvider>
+    where
+        C: FnMut(&Request) -> BoxFuture<'_, Result<AsyncRawResponse>> + Send + Sync + 'static,
+    {
+        run_instrumentation_test_with_allowed_query_params(
+            test_namespace,
+            crate_name,
+            version,
+            (*DEFAULT_ALLOWED_QUERY_PARAMETERS).clone(),
+            request,
+            callback,
+        )
+        .await
+    }
+
+    async fn run_instrumentation_test_with_allowed_query_params<C>(
+        test_namespace: Option<&'static str>,
+        crate_name: Option<&'static str>,
+        version: Option<&'static str>,
+        allowed_query_params: HashSet<Cow<'static, str>>,
         request: &mut Request,
         callback: C,
     ) -> Arc<MockTracingProvider>
@@ -217,7 +254,10 @@ pub(crate) mod tests {
             crate_name.unwrap_or("unknown"),
             version,
         );
-        let policy = Arc::new(RequestInstrumentationPolicy::new(Some(tracer.clone())));
+        let policy = Arc::new(RequestInstrumentationPolicy::new(
+            Some(tracer.clone()),
+            allowed_query_params,
+        ));
 
         let transport =
             TransportPolicy::new(Transport::new(Arc::new(MockHttpClient::new(callback))));
@@ -250,8 +290,10 @@ pub(crate) mod tests {
             crate_name.unwrap_or("unknown"),
             version,
         );
-        let instrumentation_policy =
-            Arc::new(RequestInstrumentationPolicy::new(Some(tracer.clone()))) as Arc<dyn Policy>;
+        let instrumentation_policy = Arc::new(RequestInstrumentationPolicy::new(
+            Some(tracer.clone()),
+            (*DEFAULT_ALLOWED_QUERY_PARAMETERS).clone(),
+        )) as Arc<dyn Policy>;
 
         let transport =
             TransportPolicy::new(Transport::new(Arc::new(MockHttpClient::new(callback))));
@@ -322,9 +364,11 @@ pub(crate) mod tests {
                         (SERVER_PORT_ATTRIBUTE, AttributeValue::from(80)),
                         (
                             URL_FULL_ATTRIBUTE,
-                            AttributeValue::from(
-                                "http://example.com/path?query=value&api-version=2024-01-01",
-                            ),
+                            AttributeValue::from(if cfg!(feature = "debug") {
+                                "http://example.com/path?query=value&api-version=2024-01-01"
+                            } else {
+                                "http://example.com/path?query=REDACTED&api-version=2024-01-01"
+                            }),
                         ),
                     ],
                     ..Default::default()
@@ -419,9 +463,11 @@ pub(crate) mod tests {
                         (SERVER_PORT_ATTRIBUTE, AttributeValue::from(80)),
                         (
                             URL_FULL_ATTRIBUTE,
-                            AttributeValue::from(
-                                "http://example.com/path?query=value&api-version=2024-01-01",
-                            ),
+                            AttributeValue::from(if cfg!(feature = "debug") {
+                                "http://example.com/path?query=value&api-version=2024-01-01"
+                            } else {
+                                "http://example.com/path?query=REDACTED&api-version=2024-01-01"
+                            }),
                         ),
                     ],
                     ..Default::default()
@@ -432,19 +478,24 @@ pub(crate) mod tests {
 
     #[test]
     fn test_request_instrumentation_policy_creation() {
-        let policy = RequestInstrumentationPolicy::new(None);
+        let policy =
+            RequestInstrumentationPolicy::new(None, (*DEFAULT_ALLOWED_QUERY_PARAMETERS).clone());
         assert!(policy.tracer.is_none());
 
         let mock_tracer_provider = Arc::new(MockTracingProvider::new());
         let tracer =
             mock_tracer_provider.get_tracer(Some("test namespace"), "test_crate", Some("1.0.0"));
-        let policy_with_tracer = RequestInstrumentationPolicy::new(Some(tracer));
+        let policy_with_tracer = RequestInstrumentationPolicy::new(
+            Some(tracer),
+            (*DEFAULT_ALLOWED_QUERY_PARAMETERS).clone(),
+        );
         assert!(policy_with_tracer.tracer.is_some());
     }
 
     #[test]
     fn test_request_instrumentation_policy_without_tracer() {
-        let policy = RequestInstrumentationPolicy::new(None);
+        let policy =
+            RequestInstrumentationPolicy::new(None, (*DEFAULT_ALLOWED_QUERY_PARAMETERS).clone());
         assert!(policy.tracer.is_none());
     }
 
@@ -624,6 +675,130 @@ pub(crate) mod tests {
                         (
                             URL_FULL_ATTRIBUTE,
                             AttributeValue::from("https://microsoft.com/request_failed.htm"),
+                        ),
+                    ],
+                    ..Default::default()
+                }],
+            }],
+        );
+    }
+
+    #[tokio::test]
+    async fn url_sanitized_with_custom_allowed_query_params() {
+        let url = "http://example.com/path?query=value&api-version=2024-01-01&sig=secret";
+        let mut request = Request::new(url.parse().unwrap(), Method::Get);
+
+        let mut allowed = (*DEFAULT_ALLOWED_QUERY_PARAMETERS).clone();
+        allowed.insert(Cow::Borrowed("query"));
+
+        let mock_tracer = run_instrumentation_test_with_allowed_query_params(
+            Some("test namespace"),
+            Some("test_crate"),
+            Some("1.0.0"),
+            allowed,
+            &mut request,
+            |_req| {
+                Box::pin(async move {
+                    Ok(AsyncRawResponse::from_bytes(
+                        StatusCode::Ok,
+                        Headers::new(),
+                        vec![],
+                    ))
+                })
+            },
+        )
+        .await;
+
+        check_instrumentation_result(
+            mock_tracer,
+            vec![ExpectedTracerInformation {
+                namespace: Some("test namespace"),
+                name: "test_crate",
+                version: Some("1.0.0"),
+                spans: vec![ExpectedSpanInformation {
+                    span_name: "GET",
+                    status: SpanStatus::Unset,
+                    kind: SpanKind::Client,
+                    span_id: Uuid::new_v4(),
+                    parent_id: None,
+                    attributes: vec![
+                        (
+                            AZ_NAMESPACE_ATTRIBUTE,
+                            AttributeValue::from("test namespace"),
+                        ),
+                        (
+                            HTTP_RESPONSE_STATUS_CODE_ATTRIBUTE,
+                            AttributeValue::from(200),
+                        ),
+                        (HTTP_REQUEST_METHOD_ATTRIBUTE, AttributeValue::from("GET")),
+                        (
+                            SERVER_ADDRESS_ATTRIBUTE,
+                            AttributeValue::from("example.com"),
+                        ),
+                        (SERVER_PORT_ATTRIBUTE, AttributeValue::from(80)),
+                        (
+                            URL_FULL_ATTRIBUTE,
+                            AttributeValue::from(if cfg!(feature = "debug") {
+                                "http://example.com/path?query=value&api-version=2024-01-01&sig=secret"
+                            } else {
+                                "http://example.com/path?query=value&api-version=2024-01-01&sig=REDACTED"
+                            }),
+                        ),
+                    ],
+                    ..Default::default()
+                }],
+            }],
+        );
+    }
+
+    #[tokio::test]
+    async fn url_without_query_params_unchanged() {
+        let url = "https://example.com/path";
+        let mut request = Request::new(url.parse().unwrap(), Method::Get);
+
+        let mock_tracer = run_instrumentation_test(
+            None,
+            Some("test_crate"),
+            Some("1.0.0"),
+            &mut request,
+            |_req| {
+                Box::pin(async move {
+                    Ok(AsyncRawResponse::from_bytes(
+                        StatusCode::Ok,
+                        Headers::new(),
+                        vec![],
+                    ))
+                })
+            },
+        )
+        .await;
+
+        check_instrumentation_result(
+            mock_tracer,
+            vec![ExpectedTracerInformation {
+                namespace: None,
+                name: "test_crate",
+                version: Some("1.0.0"),
+                spans: vec![ExpectedSpanInformation {
+                    span_name: "GET",
+                    status: SpanStatus::Unset,
+                    kind: SpanKind::Client,
+                    span_id: Uuid::new_v4(),
+                    parent_id: None,
+                    attributes: vec![
+                        (
+                            HTTP_RESPONSE_STATUS_CODE_ATTRIBUTE,
+                            AttributeValue::from(200),
+                        ),
+                        (HTTP_REQUEST_METHOD_ATTRIBUTE, AttributeValue::from("GET")),
+                        (
+                            SERVER_ADDRESS_ATTRIBUTE,
+                            AttributeValue::from("example.com"),
+                        ),
+                        (SERVER_PORT_ATTRIBUTE, AttributeValue::from(443)),
+                        (
+                            URL_FULL_ATTRIBUTE,
+                            AttributeValue::from("https://example.com/path"),
                         ),
                     ],
                     ..Default::default()


### PR DESCRIPTION
Uses `LoggingOptions::additional_allowed_query_params`.
