### PR TITLE
[Storage] Fix partitioned download deadlock, prepare for `azure_storage_blob` release

### DIFF
--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.12.0 (2026-04-21)
+## 0.12.0 (2026-04-22)
 
 ### Features Added
 

--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -1,17 +1,11 @@
 # Release History
 
-## 0.12.0 (Unreleased)
-
-### Features Added
+## 0.12.0 (2026-04-21)
 
 ### Breaking Changes
 
 - Responses are no longer automatically decompressed.
 - Removed `download_into()` from existing clients. Callers can still use `download()` and collect the streamed `Bytes` into memory.
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 0.11.0 (2026-04-14)
 

--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -2,8 +2,18 @@
 
 ## 0.12.0 (2026-04-21)
 
+### Features Added
+
+- Added the `reqwest_rustls` feature to use `aws-lc-rs` as the default TLS provider.
+
+### Bugs Fixed
+
+- Fixed a potential deadlock in partitioned downloads when `total_chunks > max_buffers`.
+
 ### Breaking Changes
 
+- Added default connection timeout of 20s and read timeout of 60s.
+- Removed the `reqwest_native_tls` feature in favor of `reqwest_rustls`.
 - Responses are no longer automatically decompressed.
 - Removed `download_into()` from existing clients. Callers can still use `download()` and collect the streamed `Bytes` into memory.
 

--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 - Added the `reqwest_rustls` feature to use `aws-lc-rs` as the default TLS provider.
 
-### Bugs Fixed
-
-- Fixed a potential deadlock in partitioned downloads when `total_chunks > max_buffers`.
-
 ### Breaking Changes
 
 - Added default connection timeout of 20s and read timeout of 60s.

--- a/sdk/storage/azure_storage_blob/assets.json
+++ b/sdk/storage/azure_storage_blob/assets.json
@@ -1,6 +1,6 @@
 {
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
-  "Tag": "rust/azure_storage_blob_3dc4501152",
+  "Tag": "rust/azure_storage_blob_3bcbe9fe6f",
   "TagPrefix": "rust/azure_storage_blob"
 }

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
@@ -111,7 +111,6 @@ where
                         let i = next_task_index;
                         next_task_index += 1;
                         active_tasks_counter.fetch_add(1, Ordering::Relaxed);
-
                         let t = tx_opt.as_ref().ok_or_else(||Error::with_message(ErrorKind::Other, "Channel closed unexpectedly."))?.clone();
                         task_bucket.push(start_download_task(client.clone(), range, etag_lock.clone(), t, active_tasks_counter.clone(), i));
                     }
@@ -124,24 +123,16 @@ where
                 }
             }
 
-            // return next readied bytes, if any
-            while let Some(bytes) = drain.pop() {
-                yield bytes;
-            }
-
-            // early break if finished
-            if drain.position() >= total_chunks {
-                break;
-            }
-
-            // max tasks are spawned and sequential ready bytes already returned
-            // this will not change until either:
-            //   1. a task sends a message through this channel
-            //   2. a task fails
+            // await the next completed download
             let channel_message;
             (channel_message, task_bucket) = await_message_while_joining_workers(&mut rx, task_bucket).await?;
             let (idx, bytes) = channel_message?;
             drain.push(idx, bytes)?;
+
+            // return next readied bytes, if any
+            while let Some(bytes) = drain.pop() {
+                yield bytes;
+            }
         }
     };
 
@@ -203,7 +194,7 @@ async fn await_message_while_joining_workers<T>(
     };
 
     let mut message_fut = receiver.recv();
