### PR TITLE
[Storage] Partitioned Download CI Deadlock Fix

### DIFF
--- a/sdk/core/azure_core_test/src/lib.rs
+++ b/sdk/core/azure_core_test/src/lib.rs
@@ -19,6 +19,13 @@ use azure_core::Error;
 pub use azure_core::{error::ErrorKind, test::TestMode};
 pub use proxy::{matchers::*, sanitizers::*};
 pub use recording::*;
+
+/// Hidden re-exports used by the `#[recorded::test]` proc macro.
+/// Not part of the public API.
+#[doc(hidden)]
+pub mod __macro_support {
+    pub use ::tracing;
+}
 use std::path::{Path, PathBuf};
 
 const ASSETS_FILE: &str = "assets.json";

--- a/sdk/core/azure_core_test_macros/src/test.rs
+++ b/sdk/core/azure_core_test_macros/src/test.rs
@@ -63,61 +63,29 @@ pub fn parse_test(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
     let setup = match inputs.next() {
         None if recorded_attrs.live => quote! {
             ::azure_core_test::__macro_support::tracing::info!("[recorded::test] starting '{}' in {}", #fn_name_str, file!());
-            let __test_future = async {
-                #fn_name().await
-            };
-            match ::tokio::time::timeout(
-                ::std::time::Duration::from_secs(300),
-                __test_future,
-            ).await {
-                Ok(result) => {
-                    if let Err(e) = &result {
-                        ::azure_core_test::__macro_support::tracing::error!("[recorded::test] finished '{}' in {} (err: {e})", #fn_name_str, file!());
-                    }
-                    result
-                }
-                Err(_) => {
-                    ::azure_core_test::__macro_support::tracing::error!("!!!! TIMEOUT !!!! test '{}' in {} exceeded 300s hard limit", #fn_name_str, file!());
-                    Err(::azure_core::Error::with_message(
-                        ::azure_core::error::ErrorKind::Other,
-                        format!("test '{}' in {} timed out after 300s", #fn_name_str, file!()),
-                    ).into())
-                }
+            let result = #fn_name().await;
+            if let Err(e) = &result {
+                ::azure_core_test::__macro_support::tracing::error!("[recorded::test] finished '{}' in {} (err: {e})", #fn_name_str, file!());
             }
+            result
         },
         Some(FnArg::Typed(PatType { ty, .. })) if is_test_context(ty.as_ref()) => {
             let test_mode = test_mode_to_tokens(test_mode);
             quote! {
                 ::azure_core_test::__macro_support::tracing::info!("[recorded::test] starting '{}' in {}", #fn_name_str, file!());
-                let __test_future = async {
-                    #[allow(dead_code)]
-                    let mut ctx = ::azure_core_test::recorded::start(
-                        #test_mode,
-                        env!("CARGO_MANIFEST_DIR"),
-                        file!(),
-                        stringify!(#fn_name),
-                        ::std::option::Option::None,
-                    ).await?;
-                    #fn_name(ctx).await
-                };
-                match ::tokio::time::timeout(
-                    ::std::time::Duration::from_secs(300),
-                    __test_future,
-                ).await {
-                    Ok(result) => {
-                        if let Err(e) = &result {
-                            ::azure_core_test::__macro_support::tracing::error!("[recorded::test] finished '{}' in {} (err: {e})", #fn_name_str, file!());
-                        }
-                        result
-                    }
-                    Err(_) => {
-                        ::azure_core_test::__macro_support::tracing::error!("!!!! TIMEOUT !!!! test '{}' in {} exceeded 300s hard limit", #fn_name_str, file!());
-                        Err(::azure_core::Error::with_message(
-                            ::azure_core::error::ErrorKind::Other,
-                            format!("test '{}' in {} timed out after 300s", #fn_name_str, file!()),
-                        ).into())
-                    }
+                #[allow(dead_code)]
+                let mut ctx = ::azure_core_test::recorded::start(
+                    #test_mode,
+                    env!("CARGO_MANIFEST_DIR"),
+                    file!(),
+                    stringify!(#fn_name),
+                    ::std::option::Option::None,
+                ).await?;
+                let result = #fn_name(ctx).await;
+                if let Err(e) = &result {
+                    ::azure_core_test::__macro_support::tracing::error!("[recorded::test] finished '{}' in {} (err: {e})", #fn_name_str, file!());
                 }
+                result
             }
         }
         _ => {

--- a/sdk/core/azure_core_test_macros/src/test.rs
+++ b/sdk/core/azure_core_test_macros/src/test.rs
@@ -58,14 +58,22 @@ pub fn parse_test(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
     }
 
     let fn_name = &original_sig.ident;
+    let fn_name_str = fn_name.to_string();
     let mut inputs = original_sig.inputs.iter();
     let setup = match inputs.next() {
         None if recorded_attrs.live => quote! {
-            #fn_name().await
+            ::azure_core_test::__macro_support::tracing::info!("[recorded::test] starting '{}' in {}", #fn_name_str, file!());
+            let __result = #fn_name().await;
+            match &__result {
+                Ok(_) => ::azure_core_test::__macro_support::tracing::info!("[recorded::test] finished '{}' in {} (ok)", #fn_name_str, file!()),
+                Err(e) => ::azure_core_test::__macro_support::tracing::error!("[recorded::test] finished '{}' in {} (err: {e})", #fn_name_str, file!()),
+            }
+            __result
         },
         Some(FnArg::Typed(PatType { ty, .. })) if is_test_context(ty.as_ref()) => {
             let test_mode = test_mode_to_tokens(test_mode);
             quote! {
+                ::azure_core_test::__macro_support::tracing::info!("[recorded::test] starting '{}' in {}", #fn_name_str, file!());
                 #[allow(dead_code)]
                 let mut ctx = ::azure_core_test::recorded::start(
                     #test_mode,
@@ -74,7 +82,12 @@ pub fn parse_test(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
                     stringify!(#fn_name),
                     ::std::option::Option::None,
                 ).await?;
-                #fn_name(ctx).await
+                let __result = #fn_name(ctx).await;
+                match &__result {
+                    Ok(_) => ::azure_core_test::__macro_support::tracing::info!("[recorded::test] finished '{}' in {} (ok)", #fn_name_str, file!()),
+                    Err(e) => ::azure_core_test::__macro_support::tracing::error!("[recorded::test] finished '{}' in {} (err: {e})", #fn_name_str, file!()),
+                }
+                __result
             }
         }
         _ => {

--- a/sdk/core/azure_core_test_macros/src/test.rs
+++ b/sdk/core/azure_core_test_macros/src/test.rs
@@ -63,31 +63,61 @@ pub fn parse_test(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
     let setup = match inputs.next() {
         None if recorded_attrs.live => quote! {
             ::azure_core_test::__macro_support::tracing::info!("[recorded::test] starting '{}' in {}", #fn_name_str, file!());
-            let __result = #fn_name().await;
-            match &__result {
-                Ok(_) => ::azure_core_test::__macro_support::tracing::info!("[recorded::test] finished '{}' in {} (ok)", #fn_name_str, file!()),
-                Err(e) => ::azure_core_test::__macro_support::tracing::error!("[recorded::test] finished '{}' in {} (err: {e})", #fn_name_str, file!()),
+            let __test_future = async {
+                #fn_name().await
+            };
+            match ::tokio::time::timeout(
+                ::std::time::Duration::from_secs(300),
+                __test_future,
+            ).await {
+                Ok(result) => {
+                    if let Err(e) = &result {
+                        ::azure_core_test::__macro_support::tracing::error!("[recorded::test] finished '{}' in {} (err: {e})", #fn_name_str, file!());
+                    }
+                    result
+                }
+                Err(_) => {
+                    ::azure_core_test::__macro_support::tracing::error!("!!!! TIMEOUT !!!! test '{}' in {} exceeded 300s hard limit", #fn_name_str, file!());
+                    Err(::azure_core::Error::with_message(
+                        ::azure_core::error::ErrorKind::Other,
+                        format!("test '{}' in {} timed out after 300s", #fn_name_str, file!()),
+                    ).into())
+                }
             }
-            __result
         },
         Some(FnArg::Typed(PatType { ty, .. })) if is_test_context(ty.as_ref()) => {
             let test_mode = test_mode_to_tokens(test_mode);
             quote! {
                 ::azure_core_test::__macro_support::tracing::info!("[recorded::test] starting '{}' in {}", #fn_name_str, file!());
-                #[allow(dead_code)]
-                let mut ctx = ::azure_core_test::recorded::start(
-                    #test_mode,
-                    env!("CARGO_MANIFEST_DIR"),
-                    file!(),
-                    stringify!(#fn_name),
-                    ::std::option::Option::None,
-                ).await?;
-                let __result = #fn_name(ctx).await;
-                match &__result {
-                    Ok(_) => ::azure_core_test::__macro_support::tracing::info!("[recorded::test] finished '{}' in {} (ok)", #fn_name_str, file!()),
-                    Err(e) => ::azure_core_test::__macro_support::tracing::error!("[recorded::test] finished '{}' in {} (err: {e})", #fn_name_str, file!()),
+                let __test_future = async {
+                    #[allow(dead_code)]
+                    let mut ctx = ::azure_core_test::recorded::start(
+                        #test_mode,
+                        env!("CARGO_MANIFEST_DIR"),
+                        file!(),
+                        stringify!(#fn_name),
+                        ::std::option::Option::None,
+                    ).await?;
+                    #fn_name(ctx).await
+                };
+                match ::tokio::time::timeout(
+                    ::std::time::Duration::from_secs(300),
+                    __test_future,
+                ).await {
+                    Ok(result) => {
+                        if let Err(e) = &result {
+                            ::azure_core_test::__macro_support::tracing::error!("[recorded::test] finished '{}' in {} (err: {e})", #fn_name_str, file!());
+                        }
+                        result
+                    }
+                    Err(_) => {
+                        ::azure_core_test::__macro_support::tracing::error!("!!!! TIMEOUT !!!! test '{}' in {} exceeded 300s hard limit", #fn_name_str, file!());
+                        Err(::azure_core::Error::with_message(
+                            ::azure_core::error::ErrorKind::Other,
+                            format!("test '{}' in {} timed out after 300s", #fn_name_str, file!()),
+                        ).into())
+                    }
                 }
-                __result
             }
         }
         _ => {

--- a/sdk/core/typespec_client_core/src/http/policies/retry/mod.rs
+++ b/sdk/core/typespec_client_core/src/http/policies/retry/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use std::{ops::Deref, sync::Arc};
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 use typespec::error::{ErrorKind, ResultExt};
 
 /// Attempts to parse the supplied string as an HTTP date, of the form defined by RFC 7231 (e.g. `Fri, 01 Jan 2021 00:00:00 GMT`).
@@ -217,6 +217,13 @@ where
                 }
                 Err(error) => {
                     if matches!(error.kind(), &ErrorKind::Io | &ErrorKind::Connection) {
+                        warn!(
+                            "[retry] transport error on attempt {} for {} {}: {}",
+                            retry_count + 1,
+                            request.method(),
+                            request.url(),
+                            error,
+                        );
                         debug!(
                             "transport error occurred when making request which will be retried: {}",
                             error
@@ -236,12 +243,28 @@ where
             if self.is_expired(time_since_start, retry_count) {
                 return match last_result {
                     Ok(result) => Ok(result),
-                    Err(last_error) => Err(last_error.with_context(
-                        "retry policy expired and the request will no longer be retried",
-                    )),
+                    Err(last_error) => {
+                        warn!(
+                            "[retry] giving up on {} {} after {} attempts ({:.1}s elapsed): {}",
+                            request.method(),
+                            request.url(),
+                            retry_count + 1,
+                            time_since_start.as_seconds_f64(),
+                            last_error,
+                        );
+                        Err(last_error.with_context(
+                            "retry policy expired and the request will no longer be retried",
+                        ))
+                    }
                 };
             }
             retry_count += 1;
+            warn!(
+                "[retry] will retry {} {} (attempt {})",
+                request.method(),
+                request.url(),
+                retry_count + 1,
+            );
 
             self.wait(retry_count, retry_after).await;
         }

--- a/sdk/storage/azure_storage_blob/Cargo.toml
+++ b/sdk/storage/azure_storage_blob/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { workspace = true, optional = true, features = [
   "io-util",
   "sync",
 ] }
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
@@ -185,6 +185,39 @@ where
                 break;
             }
 
+            // BUG FIX: Deadlock when total_chunks > max_buffers (parallel * 2).
+            //
+            // The dispatch loop above is gated by `drain.currently_accepting()`,
+            // which returns `drain_pos .. drain_pos + max_buffers`.  When there
+            // are more chunks than max_buffers, the dispatch loop stops once
+            // next_task_index reaches the upper bound of that window.
+            //
+            // After yielding, drain_pos advances, which shifts the accepting
+            // window forward — potentially making room for more tasks.  Without
+            // this `continue`, we fall through to `await_message`, which blocks
+            // on the channel.  If all previously-dispatched tasks have already
+            // completed and sent their messages (active == 0), no new message
+            // will ever arrive, causing a permanent hang.
+            //
+            // Observed in CI: parallel=8, partition_len=31, 1024-byte blob →
+            // 34 chunks, max_buffers=16.  After draining to position 26 with
+            // active=0, chunks 26–33 were never dispatched and the stream
+            // blocked forever on `await_message`.
+            //
+            // Hypothesis (after a little chat with good ol' Copilot)
+            // This is a race condition that reproduces reliably in CI because
+            // the test proxy returns responses almost instantly — tasks
+            // complete in microseconds, so by the time the stream loop yields
+            // and re-checks, every dispatched task has already finished and
+            // the channel is drained (active == 0).  Against real Azure Blob
+            // Storage, network latency keeps at least one task in-flight at
+            // the critical moment, so its eventual message unblocks the loop
+            // and the next iteration dispatches the remaining chunks.  This
+            // explains why the bug was not caught earlier.
+            if yielded_count > 0 && !remaining_ranges.is_empty() {
+                continue;
+            }
+
             // max tasks are spawned and sequential ready bytes already returned
             // this will not change until either:
             //   1. a task sends a message through this channel

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
@@ -80,6 +80,15 @@ where
     }
     let total_chunks = remaining_ranges.len() + 1;
 
+    tracing::info!(
+        total_chunks,
+        remaining = remaining_ranges.len(),
+        parallel,
+        max_buffers,
+        partition_size,
+        "partitioned download: orchestrating"
+    );
+
     // channel for download workers to send results to their coordinator.
     let (tx, mut rx) = mpsc::unbounded();
 
@@ -104,18 +113,42 @@ where
     // download, indexed by chunk.
     let stream = async_stream::try_stream! {
         while drain.position() < total_chunks {
+            let loop_active = active_tasks_counter.load(Ordering::Relaxed);
+            let loop_accepting = drain.currently_accepting();
+            tracing::info!(
+                drain_pos = drain.position(),
+                total_chunks,
+                next_task_index,
+                active = loop_active,
+                accepting = ?loop_accepting,
+                task_bucket_len = task_bucket.len(),
+                "partitioned download: stream loop top"
+            );
+
             // while there is room in the buffer drain and not at max connections, start new range downloads
+            let mut tasks_started_this_round = 0usize;
             while drain.currently_accepting().contains(&next_task_index) && active_tasks_counter.load(Ordering::Relaxed) < parallel {
                 match remaining_ranges.pop_front() {
                     Some(range) => {
                         let i = next_task_index;
                         next_task_index += 1;
                         active_tasks_counter.fetch_add(1, Ordering::Relaxed);
+                        tasks_started_this_round += 1;
 
+                        tracing::debug!(
+                            chunk_idx = i,
+                            ?range,
+                            active = active_tasks_counter.load(Ordering::Relaxed),
+                            "partitioned download: starting task"
+                        );
                         let t = tx_opt.as_ref().ok_or_else(||Error::with_message(ErrorKind::Other, "Channel closed unexpectedly."))?.clone();
                         task_bucket.push(start_download_task(client.clone(), range, etag_lock.clone(), t, active_tasks_counter.clone(), i));
                     }
                     None => {
+                        tracing::info!(
+                            next_task_index,
+                            "partitioned download: all ranges dispatched, dropping spare sender"
+                        );
                         // if ranges are finished, we'll never need to clone the transmitter again.
                         // drop this transmitter to ensure channel closes when expected
                         tx_opt = None;
@@ -123,14 +156,32 @@ where
                     }
                 }
             }
+            if tasks_started_this_round > 0 {
+                tracing::info!(
+                    tasks_started_this_round,
+                    next_task_index,
+                    active = active_tasks_counter.load(Ordering::Relaxed),
+                    "partitioned download: dispatched new tasks"
+                );
+            }
 
             // return next readied bytes, if any
+            let mut yielded_count = 0usize;
             while let Some(bytes) = drain.pop() {
+                yielded_count += 1;
                 yield bytes;
+            }
+            if yielded_count > 0 {
+                tracing::info!(
+                    yielded_count,
+                    drain_pos = drain.position(),
+                    "partitioned download: yielded chunks"
+                );
             }
 
             // early break if finished
             if drain.position() >= total_chunks {
+                tracing::info!("partitioned download: all chunks yielded, breaking");
                 break;
             }
 
@@ -138,9 +189,21 @@ where
             // this will not change until either:
             //   1. a task sends a message through this channel
             //   2. a task fails
+            tracing::info!(
+                drain_pos = drain.position(),
+                active = active_tasks_counter.load(Ordering::Relaxed),
+                task_bucket_len = task_bucket.len(),
+                "partitioned download: awaiting message"
+            );
             let channel_message;
             (channel_message, task_bucket) = await_message_while_joining_workers(&mut rx, task_bucket).await?;
             let (idx, bytes) = channel_message?;
+            tracing::info!(
+                chunk_idx = idx,
+                bytes_len = bytes.len(),
+                drain_pos = drain.position(),
+                "partitioned download: received chunk"
+            );
             drain.push(idx, bytes)?;
         }
     };
@@ -204,12 +267,24 @@ async fn await_message_while_joining_workers<T>(
 
     let mut message_fut = receiver.recv();
     // `task_bucket`` may be empty. `select_all` cannot handle that.
+    let mut join_loop_count = 0usize;
     while !task_bucket.is_empty() {
         match future::select(message_fut, future::select_all(task_bucket)).await {
             Either::Left((message, task_select)) => {
+                tracing::debug!(
+                    join_loop_count,
+                    "partitioned download: await_message got channel message"
+                );
                 return Ok((message.map_err(on_recv_err)?, task_select.into_inner()));
             }
-            Either::Right(((completed_task, _, remaining_tasks), m_fut)) => {
+            Either::Right(((completed_task, idx, remaining_tasks), m_fut)) => {
+                join_loop_count += 1;
+                tracing::debug!(
+                    join_loop_count,
+                    joined_task_idx = idx,
+                    remaining_tasks = remaining_tasks.len(),
+                    "partitioned download: await_message joined task, looping"
+                );
                 completed_task.map_err(map_spawned_task_error)?;
                 task_bucket = remaining_tasks;
                 message_fut = m_fut;
@@ -217,6 +292,7 @@ async fn await_message_while_joining_workers<T>(
         }
     }
 
+    tracing::debug!("partitioned download: await_message all tasks joined, waiting for channel");
     Ok((message_fut.await.map_err(on_recv_err)?, task_bucket))
 }
 
@@ -229,6 +305,10 @@ fn start_initial_download_task(
     partition_size: usize,
 ) -> SpawnedTask {
     get_async_runtime().spawn(Box::pin(async move {
+        tracing::info!(
+            partition_size,
+            "partitioned download: initial task collecting body"
+        );
         let mut dst = vec![0u8; partition_size];
         let res = initial_response
             .into_body()
@@ -236,8 +316,13 @@ fn start_initial_download_task(
             .await
             // this is the initial download task, it's chunk index is 0
             .map(|_| (0usize, dst.into()));
+        tracing::info!(
+            ok = res.is_ok(),
+            "partitioned download: initial task body collected"
+        );
         active_tasks_counter.fetch_sub(1, Ordering::Relaxed);
         let _send_res = sender.send(res).await;
+        tracing::debug!("partitioned download: initial task sent result");
     }))
 }
 
@@ -252,6 +337,7 @@ fn start_download_task<Behavior: PartitionedDownloadBehavior + Send + Sync + 'st
     chunk_idx: usize,
 ) -> SpawnedTask {
     get_async_runtime().spawn(Box::pin(async move {
+        tracing::debug!(chunk_idx, "partitioned download: task requesting range");
         let mut dst = vec![0u8; range.len()];
         let res = async {
             client
@@ -265,8 +351,14 @@ fn start_download_task<Behavior: PartitionedDownloadBehavior + Send + Sync + 'st
         if let Ok(count) = res {
             dst.truncate(count);
         }
+        tracing::debug!(
+            chunk_idx,
+            ok = res.is_ok(),
+            "partitioned download: task request complete"
+        );
         active_tasks_counter.fetch_sub(1, Ordering::Relaxed);
         let _send_res = sender.send(res.map(|_| (chunk_idx, dst.into()))).await;
+        tracing::debug!(chunk_idx, "partitioned download: task sent result");
     }))
 }
 

--- a/sdk/storage/azure_storage_blob/tests/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client.rs
@@ -938,7 +938,6 @@ fn test_managed_download_args() -> impl IntoIterator<Item = TestManagedDownloadA
 }
 
 #[recorded::test]
-#[ignore = "Temporarily ignoring until we can figure out how to get this to not take down the whole test pipeline."]
 async fn test_managed_download(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     let request_count = Arc::new(AtomicUsize::new(0));
     let count_policy = Arc::new(TestPolicy::count_requests(request_count.clone(), None));
@@ -1409,7 +1408,6 @@ async fn test_gzip_blob_no_metadata_roundtrip(ctx: TestContext) -> Result<(), Bo
 }
 
 #[recorded::test]
-#[ignore = "Temporarily ignoring until we can figure out how to get this to not take down the whole test pipeline."]
 async fn test_gzip_blob_with_metadata_roundtrip(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     let recording = ctx.recording();
     let container_client =

--- a/sdk/storage/azure_storage_blob/tests/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client.rs
@@ -952,14 +952,24 @@ async fn test_managed_download(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     .await?;
     let blob_client = container_client.blob_client(&get_blob_name(recording));
 
-    for TestManagedDownloadArgSet {
-        data_len,
-        parallel,
-        partition_len,
-        download_range,
-        expected_gets,
-    } in test_managed_download_args()
+    for (
+        iteration,
+        TestManagedDownloadArgSet {
+            data_len,
+            parallel,
+            partition_len,
+            download_range,
+            expected_gets,
+        },
+    ) in test_managed_download_args().into_iter().enumerate()
     {
+        tracing::info!(
+            iteration,
+            parallel,
+            partition_len,
+            ?download_range,
+            "starting managed download iteration"
+        );
         let data: Vec<u8> = (0..data_len).map(|_| recording.random()).collect();
         blob_client
             .upload(RequestContent::from(data.to_vec()), None)
@@ -967,6 +977,7 @@ async fn test_managed_download(ctx: TestContext) -> Result<(), Box<dyn Error>> {
 
         request_count.store(0, Ordering::Relaxed);
         let _scope = count_policy.check_request_scope();
+        tracing::debug!(iteration, "calling download");
         let mut download_stream = blob_client
             .download(Some(BlobClientDownloadOptions {
                 partition_size: Some(NonZero::new(partition_len).unwrap()),
@@ -977,10 +988,20 @@ async fn test_managed_download(ctx: TestContext) -> Result<(), Box<dyn Error>> {
             .await?
             .body;
 
+        tracing::debug!(iteration, "streaming download chunks");
         let mut downloaded_data = BytesMut::new();
+        let mut chunk_count = 0usize;
         while let Some(bytes) = download_stream.try_next().await? {
+            chunk_count += 1;
+            tracing::trace!(iteration, chunk_count, len = bytes.len(), "received chunk");
             downloaded_data.put(bytes);
         }
+        tracing::debug!(
+            iteration,
+            chunk_count,
+            total_bytes = downloaded_data.len(),
+            "download complete"
+        );
         let downloaded_data = downloaded_data.freeze();
         assert_eq!(
             &downloaded_data,
@@ -1429,8 +1450,10 @@ async fn test_gzip_blob_with_metadata_roundtrip(ctx: TestContext) -> Result<(), 
             }),
         )
         .await?;
+    tracing::info!("gzip upload complete");
 
     // Download - auto-decompression is disabled so we get raw bytes.
+    tracing::debug!("starting gzip download");
     let response = blob_client.download(None).await?;
 
     // content-encoding header is present because reqwest did not strip it.
@@ -1441,6 +1464,7 @@ async fn test_gzip_blob_with_metadata_roundtrip(ctx: TestContext) -> Result<(), 
     );
 
     let downloaded_bytes = response.body.collect().await?;
+    tracing::debug!(len = downloaded_bytes.len(), "gzip download complete");
     // The body is a valid gzip stream that decodes back to the original plaintext.
     // Note: we compare decompressed output rather than raw bytes because the service
     // may normalize the OS byte in the gzip header.

--- a/sdk/storage/azure_storage_blob/tests/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client.rs
@@ -979,54 +979,32 @@ async fn test_managed_download(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         request_count.store(0, Ordering::Relaxed);
         let _scope = count_policy.check_request_scope();
 
-        // Per-iteration timeout to isolate which iteration hangs and collect diagnostics.
-        let iter_result = time::timeout(Duration::from_secs(60), async {
-            tracing::info!(iteration, "calling download");
-            let mut download_stream = blob_client
-                .download(Some(BlobClientDownloadOptions {
-                    partition_size: Some(NonZero::new(partition_len).unwrap()),
-                    parallel: Some(NonZero::new(parallel).unwrap()),
-                    range: download_range.map(|r| r.0..r.1),
-                    ..Default::default()
-                }))
-                .await?
-                .body;
+        tracing::info!(iteration, "calling download");
+        let mut download_stream = blob_client
+            .download(Some(BlobClientDownloadOptions {
+                partition_size: Some(NonZero::new(partition_len).unwrap()),
+                parallel: Some(NonZero::new(parallel).unwrap()),
+                range: download_range.map(|r| r.0..r.1),
+                ..Default::default()
+            }))
+            .await?
+            .body;
 
-            tracing::info!(iteration, "streaming download chunks");
-            let mut downloaded_data = BytesMut::new();
-            let mut chunk_count = 0usize;
-            while let Some(bytes) = download_stream.try_next().await? {
-                chunk_count += 1;
-                tracing::info!(iteration, chunk_count, len = bytes.len(), "received chunk");
-                downloaded_data.put(bytes);
-            }
-            tracing::info!(
-                iteration,
-                chunk_count,
-                total_bytes = downloaded_data.len(),
-                "download complete"
-            );
-            Ok::<_, Box<dyn Error>>(downloaded_data.freeze())
-        })
-        .await;
-
-        let downloaded_data = match iter_result {
-            Ok(Ok(data)) => data,
-            Ok(Err(e)) => return Err(e),
-            Err(_) => {
-                tracing::error!(
-                    iteration,
-                    parallel,
-                    partition_len,
-                    ?download_range,
-                    "managed download iteration timed out after 60s"
-                );
-                return Err(format!(
-                    "iteration {iteration} (parallel={parallel}, partition_len={partition_len}) timed out after 60s"
-                )
-                .into());
-            }
-        };
+        tracing::info!(iteration, "streaming download chunks");
+        let mut downloaded_data = BytesMut::new();
+        let mut chunk_count = 0usize;
+        while let Some(bytes) = download_stream.try_next().await? {
+            chunk_count += 1;
+            tracing::info!(iteration, chunk_count, len = bytes.len(), "received chunk");
+            downloaded_data.put(bytes);
+        }
+        tracing::info!(
+            iteration,
+            chunk_count,
+            total_bytes = downloaded_data.len(),
+            "download complete"
+        );
+        let downloaded_data = downloaded_data.freeze();
 
         assert_eq!(
             &downloaded_data,

--- a/sdk/storage/azure_storage_blob/tests/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client.rs
@@ -968,6 +968,7 @@ async fn test_managed_download(ctx: TestContext) -> Result<(), Box<dyn Error>> {
             parallel,
             partition_len,
             ?download_range,
+            expected_gets,
             "starting managed download iteration"
         );
         let data: Vec<u8> = (0..data_len).map(|_| recording.random()).collect();
@@ -977,32 +978,56 @@ async fn test_managed_download(ctx: TestContext) -> Result<(), Box<dyn Error>> {
 
         request_count.store(0, Ordering::Relaxed);
         let _scope = count_policy.check_request_scope();
-        tracing::debug!(iteration, "calling download");
-        let mut download_stream = blob_client
-            .download(Some(BlobClientDownloadOptions {
-                partition_size: Some(NonZero::new(partition_len).unwrap()),
-                parallel: Some(NonZero::new(parallel).unwrap()),
-                range: download_range.map(|r| r.0..r.1),
-                ..Default::default()
-            }))
-            .await?
-            .body;
 
-        tracing::debug!(iteration, "streaming download chunks");
-        let mut downloaded_data = BytesMut::new();
-        let mut chunk_count = 0usize;
-        while let Some(bytes) = download_stream.try_next().await? {
-            chunk_count += 1;
-            tracing::trace!(iteration, chunk_count, len = bytes.len(), "received chunk");
-            downloaded_data.put(bytes);
-        }
-        tracing::debug!(
-            iteration,
-            chunk_count,
-            total_bytes = downloaded_data.len(),
-            "download complete"
-        );
-        let downloaded_data = downloaded_data.freeze();
+        // Per-iteration timeout to isolate which iteration hangs and collect diagnostics.
+        let iter_result = time::timeout(Duration::from_secs(60), async {
+            tracing::info!(iteration, "calling download");
+            let mut download_stream = blob_client
+                .download(Some(BlobClientDownloadOptions {
+                    partition_size: Some(NonZero::new(partition_len).unwrap()),
+                    parallel: Some(NonZero::new(parallel).unwrap()),
+                    range: download_range.map(|r| r.0..r.1),
+                    ..Default::default()
+                }))
+                .await?
+                .body;
+
+            tracing::info!(iteration, "streaming download chunks");
+            let mut downloaded_data = BytesMut::new();
+            let mut chunk_count = 0usize;
+            while let Some(bytes) = download_stream.try_next().await? {
+                chunk_count += 1;
+                tracing::info!(iteration, chunk_count, len = bytes.len(), "received chunk");
+                downloaded_data.put(bytes);
+            }
+            tracing::info!(
+                iteration,
+                chunk_count,
+                total_bytes = downloaded_data.len(),
+                "download complete"
+            );
+            Ok::<_, Box<dyn Error>>(downloaded_data.freeze())
+        })
+        .await;
+
+        let downloaded_data = match iter_result {
+            Ok(Ok(data)) => data,
+            Ok(Err(e)) => return Err(e),
+            Err(_) => {
+                tracing::error!(
+                    iteration,
+                    parallel,
+                    partition_len,
+                    ?download_range,
+                    "managed download iteration timed out after 60s"
+                );
+                return Err(format!(
+                    "iteration {iteration} (parallel={parallel}, partition_len={partition_len}) timed out after 60s"
+                )
+                .into());
+            }
+        };
+
         assert_eq!(
             &downloaded_data,
             match download_range {

--- a/sdk/storage/azure_storage_blob/tests/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/block_blob_client.rs
@@ -452,6 +452,11 @@ async fn upload_large(ctx: TestContext) -> Result<(), Box<dyn Error>> {
 
     let data_len = 50 * MB;
     let expected_stage_block_count = data_len.div_ceil(4 * MB);
+    tracing::info!(
+        data_len,
+        expected_stage_block_count,
+        "generating upload data"
+    );
     let mut bytes = BytesMut::with_capacity(data_len).writer();
     {
         let mut buf = [0u8; 4 * KB];
@@ -465,9 +470,13 @@ async fn upload_large(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     stage_block_count.store(0, Ordering::Relaxed);
     {
         let _scope = count_policy.check_request_scope();
+        tracing::info!(data_len, "starting large upload");
         block_blob_client.upload(bytes.clone().into(), None).await?;
+        tracing::info!("large upload complete");
     }
+    tracing::debug!("starting large download for verification");
     let body_data = blob_client.download(None).await?.body.collect().await?;
+    tracing::debug!(downloaded_len = body_data.len(), "large download complete");
     assert_eq!(body_data[..], bytes[..]);
     assert_eq!(
         stage_block_count.load(Ordering::Relaxed),

--- a/sdk/storage/azure_storage_blob/tests/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/block_blob_client.rs
@@ -432,7 +432,6 @@ async fn upload_empty(ctx: TestContext) -> Result<(), Box<dyn Error>> {
 }
 
 #[recorded::test]
-#[ignore = "Temporarily ignoring until we can figure out how to get this to not take down the whole test pipeline."]
 async fn upload_large(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     let stage_block_count = Arc::new(AtomicUsize::new(0));
     let count_policy = Arc::new(TestPolicy::count_requests(

--- a/sdk/storage/azure_storage_blob/tests/streaming.rs
+++ b/sdk/storage/azure_storage_blob/tests/streaming.rs
@@ -25,10 +25,14 @@ async fn stream(ctx: TestContext) -> Result<(), Box<dyn Error>> {
 
     // Upload from a stream.
     const CONTENT_LENGTH: usize = 40_960_000;
+    tracing::info!(CONTENT_LENGTH, "starting stream upload");
     upload::<CONTENT_LENGTH>(&blob_client).await?;
+    tracing::info!("stream upload complete");
 
     // Download to a stream.
+    tracing::info!("starting stream download");
     let len = download(&blob_client).await? as usize;
+    tracing::info!(len, "stream download complete");
     assert_eq!(len, CONTENT_LENGTH);
 
     // Cleanup

--- a/sdk/storage/azure_storage_blob/tests/streaming.rs
+++ b/sdk/storage/azure_storage_blob/tests/streaming.rs
@@ -16,7 +16,6 @@ use futures::TryStreamExt as _;
 use std::error::Error;
 
 #[recorded::test]
-#[ignore = "Temporarily ignoring until we can figure out how to get this to not take down the whole test pipeline."]
 async fn stream(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Setup
     let recording = ctx.recording();


### PR DESCRIPTION
## Partitioned Download Deadlock(?)

### Result

`test_managed_download` **failed** (1 of 257 tests). All other tests passed.

### Failing Iteration

**Iteration 4**: `parallel=8`, `partition_size=31`, `total_chunks=34`, `max_buffers=16`

### Timeline

| Timestamp | Event |
|-----------|-------|
| `00:09:58.598` | Iteration 4 starts |
| `00:09:58.612` | Orchestration begins: 34 chunks, 33 remaining, 8 parallel, 16 max_buffers |
| `00:09:58.612`–`00:09:58.785` | Chunks dispatched and received rapidly (31-byte payloads via test proxy) |
| **`00:09:58.785`** | **Last orchestration log**: `awaiting message drain_pos=26 active=0 task_bucket_len=1` |
| `00:10:58.610` | **Timeout fires** — 60s of silence |

### Root Cause (from logs)

At the deadlock moment:

- **`drain_pos=26`** — 26 of 34 chunks yielded to consumer
- **`active=0`** — all spawned tasks have completed
- **`next_task_index=26`** — only chunks 0–25 were ever dispatched; **chunks 26–33 never started**
- Code fell through to `await_message` on the mpsc receiver, but with `active=0`, no message will ever arrive → **permanent deadlock**

### Why It Happens

The test proxy returns 31-byte chunks instantly. All 8 parallel tasks complete before the stream loop re-enters the dispatch phase. After yielding 16 buffered chunks (drain_pos 10→26), the code drops into `await_message` without dispatching chunks 26–33, despite `remaining_ranges` still having work.

### Why Other Downloads Succeed

| Test | Chunks | max_buffers | Why OK |
|------|--------|-------------|--------|
| Iterations 0–1 | 1 | — | Single chunk, no partitioning |
| Iteration 2 | 2 | 4 | `total_chunks ≤ max_buffers`, all dispatched upfront |
| Iteration 3 | 4 | 2 | `parallel=1`, serialized dispatch keeps pace |
| `etag_lock` | 9 | 8 | All 9 ranges dispatched before completion |
| `upload_large` | 13 | 8 | 4MB chunks take time, interleaving prevents the race |
| `streaming` | 10 | 8 | All 10 ranges dispatched; `active=0` reached after full dispatch |

### Fix

Add a `continue` guard after the yield loop: when chunks were yielded and undispatched ranges remain, re-enter the dispatch phase instead of falling through to `await_message`.

Logs: 
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6183334&view=logs&j=63f68438-03da-5fcc-ba76-f9b792e18862&t=bd152872-604e-5f63-04b7-51b9b8fd9f96