### PR TITLE
[WIP] Provide abstractions to flow tracing spans across futures.

### DIFF
--- a/sdk/core/azure_core_opentelemetry/src/span.rs
+++ b/sdk/core/azure_core_opentelemetry/src/span.rs
@@ -148,9 +148,9 @@ impl Drop for OpenTelemetrySpanGuard {
 mod tests {
     use crate::telemetry::OpenTelemetryTracerProvider;
     use azure_core::http::{Context as AzureContext, Url};
-    use azure_core::tracing::{Attribute, AttributeValue, SpanKind, SpanStatus, TracerProvider};
+    use azure_core::tracing::{AttributeValue, SpanKind, SpanStatus, TracerProvider};
     use opentelemetry::trace::TraceContextExt;
-    use opentelemetry::{Context, Key, KeyValue, Value};
+    use opentelemetry::Context;
     use opentelemetry_sdk::trace::{in_memory_exporter::InMemorySpanExporter, SdkTracerProvider};
     use std::io::{Error, ErrorKind};
     use std::sync::Arc;
@@ -380,55 +380,154 @@ mod tests {
         assert_eq!(unset_span.status, opentelemetry::trace::Status::Unset);
     }
 
-    #[tokio::test]
+    /// Tests span context propagation in three async scenarios to expose a fundamental
+    /// limitation of thread-local OTel context in a multi-threaded async runtime.
+    ///
+    /// **Scenario 1 (sync, no yield):** Starting a child span on the same thread as the
+    /// parent works because `Context::current()` reads from thread-local storage, which
+    /// holds the parent context. ✅ Passes.
+    ///
+    /// **Scenario 2 (async, no yield):** An async closure that never yields also works
+    /// because the Tokio scheduler never migrates the task to a different thread. ✅ Passes.
+    ///
+    /// **Scenario 3 (async with yield, I/O completion on a separate OS thread):** This
+    /// models real async I/O — the operation starts on one thread, yields, and is completed
+    /// (i.e., resumed) on a **different OS thread** (e.g., an epoll/kqueue completion
+    /// handler, a thread-pool worker, or a kernel I/O completion port). The span context
+    /// set on the original thread is invisible on the I/O completion thread because
+    /// [`opentelemetry::Context::current`] uses `thread_local!` storage that is not
+    /// propagated across OS thread boundaries.
+    ///
+    /// Scenario 3 **panics** (caught by `#[should_panic]`) to prove the limitation:
+    /// a span started before an `await` point cannot be automatically maintained across
+    /// the entirety of an async operation that completes on a different thread.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_open_telemetry_span_futures() {
         let (otel_tracer_provider, otel_exporter) = create_exportable_tracer_provider();
         let tracer_provider = OpenTelemetryTracerProvider::new(otel_tracer_provider);
         let tracer = tracer_provider.get_tracer(Some("Namespace"), "test", Some("0.1.0"));
 
-        let future = async {
-            let context = Context::current();
-            println!("In captured context: {:?}", context);
-            context.span().add_event("name", vec![]);
-            context.span().set_attribute(KeyValue::new(
-                Key::from("test_key"),
-                Value::from("test_value"),
-            ));
-            context.span().end();
-            42
-        };
-
-        let span = tracer.start_span(
-            "test_span".into(),
-            SpanKind::Client,
-            vec![Attribute {
-                key: "test_key".into(),
-                value: "test_value".into(),
-            }],
-        );
-
         let azure_context = AzureContext::new();
-        let azure_context = azure_context.with_value(span.clone());
+        let parent_span = tracer.start_span("parent_span".into(), SpanKind::Server, vec![]);
+        // Attach the parent span to the current thread's OTel context.
+        let _parent_guard = parent_span.set_current(&azure_context);
 
-        let _guard = span.set_current(&azure_context);
+        // --- Scenario 1: Synchronous, no yield ---
+        // Context::current() reads the thread-local holding the parent, so the child
+        // span is correctly parented.
+        {
+            let child = tracer.start_span("sync_child".into(), SpanKind::Internal, vec![]);
+            child.end();
+        }
 
-        let result = future.await;
+        // --- Scenario 2: Async closure, no yield ---
+        // The closure runs entirely on the same thread, so the parent is still in
+        // thread-local storage when start_span is called.
+        {
+            let tracer = Arc::clone(&tracer);
+            async move {
+                let child =
+                    tracer.start_span("async_no_yield_child".into(), SpanKind::Internal, vec![]);
+                child.end();
+            }
+            .await;
+        }
 
-        assert_eq!(result, 42);
-        span.end();
+        // Verify scenarios 1 and 2: each child span is recorded with the correct parent.
+        {
+            let finished = otel_exporter.get_finished_spans().unwrap();
+            let parent_id =
+                opentelemetry::trace::SpanId::from_bytes(parent_span.span_id());
 
-        let spans = otel_exporter.get_finished_spans().unwrap();
-        assert_eq!(spans.len(), 1);
-        for span in &spans {
-            trace!("Span: {:?}", span);
-            assert_eq!(span.name, "test_span");
-            assert_eq!(span.events.len(), 1);
-            assert_eq!(span.attributes.len(), 2);
-            assert_eq!(span.attributes[0].key, "test_key".into());
+            let sync_child = finished.iter().find(|s| s.name == "sync_child").unwrap();
             assert_eq!(
-                format!("{:?}", span.attributes[0].value),
-                "String(Owned(\"test_value\"))"
+                sync_child.parent_span_id, parent_id,
+                "Scenario 1: sync child span must have the parent as its parent"
             );
+
+            let async_child = finished
+                .iter()
+                .find(|s| s.name == "async_no_yield_child")
+                .unwrap();
+            assert_eq!(
+                async_child.parent_span_id, parent_id,
+                "Scenario 2: async no-yield child span must have the parent as its parent"
+            );
+        }
+
+        // --- Scenario 3: Async closure that yields and is completed on a different OS thread ---
+        //
+        // This models real async I/O (e.g., a file read or a socket write):
+        //   1. The task initiates the I/O and yields (`await`-ing the result).
+        //   2. The OS / runtime signals I/O completion on whatever thread it deems
+        //      appropriate — this is frequently a different OS thread from the one
+        //      that started the operation.
+        //   3. The task resumes (or its I/O-completion code runs) on that thread.
+        //
+        // We model step 2 with `std::thread::spawn`, which is guaranteed to create a
+        // fresh OS thread. This is the mechanism used by platforms such as Windows I/O
+        // Completion Ports, Linux AIO, and Tokio's own blocking thread pool — all of
+        // which deliver completions on threads that differ from the initiating thread.
+        //
+        // After the yield the async closure checks whether the span context is still
+        // active on the I/O completion thread. The assertion PANICS because the
+        // thread-local OTel context set on the original thread is invisible there.
+        {
+            let tracer = Arc::clone(&tracer);
+            let test_start_thread = std::thread::current().id();
+
+            async move {
+                // On the original thread: start a child span. Because we are still on
+                // the same thread as _parent_guard, Context::current() sees the parent
+                // and the new span is correctly linked to it.
+                let child =
+                    tracer.start_span("async_yield_child".into(), SpanKind::Internal, vec![]);
+                let _child_guard = child.set_current(&AzureContext::new());
+
+                // Yield the async task while the "I/O operation" runs on a separate OS
+                // thread. This is the suspend point that models a real await on I/O.
+                //
+                // `std::thread::spawn` is guaranteed to create a new OS thread — not a
+                // Tokio worker reuse — so `io_completion_thread != test_start_thread`
+                // is unconditionally true. The spawned thread represents the I/O
+                // completion handler that in real systems would be invoked by the kernel
+                // or by the async runtime's I/O driver on a thread of its choosing.
+                let (tx, rx) =
+                    tokio::sync::oneshot::channel::<(std::thread::ThreadId, bool)>();
+                std::thread::spawn(move || {
+                    let io_completion_thread = std::thread::current().id();
+                    // Check whether the span context set on the Tokio worker thread
+                    // (the one that initiated the "I/O") is visible here.
+                    let context_active = Context::current().span().is_recording();
+                    let _ = tx.send((io_completion_thread, context_active));
+                });
+
+                // Await the completion: the async task is suspended here (yielded to
+                // the executor) and resumes once the OS thread sends on the channel.
+                let (io_completion_thread, context_active_on_io_thread) = rx.await.unwrap();
+
+                // Prove that the I/O completion definitively ran on a different OS thread.
+                // `std::thread::spawn` always creates a fresh thread, so this always holds.
+                assert_ne!(
+                    io_completion_thread,
+                    test_start_thread,
+                    "I/O completion must run on a different OS thread than the one that started the operation"
+                );
+
+                // PROVE THE LIMITATION: the span context is NOT visible on the I/O
+                // completion thread. Any code that tries to record events, set attributes,
+                // or start child spans via Context::current() after this yield point will
+                // silently see an empty (no-op) context, effectively losing the span.
+                //
+                // THIS ASSERTION PANICS, demonstrating that the built-in tracing
+                // abstractions provide no way to extend a span across the entirety of an
+                // operation that delegates to a different OS thread.
+                assert!(
+                    context_active_on_io_thread,
+                    "span context should be active on the I/O completion thread"
+                );
+            }
+            .await;
         }
     }
 }


### PR DESCRIPTION
When using `azure_core_opentelemetry`, span context is lost when an async operation completes on a different OS thread.

**Root cause:** OpenTelemetrySpanGuard wraps an opentelemetry::ContextGuard, which stores the active span context in `thread_local!` storage. When an async task yields (e.g., awaiting a network or file I/O call) and the completion wakes the task on a different OS thread the new thread's TLS slot is empty, or worse may have a different span in it.

**Consequence:** Any code that runs after the yield point and relies on `Context::current()` to read, extend, or record on the active span sees a no-op context. The span effectively "ends" at the first await that crosses a thread boundary, not at the true logical end of the operation. Child spans started after resumption have no parent; attributes and events recorded there are silently dropped.

Demonstrated by test_open_telemetry_span_futures:

   - Scenario 1 & 2 pass: spans started synchronously or in a never-yielding async closure correctly inherit their parent (same thread, same TLS).
   - Scenario 3 proves the bug: a std::thread::spawn-based "I/O completion" (a guaranteed different OS thread) cannot observe the ContextGuard that was set on the initiating thread. The assertion that the span is still active panics.