-    // `task_bucket`` may be empty. `select_all` cannot handle that.
+    // `task_bucket` may be empty. `select_all` cannot handle that.
     while !task_bucket.is_empty() {
         match future::select(message_fut, future::select_all(task_bucket)).await {
             Either::Left((message, task_select)) => {

--- a/sdk/storage/azure_storage_blob/tests/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client.rs
@@ -938,7 +938,6 @@ fn test_managed_download_args() -> impl IntoIterator<Item = TestManagedDownloadA
 }
 
 #[recorded::test]
-#[ignore = "Temporarily ignoring until we can figure out how to get this to not take down the whole test pipeline."]
 async fn test_managed_download(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     let request_count = Arc::new(AtomicUsize::new(0));
     let count_policy = Arc::new(TestPolicy::count_requests(request_count.clone(), None));
@@ -1409,7 +1408,6 @@ async fn test_gzip_blob_no_metadata_roundtrip(ctx: TestContext) -> Result<(), Bo
 }
 
 #[recorded::test]
-#[ignore = "Temporarily ignoring until we can figure out how to get this to not take down the whole test pipeline."]
 async fn test_gzip_blob_with_metadata_roundtrip(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     let recording = ctx.recording();
     let container_client =

--- a/sdk/storage/azure_storage_blob/tests/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/block_blob_client.rs
@@ -431,8 +431,8 @@ async fn upload_empty(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[recorded::test]
-#[ignore = "Temporarily ignoring until we can figure out how to get this to not take down the whole test pipeline."]
+// This test generates a large recording, so marking as live-only.
+#[recorded::test(live)]
 async fn upload_large(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     let stage_block_count = Arc::new(AtomicUsize::new(0));
     let count_policy = Arc::new(TestPolicy::count_requests(

--- a/sdk/storage/azure_storage_blob/tests/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/block_blob_client.rs
@@ -475,6 +475,8 @@ async fn upload_large(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         expected_stage_block_count
     );
 
+    container_client.delete(None).await?;
+
     Ok(())
 }
 

--- a/sdk/storage/azure_storage_blob/tests/streaming.rs
+++ b/sdk/storage/azure_storage_blob/tests/streaming.rs
@@ -15,8 +15,8 @@ use azure_storage_blob_test::{get_blob_name, get_container_client, StorageAccoun
 use futures::TryStreamExt as _;
 use std::error::Error;
 
-#[recorded::test]
-#[ignore = "Temporarily ignoring until we can figure out how to get this to not take down the whole test pipeline."]
+// This test generates a large recording, so marking as live-only.
+#[recorded::test(live)]
 async fn stream(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Setup
     let recording = ctx.recording();

--- a/sdk/storage/azure_storage_queue/CHANGELOG.md
+++ b/sdk/storage/azure_storage_queue/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.6.0 (2026-04-21)
+## 0.6.0 (2026-04-22)
 
 ### Features Added
 

--- a/sdk/storage/azure_storage_queue/CHANGELOG.md
+++ b/sdk/storage/azure_storage_queue/CHANGELOG.md
@@ -1,14 +1,19 @@
 # Release History
 
-## 0.6.0 (Unreleased)
+## 0.6.0 (2026-04-21)
 
 ### Features Added
 
+- Added the `reqwest_rustls` feature to use `aws-lc-rs` as the default TLS provider.
+
 ### Breaking Changes
 
-### Bugs Fixed
+- Added default connection timeout of 20s and read timeout of 60s.
+- Removed the `reqwest_native_tls` feature in favor of `reqwest_rustls`.
 
 ### Other Changes
+
+- Update dependencies to match.
 
 ## 0.5.0 (2026-04-14)
 


### PR DESCRIPTION
As title states.
More context can be found offline, but the main points that got us into this situation:
(Note, some iterations have been simplified ie. AWAIT technically can only read 1 message at a time but for brevity and just showing mostly the codeflow, it has been simplified to show only the points of the iteration where things change)

### Setup

```
parallel     = 3
max_buffers  = 6    (parallel * 2 = drain capacity)
total_chunks ≥ 7    (more chunks than drain slots)
```

### Codeflow (before the contents of this PR): Spawn → Yield → Await

### Legend

```
○  task in-flight              ◉  task completed (message in channel)
●  data written to drain       ▽  chunk yielded
□  empty drain slot
```

### Walkthrough

Each row shows drain state + what happens next (steps after the `|`).

```
Slot index:       0     1     2     3     4     5
                ┌─────┬─────┬─────┬─────┬─────┬─────┐
                │  □  │  □  │  □  │  □  │  □  │  □  │
                └─────┴─────┴─────┴─────┴─────┴─────┘
  drain starts out (no data in drain to yield, no tasks spawned yet) | SPAWN
───────────────────────────────────────────────────────────────────────────────
                  ○     ○     ○
                ┌─────┬─────┬─────┬─────┬─────┬─────┐
                │  □  │  □  │  □  │  □  │  □  │  □  │
                └─────┴─────┴─────┴─────┴─────┴─────┘
  3 tasks spawned (imagine 3 workers, drain is *2 workers) | YIELD (nothing), AWAIT
───────────────────────────────────────────────────────────────────────────────
                  ○     ◉     ◉
                ┌─────┬─────┬─────┬─────┬─────┬─────┐
                │  □  │  □  │  □  │  □  │  □  │  □  │
                └─────┴─────┴─────┴─────┴─────┴─────┘
  2 tasks finished | SPAWN (nothing spawns, all workers are working/holding result), YIELD (nothing)
───────────────────────────────────────────────────────────────────────────────
                  ○
                ┌─────┬─────┬─────┬─────┬─────┬─────┐
                │  □  │  ●  │  ●  │  □  │  □  │  □  │
                └─────┴─────┴─────┴─────┴─────┴─────┘
  2 tasks who completed data written to drain | AWAIT, SPAWN (spawns 2)
───────────────────────────────────────────────────────────────────────────────
                  ○                   ○     ○
                ┌─────┬─────┬─────┬─────┬─────┬─────┐
                │  □  │  ●  │  ●  │  □  │  □  │  □  │
                └─────┴─────┴─────┴─────┴─────┴─────┘
  2 new tasks spawned | YIELD (nothing), AWAIT
───────────────────────────────────────────────────────────────────────────────
                  ○                     ◉     ◉
                ┌─────┬─────┬─────┬─────┬─────┬─────┐
                │  □  │  ●  │  ●  │  □  │  □  │  □  │
                └─────┴─────┴─────┴─────┴─────┴─────┘
  2 tasks finish | SPAWN (nothing spawns, everyone still busy), YIELD (nothing), AWAIT
───────────────────────────────────────────────────────────────────────────────
                  ○
                ┌─────┬─────┬─────┬─────┬─────┬─────┐
                │  □  │  ●  │  ●  │  ●  │  ●  │  □  │
                └─────┴─────┴─────┴─────┴─────┴─────┘
  2 tasks complete, write to the drain | SPAWN
───────────────────────────────────────────────────────────────────────────────
                  ○                             ○
                ┌─────┬─────┬─────┬─────┬─────┬─────┐
                │  □  │  ●  │  ●  │  ●  │  ●  │  □  │
                └─────┴─────┴─────┴─────┴─────┴─────┘
  last drain slot gets a task, will complete it, and then write to the drain | YIELD (nothing), AWAIT
───────────────────────────────────────────────────────────────────────────────
                  ○                                   ◉
                ┌─────┬─────┬─────┬─────┬─────┬─────┐
                │  □  │  ●  │  ●  │  ●  │  ●  │  ●  │
                └─────┴─────┴─────┴─────┴─────┴─────┘
  finally first slot task finishes, gets written to drain |
  SPAWN (nothing), YIELD (yields all contents of drain)
───────────────────────────────────────────────────────────────────────────────
                  ◉
                ┌─────┬─────┬─────┬─────┬─────┬─────┐
                │  ●  │  ●  │  ●  │  ●  │  ●  │  ●  │
                └─────┴─────┴─────┴─────┴─────┴─────┘
  all contents of drain get yielded since all fields are full of content | AWAIT
───────────────────────────────────────────────────────────────────────────────
                  ▽     ▽     ▽     ▽     ▽     ▽
                ┌─────┬─────┬─────┬─────┬─────┬─────┐
                │  □  │  □  │  □  │  □  │  □  │  □  │
                └─────┴─────┴─────┴─────┴─────┴─────┘

  ╔═══════════════════════════════════════════════════════════════════════════╗
  ║  💀 DEADLOCK                                                            ║
  ║                                                                         ║
  ║  Now we reach deadlock. We are stuck awaiting, but no jobs are in       ║
  ║  flight. No tasks will ever be spawned.                                 ║
  ║                                                                         ║
  ║  The yield shifted the drain window forward, opening room for new       ║
  ║  tasks - but SPAWN already ran before the yield. AWAIT blocks on an     ║
  ║  empty channel with active = 0. The remaining chunks are never          ║
  ║  dispatched.                                                            ║
  ╚═══════════════════════════════════════════════════════════════════════════╝
```

### The Fix: Swap Yield and Await → Spawn → Await → Yield

By reordering so that **Await** comes before **Yield**, the yield's window shift happens
at the end of the loop body. The next iteration's **Spawn** step sees the updated window
and dispatches the remaining chunks before the code ever reaches **Await**. The deadlock
is structurally impossible.
