### PR TITLE
[Storage] `HttpRange` handwritten model

### DIFF
--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -5,8 +5,11 @@
 ### Features Added
 
 - Added `stream::tokio` module (gated on the `tokio` feature) with `FileStream` and `FileStreamBuilder` for streaming file uploads.
+- Added `models::HttpRange` for specifying byte ranges in blob operations, replacing the removed `format_page_range()` helper.
 
 ### Breaking Changes
+
+- Removed `format_page_range()`. Use `HttpRange::new(offset, length)` or `HttpRange::from_offset(offset)` instead.
 
 - Revised `download()` on `BlobClient` with the following breaking changes:
   - Now uses managed (multi-part) download logic for optimal performance on single-shot and parallel range transfers.

--- a/sdk/storage/azure_storage_blob/assets.json
+++ b/sdk/storage/azure_storage_blob/assets.json
@@ -1,6 +1,6 @@
 {
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
-  "Tag": "rust/azure_storage_blob_0221cdcd7a",
+  "Tag": "rust/azure_storage_blob_f104b74007",
   "TagPrefix": "rust/azure_storage_blob"
 }

--- a/sdk/storage/azure_storage_blob/src/models/http_ranges.rs
+++ b/sdk/storage/azure_storage_blob/src/models/http_ranges.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use azure_core::error::{Error, ErrorKind, ResultExt};
-use azure_core::http::headers::{Header, HeaderName};
+use azure_core::http::headers::{Header, HeaderName, HeaderValue};
 use std::fmt;
 use std::ops::{Range, RangeFrom};
 use std::str::FromStr;
@@ -186,5 +186,127 @@ mod tests {
         let txt = format!("{range}");
 
         assert_eq!(txt, "bytes 100-499/5000");
+    }
+}
+
+/// Represents an HTTP Range header value for blob operations.
+///
+/// Defines a range of bytes within an HTTP resource, starting at an offset and
+/// ending at `offset + length - 1` inclusively. This matches the semantics of .NET's
+/// `Azure.HttpRange`.
+///
+/// # Examples
+///
+/// ```
+/// use azure_storage_blob::models::HttpRange;
+///
+/// // Range of 512 bytes starting at offset 0: bytes=0-511
+/// let range = HttpRange::new(0, 512);
+/// assert_eq!(range.to_string(), "bytes=0-511");
+///
+/// // Open-ended range starting at offset 255: bytes=255-
+/// let range = HttpRange::from_offset(255);
+/// assert_eq!(range.to_string(), "bytes=255-");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpRange {
+    /// The starting byte offset.
+    pub offset: u64,
+    /// The length of the range. If `None`, the range extends to the end of the resource.
+    pub length: Option<u64>,
+}
+
+impl HttpRange {
+    /// Creates a new `HttpRange` with the specified offset and length.
+    ///
+    /// The range will cover bytes from `offset` to `offset + length - 1` inclusive.
+    ///
+    /// # Arguments
+    ///
+    /// * `offset` - The starting byte offset.
+    /// * `length` - The number of bytes in the range.
+    pub fn new(offset: u64, length: u64) -> Self {
+        Self {
+            offset,
+            length: Some(length),
+        }
+    }
+
+    /// Creates a new `HttpRange` that starts at the specified offset and extends to the end.
+    ///
+    /// # Arguments
+    ///
+    /// * `offset` - The starting byte offset.
+    pub fn from_offset(offset: u64) -> Self {
+        Self {
+            offset,
+            length: None,
+        }
+    }
+}
+
+impl fmt::Display for HttpRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.length {
+            Some(length) => write!(f, "bytes={}-{}", self.offset, self.offset + length - 1),
+            None => write!(f, "bytes={}-", self.offset),
+        }
+    }
+}
+
+impl From<HttpRange> for String {
+    fn from(range: HttpRange) -> Self {
+        range.to_string()
+    }
+}
+
+impl From<HttpRange> for HeaderValue {
+    fn from(range: HttpRange) -> Self {
+        HeaderValue::from(range.to_string())
+    }
+}
+
+#[cfg(test)]
+mod http_range_tests {
+    use super::*;
+
+    #[test]
+    fn new_creates_bounded_range() {
+        let range = HttpRange::new(0, 512);
+        assert_eq!(range.offset, 0);
+        assert_eq!(range.length, Some(512));
+    }
+
+    #[test]
+    fn from_offset_creates_open_ended_range() {
+        let range = HttpRange::from_offset(255);
+        assert_eq!(range.offset, 255);
+        assert_eq!(range.length, None);
+    }
+
+    #[test]
+    fn display_bounded_range() {
+        let range = HttpRange::new(0, 512);
+        assert_eq!(range.to_string(), "bytes=0-511");
+    }
+
+    #[test]
+    fn display_open_ended_range() {
+        let range = HttpRange::from_offset(255);
+        assert_eq!(range.to_string(), "bytes=255-");
+    }
+
+    #[test]
+    fn into_string() {
+        let range = HttpRange::new(100, 101);
+        let s: String = range.into();
+        assert_eq!(s, "bytes=100-200");
+    }
+
+    #[test]
+    fn into_header_value() {
+        let range = HttpRange::new(0, 512);
+        let header_value: HeaderValue = range.into();
+        assert_eq!(header_value.as_str(), "bytes=0-511");
     }
 }

