### PR TITLE
Prepare azure_core@0.35.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2838,9 +2838,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ version = "0.35.0"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core_macros",
+ "azure_core_macros 0.8.0",
  "azure_core_test",
  "azure_identity",
  "azure_security_keyvault_certificates",
@@ -239,7 +239,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec",
+ "typespec 0.14.0",
  "typespec_client_core",
  "ureq",
 ]
@@ -262,8 +262,20 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec",
- "typespec_macros",
+ "typespec 0.14.0",
+ "typespec_macros 0.13.0",
+]
+
+[[package]]
+name = "azure_core_macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70066e34b8db2c3f0b852c56a99333bd25fdedfb8850cd95dddf930928b47b80"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "tracing",
 ]
 
 [[package]]
@@ -3565,6 +3577,21 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typespec"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247afbeabe0c383f630d0fdcb4fb92818c31cd3fe5d293335daff8cac79d4e0f"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "quick-xml",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "typespec"
 version = "0.15.0"
 dependencies = [
  "base64",
@@ -3597,10 +3624,22 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec",
- "typespec_macros",
+ "typespec 0.14.0",
+ "typespec_macros 0.13.0",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "typespec_macros"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17153fde258b3c862cecffad95e185c0eb83e619e76542c4b3ed9828af840f0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,7 @@ rust-version = "1.88"
 
 [workspace.dependencies.typespec]
 default-features = false
-path = "sdk/core/typespec"
-version = "0.15.0"
+version = "0.14.0"
 
 [workspace.dependencies.typespec_client_core]
 default-features = false
@@ -50,8 +49,7 @@ path = "sdk/core/typespec_client_core"
 version = "0.14.0"
 
 [workspace.dependencies.typespec_macros]
-version = "0.14.0"
-path = "sdk/core/typespec_macros"
+version = "0.13.0"
 
 [workspace.dependencies.azure_core]
 default-features = false
@@ -59,8 +57,7 @@ version = "0.35.0"
 path = "sdk/core/azure_core"
 
 [workspace.dependencies.azure_core_macros]
-version = "0.9.0"
-path = "sdk/core/azure_core_macros"
+version = "0.8.0"
 
 [workspace.dependencies.azure_core_amqp]
 version = "0.14.0"
@@ -73,6 +70,7 @@ path = "sdk/eventhubs/azure_messaging_eventhubs"
 [workspace.dependencies.azure_core_opentelemetry]
 # azure_core_opentelemetry should only ever be in dev-dependencies herein
 path = "sdk/core/azure_core_opentelemetry"
+version = "0.9.0"
 
 [workspace.dependencies.azure_core_test]
 # azure_core_test is not published and only ever a dev-dependency

--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.35.0 (Unreleased)
+## 0.35.0 (2026-04-22)
 
 ### Features Added
 
@@ -11,10 +11,6 @@
 - Added connection timeout of 20s and read timeout of 60s.
 - Removed the `reqwest_native_tls` feature in favor of `reqwest_rustls`.
 - `new_http_client()` now takes an `Option<HttpClientOptions>` to disable automatic decompression - still enabled by default if `reqwest_gzip` or `reqwest_deflate` features are enabled.
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 0.34.0 (2026-04-07)
 

--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -38,7 +38,7 @@ typespec_client_core = { workspace = true, default-features = false, features = 
 rustc_version.workspace = true
 
 [dev-dependencies]
-azure_core_macros.path = "../azure_core_macros"
+azure_core_macros.workspace = true
 azure_core_test.workspace = true
 azure_identity.workspace = true
 azure_security_keyvault_certificates.path = "../../keyvault/azure_security_keyvault_certificates"

--- a/sdk/core/azure_core_amqp/CHANGELOG.md
+++ b/sdk/core/azure_core_amqp/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 0.14.0 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 0.14.0 (2026-04-22)
 
 ### Other Changes
+
+- Updated dependencies.
 
 ## 0.13.0 (2026-04-07)
 

--- a/sdk/core/azure_core_opentelemetry/CHANGELOG.md
+++ b/sdk/core/azure_core_opentelemetry/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 0.9.0 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 0.9.0 (2026-04-22)
 
 ### Other Changes
+
+- Updated dependencies.
 
 ## 0.8.0 (2026-04-07)
 

--- a/sdk/core/typespec_client_core/CHANGELOG.md
+++ b/sdk/core/typespec_client_core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.14.0 (Unreleased)
+## 0.14.0 (2026-04-22)
 
 ### Features Added
 
@@ -11,10 +11,6 @@
 - Added connection timeout of 20s and read timeout of 60s.
 - Removed the `reqwest_native_tls` feature in favor of `reqwest_rustls`.
 - `new_http_client()` now takes an `Option<HttpClientOptions>` to disable automatic decompression - still enabled by default if `reqwest_gzip` or `reqwest_deflate` features are enabled.
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 0.13.0 (2026-04-07)
 

--- a/sdk/core/typespec_client_core/Cargo.toml
+++ b/sdk/core/typespec_client_core/Cargo.toml
@@ -39,7 +39,7 @@ uuid.workspace = true
 tokio = { workspace = true, features = ["fs"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
-typespec_macros.path = "../typespec_macros"
+typespec_macros.workspace = true
 
 [features]
 default = [


### PR DESCRIPTION
Only releasing `typespec_client_core` and crates built upon it.
This will also help test our release systems.
