### PR TITLE
Set connect, read timeouts on reqwest::Client

### DIFF
--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Breaking Changes
 
+- Added connection timeout of 20s and read timeout of 60s.
 - Removed the `reqwest_native_tls` feature in favor of `reqwest_rustls`.
 - `new_http_client()` now takes an `Option<HttpClientOptions>` to disable automatic decompression - still enabled by default if `reqwest_gzip` or `reqwest_deflate` features are enabled.
 

--- a/sdk/core/typespec_client_core/CHANGELOG.md
+++ b/sdk/core/typespec_client_core/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Breaking Changes
 
+- Added connection timeout of 20s and read timeout of 60s.
 - Removed the `reqwest_native_tls` feature in favor of `reqwest_rustls`.
 - `new_http_client()` now takes an `Option<HttpClientOptions>` to disable automatic decompression - still enabled by default if `reqwest_gzip` or `reqwest_deflate` features are enabled.
 

--- a/sdk/core/typespec_client_core/src/http/clients/reqwest.rs
+++ b/sdk/core/typespec_client_core/src/http/clients/reqwest.rs
@@ -9,9 +9,12 @@ use crate::http::{
 };
 use async_trait::async_trait;
 use futures::TryStreamExt;
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tracing::{debug, warn};
 use typespec::error::{Error, ErrorKind, Result, ResultExt};
+
+const DEFAULT_CONNECTION_TIMEOUT: Duration = Duration::from_secs(20);
+const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Create a new [`HttpClient`] with the `reqwest` backend.
 ///
@@ -40,6 +43,9 @@ pub fn new_reqwest_client(options: Option<super::HttpClientOptions>) -> Arc<dyn 
         allow(unused_mut)
     )]
     let mut builder = ::reqwest::ClientBuilder::new()
+        // TODO: Support configuration options (https://github.com/Azure/azure-sdk-for-rust/issues/4217)
+        .connect_timeout(DEFAULT_CONNECTION_TIMEOUT)
+        .read_timeout(DEFAULT_READ_TIMEOUT)
         // By default, reqwest will chase 3xx redirects up to 10 links. REST API guidelines
         // discourage services from using 3xx redirects, so disabling the reqwest redirect logic
         // simplifies the client logic.


### PR DESCRIPTION
Resolves #4209. We'll use the Python Storage SDK connection and read timeouts for now.
Some other Azure SDK languages default to 10s and 60s but we'll provide configurable options and may change the defaults in a subsequent release.
