### PR TITLE
Updated CHANGELOGs for TLS provider change

### DIFF
--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ### Features Added
 
+- Added the `reqwest_rustls` feature to use `aws-lc-rs` as the default TLS provider.
+
 ### Breaking Changes
 
+- Removed the `reqwest_native_tls` feature in favor of `reqwest_rustls`.
 - `new_http_client()` now takes an `Option<HttpClientOptions>` to disable automatic decompression - still enabled by default if `reqwest_gzip` or `reqwest_deflate` features are enabled.
 
 ### Bugs Fixed

--- a/sdk/core/typespec_client_core/CHANGELOG.md
+++ b/sdk/core/typespec_client_core/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ### Features Added
 
+- Added the `reqwest_rustls` feature to use `aws-lc-rs` as the default TLS provider.
+
 ### Breaking Changes
 
+- Removed the `reqwest_native_tls` feature in favor of `reqwest_rustls`.
 - `new_http_client()` now takes an `Option<HttpClientOptions>` to disable automatic decompression - still enabled by default if `reqwest_gzip` or `reqwest_deflate` features are enabled.
 
 ### Bugs Fixed

--- a/sdk/core/typespec_client_core/README.md
+++ b/sdk/core/typespec_client_core/README.md
@@ -9,7 +9,7 @@ This is the runtime for [TypeSpec](https://typespec.io)-generated clients.
 - `derive`: enable derive macros e.g., `SafeDebug`.
 - `http` (default): enables HTTP support.
 - `json` (default): enables JSON support.
-- `reqwest` (default): enables and sets `reqwest` as the default `HttpClient`. Enables `reqwest`'s `rustls` feature.
+- `reqwest` (default): enables and sets `reqwest` as the default `HttpClient`.
 - `reqwest_deflate` (default): enables deflate compression for `reqwest`.
 - `reqwest_gzip` (default): enables gzip compression for `reqwest`.
 - `reqwest_rustls` (default): enables `reqwest`'s `rustls` feature, which uses `aws-lc-rs`.


### PR DESCRIPTION
Missed from #4190 along with a small `README.md` change I forgot to commit.