--- a/sdk/storage/azure_storage_blob/src/models/http_ranges.rs
+++ b/sdk/storage/azure_storage_blob/src/models/http_ranges.rs
@@ -211,9 +211,9 @@ mod tests {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HttpRange {
     /// The starting byte offset.
-    pub offset: u64,
+    offset: u64,
     /// The length of the range. If `None`, the range extends to the end of the resource.
-    pub length: Option<u64>,
+    length: Option<u64>,
 }
 
 impl HttpRange {

--- a/sdk/storage/azure_storage_blob/src/models/http_ranges.rs
+++ b/sdk/storage/azure_storage_blob/src/models/http_ranges.rs
@@ -248,7 +248,12 @@ impl HttpRange {
 impl fmt::Display for HttpRange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.length {
-            Some(length) => write!(f, "bytes={}-{}", self.offset, self.offset + length - 1),
+            Some(length) => write!(
+                f,
+                "bytes={}-{}",
+                self.offset,
+                self.offset.saturating_add(length).saturating_sub(1)
+            ),
             None => write!(f, "bytes={}-", self.offset),
         }
     }
@@ -308,5 +313,20 @@ mod http_range_tests {
         let range = HttpRange::new(0, 512);
         let header_value: HeaderValue = range.into();
         assert_eq!(header_value.as_str(), "bytes=0-511");
+    }
+
+    #[test]
+    fn display_zero_length_does_not_panic() {
+        // length == 0 would underflow without saturating arithmetic; must not panic
+        let range = HttpRange::new(0, 0);
+        // saturating_add(0).saturating_sub(1) on offset 0 saturates to 0
+        let _ = range.to_string();
+    }
+
+    #[test]
+    fn display_overflow_does_not_panic() {
+        // offset + length would overflow u64 without saturating arithmetic; must not panic
+        let range = HttpRange::new(u64::MAX, u64::MAX);
+        let _ = range.to_string();
     }
 }

--- a/sdk/storage/azure_storage_blob/src/models/http_ranges.rs
+++ b/sdk/storage/azure_storage_blob/src/models/http_ranges.rs
@@ -259,12 +259,6 @@ impl fmt::Display for HttpRange {
     }
 }
 
