### PR TITLE
[Storage] Alter comment on error behavior

### DIFF
--- a/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
@@ -257,9 +257,12 @@ impl PartitionedUploadBehavior for BlockBlobClientUploadBehavior<'_, '_> {
         // This should only ever be called by a managed uploader when the length is known.
         // Otherwise, we can only buffer or error.
         // Buffering strategy must be left to the caller, so we must error.
-        let content_len = content.len().ok_or_else(|| {
-            azure_core::Error::with_message(azure_core::error::ErrorKind::Io, "length unknown")
-        })?;
+        let Some(content_len) = content.len() else {
+            return Err(azure_core::Error::with_message(
+                azure_core::error::ErrorKind::Io,
+                "length unknown",
+            ));
+        };
         let rsp = self
             .client
             .upload_internal(

--- a/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
@@ -286,11 +286,16 @@ impl PartitionedUploadBehavior for BlockBlobClientUploadBehavior<'_, '_> {
     }
 
     async fn transfer_partition(&self, offset: u64, content: Body) -> Result<()> {
+        // This should only ever be called by a managed uploader when the length is known.
+        // Otherwise, we can only buffer or error.
+        // Buffering strategy must be left to the caller, so we must error.
+        let Some(content_len) = content.len() else {
+            return Err(azure_core::Error::with_message(
+                azure_core::error::ErrorKind::Io,
+                "length unknown",
+            ));
+        };
         let block_id = Uuid::new_v4();
-        // TODO (jaschrep-msft) support oneshot given optional length
-        let content_len = content.len().ok_or_else(|| {
-            azure_core::Error::with_message(azure_core::error::ErrorKind::Io, "length unknown")
-        })?;
         {
             self.blocks
                 .lock()

--- a/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
@@ -254,8 +254,9 @@ impl<'c, 'opt> BlockBlobClientUploadBehavior<'c, 'opt> {
 #[async_trait]
 impl PartitionedUploadBehavior for BlockBlobClientUploadBehavior<'_, '_> {
     async fn transfer_oneshot(&self, content: Body) -> Result<()> {
-        // cspell:ignore jaschrep
-        // TODO (jaschrep-msft) support oneshot given optional length
+        // This should only ever be called by a managed uploader when the length is known.
+        // Otherwise, we can only buffer or error.
+        // Buffering strategy must be left to the caller, so we must error.
         let content_len = content.len().ok_or_else(|| {
             azure_core::Error::with_message(azure_core::error::ErrorKind::Io, "length unknown")
         })?;


### PR DESCRIPTION
A todo was left from a previous change to address behavior in a given case, but the behavior is actually what we want. Update the comment accordingly.

This trait is internal for use by managed uploaders which are responsible for the buffering strategy. They should only call this method if the body can be handled by this operation in the first place.

This error should be unreachable code in a functioning library.