### PR TITLE
[Storage] Replace body input type for managed upload

### DIFF
--- a/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/src/checkpoint_store.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/src/checkpoint_store.rs
@@ -20,7 +20,7 @@ use azure_storage_blob::{
         BlobClientSetMetadataOptions, BlobContainerClientListBlobsOptions,
         BlockBlobClientUploadOptions, ListBlobsIncludeItem,
     },
-    BlobContainerClient, StorageUploadBody,
+    BlobContainerClient,
 };
 use futures::TryStreamExt;
 use std::{collections::HashMap, sync::Arc};

--- a/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/src/checkpoint_store.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/src/checkpoint_store.rs
@@ -6,10 +6,10 @@
 use azure_core::{
     http::{
         headers::{ETAG, LAST_MODIFIED},
-        Etag, NoFormat, RequestContent, StatusCode,
+        Etag, StatusCode,
     },
     time::parse_rfc7231,
-    Bytes, Result,
+    Result,
 };
 use azure_messaging_eventhubs::{
     models::{Checkpoint, Ownership},
@@ -20,7 +20,7 @@ use azure_storage_blob::{
         BlobClientSetMetadataOptions, BlobContainerClientListBlobsOptions,
         BlockBlobClientUploadOptions, ListBlobsIncludeItem,
     },
-    BlobContainerClient,
+    BlobContainerClient, StorageUploadBody,
 };
 use futures::TryStreamExt;
 use std::{collections::HashMap, sync::Arc};
