### PR TITLE
fix some `allow`s when no compression feature enabled

### DIFF
--- a/sdk/core/typespec_client_core/src/http/clients/reqwest.rs
+++ b/sdk/core/typespec_client_core/src/http/clients/reqwest.rs
@@ -23,7 +23,7 @@ use typespec::error::{Error, ErrorKind, Result, ResultExt};
 ///   when calling this function.
 #[cfg_attr(
     not(any(feature = "reqwest_gzip", feature = "reqwest_deflate")),
-    allow(unused_variable)
+    allow(unused_variables)
 )]
 pub fn new_reqwest_client(options: Option<super::HttpClientOptions>) -> Arc<dyn HttpClient> {
     debug!("creating an http client using `reqwest`");
@@ -35,6 +35,10 @@ pub fn new_reqwest_client(options: Option<super::HttpClientOptions>) -> Arc<dyn 
     //
     // Due to the significant performance impact when disabling connection pooling,
     // it is enabled here by default. See the `azure_core` troubleshooting guide to disable pooling.
+    #[cfg_attr(
+        not(any(feature = "reqwest_gzip", feature = "reqwest_deflate")),
+        allow(unused_mut)
+    )]
     let mut builder = ::reqwest::ClientBuilder::new()
         // By default, reqwest will chase 3xx redirects up to 10 links. REST API guidelines
         // discourage services from using 3xx redirects, so disabling the reqwest redirect logic


### PR DESCRIPTION
If someone depends on `typespec_client_core` with neither `reqwest_gzip`, nor `reqwest_deflate` enabled, they get these warnings (as error on CI):

```
 Compiling typespec_client_core v0.14.0 (/home/ashleyst/dev/azure-sdk-for-rust/main/sdk/core/typespec_client_core)
warning: unknown lint: `unused_variable`
  --> sdk/core/typespec_client_core/src/http/clients/reqwest.rs:26:11
   |
26 |     allow(unused_variable)
   |           ^^^^^^^^^^^^^^^ help: did you mean: `unused_variables`
   |
   = note: `#[warn(unknown_lints)]` on by default

warning: variable does not need to be mutable
  --> sdk/core/typespec_client_core/src/http/clients/reqwest.rs:38:9
   |
38 |     let mut builder = ::reqwest::ClientBuilder::new()
   |         ----^^^^^^^
   |         |
   |         help: remove this `mut`
   |
   = note: `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default

warning: unused variable: `options`
  --> sdk/core/typespec_client_core/src/http/clients/reqwest.rs:30:9
   |
30 |     let options = options.unwrap_or_default();
   |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_options`
   |
   = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default

warning: `typespec_client_core` (lib) generated 3 warnings (run `cargo fix --lib -p typespec_client_core` to apply 2 suggestions)

```

These don't show up when you use either feature, because the lints aren't relevant when at least one compression feature is enabled.