-impl From<HttpRange> for String {
-    fn from(range: HttpRange) -> Self {
-        range.to_string()
-    }
-}
-
 impl From<HttpRange> for HeaderValue {
     fn from(range: HttpRange) -> Self {
         HeaderValue::from(range.to_string())
@@ -278,15 +272,13 @@ mod http_range_tests {
     #[test]
     fn new_creates_bounded_range() {
         let range = HttpRange::new(0, 512);
-        assert_eq!(range.offset, 0);
-        assert_eq!(range.length, Some(512));
+        assert_eq!(range.to_string(), "bytes=0-511");
     }
 
     #[test]
     fn from_offset_creates_open_ended_range() {
         let range = HttpRange::from_offset(255);
-        assert_eq!(range.offset, 255);
-        assert_eq!(range.length, None);
+        assert_eq!(range.to_string(), "bytes=255-");
     }
 
     #[test]
@@ -302,10 +294,9 @@ mod http_range_tests {
     }
 
     #[test]
-    fn into_string() {
+    fn to_string_bounded_range() {
         let range = HttpRange::new(100, 101);
-        let s: String = range.into();
-        assert_eq!(s, "bytes=100-200");
+        assert_eq!(range.to_string(), "bytes=100-200");
     }
 
     #[test]

--- a/sdk/storage/azure_storage_blob/src/models/mod.rs
+++ b/sdk/storage/azure_storage_blob/src/models/mod.rs
@@ -9,6 +9,8 @@ pub mod error;
 mod extensions;
 pub(crate) mod http_ranges;
 pub mod method_options;
+
+pub use http_ranges::HttpRange;
 pub(crate) mod response_ext;
 pub(crate) mod slice;
 mod upload_result;

--- a/sdk/storage/azure_storage_blob/src/parsers.rs
+++ b/sdk/storage/azure_storage_blob/src/parsers.rs
@@ -3,40 +3,6 @@
 
 use std::collections::HashMap;
 use std::io::{Error, ErrorKind};
-
-/// Takes in an offset and a length, verifies alignment to a 512-byte boundary, and
-///  returns the HTTP range in String format.
-///
-/// # Arguments
-///
-/// * `offset` - Start of the byte range to use for writing to a section of the blob.
-///   The offset specified must be a modulus of 512.
-/// * `length` - Number of bytes to use for writing to a section of the blob.
-///   The length specified must be a modulus of 512.
-pub fn format_page_range(offset: u64, length: u64) -> Result<String, Error> {
-    if !offset.is_multiple_of(512) {
-        return Err(Error::new(
-            ErrorKind::InvalidInput,
-            format!(
-                "provided offset {} is not aligned to a 512-byte boundary.",
-                offset
-            ),
-        ));
-    }
-    if !length.is_multiple_of(512) {
-        return Err(Error::new(
-            ErrorKind::InvalidInput,
-            format!(
-                "provided length {} is not aligned to a 512-byte boundary.",
-                length
-            ),
-        ));
-    }
-    let end_range = offset + length - 1;
-    let content_range = format!("bytes={}-{}", offset, end_range);
-    Ok(content_range)
-}
-
 /// Takes in a HashMap of tag key-value pairs and converts them to a filter expression
 /// for use with [`BlobServiceClient::find_blobs_by_tags()`](crate::BlobServiceClient::find_blobs_by_tags) or [`BlobContainerClient::find_blobs_by_tags()`](crate::BlobContainerClient::find_blobs_by_tags).
 ///

--- a/sdk/storage/azure_storage_blob/tests/blob_client_options.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client_options.rs
@@ -21,6 +21,58 @@ use futures::TryStreamExt;
 use std::{collections::HashMap, error::Error, time::Duration};
 
 #[recorded::test]
+async fn test_ranged_download(ctx: TestContext) -> Result<(), Box<dyn Error>> {
+    // Recording Setup
+    let recording = ctx.recording();
+    let container_client =
+        get_container_client(recording, true, StorageAccount::Standard, None).await?;
+    let blob_client = container_client.blob_client(&get_blob_name(recording));
+    let data = b"hello rusty world";
+    create_test_blob(
+        &blob_client,
+        Some(RequestContent::from(data.to_vec())),
+        None,
+    )
+    .await?;
+
+    // Bounded Range Download (first 5 bytes: "hello")
+    let response = blob_client
+        .download(Some(BlobClientDownloadOptions {
+            range: Some(0..5),
+            ..Default::default()
+        }))
+        .await?;
+    assert_eq!(5, response.properties.content_length.unwrap());
+    let body = response.body.collect().await?;
+    assert_eq!(b"hello".to_vec(), body.to_vec());
+
+    // Bounded Range Download (middle 6 bytes: " rusty")
+    let response = blob_client
+        .download(Some(BlobClientDownloadOptions {
+            range: Some(5..11),
+            ..Default::default()
+        }))
+        .await?;
+    assert_eq!(6, response.properties.content_length.unwrap());
+    let body = response.body.collect().await?;
+    assert_eq!(b" rusty".to_vec(), body.to_vec());
+
+    // Bounded Range Download (last 6 bytes: " world")
+    let response = blob_client
+        .download(Some(BlobClientDownloadOptions {
+            range: Some(11..17),
+            ..Default::default()
+        }))
+        .await?;
+    assert_eq!(6, response.properties.content_length.unwrap());
+    let body = response.body.collect().await?;
+    assert_eq!(b" world".to_vec(), body.to_vec());
+
+    container_client.delete(None).await?;
+    Ok(())
+}
+
+#[recorded::test]
 async fn test_blob_version_read_operations(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Recording Setup
     let recording = ctx.recording();

--- a/sdk/storage/azure_storage_blob/tests/blob_conditional_headers.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_conditional_headers.rs
@@ -3,29 +3,25 @@
 
 use azure_core::http::{RequestContent, StatusCode};
 use azure_core_test::{recorded, TestContext};
-use azure_storage_blob::{
-    format_page_range,
-    models::{
-        AccessTier, AppendBlobClientAppendBlockOptions, AppendBlobClientCreateOptions,
-        AppendBlobClientSealOptions, BlobClientAcquireLeaseOptions,
-        BlobClientAcquireLeaseResultHeaders, BlobClientBreakLeaseOptions,
-        BlobClientChangeLeaseOptions, BlobClientChangeLeaseResultHeaders,
-        BlobClientCreateSnapshotOptions, BlobClientDeleteOptions, BlobClientDownloadOptions,
-        BlobClientGetPropertiesOptions, BlobClientGetPropertiesResultHeaders,
-        BlobClientGetTagsOptions, BlobClientReleaseLeaseOptions, BlobClientRenewLeaseOptions,
-        BlobClientSetMetadataOptions, BlobClientSetPropertiesOptions, BlobClientSetTagsOptions,
-        BlobClientSetTierOptions, BlobContainerClientAcquireLeaseOptions,
-        BlobContainerClientAcquireLeaseResultHeaders, BlobContainerClientBreakLeaseOptions,
-        BlobContainerClientChangeLeaseOptions, BlobContainerClientDeleteOptions,
-        BlobContainerClientGetPropertiesResultHeaders, BlobContainerClientReleaseLeaseOptions,
-        BlobContainerClientRenewLeaseOptions, BlobContainerClientSetAccessPolicyOptions,
-        BlobContainerClientSetMetadataOptions, BlobTags, BlockBlobClientCommitBlockListOptions,
-        BlockBlobClientGetBlockListOptions, BlockBlobClientUploadOptions, BlockListType,
-        BlockLookupList, DeleteSnapshotsOptionType, PageBlobClientClearPagesOptions,
-        PageBlobClientCreateOptions, PageBlobClientGetPageRangesOptions,
-        PageBlobClientResizeOptions, PageBlobClientSetSequenceNumberOptions,
-        PageBlobClientUploadPagesOptions, SequenceNumberActionType, SignedIdentifiers,
-    },
+use azure_storage_blob::models::{
+    AccessTier, AppendBlobClientAppendBlockOptions, AppendBlobClientCreateOptions,
+    AppendBlobClientSealOptions, BlobClientAcquireLeaseOptions,
+    BlobClientAcquireLeaseResultHeaders, BlobClientBreakLeaseOptions, BlobClientChangeLeaseOptions,
+    BlobClientChangeLeaseResultHeaders, BlobClientCreateSnapshotOptions, BlobClientDeleteOptions,
+    BlobClientDownloadOptions, BlobClientGetPropertiesOptions,
+    BlobClientGetPropertiesResultHeaders, BlobClientGetTagsOptions, BlobClientReleaseLeaseOptions,
+    BlobClientRenewLeaseOptions, BlobClientSetMetadataOptions, BlobClientSetPropertiesOptions,
+    BlobClientSetTagsOptions, BlobClientSetTierOptions, BlobContainerClientAcquireLeaseOptions,
+    BlobContainerClientAcquireLeaseResultHeaders, BlobContainerClientBreakLeaseOptions,
+    BlobContainerClientChangeLeaseOptions, BlobContainerClientDeleteOptions,
+    BlobContainerClientGetPropertiesResultHeaders, BlobContainerClientReleaseLeaseOptions,
+    BlobContainerClientRenewLeaseOptions, BlobContainerClientSetAccessPolicyOptions,
+    BlobContainerClientSetMetadataOptions, BlobTags, BlockBlobClientCommitBlockListOptions,
+    BlockBlobClientGetBlockListOptions, BlockBlobClientUploadOptions, BlockListType,
+    BlockLookupList, DeleteSnapshotsOptionType, HttpRange, PageBlobClientClearPagesOptions,
+    PageBlobClientCreateOptions, PageBlobClientGetPageRangesOptions, PageBlobClientResizeOptions,
+    PageBlobClientSetSequenceNumberOptions, PageBlobClientUploadPagesOptions,
+    SequenceNumberActionType, SignedIdentifiers,
 };
 use azure_storage_blob_test::{
     create_test_blob, get_blob_name, get_container_client, StorageAccount,
@@ -1685,7 +1681,7 @@ async fn test_page_blob_client_conditional_headers(ctx: TestContext) -> Result<(
     // Upload Pages - PageBlobClientUploadPagesOptions
 
     let page_data = RequestContent::from(vec![1u8; PAGE_SIZE]);
-    let range = format_page_range(0, PAGE_SIZE as u64)?;
+    let range: String = HttpRange::new(0, PAGE_SIZE as u64).into();
 
     // if_match Failure
     let err = page_blob_client

--- a/sdk/storage/azure_storage_blob/tests/blob_conditional_headers.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_conditional_headers.rs
@@ -1681,7 +1681,7 @@ async fn test_page_blob_client_conditional_headers(ctx: TestContext) -> Result<(
     // Upload Pages - PageBlobClientUploadPagesOptions
 
     let page_data = RequestContent::from(vec![1u8; PAGE_SIZE]);
-    let range: String = HttpRange::new(0, PAGE_SIZE as u64).into();
+    let range = HttpRange::new(0, PAGE_SIZE as u64).to_string();
 
     // if_match Failure
     let err = page_blob_client

--- a/sdk/storage/azure_storage_blob/tests/blob_cpk.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_cpk.rs
@@ -942,7 +942,7 @@ mod page_blob_client {
             .upload_pages(
                 RequestContent::from(vec![b'P'; 512]),
                 512,
-                HttpRange::new(0, 512).into(),
+                HttpRange::new(0, 512).to_string(),
                 Some(PageBlobClientUploadPagesOptions {
                     encryption_algorithm: Some(encryption_algorithm),
                     encryption_key: Some(encryption_key),
@@ -1013,7 +1013,7 @@ mod page_blob_client {
             .upload_pages(
                 RequestContent::from(content.clone()),
                 512,
-                HttpRange::new(0, 512).into(),
+                HttpRange::new(0, 512).to_string(),
                 Some(PageBlobClientUploadPagesOptions {
                     encryption_algorithm: Some(algo),
                     encryption_key: Some(key.clone()),
@@ -1039,7 +1039,7 @@ mod page_blob_client {
             .upload_pages(
                 RequestContent::from(vec![b'B'; 512]),
                 512,
-                HttpRange::new(0, 512).into(),
+                HttpRange::new(0, 512).to_string(),
                 Some(PageBlobClientUploadPagesOptions {
                     encryption_scope: Some(get_invalid_encryption_scope()),
                     ..Default::default()
@@ -1051,7 +1051,7 @@ mod page_blob_client {
         // Clear Pages with CPK
         page_blob
             .clear_pages(
-                HttpRange::new(0, 512).into(),
+                HttpRange::new(0, 512).to_string(),
                 Some(PageBlobClientClearPagesOptions {
                     encryption_algorithm: Some(algo),
                     encryption_key: Some(key.clone()),
@@ -1074,7 +1074,7 @@ mod page_blob_client {
         // Invalid Scope Clear Pages
         let err = bad_scope_page_blob
             .clear_pages(
-                HttpRange::new(0, 512).into(),
+                HttpRange::new(0, 512).to_string(),
                 Some(PageBlobClientClearPagesOptions {
                     encryption_scope: Some(get_invalid_encryption_scope()),
                     ..Default::default()
@@ -1138,7 +1138,7 @@ mod page_blob_client {
             .upload_pages(
                 RequestContent::from(source_content.clone()),
                 512,
-                HttpRange::new(0, 512).into(),
+                HttpRange::new(0, 512).to_string(),
                 Some(PageBlobClientUploadPagesOptions {
                     encryption_algorithm: Some(algo),
                     encryption_key: Some(key.clone()),
@@ -1167,9 +1167,9 @@ mod page_blob_client {
         dest_page_blob
             .upload_pages_from_url(
                 source_blob.url().as_str().into(),
-                HttpRange::new(0, 512).into(),
+                HttpRange::new(0, 512).to_string(),
                 512,
-                HttpRange::new(0, 512).into(),
+                HttpRange::new(0, 512).to_string(),
                 Some(PageBlobClientUploadPagesFromUrlOptions {
                     encryption_algorithm: Some(algo),
                     encryption_key: Some(key.clone()),
@@ -1200,9 +1200,9 @@ mod page_blob_client {
         let err = source_mismatch_dest_page_blob
             .upload_pages_from_url(
                 source_blob.url().as_str().into(),
-                HttpRange::new(0, 512).into(),
+                HttpRange::new(0, 512).to_string(),
                 512,
-                HttpRange::new(0, 512).into(),
+                HttpRange::new(0, 512).to_string(),
                 Some(PageBlobClientUploadPagesFromUrlOptions {
                     source_encryption_algorithm: Some(algo),
                     source_encryption_key: Some(wrong_key.clone()),
@@ -1222,7 +1222,7 @@ mod page_blob_client {
             .upload_pages(
                 RequestContent::from(vec![b'T'; 512]),
                 512,
-                HttpRange::new(0, 512).into(),
+                HttpRange::new(0, 512).to_string(),
                 None,
             )
             .await?;
@@ -1245,9 +1245,9 @@ mod page_blob_client {
         let err = dest_mismatch_page_blob
             .upload_pages_from_url(
                 plain_source_blob.url().as_str().into(),
-                HttpRange::new(0, 512).into(),
+                HttpRange::new(0, 512).to_string(),
                 512,
-                HttpRange::new(0, 512).into(),
+                HttpRange::new(0, 512).to_string(),
                 Some(PageBlobClientUploadPagesFromUrlOptions {
                     encryption_algorithm: Some(algo),
                     encryption_key: Some(wrong_key),
@@ -1266,9 +1266,9 @@ mod page_blob_client {
         let err = bad_scope_dest_page_blob
             .upload_pages_from_url(
                 plain_source_blob.url().as_str().into(),
-                HttpRange::new(0, 512).into(),
+                HttpRange::new(0, 512).to_string(),
                 512,
-                HttpRange::new(0, 512).into(),
+                HttpRange::new(0, 512).to_string(),
                 Some(PageBlobClientUploadPagesFromUrlOptions {
                     encryption_scope: Some(get_invalid_encryption_scope()),
                     ..Default::default()

--- a/sdk/storage/azure_storage_blob/tests/blob_cpk.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_cpk.rs
@@ -3,19 +3,16 @@
 
 use azure_core::http::RequestContent;
 use azure_core_test::{recorded, TestContext};
-use azure_storage_blob::{
-    format_page_range,
-    models::{
-        AppendBlobClientAppendBlockFromUrlOptions, AppendBlobClientAppendBlockOptions,
-        AppendBlobClientCreateOptions, BlobClientCreateSnapshotOptions,
-        BlobClientCreateSnapshotResultHeaders, BlobClientDownloadOptions,
-        BlobClientGetPropertiesOptions, BlobClientGetPropertiesResultHeaders,
-        BlobClientSetMetadataOptions, BlobType, BlockBlobClientCommitBlockListOptions,
-        BlockBlobClientStageBlockFromUrlOptions, BlockBlobClientStageBlockOptions,
-        BlockBlobClientUploadBlobFromUrlOptions, BlockBlobClientUploadOptions,
-        PageBlobClientClearPagesOptions, PageBlobClientCreateOptions, PageBlobClientResizeOptions,
-        PageBlobClientUploadPagesFromUrlOptions, PageBlobClientUploadPagesOptions,
-    },
+use azure_storage_blob::models::{
+    AppendBlobClientAppendBlockFromUrlOptions, AppendBlobClientAppendBlockOptions,
+    AppendBlobClientCreateOptions, BlobClientCreateSnapshotOptions,
+    BlobClientCreateSnapshotResultHeaders, BlobClientDownloadOptions,
+    BlobClientGetPropertiesOptions, BlobClientGetPropertiesResultHeaders,
+    BlobClientSetMetadataOptions, BlobType, BlockBlobClientCommitBlockListOptions,
+    BlockBlobClientStageBlockFromUrlOptions, BlockBlobClientStageBlockOptions,
+    BlockBlobClientUploadBlobFromUrlOptions, BlockBlobClientUploadOptions, HttpRange,
+    PageBlobClientClearPagesOptions, PageBlobClientCreateOptions, PageBlobClientResizeOptions,
+    PageBlobClientUploadPagesFromUrlOptions, PageBlobClientUploadPagesOptions,
 };
 use azure_storage_blob_test::{
     assert_bad_request_or_conflict, block_lookup, create_test_blob, get_blob_name,
@@ -945,7 +942,7 @@ mod page_blob_client {
             .upload_pages(
                 RequestContent::from(vec![b'P'; 512]),
                 512,
-                format_page_range(0, 512)?,
+                HttpRange::new(0, 512).into(),
                 Some(PageBlobClientUploadPagesOptions {
                     encryption_algorithm: Some(encryption_algorithm),
                     encryption_key: Some(encryption_key),
@@ -1016,7 +1013,7 @@ mod page_blob_client {
             .upload_pages(
                 RequestContent::from(content.clone()),
                 512,
-                format_page_range(0, 512)?,
+                HttpRange::new(0, 512).into(),
                 Some(PageBlobClientUploadPagesOptions {
                     encryption_algorithm: Some(algo),
                     encryption_key: Some(key.clone()),
@@ -1042,7 +1039,7 @@ mod page_blob_client {
             .upload_pages(
                 RequestContent::from(vec![b'B'; 512]),
                 512,
-                format_page_range(0, 512)?,
+                HttpRange::new(0, 512).into(),
                 Some(PageBlobClientUploadPagesOptions {
                     encryption_scope: Some(get_invalid_encryption_scope()),
                     ..Default::default()
@@ -1054,7 +1051,7 @@ mod page_blob_client {
         // Clear Pages with CPK
         page_blob
             .clear_pages(
-                format_page_range(0, 512)?,
+                HttpRange::new(0, 512).into(),
                 Some(PageBlobClientClearPagesOptions {
                     encryption_algorithm: Some(algo),
                     encryption_key: Some(key.clone()),
@@ -1077,7 +1074,7 @@ mod page_blob_client {
         // Invalid Scope Clear Pages
         let err = bad_scope_page_blob
             .clear_pages(
-                format_page_range(0, 512)?,
+                HttpRange::new(0, 512).into(),
                 Some(PageBlobClientClearPagesOptions {
                     encryption_scope: Some(get_invalid_encryption_scope()),
                     ..Default::default()
@@ -1141,7 +1138,7 @@ mod page_blob_client {
             .upload_pages(
                 RequestContent::from(source_content.clone()),
                 512,
-                format_page_range(0, 512)?,
+                HttpRange::new(0, 512).into(),
                 Some(PageBlobClientUploadPagesOptions {
                     encryption_algorithm: Some(algo),
                     encryption_key: Some(key.clone()),
@@ -1170,9 +1167,9 @@ mod page_blob_client {
         dest_page_blob
             .upload_pages_from_url(
                 source_blob.url().as_str().into(),
-                format_page_range(0, 512)?,
+                HttpRange::new(0, 512).into(),
                 512,
-                format_page_range(0, 512)?,
+                HttpRange::new(0, 512).into(),
                 Some(PageBlobClientUploadPagesFromUrlOptions {
                     encryption_algorithm: Some(algo),
                     encryption_key: Some(key.clone()),
@@ -1203,9 +1200,9 @@ mod page_blob_client {
         let err = source_mismatch_dest_page_blob
             .upload_pages_from_url(
                 source_blob.url().as_str().into(),
-                format_page_range(0, 512)?,
+                HttpRange::new(0, 512).into(),
                 512,
-                format_page_range(0, 512)?,
+                HttpRange::new(0, 512).into(),
                 Some(PageBlobClientUploadPagesFromUrlOptions {
                     source_encryption_algorithm: Some(algo),
                     source_encryption_key: Some(wrong_key.clone()),
@@ -1225,7 +1222,7 @@ mod page_blob_client {
             .upload_pages(
                 RequestContent::from(vec![b'T'; 512]),
                 512,
-                format_page_range(0, 512)?,
+                HttpRange::new(0, 512).into(),
                 None,
             )
             .await?;
@@ -1248,9 +1245,9 @@ mod page_blob_client {
         let err = dest_mismatch_page_blob
             .upload_pages_from_url(
                 plain_source_blob.url().as_str().into(),
-                format_page_range(0, 512)?,
+                HttpRange::new(0, 512).into(),
                 512,
-                format_page_range(0, 512)?,
+                HttpRange::new(0, 512).into(),
                 Some(PageBlobClientUploadPagesFromUrlOptions {
                     encryption_algorithm: Some(algo),
                     encryption_key: Some(wrong_key),
@@ -1269,9 +1266,9 @@ mod page_blob_client {
         let err = bad_scope_dest_page_blob
             .upload_pages_from_url(
                 plain_source_blob.url().as_str().into(),
-                format_page_range(0, 512)?,
+                HttpRange::new(0, 512).into(),
                 512,
-                format_page_range(0, 512)?,
+                HttpRange::new(0, 512).into(),
                 Some(PageBlobClientUploadPagesFromUrlOptions {
                     encryption_scope: Some(get_invalid_encryption_scope()),
                     ..Default::default()

--- a/sdk/storage/azure_storage_blob/tests/page_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/page_blob_client.rs
@@ -66,7 +66,7 @@ async fn test_upload_page(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         .upload_pages(
             RequestContent::from(data.clone()),
             512,
-            HttpRange::new(0, 512).into(),
+            HttpRange::new(0, 512).to_string(),
             None,
         )
         .await?;
@@ -95,13 +95,13 @@ async fn test_clear_page(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         .upload_pages(
             RequestContent::from(data),
             512,
-            HttpRange::new(0, 512).into(),
+            HttpRange::new(0, 512).to_string(),
             None,
         )
         .await?;
 
     page_blob_client
-        .clear_pages(HttpRange::new(0, 512).into(), None)
+        .clear_pages(HttpRange::new(0, 512).to_string(), None)
         .await?;
 
     // Assert
@@ -130,7 +130,7 @@ async fn test_resize_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         .upload_pages(
             RequestContent::from(data.clone()),
             1024,
-            HttpRange::new(0, 1024).into(),
+            HttpRange::new(0, 1024).to_string(),
             None,
         )
         .await;
@@ -143,7 +143,7 @@ async fn test_resize_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         .upload_pages(
             RequestContent::from(data.clone()),
             1024,
-            HttpRange::new(0, 1024).into(),
+            HttpRange::new(0, 1024).to_string(),
             None,
         )
         .await?;
@@ -225,7 +225,7 @@ async fn test_upload_page_from_url(ctx: TestContext) -> Result<(), Box<dyn Error
         .upload_pages(
             RequestContent::from(data_b.clone()),
             512,
-            HttpRange::new(0, 512).into(),
+            HttpRange::new(0, 512).to_string(),
             None,
         )
         .await?;
@@ -236,16 +236,16 @@ async fn test_upload_page_from_url(ctx: TestContext) -> Result<(), Box<dyn Error
         .upload_pages(
             RequestContent::from(data_a.clone()),
             512,
-            HttpRange::new(0, 512).into(),
+            HttpRange::new(0, 512).to_string(),
             None,
         )
         .await?;
     page_blob_client_2
         .upload_pages_from_url(
             blob_client_1.url().as_str().into(),
-            HttpRange::new(0, data_b.len() as u64).into(),
+            HttpRange::new(0, data_b.len() as u64).to_string(),
             data_b.len() as u64,
-            HttpRange::new(512, data_b.len() as u64).into(),
+            HttpRange::new(512, data_b.len() as u64).to_string(),
             None,
         )
         .await?;
@@ -284,7 +284,7 @@ async fn test_get_page_ranges(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         .upload_pages(
             RequestContent::from(data.clone()),
             512,
-            HttpRange::new(0, 512).into(),
+            HttpRange::new(0, 512).to_string(),
             None,
         )
         .await?;

--- a/sdk/storage/azure_storage_blob/tests/page_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/page_blob_client.rs
@@ -3,13 +3,10 @@
 
 use azure_core::http::{headers::CONTENT_TYPE, RequestContent, StatusCode};
 use azure_core_test::{recorded, TestContext};
-use azure_storage_blob::{
-    format_page_range,
-    models::{
-        BlobClientGetPropertiesResultHeaders, BlobType, PageBlobClientCreateOptions,
-        PageBlobClientSetSequenceNumberOptions, PageBlobClientSetSequenceNumberResultHeaders,
-        SequenceNumberActionType,
-    },
+use azure_storage_blob::models::{
+    BlobClientGetPropertiesResultHeaders, BlobType, HttpRange, PageBlobClientCreateOptions,
+    PageBlobClientSetSequenceNumberOptions, PageBlobClientSetSequenceNumberResultHeaders,
+    SequenceNumberActionType,
 };
 use azure_storage_blob_test::{get_blob_name, get_container_client, StorageAccount};
 use std::error::Error;
@@ -69,7 +66,7 @@ async fn test_upload_page(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         .upload_pages(
             RequestContent::from(data.clone()),
             512,
-            format_page_range(0, 512)?,
+            HttpRange::new(0, 512).into(),
             None,
         )
         .await?;
@@ -98,13 +95,13 @@ async fn test_clear_page(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         .upload_pages(
             RequestContent::from(data),
             512,
-            format_page_range(0, 512)?,
+            HttpRange::new(0, 512).into(),
             None,
         )
         .await?;
 
     page_blob_client
-        .clear_pages(format_page_range(0, 512)?, None)
+        .clear_pages(HttpRange::new(0, 512).into(), None)
         .await?;
 
     // Assert
@@ -133,7 +130,7 @@ async fn test_resize_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         .upload_pages(
             RequestContent::from(data.clone()),
             1024,
-            format_page_range(0, 1024)?,
+            HttpRange::new(0, 1024).into(),
             None,
         )
         .await;
@@ -146,7 +143,7 @@ async fn test_resize_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         .upload_pages(
             RequestContent::from(data.clone()),
             1024,
-            format_page_range(0, 1024)?,
+            HttpRange::new(0, 1024).into(),
             None,
         )
         .await?;
@@ -228,7 +225,7 @@ async fn test_upload_page_from_url(ctx: TestContext) -> Result<(), Box<dyn Error
         .upload_pages(
             RequestContent::from(data_b.clone()),
             512,
-            format_page_range(0, 512)?,
+            HttpRange::new(0, 512).into(),
             None,
         )
         .await?;
@@ -239,16 +236,16 @@ async fn test_upload_page_from_url(ctx: TestContext) -> Result<(), Box<dyn Error
         .upload_pages(
             RequestContent::from(data_a.clone()),
             512,
-            format_page_range(0, 512)?,
+            HttpRange::new(0, 512).into(),
             None,
         )
         .await?;
     page_blob_client_2
         .upload_pages_from_url(
             blob_client_1.url().as_str().into(),
-            format_page_range(0, data_b.len() as u64)?,
+            HttpRange::new(0, data_b.len() as u64).into(),
             data_b.len() as u64,
-            format_page_range(512, data_b.len() as u64)?,
+            HttpRange::new(512, data_b.len() as u64).into(),
             None,
         )
         .await?;
@@ -287,7 +284,7 @@ async fn test_get_page_ranges(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         .upload_pages(
             RequestContent::from(data.clone()),
             512,
-            format_page_range(0, 512)?,
+            HttpRange::new(0, 512).into(),
             None,
         )
         .await?;

--- a/sdk/storage/azure_storage_blob/tests/streaming.rs
+++ b/sdk/storage/azure_storage_blob/tests/streaming.rs
@@ -7,7 +7,10 @@ use azure_core::{
     Bytes,
 };
 use azure_core_test::{recorded, stream::GeneratedStream, TestContext};
-use azure_storage_blob::{format_page_range, models::BlockLookupList, BlobClient};
+use azure_storage_blob::{
+    models::{BlockLookupList, HttpRange},
+    BlobClient,
+};
 use azure_storage_blob_test::{get_blob_name, get_container_client, StorageAccount};
 use futures::TryStreamExt as _;
 use std::error::Error;
@@ -182,7 +185,7 @@ async fn stream_upload_pages(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         .upload_pages(
             request_content_from_bytes(&data),
             512,
-            format_page_range(0, 512)?,
+            HttpRange::new(0, 512).into(),
             None,
         )
         .await?;

--- a/sdk/storage/azure_storage_blob/tests/streaming.rs
+++ b/sdk/storage/azure_storage_blob/tests/streaming.rs
@@ -185,7 +185,7 @@ async fn stream_upload_pages(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         .upload_pages(
             request_content_from_bytes(&data),
             512,
-            HttpRange::new(0, 512).into(),
+            HttpRange::new(0, 512).to_string(),
             None,
         )
         .await?;


### PR DESCRIPTION
Adds `HttpRange` in place of our `format_page_range` helper parser, we are hoping to get typespec `@@alternateType` support pre-GA to remove the necessity of the `into()`.
`.tsp:` https://github.com/Azure/azure-rest-api-specs/pull/42277