### PR TITLE
fix: remove unintentional default-features=false for azure_data_cosmos workspace dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,6 @@ path = "sdk/storage/azure_storage_blob"
 version = "0.12.0"
 
 [workspace.dependencies.azure_data_cosmos]
-default-features = false
 version = "0.33.0"
 path = "sdk/cosmos/azure_data_cosmos"
 


### PR DESCRIPTION
## Problem

The merge commit e753b8e ("Merge branch 'main' into release/azure_data_cosmos-previews") introduced a new `[workspace.dependencies.azure_data_cosmos]` block with `default-features = false`. This block did not exist in either merge parent — it was created during conflict resolution, modeled after the `azure_data_cosmos_driver` block which legitimately disables defaults.

With default features disabled, the `reqwest` feature is no longer enabled for downstream workspace crates like `azure_data_cosmos_perf`. This causes a compilation failure because `cosmos_client_builder.rs` uses `COSMOS_ALLOWED_HEADERS` and `AZURE_COSMOS_PER_PARTITION_CIRCUIT_BREAKER_ENABLED` unconditionally, but their imports are gated behind `#[cfg(feature = "reqwest")]`:

```
error[E0425]: cannot find value `COSMOS_ALLOWED_HEADERS` in this scope
  --> sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client_builder.rs:312:27

error[E0425]: cannot find value `AZURE_COSMOS_PER_PARTITION_CIRCUIT_BREAKER_ENABLED` in this scope
  --> sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client_builder.rs:371:27
```

## Impact

This broke the AKS perf CronJob (`cosmos-perf-updater`) in `rg-cosmos-perf-pr4159`. The updater correctly detected the new commit and attempted to rebuild, but the Docker image build fails due to the compilation error above. The perf workload is stuck on commit `0b99c1158` and cannot auto-update.

## Fix

Remove `default-features = false` from the `[workspace.dependencies.azure_data_cosmos]` block. This restores the default feature set (which includes `reqwest`) and allows the perf crate to compile.

## Verification

- Neither merge parent had this workspace dependency block, confirming it was introduced during conflict resolution
- `main` branch does not have a `[workspace.dependencies.azure_data_cosmos]` block at all
- The `azure_data_cosmos` crate's default features include `reqwest`, which is required for the unconditional use of `COSMOS_ALLOWED_HEADERS` and `AZURE_COSMOS_PER_PARTITION_CIRCUIT_BREAKER_ENABLED`