### PR TITLE
Fix lint issue in main

### DIFF
--- a/sdk/core/azure_core_test/src/recording.rs
+++ b/sdk/core/azure_core_test/src/recording.rs
@@ -542,7 +542,7 @@ impl Recording {
             TestMode::Playback => {
                 let result = client.playback_start(payload.try_into()?, None).await?;
                 let mut variables = self.variables.write().map_err(write_lock_error)?;
-                variables.extend(result.variables.into_iter());
+                variables.extend(result.variables);
 
                 result.recording_id
             }

--- a/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
@@ -319,7 +319,7 @@ impl PartitionedUploadBehavior for BlockBlobClientUploadBehavior<'_, '_> {
 
     async fn finalize(&self) -> Result<()> {
         let mut blocks = self.blocks.lock().await;
-        blocks.sort_by(|left, right| left.offset.cmp(&right.offset));
+        blocks.sort_by_key(|left| left.offset);
         let blocklist = BlockLookupList {
             latest: Some(
                 blocks

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/upload.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/upload.rs
@@ -361,8 +361,7 @@ mod tests {
                 _ => None,
             })
             .collect();
-        sorted_transfer_partition_invocations
-            .sort_by_key(|(left_offset, _, _)| *left_offset);
+        sorted_transfer_partition_invocations.sort_by_key(|(left_offset, _, _)| *left_offset);
 
         assert_eq!(
             sorted_transfer_partition_invocations.len(),

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/upload.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/upload.rs
@@ -362,7 +362,7 @@ mod tests {
             })
             .collect();
         sorted_transfer_partition_invocations
-            .sort_by(|(left_offset, _, _), (right_offset, _, _)| left_offset.cmp(right_offset));
+            .sort_by_key(|(left_offset, _, _)| *left_offset);
 
         assert_eq!(
             sorted_transfer_partition_invocations.len(),


### PR DESCRIPTION
The clippy build is failing in main because of these two lints:

* `unnecessary_sort_by` in `azure_storage_blobs`
* `useless_conversion` in `azure_core_test`

These were all trivially fixable with `cargo clippy --fix`, so I did so ;).