@@ -79,7 +79,7 @@ impl BlobCheckpointStore {
             Err(e) => match e.http_status() {
                 Some(StatusCode::NotFound) => {
                     info!("Blob {blob_name} not found, creating.");
-                    let blob_content = RequestContent::<Bytes, NoFormat>::from(Vec::new());
+                    let blob_content = Vec::new().into();
                     let options = BlockBlobClientUploadOptions {
                         metadata: Some(metadata),
                         ..Default::default()
@@ -124,7 +124,7 @@ impl BlobCheckpointStore {
         }
         debug!("Claiming ownership for {} without etag", blob_name);
 
-        let blob_content = RequestContent::<Bytes, NoFormat>::from(Vec::new());
+        let blob_content = Vec::new().into();
         let options = BlockBlobClientUploadOptions {
             metadata: metadata.clone(),
             if_none_match: Some(Etag::from("*")), // Upload without an etag, creating a new blob

--- a/sdk/storage/azure_storage_blob/README.md
+++ b/sdk/storage/azure_storage_blob/README.md
@@ -105,8 +105,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let data = b"hello world";
     blob_client
         .upload(
-            RequestContent::from(data.to_vec()), // Data
-            None,                                // Upload Options
+            data.to_vec().into(),   // Data
+            None,                   // Upload Options
         )
         .await?;
     Ok(())

--- a/sdk/storage/azure_storage_blob/examples/blob_storage_logging.rs
+++ b/sdk/storage/azure_storage_blob/examples/blob_storage_logging.rs
@@ -48,7 +48,7 @@
 //! ```
 
 use azure_core::{
-    http::{ClientOptions, InstrumentationOptions, RequestContent},
+    http::{ClientOptions, InstrumentationOptions},
     tracing::TracerProvider,
 };
 use azure_core_opentelemetry::OpenTelemetryTracerProvider;
@@ -139,9 +139,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Upload the file
     println!("\nUploading blob '{}'...", blob_name);
-    blob_client
-        .upload(RequestContent::from(content.to_vec()), None)
-        .await?;
+    blob_client.upload(content.to_vec().into(), None).await?;
     println!("Blob uploaded successfully");
 
     // Download the file

--- a/sdk/storage/azure_storage_blob/examples/blob_storage_roundtrip.rs
+++ b/sdk/storage/azure_storage_blob/examples/blob_storage_roundtrip.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! This example demonstrates uploading data from an arbitrary `AsyncRead`, in this case an Azure
+//! Storage download stream.
+//!
+//! Please note that the recommended mechanism to copy data from a web resource to Azure Blob
+//! Storage is to use [`BlockBlobClient::stage_block_from_url`]. This example just demonstrates
+//! library functionality when working with existing network input.
+//!
+//! # Prerequisites
+//!
+//! - Authenticate using Azure CLI: `az login`
+//!
+//! # Usage
+//!
+//! ```bash
+//! az login
+//! cargo run --package azure_storage_blob --example blob_storage_upload_file -- \
+//!     <ACCOUNT_NAME> \
+//!     <CONTAINER_NAME> \
+//!     <SOURCE_BLOB_NAME> \
+//!     <DESTINATION_BLOB_NAME>
+//! ```
+//!
+//! The `<ACCOUNT_NAME>` flag can also be provided via the `AZURE_STORAGE_ACCOUNT_NAME`
+//! environment variable.
+
+use azure_identity::AzureCliCredential;
+use azure_storage_blob::{AsyncReadLenExt, BlobContainerClient, StorageUploadBody};
+use clap::Parser;
+use futures::TryStreamExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    let endpoint = format!("https://{}.blob.core.windows.net", args.account_name);
+    let credential = AzureCliCredential::new(None)?;
+    let container =
+        BlobContainerClient::new(&endpoint, &args.container_name, Some(credential), None)?;
+
+    let data = "Hello, World!".as_bytes().to_vec();
+
+    // Setup some sample data to work with
+    container
+        .blob_client(&args.src_blob_name)
+        .upload(data.clone().into(), None)
+        .await?;
+
+    // Clients for this transfer
+    let src_blob = container.blob_client(&args.src_blob_name);
+    let dst_blob = container.blob_client(&args.dst_blob_name);
+
+    // Obtain the download stream
+    let download_stream = src_blob
+        .download(None)
+        .await?
+        .body
+        .map_err(std::io::Error::other)
+        .into_async_read();
+
+    // Upload the contents of the download stream
+    dst_blob
+        .upload(
+            StorageUploadBody::AsyncRead(Box::new(
+                download_stream.with_len_hint(Some(data.len() as u64)),
+            )),
+            None,
+        )
+        .await?;
+
+    assert_eq!(
+        src_blob.download(None).await?.body.collect().await?,
+        dst_blob.download(None).await?.body.collect().await?,
+    );
+
+    Ok(())
+}
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Azure Storage account name.
+    ///
+    /// Can also be set via the `AZURE_STORAGE_ACCOUNT_NAME` environment variable.
+    #[arg(env = "AZURE_STORAGE_ACCOUNT_NAME")]
+    account_name: String,
+
+    /// Blob container name.
+    container_name: String,
+
+    /// Source blob name.
+    src_blob_name: String,
+
+    /// Destination blob name.
+    dst_blob_name: String,
+}

--- a/sdk/storage/azure_storage_blob/examples/blob_storage_upload_file.rs
+++ b/sdk/storage/azure_storage_blob/examples/blob_storage_upload_file.rs
@@ -31,7 +31,10 @@
 
 use azure_core::{http::Body, stream::DEFAULT_BUFFER_SIZE};
 use azure_identity::AzureCliCredential;
-use azure_storage_blob::{models::BlobClientUploadOptions, stream::tokio::FileStream, BlobClient};
+use azure_storage_blob::{
+    models::BlobClientUploadOptions, stream::tokio::FileStream, AsyncReadWithLenHint, BlobClient,
+    StorageUploadBody,
+};
 use clap::Parser;
 use std::{num::NonZero, path::PathBuf};
 
@@ -51,7 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let file_size = std::fs::metadata(&args.file_path)?.len();
 
-    let body: Body = if file_size <= DEFAULT_BUFFER_SIZE as u64 {
+    let body: StorageUploadBody = if file_size <= DEFAULT_BUFFER_SIZE as u64 {
         // Small file: read entirely into memory.
         let bytes = std::fs::read(&args.file_path)?;
         println!("Uploading {} bytes from memory...", bytes.len());
@@ -63,7 +66,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         if let Some(buffer_size) = args.buffer_size {
             builder = builder.with_buffer_size(buffer_size);
         }
-        let stream = builder.build().await?;
+        let stream: Box<dyn AsyncReadWithLenHint> = Box::new(builder.build().await?);
         println!("Streaming {} bytes from disk...", file_size);
         stream.into()
     };
@@ -77,7 +80,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         None
     };
-    client.upload(body.into(), options).await?;
+    client.upload(body, options).await?;
     println!(
         "Uploaded {} bytes from {}",
         file_size,

--- a/sdk/storage/azure_storage_blob/examples/blob_storage_upload_file.rs
+++ b/sdk/storage/azure_storage_blob/examples/blob_storage_upload_file.rs
@@ -29,7 +29,7 @@
 //! The `<ACCOUNT_NAME>` flag can also be provided via the `AZURE_STORAGE_ACCOUNT_NAME`
 //! environment variable.
 
-use azure_core::{http::Body, stream::DEFAULT_BUFFER_SIZE};
+use azure_core::stream::DEFAULT_BUFFER_SIZE;
 use azure_identity::AzureCliCredential;
 use azure_storage_blob::{
     models::BlobClientUploadOptions, stream::tokio::FileStream, AsyncReadWithLenHint, BlobClient,

--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -4,8 +4,9 @@
 pub use crate::generated::clients::{BlobClient, BlobClientOptions};
 
 use crate::{
-    generated::clients::BlobClient as GeneratedBlobClient,
-    generated::models::BlobClientDownloadInternalOptions,
+    generated::{
+        clients::BlobClient as GeneratedBlobClient, models::BlobClientDownloadInternalOptions,
+    },
     logging::apply_storage_logging_defaults,
     models::{
         http_ranges::IntoRangeHeader, BlobClientDownloadOptions, BlobClientDownloadResult,
@@ -13,7 +14,7 @@ use crate::{
     },
     partitioned_transfer::{self, PartitionedDownloadBehavior},
     pipeline::StorageHeadersPolicy,
-    AppendBlobClient, BlockBlobClient, PageBlobClient,
+    AppendBlobClient, BlockBlobClient, PageBlobClient, StorageUploadBody,
 };
 use async_trait::async_trait;
 use azure_core::{
@@ -21,10 +22,9 @@ use azure_core::{
     error::ErrorKind,
     http::{
         policies::{auth::BearerTokenAuthorizationPolicy, Policy},
-        AsyncRawResponse, ClientMethodOptions, NoFormat, Pipeline, RequestContent, StatusCode, Url,
-        UrlExt,
+        AsyncRawResponse, ClientMethodOptions, Pipeline, StatusCode, Url, UrlExt,
     },
-    tracing, Bytes, Result,
+    tracing, Result,
 };
 use std::{num::NonZero, ops::Range, sync::Arc};
 
@@ -321,7 +321,7 @@ impl BlobClient {
     /// * `options` - Optional parameters for the request.
     pub async fn upload(
         &self,
-        content: RequestContent<Bytes, NoFormat>,
+        content: StorageUploadBody,
         options: Option<BlobClientUploadOptions<'_>>,
     ) -> Result<BlobClientUploadResult> {
         self.block_blob_client().upload(content, options).await

--- a/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
@@ -15,15 +15,16 @@ use crate::{
     },
     partitioned_transfer::{self, PartitionedUploadBehavior},
     pipeline::StorageHeadersPolicy,
+    StorageUploadBody,
 };
 use async_trait::async_trait;
 use azure_core::{
     credentials::TokenCredential,
     http::{
         policies::{auth::BearerTokenAuthorizationPolicy, Policy},
-        Body, NoFormat, Pipeline, RequestContent, Url,
+        Body, Pipeline, Url,
     },
-    tracing, Bytes, Result, Uuid,
+    tracing, Result, Uuid,
 };
 use futures::lock::Mutex;
 use std::{num::NonZero, sync::Arc};
@@ -129,7 +130,7 @@ impl BlockBlobClient {
     #[tracing::function("Storage.Blob.BlockBlob.upload")]
     pub async fn upload(
         &self,
-        content: RequestContent<Bytes, NoFormat>,
+        content: StorageUploadBody,
         options: Option<BlockBlobClientUploadOptions<'_>>,
     ) -> Result<BlockBlobClientUploadResult> {
         let options = options.unwrap_or_default();
@@ -213,7 +214,7 @@ impl BlockBlobClient {
             stage_block_options,
             commit_block_list_options,
         );
-        partitioned_transfer::upload(content.into(), parallel, partition_size, &behavior).await?;
+        partitioned_transfer::upload(content, parallel, partition_size, &behavior).await?;
         behavior.result.into_inner().ok_or_else(|| {
             azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,

--- a/sdk/storage/azure_storage_blob/src/lib.rs
+++ b/sdk/storage/azure_storage_blob/src/lib.rs
@@ -19,5 +19,6 @@ pub use clients::*;
 pub use parsers::*;
 mod logging;
 pub mod models;
+pub use models::content_adapters::*;
 pub use models::error;
 pub use models::error::{Result, StorageError};

--- a/sdk/storage/azure_storage_blob/src/models/content_adapters.rs
+++ b/sdk/storage/azure_storage_blob/src/models/content_adapters.rs
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+use std::future::Future;
+
 use azure_core::stream::SeekableStream;
 use bytes::Bytes;
-use futures::AsyncRead;
+use futures::{AsyncRead, AsyncReadExt};
 
 pub enum StorageUploadBody {
     Bytes(Bytes),
@@ -63,13 +65,15 @@ struct AsyncReadLenHintWrapper<T> {
     pub async_read: T,
     pub len_hint: Option<u64>,
 }
-impl<T: AsyncRead> AsyncRead for AsyncReadLenHintWrapper<T> {
+impl<T: AsyncRead + Unpin> AsyncRead for AsyncReadLenHintWrapper<T> {
     fn poll_read(
-        self: std::pin::Pin<&mut Self>,
-        _cx: &mut std::task::Context<'_>,
-        _buf: &mut [u8],
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
     ) -> std::task::Poll<std::io::Result<usize>> {
-        todo!()
+        let fut = self.async_read.read(buf);
+        futures::pin_mut!(fut);
+        fut.poll(cx)
     }
 }
 impl<T: AsyncRead + Send + Sync + Unpin> AsyncReadWithLenHint for AsyncReadLenHintWrapper<T> {
@@ -78,11 +82,11 @@ impl<T: AsyncRead + Send + Sync + Unpin> AsyncReadWithLenHint for AsyncReadLenHi
     }
 }
 
-pub trait AsyncReadExt {
+pub trait AsyncReadLenExt {
     fn with_len_hint(self, len_hint: Option<u64>) -> impl AsyncReadWithLenHint;
 }
 
-impl<T> AsyncReadExt for T
+impl<T> AsyncReadLenExt for T
 where
     T: AsyncRead + Send + Sync + Unpin,
 {

--- a/sdk/storage/azure_storage_blob/src/models/content_adapters.rs
+++ b/sdk/storage/azure_storage_blob/src/models/content_adapters.rs
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 
 use azure_core::stream::SeekableStream;
+use bytes::Bytes;
 use futures::AsyncRead;
 
 pub enum StorageUploadBody {
-    Bytes(bytes::Bytes),
+    Bytes(Bytes),
     AsyncRead(Box<dyn AsyncReadWithLenHint>),
 }
 
@@ -18,6 +19,30 @@ impl StorageUploadBody {
     }
     pub fn is_empty(&self) -> Option<bool> {
         self.len().map(|len| len == 0)
+    }
+}
+
+impl<B> From<B> for StorageUploadBody
+where
+    B: Into<Bytes>,
+{
+    fn from(bytes: B) -> Self {
+        Self::Bytes(bytes.into())
+    }
+}
+
+impl From<&StorageUploadBody> for Bytes {
+    fn from(value: &StorageUploadBody) -> Self {
+        match value {
+            StorageUploadBody::Bytes(bytes) => bytes.clone(),
+            StorageUploadBody::AsyncRead(_) => unimplemented!(),
+        }
+    }
+}
+
+impl From<Box<dyn AsyncReadWithLenHint>> for StorageUploadBody {
+    fn from(async_read: Box<dyn AsyncReadWithLenHint>) -> Self {
+        Self::AsyncRead(async_read)
     }
 }
 

--- a/sdk/storage/azure_storage_blob/src/models/content_adapters.rs
+++ b/sdk/storage/azure_storage_blob/src/models/content_adapters.rs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use azure_core::stream::SeekableStream;
+use futures::AsyncRead;
+
+pub enum StorageUploadBody {
+    Bytes(bytes::Bytes),
+    AsyncRead(Box<dyn AsyncReadWithLenHint>),
+}
+
+impl StorageUploadBody {
+    pub fn len(&self) -> Option<u64> {
+        match self {
+            Self::Bytes(bytes) => Some(bytes.len() as u64),
+            Self::AsyncRead(read) => read.len(),
+        }
+    }
+    pub fn is_empty(&self) -> Option<bool> {
+        self.len().map(|len| len == 0)
+    }
+}
+
+pub trait AsyncReadWithLenHint: AsyncRead + Send + Sync + Unpin {
+    fn len(&self) -> Option<u64>;
+    fn is_empty(&self) -> Option<bool> {
+        self.len().map(|len| len == 0)
+    }
+}
+
+impl<T: SeekableStream> AsyncReadWithLenHint for T {
+    fn len(&self) -> Option<u64> {
+        self.len()
+    }
+}
+
+struct AsyncReadLenHintWrapper<T> {
+    pub async_read: T,
+    pub len_hint: Option<u64>,
+}
+impl<T: AsyncRead> AsyncRead for AsyncReadLenHintWrapper<T> {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        _buf: &mut [u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        todo!()
+    }
+}
+impl<T: AsyncRead + Send + Sync + Unpin> AsyncReadWithLenHint for AsyncReadLenHintWrapper<T> {
+    fn len(&self) -> Option<u64> {
+        self.len_hint
+    }
+}
+
+pub trait AsyncReadExt {
+    fn with_len_hint(self, len_hint: Option<u64>) -> impl AsyncReadWithLenHint;
+}
+
+impl<T> AsyncReadExt for T
+where
+    T: AsyncRead + Send + Sync + Unpin,
+{
+    fn with_len_hint(self, len_hint: Option<u64>) -> impl AsyncReadWithLenHint {
+        AsyncReadLenHintWrapper {
+            async_read: self,
+            len_hint,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use azure_core::stream::SeekableStream;
+
+    /// Sanity check that types do as expected.
+    fn seekable_stream_convert<T>(stream: T) -> StorageUploadBody
+    where
+        T: SeekableStream + 'static,
+    {
+        StorageUploadBody::AsyncRead(Box::new(stream))
+    }
+
+    /// Sanity check that types do as expected.
+    fn async_read_convert<T>(stream: T) -> StorageUploadBody
+    where
+        T: AsyncRead + Clone + std::fmt::Debug + Send + Sync + Unpin + 'static,
+    {
+        StorageUploadBody::AsyncRead(Box::new(stream.with_len_hint(None)))
+    }
+}

--- a/sdk/storage/azure_storage_blob/src/models/content_adapters.rs
+++ b/sdk/storage/azure_storage_blob/src/models/content_adapters.rs
@@ -48,7 +48,7 @@ impl From<Box<dyn AsyncReadWithLenHint>> for StorageUploadBody {
     }
 }
 
-pub trait AsyncReadWithLenHint: AsyncRead + Send + Sync + Unpin {
+pub trait AsyncReadWithLenHint: AsyncRead + Send + Unpin {
     fn len(&self) -> Option<u64>;
     fn is_empty(&self) -> Option<bool> {
         self.len().map(|len| len == 0)
@@ -76,7 +76,7 @@ impl<T: AsyncRead + Unpin> AsyncRead for AsyncReadLenHintWrapper<T> {
         fut.poll(cx)
     }
 }
-impl<T: AsyncRead + Send + Sync + Unpin> AsyncReadWithLenHint for AsyncReadLenHintWrapper<T> {
+impl<T: AsyncRead + Send + Unpin> AsyncReadWithLenHint for AsyncReadLenHintWrapper<T> {
     fn len(&self) -> Option<u64> {
         self.len_hint
     }
@@ -88,7 +88,7 @@ pub trait AsyncReadLenExt {
 
 impl<T> AsyncReadLenExt for T
 where
-    T: AsyncRead + Send + Sync + Unpin,
+    T: AsyncRead + Send + Unpin,
 {
     fn with_len_hint(self, len_hint: Option<u64>) -> impl AsyncReadWithLenHint {
         AsyncReadLenHintWrapper {
@@ -114,7 +114,7 @@ mod tests {
     /// Sanity check that types do as expected.
     fn async_read_convert<T>(stream: T) -> StorageUploadBody
     where
-        T: AsyncRead + Clone + std::fmt::Debug + Send + Sync + Unpin + 'static,
+        T: AsyncRead + Clone + std::fmt::Debug + Send + Unpin + 'static,
     {
         StorageUploadBody::AsyncRead(Box::new(stream.with_len_hint(None)))
     }

--- a/sdk/storage/azure_storage_blob/src/models/mod.rs
+++ b/sdk/storage/azure_storage_blob/src/models/mod.rs
@@ -3,6 +3,7 @@
 
 //! Model types for Azure Blob Storage.
 
+pub(crate) mod content_adapters;
 mod download_result;
 pub(crate) mod drains;
 pub mod error;

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/upload.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/upload.rs
@@ -33,12 +33,12 @@ pub(crate) async fn upload(
     partition_size: NonZero<u64>,
     client: &impl PartitionedUploadBehavior,
 ) -> AzureResult<()> {
-    // if let Some(content_len) = content.len() {
-    //     if content_len <= partition_size.get() {
-    //         client.transfer_oneshot(content).await?;
-    //         return Ok(());
-    //     }
-    // };
+    if let StorageUploadBody::Bytes(bytes) = &content {
+        if bytes.len() as u64 <= partition_size.get() {
+            client.transfer_oneshot(bytes.clone().into()).await?;
+            return Ok(());
+        }
+    };
 
     client.initialize(content.len()).await?;
 
@@ -271,27 +271,27 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn one_shot_stream_when_within_partition_size() -> AzureResult<()> {
-        let data_size: usize = 1024;
-        let partition_size = data_size as u64;
-        let concurrency: usize = 2;
+    // #[tokio::test]
+    // async fn one_shot_stream_when_within_partition_size() -> AzureResult<()> {
+    //     let data_size: usize = 1024;
+    //     let partition_size = data_size as u64;
+    //     let concurrency: usize = 2;
 
-        let mock = MockPartitionedUploadBehavior::new();
-        let src_data = get_random_data(data_size);
+    //     let mock = MockPartitionedUploadBehavior::new();
+    //     let src_data = get_random_data(data_size);
 
-        upload(
-            StorageUploadBody::AsyncRead(Box::new(BytesStream::new(Bytes::from(src_data.clone())))),
-            NonZero::new(concurrency).unwrap(),
-            NonZero::new(partition_size).unwrap(),
-            &mock,
-        )
-        .await?;
+    //     upload(
+    //         StorageUploadBody::AsyncRead(Box::new(BytesStream::new(Bytes::from(src_data.clone())))),
+    //         NonZero::new(concurrency).unwrap(),
+    //         NonZero::new(partition_size).unwrap(),
+    //         &mock,
+    //     )
+    //     .await?;
 
-        assert_upload_oneshot_invocations(&mock, &src_data[..], BodyType::SeekableStream).await;
+    //     assert_upload_oneshot_invocations(&mock, &src_data[..], BodyType::SeekableStream).await;
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 
     #[tokio::test]
     async fn partition_stream_when_over_partition_size() -> AzureResult<()> {

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/upload.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/upload.rs
@@ -5,12 +5,16 @@ use azure_core::http::Body;
 use bytes::Bytes;
 
 use async_trait::async_trait;
-use azure_core::stream::SeekableStream;
 use futures::StreamExt;
 
-use crate::streams::{
-    multi_bytes_stream::MultiBytesStream,
-    partitioned_stream::{self, stream_multi_buffer_partitions, stream_single_buffer_partitions},
+use crate::{
+    streams::{
+        multi_bytes_stream::MultiBytesStream,
+        partitioned_stream::{
+            self, stream_multi_buffer_partitions, stream_single_buffer_partitions,
+        },
+    },
+    AsyncReadWithLenHint, StorageUploadBody,
 };
 
 use super::*;
@@ -24,26 +28,26 @@ pub(crate) trait PartitionedUploadBehavior {
 }
 
 pub(crate) async fn upload(
-    content: Body,
+    content: StorageUploadBody,
     parallel: NonZero<usize>,
     partition_size: NonZero<u64>,
     client: &impl PartitionedUploadBehavior,
 ) -> AzureResult<()> {
-    if let Some(content_len) = content.len() {
-        if content_len <= partition_size.get() {
-            client.transfer_oneshot(content).await?;
-            return Ok(());
-        }
-    };
+    // if let Some(content_len) = content.len() {
+    //     if content_len <= partition_size.get() {
+    //         client.transfer_oneshot(content).await?;
+    //         return Ok(());
+    //     }
+    // };
 
     client.initialize(content.len()).await?;
 
     match content {
-        Body::Bytes(bytes) => {
+        StorageUploadBody::Bytes(bytes) => {
             upload_bytes_partitions(bytes, parallel, partition_size, client).await?;
         }
-        Body::SeekableStream(seekable_stream) => {
-            upload_stream_partitions(seekable_stream, parallel, partition_size, client).await?;
+        StorageUploadBody::AsyncRead(async_read) => {
+            upload_stream_partitions(async_read, parallel, partition_size, client).await?;
         }
     }
 
@@ -71,7 +75,7 @@ async fn upload_bytes_partitions(
 }
 
 async fn upload_stream_partitions(
-    content: Box<dyn SeekableStream>,
+    content: Box<dyn AsyncReadWithLenHint>,
     parallel: NonZero<usize>,
     partition_size: NonZero<u64>,
     client: &impl PartitionedUploadBehavior,
@@ -227,7 +231,7 @@ mod tests {
         let src_data = get_random_data(data_size);
 
         upload(
-            Body::Bytes(Bytes::from(src_data.clone())),
+            StorageUploadBody::Bytes(Bytes::from(src_data.clone())),
             NonZero::new(concurrency).unwrap(),
             NonZero::new(partition_size).unwrap(),
             &mock,
@@ -249,7 +253,7 @@ mod tests {
         let src_data = get_random_data(data_size);
 
         upload(
-            Body::Bytes(Bytes::from(src_data.clone())),
+            StorageUploadBody::Bytes(Bytes::from(src_data.clone())),
             NonZero::new(concurrency).unwrap(),
             NonZero::new(partition_size).unwrap(),
             &mock,
@@ -277,7 +281,7 @@ mod tests {
         let src_data = get_random_data(data_size);
 
         upload(
-            Body::SeekableStream(Box::new(BytesStream::new(Bytes::from(src_data.clone())))),
+            StorageUploadBody::AsyncRead(Box::new(BytesStream::new(Bytes::from(src_data.clone())))),
             NonZero::new(concurrency).unwrap(),
             NonZero::new(partition_size).unwrap(),
             &mock,
@@ -299,7 +303,7 @@ mod tests {
         let src_data = get_random_data(data_size);
 
         upload(
-            Body::SeekableStream(Box::new(BytesStream::new(Bytes::from(src_data.clone())))),
+            StorageUploadBody::AsyncRead(Box::new(BytesStream::new(Bytes::from(src_data.clone())))),
             NonZero::new(concurrency).unwrap(),
             NonZero::new(partition_size).unwrap(),
             &mock,

--- a/sdk/storage/azure_storage_blob/src/streams/partitioned_stream.rs
+++ b/sdk/storage/azure_storage_blob/src/streams/partitioned_stream.rs
@@ -4,9 +4,10 @@
 use async_stream::try_stream;
 use std::{cmp::min, mem, num::NonZero, slice};
 
-use azure_core::stream::SeekableStream;
 use bytes::{BufMut, Bytes, BytesMut};
 use futures::{AsyncReadExt, Stream};
+
+use crate::AsyncReadWithLenHint;
 
 type Result<T> = azure_core::Result<T>;
 
@@ -15,7 +16,7 @@ pub(crate) const MAX_CONTIGUOUS_ELEMENTS: usize = isize::MAX as usize;
 /// Converts the given AsyncRead into a Stream<Item = Bytes>, where each item is a chunk of data
 /// that is exactly `partition_len` bytes. The last item may be smaller.
 pub(crate) fn stream_single_buffer_partitions(
-    mut inner: Box<dyn SeekableStream>,
+    mut inner: Box<dyn AsyncReadWithLenHint>,
     partition_len: NonZero<usize>,
 ) -> impl Stream<Item = Result<Bytes>> {
     let partition_len = partition_len.get();
@@ -143,7 +144,7 @@ const MULTI_BUF_PARTITION_BUF_LEN: usize = 4 * 1024 * 1024;
 /// Converts the given AsyncRead into a Stream<Item = Vec<Bytes>>, where each item is a chunk of
 /// data that is exactly `partition_len` bytes. The last item may be smaller.
 pub(crate) fn stream_multi_buffer_partitions(
-    mut inner: Box<dyn SeekableStream>,
+    mut inner: Box<dyn AsyncReadWithLenHint>,
     partition_len: NonZero<u64>,
 ) -> impl Stream<Item = Result<Vec<Bytes>>> {
     let partition_len = partition_len.get();

--- a/sdk/storage/azure_storage_blob/tests/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client.rs
@@ -120,9 +120,7 @@ async fn test_upload_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     let data = b"hello rusty world";
 
     // No Overwrite Scenario
-    let upload_result = blob_client
-        .upload(RequestContent::from(data.to_vec()), None)
-        .await?;
+    let upload_result = blob_client.upload(data.to_vec().into(), None).await?;
 
     // Assert upload result fields and raw response
     assert!(upload_result.etag.is_some());
@@ -147,7 +145,7 @@ async fn test_upload_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Error Case (overwrite=false/none)
     let response = blob_client
         .upload(
-            RequestContent::from(new_data.to_vec()),
+            new_data.to_vec().into(),
             Some(BlockBlobClientUploadOptions::default().with_if_not_exists()),
         )
         .await;
@@ -158,9 +156,7 @@ async fn test_upload_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     assert_eq!(StatusCode::Conflict, error.unwrap());
 
     // Working Case (overwrite=true)
-    blob_client
-        .upload(RequestContent::from(new_data.to_vec()), None)
-        .await?;
+    blob_client.upload(new_data.to_vec().into(), None).await?;
     let response = blob_client.download(None).await?;
     // Assert
     assert_eq!(29, response.properties.content_length.unwrap());
@@ -232,9 +228,7 @@ async fn test_download_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     let blob_client = container_client.blob_client(&get_blob_name(recording));
     let data = b"hello rusty world";
 
-    blob_client
-        .upload(RequestContent::from(data.to_vec()), None)
-        .await?;
+    blob_client.upload(data.to_vec().into(), None).await?;
     let response = blob_client.download(None).await?;
 
     // Assert
@@ -264,10 +258,7 @@ async fn test_set_blob_metadata(ctx: TestContext) -> Result<(), Box<dyn Error>> 
         ..Default::default()
     };
     blob_client
-        .upload(
-            RequestContent::from(data.to_vec()),
-            Some(options_with_metadata),
-        )
+        .upload(data.to_vec().into(), Some(options_with_metadata))
         .await?;
     // Assert
     let response = blob_client.get_properties(None).await?;
@@ -439,7 +430,7 @@ async fn test_leased_blob_operations(ctx: TestContext) -> Result<(), Box<dyn Err
         ..Default::default()
     };
     blob_client
-        .upload(RequestContent::from(data.to_vec()), Some(upload_options))
+        .upload(data.to_vec().into(), Some(upload_options))
         .await?;
 
     // Assert
@@ -587,7 +578,7 @@ async fn test_encoding_edge_cases(ctx: TestContext) -> Result<(), Box<dyn Error>
 
         // Upload Blob
         blob_client_new
-            .upload(RequestContent::from(b"hello rusty world".to_vec()), None)
+            .upload(b"hello rusty world".to_vec().into(), None)
             .await?;
 
         // Get Properties
@@ -610,7 +601,7 @@ async fn test_encoding_edge_cases(ctx: TestContext) -> Result<(), Box<dyn Error>
 
         // Upload Blob
         blob_client_from_url
-            .upload(RequestContent::from(b"hello rusty world".to_vec()), None)
+            .upload(b"hello rusty world".to_vec().into(), None)
             .await?;
 
         // Get Properties
@@ -622,7 +613,7 @@ async fn test_encoding_edge_cases(ctx: TestContext) -> Result<(), Box<dyn Error>
 
         // Upload Blob
         blob_client_from_cc
-            .upload(RequestContent::from(b"hello rusty world".to_vec()), None)
+            .upload(b"hello rusty world".to_vec().into(), None)
             .await?;
 
         // Get Properties
@@ -857,7 +848,7 @@ async fn test_storage_error_model_additional_info(ctx: TestContext) -> Result<()
     let overwrite_blob_client = container_client.blob_client(&blob_name);
     create_test_blob(
         &overwrite_blob_client,
-        Some(RequestContent::from(b"overruled!".to_vec())),
+        Some(b"overruled!".to_vec().into()),
         None,
     )
     .await?;
@@ -959,9 +950,7 @@ async fn test_managed_download(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     } in test_managed_download_args()
     {
         let data: Vec<u8> = (0..data_len).map(|_| recording.random()).collect();
-        blob_client
-            .upload(RequestContent::from(data.to_vec()), None)
-            .await?;
+        blob_client.upload(data.to_vec().into(), None).await?;
 
         request_count.store(0, Ordering::Relaxed);
         let _scope = count_policy.check_request_scope();
@@ -1017,9 +1006,7 @@ async fn test_download_into(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     } in test_managed_download_args()
     {
         let data: Vec<u8> = (0..data_len).map(|_| recording.random()).collect();
-        blob_client
-            .upload(RequestContent::from(data.to_vec()), None)
-            .await?;
+        blob_client.upload(data.to_vec().into(), None).await?;
 
         request_count.store(0, Ordering::Relaxed);
         let _scope = count_policy.check_request_scope();
@@ -1074,9 +1061,7 @@ async fn test_managed_download_empty(ctx: TestContext) -> Result<(), Box<dyn Err
     .await?;
     let blob_client = container_client.blob_client(&get_blob_name(recording));
 
-    blob_client
-        .upload(RequestContent::from(vec![]), None)
-        .await?;
+    blob_client.upload(vec![].into(), None).await?;
 
     request_count.store(0, Ordering::Relaxed);
     let _scope = count_policy.check_request_scope();
@@ -1110,9 +1095,7 @@ async fn test_download_into_empty(ctx: TestContext) -> Result<(), Box<dyn Error>
     .await?;
     let blob_client = container_client.blob_client(&get_blob_name(recording));
 
-    blob_client
-        .upload(RequestContent::from(vec![]), None)
-        .await?;
+    blob_client.upload(vec![].into(), None).await?;
 
     request_count.store(0, Ordering::Relaxed);
     let _scope = count_policy.check_request_scope();
@@ -1139,7 +1122,7 @@ async fn test_blob_content_headers_roundtrip(ctx: TestContext) -> Result<(), Box
     // here; it is tested as stored metadata via set_properties in test_set_properties_content_headers.
     blob_client
         .upload(
-            RequestContent::from(content.to_vec()),
+            content.to_vec().into(),
             Some(BlockBlobClientUploadOptions {
                 blob_cache_control: Some("no-cache".to_string()),
                 blob_content_disposition: Some("inline".to_string()),
@@ -1186,7 +1169,7 @@ async fn test_blob_content_headers_roundtrip(ctx: TestContext) -> Result<(), Box
     // Overwrite with Different Content Headers - new headers replace old ones
     blob_client
         .upload(
-            RequestContent::from(b"overwrite-content-headers".to_vec()),
+            b"overwrite-content-headers".to_vec().into(),
             Some(BlockBlobClientUploadOptions {
                 blob_cache_control: Some("max-age=3600".to_string()),
                 blob_content_type: Some("image/png".to_string()),
@@ -1215,9 +1198,7 @@ async fn test_set_blob_properties_content_headers(ctx: TestContext) -> Result<()
     let md5: Vec<u8> = (0u8..16).collect();
 
     // Upload with Default Content Headers
-    blob_client
-        .upload(RequestContent::from(content.to_vec()), None)
-        .await?;
+    blob_client.upload(content.to_vec().into(), None).await?;
 
     // Set All Content Headers via Set Properties
     // Note: set_properties does not validate blob_content_md5 against actual content,

--- a/sdk/storage/azure_storage_blob/tests/blob_client_options.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client_options.rs
@@ -30,21 +30,11 @@ async fn test_blob_version_read_operations(ctx: TestContext) -> Result<(), Box<d
 
     // Create Multiple Versions
     let data_v1 = b"version 1 content";
-    create_test_blob(
-        &blob_client,
-        Some(RequestContent::from(data_v1.to_vec())),
-        None,
-    )
-    .await?;
+    create_test_blob(&blob_client, Some(data_v1.to_vec().into()), None).await?;
     let response = blob_client.get_properties(None).await?;
     let version_1 = response.version_id()?.unwrap();
     let data_v2 = b"version 2 content";
-    create_test_blob(
-        &blob_client,
-        Some(RequestContent::from(data_v2.to_vec())),
-        None,
-    )
-    .await?;
+    create_test_blob(&blob_client, Some(data_v2.to_vec().into()), None).await?;
     let response = blob_client.get_properties(None).await?;
     let version_2 = response.version_id()?.unwrap();
 
@@ -100,7 +90,7 @@ async fn test_blob_version_metadata_operations(ctx: TestContext) -> Result<(), B
     };
     create_test_blob(
         &blob_client,
-        Some(RequestContent::from(b"content v1".to_vec())),
+        Some(b"content v1".to_vec().into()),
         Some(upload_options),
     )
     .await?;
@@ -123,12 +113,7 @@ async fn test_blob_version_metadata_operations(ctx: TestContext) -> Result<(), B
     assert_ne!(version_1, version_2);
 
     // Upload New Content (Creates Version 3)
-    create_test_blob(
-        &blob_client,
-        Some(RequestContent::from(b"content v3".to_vec())),
-        None,
-    )
-    .await?;
+    create_test_blob(&blob_client, Some(b"content v3".to_vec().into()), None).await?;
     let response = blob_client.get_properties(None).await?;
     let version_3 = response.version_id()?.unwrap();
     assert_ne!(version_2, version_3);
@@ -180,7 +165,7 @@ async fn test_blob_version_tier_operations(ctx: TestContext) -> Result<(), Box<d
     // Create Version 2
     create_test_blob(
         &blob_client,
-        Some(RequestContent::from(b"version 2 content".to_vec())),
+        Some(b"version 2 content".to_vec().into()),
         None,
     )
     .await?;
@@ -303,25 +288,25 @@ async fn test_blob_version_feature_interactions(ctx: TestContext) -> Result<(), 
     // Create Source Blob with Multiple Versions
     let data_v1 = b"source version 1";
     source_blob_client
-        .upload(RequestContent::from(data_v1.to_vec()), None)
+        .upload(data_v1.to_vec().into(), None)
         .await?;
 
     let data_v2 = b"source version 2";
     source_blob_client
-        .upload(RequestContent::from(data_v2.to_vec()), None)
+        .upload(data_v2.to_vec().into(), None)
         .await?;
 
     // Test: Lease on Current Version
     let lease_blob_name = format!("{}-lease", get_blob_name(recording));
     let lease_blob_client = container_client.blob_client(&lease_blob_name);
     lease_blob_client
-        .upload(RequestContent::from(b"v1".to_vec()), None)
+        .upload(b"v1".to_vec().into(), None)
         .await?;
     let response = lease_blob_client.get_properties(None).await?;
     let lease_version_1 = response.version_id()?.unwrap();
 
     lease_blob_client
-        .upload(RequestContent::from(b"v2".to_vec()), None)
+        .upload(b"v2".to_vec().into(), None)
         .await?;
 
     // Acquire Lease on Current Version
@@ -363,12 +348,7 @@ async fn test_blob_version_immutability_operations(ctx: TestContext) -> Result<(
     create_test_blob(&blob_client, None, None).await?;
     let response = blob_client.get_properties(None).await?;
     let version_1 = response.version_id()?.unwrap();
-    create_test_blob(
-        &blob_client,
-        Some(RequestContent::from(b"version 2".to_vec())),
-        None,
-    )
-    .await?;
+    create_test_blob(&blob_client, Some(b"version 2".to_vec().into()), None).await?;
     let response = blob_client.get_properties(None).await?;
     let version_2 = response.version_id()?.unwrap();
 
@@ -449,7 +429,7 @@ async fn test_blob_version_error_cases(ctx: TestContext) -> Result<(), Box<dyn E
     assert!(error == Some(StatusCode::NotFound));
 
     // Test: Delete Non-Current Version and Verify It's Gone
-    create_test_blob(&blob_client, Some(RequestContent::from(b"v2".into())), None).await?;
+    create_test_blob(&blob_client, Some(b"v2".to_vec().into()), None).await?;
     let version_1_client = blob_client.with_version(&valid_version)?;
     let delete_options = BlobClientDeleteOptions {
         version_id: Some(valid_version.clone()),
@@ -477,12 +457,7 @@ async fn test_blob_snapshot_basic_operations(ctx: TestContext) -> Result<(), Box
     let data_v1 = b"snapshot version 1";
 
     // Create Base Blob
-    create_test_blob(
-        &blob_client,
-        Some(RequestContent::from(data_v1.to_vec())),
-        None,
-    )
-    .await?;
+    create_test_blob(&blob_client, Some(data_v1.to_vec().into()), None).await?;
 
     // Create Snapshot
     let snapshot_response = blob_client.create_snapshot(None).await?;
@@ -504,9 +479,7 @@ async fn test_blob_snapshot_basic_operations(ctx: TestContext) -> Result<(), Box
 
     // Modify Base Blob
     let data_v2 = b"snapshot version 2";
-    blob_client
-        .upload(RequestContent::from(data_v2.to_vec()), None)
-        .await?;
+    blob_client.upload(data_v2.to_vec().into(), None).await?;
 
     // Create Second Snapshot
     let snapshot_response_2 = blob_client.create_snapshot(None).await?;
@@ -553,7 +526,7 @@ async fn test_blob_snapshot_metadata_operations(ctx: TestContext) -> Result<(), 
     };
     create_test_blob(
         &blob_client,
-        Some(RequestContent::from(b"based model".to_vec())),
+        Some(b"based model".to_vec().into()),
         Some(upload_options),
     )
     .await?;
@@ -843,9 +816,7 @@ async fn test_blob_snapshot_error_cases(ctx: TestContext) -> Result<(), Box<dyn 
 
     // Try to Upload to Snapshot
     let data = b"squash data";
-    let result = snapshot_client
-        .upload(RequestContent::from(data.to_vec()), None)
-        .await;
+    let result = snapshot_client.upload(data.to_vec().into(), None).await;
     assert!(result.is_err());
 
     container_client.delete(None).await?;

--- a/sdk/storage/azure_storage_blob/tests/blob_client_snapshot.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client_snapshot.rs
@@ -26,12 +26,7 @@ async fn test_blob_snapshot_basic_operations(ctx: TestContext) -> Result<(), Box
     let data_v1 = b"snapshot version 1";
 
     // Create Base Blob
-    create_test_blob(
-        &blob_client,
-        Some(RequestContent::from(data_v1.to_vec())),
-        None,
-    )
-    .await?;
+    create_test_blob(&blob_client, Some(data_v1.to_vec().into()), None).await?;
 
     // Create Snapshot
     let snapshot_response = blob_client.create_snapshot(None).await?;
@@ -53,9 +48,7 @@ async fn test_blob_snapshot_basic_operations(ctx: TestContext) -> Result<(), Box
 
     // Modify Base Blob
     let data_v2 = b"snapshot version 2";
-    blob_client
-        .upload(RequestContent::from(data_v2.to_vec()), None)
-        .await?;
+    blob_client.upload(data_v2.to_vec().into(), None).await?;
 
     // Create Second Snapshot
     let snapshot_response_2 = blob_client.create_snapshot(None).await?;
@@ -102,7 +95,7 @@ async fn test_blob_snapshot_metadata_operations(ctx: TestContext) -> Result<(), 
     };
     create_test_blob(
         &blob_client,
-        Some(RequestContent::from(b"based model".to_vec())),
+        Some(b"based model".to_vec().into()),
         Some(upload_options),
     )
     .await?;
@@ -392,9 +385,7 @@ async fn test_blob_snapshot_error_cases(ctx: TestContext) -> Result<(), Box<dyn 
 
     // Try to Upload to Snapshot
     let data = b"squash data";
-    let result = snapshot_client
-        .upload(RequestContent::from(data.to_vec()), None)
-        .await;
+    let result = snapshot_client.upload(data.to_vec().into(), None).await;
     assert!(result.is_err());
 
     container_client.delete(None).await?;

--- a/sdk/storage/azure_storage_blob/tests/blob_client_versioning.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client_versioning.rs
@@ -29,21 +29,11 @@ async fn test_blob_version_read_operations(ctx: TestContext) -> Result<(), Box<d
 
     // Create Multiple Versions
     let data_v1 = b"version 1 content";
-    create_test_blob(
-        &blob_client,
-        Some(RequestContent::from(data_v1.to_vec())),
-        None,
-    )
-    .await?;
+    create_test_blob(&blob_client, Some(data_v1.to_vec().into()), None).await?;
     let response = blob_client.get_properties(None).await?;
     let version_1 = response.version_id()?.unwrap();
     let data_v2 = b"version 2 content";
-    create_test_blob(
-        &blob_client,
-        Some(RequestContent::from(data_v2.to_vec())),
-        None,
-    )
-    .await?;
+    create_test_blob(&blob_client, Some(data_v2.to_vec().into()), None).await?;
     let response = blob_client.get_properties(None).await?;
     let version_2 = response.version_id()?.unwrap();
 
@@ -99,7 +89,7 @@ async fn test_blob_version_metadata_operations(ctx: TestContext) -> Result<(), B
     };
     create_test_blob(
         &blob_client,
-        Some(RequestContent::from(b"content v1".to_vec())),
+        Some(b"content v1".to_vec().into()),
         Some(upload_options),
     )
     .await?;
@@ -122,12 +112,7 @@ async fn test_blob_version_metadata_operations(ctx: TestContext) -> Result<(), B
     assert_ne!(version_1, version_2);
 
     // Upload New Content (Creates Version 3)
-    create_test_blob(
-        &blob_client,
-        Some(RequestContent::from(b"content v3".to_vec())),
-        None,
-    )
-    .await?;
+    create_test_blob(&blob_client, Some(b"content v3".to_vec().into()), None).await?;
     let response = blob_client.get_properties(None).await?;
     let version_3 = response.version_id()?.unwrap();
     assert_ne!(version_2, version_3);
@@ -179,7 +164,7 @@ async fn test_blob_version_tier_operations(ctx: TestContext) -> Result<(), Box<d
     // Create Version 2
     create_test_blob(
         &blob_client,
-        Some(RequestContent::from(b"version 2 content".to_vec())),
+        Some(b"version 2 content".to_vec().into()),
         None,
     )
     .await?;
@@ -302,25 +287,25 @@ async fn test_blob_version_feature_interactions(ctx: TestContext) -> Result<(), 
     // Create Source Blob with Multiple Versions
     let data_v1 = b"source version 1";
     source_blob_client
-        .upload(RequestContent::from(data_v1.to_vec()), None)
+        .upload(data_v1.to_vec().into(), None)
         .await?;
 
     let data_v2 = b"source version 2";
     source_blob_client
-        .upload(RequestContent::from(data_v2.to_vec()), None)
+        .upload(data_v2.to_vec().into(), None)
         .await?;
 
     // Test: Lease on Current Version
     let lease_blob_name = format!("{}-lease", get_blob_name(recording));
     let lease_blob_client = container_client.blob_client(&lease_blob_name);
     lease_blob_client
-        .upload(RequestContent::from(b"v1".to_vec()), None)
+        .upload(b"v1".to_vec().into(), None)
         .await?;
     let response = lease_blob_client.get_properties(None).await?;
     let lease_version_1 = response.version_id()?.unwrap();
 
     lease_blob_client
-        .upload(RequestContent::from(b"v2".to_vec()), None)
+        .upload(b"v2".to_vec().into(), None)
         .await?;
 
     // Acquire Lease on Current Version
@@ -362,12 +347,7 @@ async fn test_blob_version_immutability_operations(ctx: TestContext) -> Result<(
     create_test_blob(&blob_client, None, None).await?;
     let response = blob_client.get_properties(None).await?;
     let version_1 = response.version_id()?.unwrap();
-    create_test_blob(
-        &blob_client,
-        Some(RequestContent::from(b"version 2".to_vec())),
-        None,
-    )
-    .await?;
+    create_test_blob(&blob_client, Some(b"version 2".to_vec().into()), None).await?;
     let response = blob_client.get_properties(None).await?;
     let version_2 = response.version_id()?.unwrap();
 
@@ -448,7 +428,7 @@ async fn test_blob_version_error_cases(ctx: TestContext) -> Result<(), Box<dyn E
     assert!(error == Some(StatusCode::NotFound));
 
     // Test: Delete Non-Current Version and Verify It's Gone
-    create_test_blob(&blob_client, Some(RequestContent::from(b"v2".into())), None).await?;
+    create_test_blob(&blob_client, Some(b"v2".to_vec().into()), None).await?;
     let version_1_client = blob_client.with_version(&valid_version)?;
     let delete_options = BlobClientDeleteOptions {
         version_id: Some(valid_version.clone()),

--- a/sdk/storage/azure_storage_blob/tests/blob_conditional_headers.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_conditional_headers.rs
@@ -1104,7 +1104,7 @@ async fn test_block_blob_client_conditional_headers(
     // if_match Failure
     let err = blob_client
         .upload(
-            RequestContent::from(b"new-content".to_vec()),
+            b"new-content".to_vec().into(),
             Some(BlockBlobClientUploadOptions {
                 if_match: Some(BAD_ETAG.to_string().into()),
                 ..Default::default()
@@ -1118,7 +1118,7 @@ async fn test_block_blob_client_conditional_headers(
     // if_none_match Failure
     let err = blob_client
         .upload(
-            RequestContent::from(b"new-content".to_vec()),
+            b"new-content".to_vec().into(),
             Some(BlockBlobClientUploadOptions {
                 if_none_match: Some(etag.clone().into()),
                 ..Default::default()
@@ -1132,7 +1132,7 @@ async fn test_block_blob_client_conditional_headers(
     // if_modified_since Failure
     let err = blob_client
         .upload(
-            RequestContent::from(b"new-content".to_vec()),
+            b"new-content".to_vec().into(),
             Some(BlockBlobClientUploadOptions {
                 if_modified_since: Some(after),
                 ..Default::default()
@@ -1146,7 +1146,7 @@ async fn test_block_blob_client_conditional_headers(
     // if_unmodified_since Failure
     let err = blob_client
         .upload(
-            RequestContent::from(b"new-content".to_vec()),
+            b"new-content".to_vec().into(),
             Some(BlockBlobClientUploadOptions {
                 if_unmodified_since: Some(before),
                 ..Default::default()
@@ -1160,7 +1160,7 @@ async fn test_block_blob_client_conditional_headers(
     // if_tags Failure
     let err = blob_client
         .upload(
-            RequestContent::from(b"new-content".to_vec()),
+            b"new-content".to_vec().into(),
             Some(BlockBlobClientUploadOptions {
                 if_tags: Some("\"env\"='wrong'".to_string()),
                 ..Default::default()
@@ -1174,7 +1174,7 @@ async fn test_block_blob_client_conditional_headers(
     // if_match Success
     blob_client
         .upload(
-            RequestContent::from(b"updated".to_vec()),
+            b"updated".to_vec().into(),
             Some(BlockBlobClientUploadOptions {
                 if_match: Some(etag.clone().into()),
                 ..Default::default()
@@ -1290,7 +1290,7 @@ async fn test_block_blob_client_conditional_headers(
     // Upload Blob With Tag
     blob_client
         .upload(
-            RequestContent::from(b"tagged".to_vec()),
+            b"tagged".to_vec().into(),
             Some(BlockBlobClientUploadOptions {
                 blob_tags_string: Some("kind=block".to_string()),
                 ..Default::default()

--- a/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
@@ -410,7 +410,7 @@ async fn test_find_blobs_by_tags_container(ctx: TestContext) -> Result<(), Box<d
     let blob1_name = get_blob_name(ctx.recording());
     create_test_blob(
         &container_client.blob_client(&blob1_name.clone()),
-        Some(RequestContent::from("hello world".as_bytes().into())),
+        Some("hello world".as_bytes().into()),
         Some(
             BlockBlobClientUploadOptions::default().with_tags(HashMap::from([
                 ("foo".to_string(), "bar".to_string()),
@@ -423,7 +423,7 @@ async fn test_find_blobs_by_tags_container(ctx: TestContext) -> Result<(), Box<d
     let blob2_tags = HashMap::from([("fizz".to_string(), "buzz".to_string())]);
     create_test_blob(
         &container_client.blob_client(&blob2_name.clone()),
-        Some(RequestContent::from("ferris the crab".as_bytes().into())),
+        Some("ferris the crab".as_bytes().into()),
         Some(BlockBlobClientUploadOptions::default().with_tags(blob2_tags.clone())),
     )
     .await?;

--- a/sdk/storage/azure_storage_blob/tests/blob_cpk.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_cpk.rs
@@ -42,7 +42,7 @@ mod blob_client {
             container_client.blob_client(&format!("{}-cpk-key-only", get_blob_name(recording)));
         let result = key_only_blob
             .upload(
-                RequestContent::from(b"key-only".to_vec()),
+                b"key-only".to_vec().into(),
                 Some(BlockBlobClientUploadOptions {
                     encryption_key: Some(encryption_key.clone()),
                     ..Default::default()
@@ -58,7 +58,7 @@ mod blob_client {
         ));
         let result = key_plus_algorithm_blob
             .upload(
-                RequestContent::from(b"key-plus-algorithm".to_vec()),
+                b"key-plus-algorithm".to_vec().into(),
                 Some(BlockBlobClientUploadOptions {
                     encryption_algorithm: Some(encryption_algorithm),
                     encryption_key: Some(encryption_key),
@@ -86,7 +86,7 @@ mod blob_client {
         let content = b"blob-cpk-operations";
         blob_client
             .upload(
-                RequestContent::from(content.to_vec()),
+                content.to_vec().into(),
                 Some(BlockBlobClientUploadOptions {
                     encryption_algorithm: Some(algo),
                     encryption_key: Some(key.clone()),
@@ -203,7 +203,7 @@ mod blob_client {
         let v2 = b"blob-cpk-operations-v2";
         blob_client
             .upload(
-                RequestContent::from(v2.to_vec()),
+                v2.to_vec().into(),
                 Some(BlockBlobClientUploadOptions {
                     encryption_algorithm: Some(algo),
                     encryption_key: Some(key.clone()),
@@ -244,7 +244,7 @@ mod blob_client {
         let content = b"scope-success";
         blob_client
             .upload(
-                RequestContent::from(content.to_vec()),
+                content.to_vec().into(),
                 Some(BlockBlobClientUploadOptions {
                     encryption_scope: Some(scope.clone()),
                     ..Default::default()
@@ -264,7 +264,7 @@ mod blob_client {
             container_client.blob_client(&format!("{}-bad-scope", get_blob_name(recording)));
         let err = invalid_blob
             .upload(
-                RequestContent::from(b"bad scope".to_vec()),
+                b"bad scope".to_vec().into(),
                 Some(BlockBlobClientUploadOptions {
                     encryption_scope: Some(get_invalid_encryption_scope()),
                     ..Default::default()
@@ -414,12 +414,7 @@ mod block_blob_client {
         let source_blob =
             container_client.blob_client(&format!("{}-source", get_blob_name(recording)));
         let source_content = b"upload-from-url-source";
-        create_test_blob(
-            &source_blob,
-            Some(RequestContent::from(source_content.to_vec())),
-            None,
-        )
-        .await?;
+        create_test_blob(&source_blob, Some(source_content.to_vec().into()), None).await?;
 
         // Upload from URL with Destination CPK
         let dest_blob =
@@ -453,7 +448,7 @@ mod block_blob_client {
         let cpk_source_content = b"upload-from-url-cpk-source";
         cpk_source_blob
             .upload(
-                RequestContent::from(cpk_source_content.to_vec()),
+                cpk_source_content.to_vec().into(),
                 Some(BlockBlobClientUploadOptions {
                     encryption_algorithm: Some(algo),
                     encryption_key: Some(key.clone()),
@@ -531,12 +526,7 @@ mod block_blob_client {
         let source_blob =
             container_client.blob_client(&format!("{}-source", get_blob_name(recording)));
         let source_content = b"stage-from-url-source";
-        create_test_blob(
-            &source_blob,
-            Some(RequestContent::from(source_content.to_vec())),
-            None,
-        )
-        .await?;
+        create_test_blob(&source_blob, Some(source_content.to_vec().into()), None).await?;
 
         // Stage from URL with Destination CPK
         let dest_blob =
@@ -584,7 +574,7 @@ mod block_blob_client {
         let cpk_source_content = b"stage-from-url-cpk-source";
         cpk_source_blob
             .upload(
-                RequestContent::from(cpk_source_content.to_vec()),
+                cpk_source_content.to_vec().into(),
                 Some(BlockBlobClientUploadOptions {
                     encryption_algorithm: Some(algo),
                     encryption_key: Some(key.clone()),
@@ -728,7 +718,7 @@ mod append_blob_client {
         let plain_source_content = b"append-from-url-plain";
         create_test_blob(
             &plain_source_blob,
-            Some(RequestContent::from(plain_source_content.to_vec())),
+            Some(plain_source_content.to_vec().into()),
             None,
         )
         .await?;
@@ -739,7 +729,7 @@ mod append_blob_client {
         let cpk_source_content = b"append-from-url-cpk";
         cpk_source_blob
             .upload(
-                RequestContent::from(cpk_source_content.to_vec()),
+                cpk_source_content.to_vec().into(),
                 Some(BlockBlobClientUploadOptions {
                     encryption_algorithm: Some(algo),
                     encryption_key: Some(key.clone()),

--- a/sdk/storage/azure_storage_blob/tests/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_service_client.rs
@@ -195,7 +195,7 @@ async fn test_find_blobs_by_tags_service(ctx: TestContext) -> Result<(), Box<dyn
     let blob1_name = get_blob_name(recording);
     create_test_blob(
         &container_client_1.blob_client(&blob1_name.clone()),
-        Some(RequestContent::from("hello world".as_bytes().into())),
+        Some("hello world".as_bytes().into()),
         Some(
             BlockBlobClientUploadOptions::default()
                 .with_tags(HashMap::from([("foo".to_string(), "bar".to_string())])),
@@ -205,7 +205,7 @@ async fn test_find_blobs_by_tags_service(ctx: TestContext) -> Result<(), Box<dyn
     let blob2_name = get_blob_name(recording);
     create_test_blob(
         &container_client_1.blob_client(&blob2_name.clone()),
-        Some(RequestContent::from("ferris the crab".as_bytes().into())),
+        Some("ferris the crab".as_bytes().into()),
         Some(
             BlockBlobClientUploadOptions::default()
                 .with_tags(HashMap::from([("fizz".to_string(), "buzz".to_string())])),
@@ -216,7 +216,7 @@ async fn test_find_blobs_by_tags_service(ctx: TestContext) -> Result<(), Box<dyn
     let blob3_tags = HashMap::from([("tagged".to_string(), "true".to_string())]);
     create_test_blob(
         &container_client_1.blob_client(&blob3_name.clone()),
-        Some(RequestContent::from("six seven".as_bytes().into())),
+        Some("six seven".as_bytes().into()),
         Some(BlockBlobClientUploadOptions::default().with_tags(blob3_tags.clone())),
     )
     .await?;

--- a/sdk/storage/azure_storage_blob/tests/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/block_blob_client.rs
@@ -133,7 +133,7 @@ async fn test_upload_blob_from_url(ctx: TestContext) -> Result<(), Box<dyn Error
     let source_blob_client = container_client.blob_client(&get_blob_name(recording));
     create_test_blob(
         &source_blob_client,
-        Some(RequestContent::from(b"initialD ata".to_vec())),
+        Some(b"initialD ata".to_vec().into()),
         None,
     )
     .await?;
@@ -143,7 +143,7 @@ async fn test_upload_blob_from_url(ctx: TestContext) -> Result<(), Box<dyn Error
     let overwrite_blob_client = container_client.blob_client(&get_blob_name(recording));
     create_test_blob(
         &overwrite_blob_client,
-        Some(RequestContent::from(b"overruled!".to_vec())),
+        Some(b"overruled!".to_vec().into()),
         None,
     )
     .await?;
@@ -222,7 +222,7 @@ async fn test_stage_block_from_url(ctx: TestContext) -> Result<(), Box<dyn Error
     let source_content = b"Hello from source blob!";
     create_test_blob(
         &source_blob_client,
-        Some(RequestContent::from(source_content.to_vec())),
+        Some(source_content.to_vec().into()),
         None,
     )
     .await?;
@@ -298,7 +298,7 @@ async fn test_stage_block_from_url(ctx: TestContext) -> Result<(), Box<dyn Error
     let source_content_2 = b"Authorized content!";
     create_test_blob(
         &source_blob_client_2,
-        Some(RequestContent::from(source_content_2.to_vec())),
+        Some(source_content_2.to_vec().into()),
         None,
     )
     .await?;

--- a/sdk/storage/azure_storage_blob/tests/streaming.rs
+++ b/sdk/storage/azure_storage_blob/tests/streaming.rs
@@ -7,7 +7,9 @@ use azure_core::{
     Bytes,
 };
 use azure_core_test::{recorded, stream::GeneratedStream, TestContext};
-use azure_storage_blob::{format_page_range, models::BlockLookupList, BlobClient};
+use azure_storage_blob::{
+    format_page_range, models::BlockLookupList, BlobClient, StorageUploadBody,
+};
 use azure_storage_blob_test::{get_blob_name, get_container_client, StorageAccount};
 use futures::TryStreamExt as _;
 use std::error::Error;
@@ -43,10 +45,9 @@ async fn stream_blob_upload(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     let blob_client = container_client.blob_client(&get_blob_name(recording));
 
     let data = b"streaming a stream";
-    let content = request_content_from_bytes(data);
 
     // Upload via BlobClient using a seekable stream body
-    blob_client.upload(content, None).await?;
+    blob_client.upload(data.to_vec().into(), None).await?;
 
     // Assert
     let response = blob_client.download(None).await?;
@@ -213,7 +214,9 @@ async fn upload<const CONTENT_LENGTH: usize>(client: &BlobClient) -> azure_core:
     // but to avoid consuming a large amount of drive space generate content.
     let stream = GeneratedStream::<_, CONTENT_LENGTH>::default();
 
-    client.upload(stream.into(), None).await?;
+    client
+        .upload(StorageUploadBody::AsyncRead(Box::new(stream)), None)
+        .await?;
 
     Ok(())
 }

--- a/sdk/storage/azure_storage_blob_test/src/lib.rs
+++ b/sdk/storage/azure_storage_blob_test/src/lib.rs
@@ -14,7 +14,7 @@ use azure_core::{
     http::StatusCode,
     http::{
         policies::{Policy, PolicyResult},
-        AsyncRawResponse, Body, ClientOptions, Context, NoFormat, Request, RequestContent,
+        AsyncRawResponse, Body, ClientOptions, Context, Request,
     },
     Bytes, Result,
 };
@@ -25,7 +25,7 @@ use azure_storage_blob::{
         EncryptionAlgorithmType,
     },
     BlobClient, BlobClientOptions, BlobContainerClient, BlobContainerClientOptions,
-    BlobServiceClient, BlobServiceClientOptions,
+    BlobServiceClient, BlobServiceClientOptions, StorageUploadBody,
 };
 use bytes::BytesMut;
 use futures::{AsyncRead, AsyncReadExt};
@@ -209,14 +209,14 @@ pub async fn get_container_client(
 /// * `options` - Optional configuration for the upload request.
 pub async fn create_test_blob(
     blob_client: &BlobClient,
-    data: Option<RequestContent<Bytes, NoFormat>>,
+    data: Option<StorageUploadBody>,
     options: Option<BlockBlobClientUploadOptions<'_>>,
 ) -> Result<BlockBlobClientUploadResult> {
     match data {
         Some(content) => blob_client.upload(content, options).await,
         None => {
             blob_client
-                .upload(RequestContent::from(b"hello rusty world".to_vec()), options)
+                .upload(b"hello rusty world".to_vec().into(), options)
                 .await
         }
     }


### PR DESCRIPTION
Replaces the Azure-standard `Body` type with `StorageUploadBody`, which accepts `Bytes` or an `AsyncReadWithLenHint` object (implements `AsyncRead + Send + ...` plus a `len()` method). 

## Usage
Because `AsyncReadWithLenHint` is blanket-implemented for `SeekableStream`, all existing implementations of `SeekableStream` work with `StorageUploadBody` just as smoothly as they do `Body`.

```rust
fn seekable_stream_convert<T>(stream: T) -> StorageUploadBody
where
    T: SeekableStream + 'static,
{
    StorageUploadBody::AsyncRead(Box::new(stream))
}
```

More to come

## To Do
- Convert `partitioned_transfer::upload()` to accept new type (waiting on #4107 to merge to avoid conflict)
- Write samples using arbitrary `AsyncRead` objects.