### PR TITLE
Use updated location for Copilot CLI

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,5 @@
 {
-  "servers": {
+  "mcpServers": {
     "azure-sdk-mcp": {
       "type": "stdio",
       "command": "pwsh",

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -23,6 +23,7 @@
     "aarch",
     "accountendpoint",
     "accountkey",
+    "agentic",
     "amqp",
     "asyncoperation",
     "azsdk",


### PR DESCRIPTION
Copilot CLI reported that .vscode/mcp.json was deprecated and to move to .mcp.json in the root.
