### PR TITLE
Make key_Version optional for encrypt, sign, wrapKey

### DIFF
--- a/sdk/keyvault/assets.json
+++ b/sdk/keyvault/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
   "TagPrefix": "rust/keyvault",
-  "Tag": "rust/keyvault_c9f2f1865c"
+  "Tag": "rust/keyvault_e3dd11701a"
 }

--- a/sdk/keyvault/azure_security_keyvault_certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure_security_keyvault_certificates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Updated dependencies.
+
 ## 0.12.0 (2026-04-08)
 
 ### Other Changes

--- a/sdk/keyvault/azure_security_keyvault_certificates/README.md
+++ b/sdk/keyvault/azure_security_keyvault_certificates/README.md
@@ -234,7 +234,7 @@ use azure_security_keyvault_certificates::{
     ResourceExt,
 };
 use azure_security_keyvault_keys::{
-    models::{SignParameters, SignatureAlgorithm},
+    models::{KeyClientSignOptions, SignParameters, SignatureAlgorithm},
 };
 use openssl::sha::sha256;
 
@@ -285,7 +285,14 @@ let body = SignParameters {
 };
 
 let signature = key_client
-    .sign("ec-signing-certificate", &certificate_version, body.try_into()?, None)
+    .sign(
+        "ec-signing-certificate",
+        body.try_into()?,
+        Some(KeyClientSignOptions {
+            key_version: Some(certificate_version.clone()),
+            ..Default::default()
+        }),
+    )
     .await?
     .into_model()?;
 

--- a/sdk/keyvault/azure_security_keyvault_certificates/tests/certificate_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/tests/certificate_client.rs
@@ -19,7 +19,7 @@ use azure_security_keyvault_certificates::{
     CertificateClient, CertificateClientOptions, ResourceExt as _,
 };
 use azure_security_keyvault_keys::{
-    models::{SignParameters, SignatureAlgorithm},
+    models::{KeyClientSignOptions, SignParameters, SignatureAlgorithm},
     KeyClient, KeyClientOptions,
 };
 use azure_security_keyvault_test::Retry;
@@ -357,7 +357,14 @@ async fn sign_jwt_with_ec_certificate(ctx: TestContext) -> Result<()> {
         value: Some(digest),
     };
     let signature = key_client
-        .sign(NAME, &certificate_version, body.try_into()?, None)
+        .sign(
+            NAME,
+            body.try_into()?,
+            Some(KeyClientSignOptions {
+                key_version: Some(certificate_version.clone()),
+                ..Default::default()
+            }),
+        )
         .await?
         .into_model()?;
     assert!(signature.result.is_some());

--- a/sdk/keyvault/azure_security_keyvault_keys/CHANGELOG.md
+++ b/sdk/keyvault/azure_security_keyvault_keys/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Features Added
 
+- Added support for `ResourceIdExt` to `KeyOperationResult`.
+
 ### Breaking Changes
+
+- Moved `key_version` parameter to be an optional parameter for `KeyClient::encrypt()`, `sign()`, and `wrapKey()`.
 
 ### Bugs Fixed
 

--- a/sdk/keyvault/azure_security_keyvault_keys/README.md
+++ b/sdk/keyvault/azure_security_keyvault_keys/README.md
@@ -234,7 +234,7 @@ use azure_security_keyvault_keys::{
     models::{
         CreateKeyParameters, EncryptionAlgorithm, KeyOperationParameters, KeyType,
     },
-    ResourceExt,
+    ResourceExt, ResourceId,
 };
 use rand::random;
 
@@ -249,7 +249,6 @@ let key = client
     .create_key("key-name", body.try_into()?, None)
     .await?
     .into_model()?;
-let key_version = key.resource_id()?.version.expect("key version required");
 
 // Generate a symmetric data encryption key (DEK). You'd encrypt your data using this DEK.
 let dek = random::<u32>().to_le_bytes().to_vec();
@@ -261,16 +260,21 @@ let mut parameters = KeyOperationParameters {
     ..Default::default()
 };
 let wrapped = client
-    .wrap_key("key-name", &key_version, parameters.clone().try_into()?, None)
+    .wrap_key("key-name", parameters.clone().try_into()?, None)
     .await?
     .into_model()?;
 
 assert!(matches!(wrapped.result.as_ref(), Some(result) if !result.is_empty()));
 
+// Retain the key ID that was used to wrap so you can unwrap using the same version later.
+// We'll parse the version to pass to `unwrap_key` below.
+let ResourceId { version, .. } = wrapped.resource_id()?;
+let key_version = version.as_deref().unwrap_or_default();
+
 // Unwrap the DEK.
 parameters.value = wrapped.result;
 let unwrapped = client
-    .unwrap_key("key-name", &key_version, parameters.try_into()?, None)
+    .unwrap_key("key-name", key_version, parameters.try_into()?, None)
     .await?
     .into_model()?;
 

--- a/sdk/keyvault/azure_security_keyvault_keys/src/generated/clients/key_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/generated/clients/key_client.rs
@@ -273,20 +273,20 @@ impl KeyClient {
     /// is supported for asymmetric keys as a convenience for callers that have a key-reference but do not have access to the
     /// public key material. This operation requires the keys/encrypt permission.
     ///
+    /// You should record the ['KeyOperationResult::kid`] that is returned by this operation
+    /// so you can later parse it with [`ResourceId`](crate::ResourceId) and pass the version to [`KeyClient::decrypt()`].
+    /// You can pass an empty string for the version to `decrypt()` to select the latest key version
+    /// but if you don't record the specific version used for encrypting, key rotation can make the data inaccessible.
+    ///
     /// # Arguments
     ///
     /// * `key_name` - The name of the key.
-    /// * `key_version` - The version of the key.
-    /// The version is required and should be recorded when encrypting so you can reliably decrypt using the same version. You
-    /// can pass an empty string to select the latest key version but if you don't record the specific version used for encryption,
-    /// key rotation can make the data inaccessible.
     /// * `parameters` - The parameters for the encryption operation.
     /// * `options` - Optional parameters for the request.
     #[tracing::function("KeyVault.encrypt")]
     pub async fn encrypt(
         &self,
         key_name: &str,
-        key_version: &str,
         parameters: RequestContent<KeyOperationParameters>,
         options: Option<KeyClientEncryptOptions<'_>>,
     ) -> Result<Response<KeyOperationResult>> {
@@ -301,7 +301,10 @@ impl KeyClient {
         let mut url = self.endpoint.clone();
         let mut path = String::from("/keys/{key-name}/{key-version}/encrypt");
         path = path.replace("{key-name}", key_name);
-        path = path.replace("{key-version}", key_version);
+        path = match options.key_version.as_ref() {
+            Some(key_version) => path.replace("{key-version}", key_version),
+            None => path.replace("{key-version}", ""),
+        };
         url.append_path(&path);
         let mut query_builder = url.query_builder();
         query_builder.set_pair("api-version", &self.api_version);
@@ -1103,20 +1106,20 @@ impl KeyClient {
     /// The SIGN operation is applicable to asymmetric and symmetric keys stored in Azure Key Vault since this operation uses
     /// the private portion of the key. This operation requires the keys/sign permission.
     ///
+    /// You should record the ['KeyOperationResult::kid`] that is returned by this operation
+    /// so you can later parse it with [`ResourceId`](crate::ResourceId) and pass the version to [`KeyClient::verify()`].
+    /// You can pass an empty string for the version to `verify()` to select the latest key version
+    /// but if you don't record the specific version used for signing, key rotation can make the data unverifiable.
+    ///
     /// # Arguments
     ///
     /// * `key_name` - The name of the key.
-    /// * `key_version` - The version of the key.
-    /// The version is required and should be recorded when signing so you can reliably verify using the same version. You can
-    /// pass an empty string to select the latest key version but if you don't record the specific version used for signing, key
-    /// rotation can make the data unverifiable.
     /// * `parameters` - The parameters for the signing operation.
     /// * `options` - Optional parameters for the request.
     #[tracing::function("KeyVault.sign")]
     pub async fn sign(
         &self,
         key_name: &str,
-        key_version: &str,
         parameters: RequestContent<SignParameters>,
         options: Option<KeyClientSignOptions<'_>>,
     ) -> Result<Response<KeyOperationResult>> {
@@ -1131,7 +1134,10 @@ impl KeyClient {
         let mut url = self.endpoint.clone();
         let mut path = String::from("/keys/{key-name}/{key-version}/sign");
         path = path.replace("{key-name}", key_name);
-        path = path.replace("{key-version}", key_version);
+        path = match options.key_version.as_ref() {
+            Some(key_version) => path.replace("{key-version}", key_version),
+            None => path.replace("{key-version}", ""),
+        };
         url.append_path(&path);
         let mut query_builder = url.query_builder();
         query_builder.set_pair("api-version", &self.api_version);
@@ -1391,20 +1397,20 @@ impl KeyClient {
     /// keys as a convenience for callers that have a key-reference but do not have access to the public key material. This operation
     /// requires the keys/wrapKey permission.
     ///
+    /// You should record the ['KeyOperationResult::kid`] that is returned by this operation
+    /// so you can later parse it with [`ResourceId`](crate::ResourceId) and pass the version to [`KeyClient::unwrap_key()`].
+    /// You can pass an empty string for the version to `unwrap_key()` to select the latest key version
+    /// but if you don't record the specific version used for wrapping a key, key rotation can make the data inaccessible.
+    ///
     /// # Arguments
     ///
     /// * `key_name` - The name of the key.
-    /// * `key_version` - The version of the key.
-    /// The version is required and should be recorded when wrapping a data encryption key so you can reliably unwrap using the
-    /// same version. You can pass an empty string to select the latest key version but if you don't record the specific version
-    /// used for wrapping a key, key encryption key rotation can make the data inaccessible.
     /// * `parameters` - The parameters for wrap operation.
     /// * `options` - Optional parameters for the request.
     #[tracing::function("KeyVault.wrapKey")]
     pub async fn wrap_key(
         &self,
         key_name: &str,
-        key_version: &str,
         parameters: RequestContent<KeyOperationParameters>,
         options: Option<KeyClientWrapKeyOptions<'_>>,
     ) -> Result<Response<KeyOperationResult>> {
@@ -1419,7 +1425,10 @@ impl KeyClient {
         let mut url = self.endpoint.clone();
         let mut path = String::from("/keys/{key-name}/{key-version}/wrapkey");
         path = path.replace("{key-name}", key_name);
-        path = path.replace("{key-version}", key_version);
+        path = match options.key_version.as_ref() {
+            Some(key_version) => path.replace("{key-version}", key_version),
+            None => path.replace("{key-version}", ""),
+        };
         url.append_path(&path);
         let mut query_builder = url.query_builder();
         query_builder.set_pair("api-version", &self.api_version);

--- a/sdk/keyvault/azure_security_keyvault_keys/src/generated/models/method_options.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/generated/models/method_options.rs
@@ -39,6 +39,9 @@ pub struct KeyClientDeleteKeyOptions<'a> {
 /// Options to be passed to [`KeyClient::encrypt()`](crate::generated::clients::KeyClient::encrypt())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyClientEncryptOptions<'a> {
+    /// The version of the key.
+    pub key_version: Option<String>,
+
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
@@ -203,6 +206,9 @@ pub struct KeyClientRotateKeyOptions<'a> {
 /// Options to be passed to [`KeyClient::sign()`](crate::generated::clients::KeyClient::sign())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyClientSignOptions<'a> {
+    /// The version of the key.
+    pub key_version: Option<String>,
+
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
@@ -241,6 +247,9 @@ pub struct KeyClientVerifyOptions<'a> {
 /// Options to be passed to [`KeyClient::wrap_key()`](crate::generated::clients::KeyClient::wrap_key())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyClientWrapKeyOptions<'a> {
+    /// The version of the key.
+    pub key_version: Option<String>,
+
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/sdk/keyvault/azure_security_keyvault_keys/src/generated/models/models.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/generated/models/models.rs
@@ -556,6 +556,14 @@ pub struct KeyOperationResult {
 
     /// Key identifier
     ///
+    /// You should record this when returned from [`KeyClient::encrypt()`](crate::KeyClient::encrypt), [`sign()`](crate::KeyClient::sign),
+    /// and [`wrap_key()`](crate::KeyClient::wrap_key) so you can later parse it with [`ResourceId`](crate::ResourceId)
+    /// and pass the version to [`decrypt()`](crate::KeyClient::decrypt), [`verify()`](crate::KeyClient::verify),
+    /// and [`unwrap_key()`](crate::KeyClient::unwrap_key).
+    /// You can pass an empty string for the version to those functions to select the latest key version
+    /// but if you don't record the specific version used encrypting, signing, or wrapping a key, key rotation can make the data
+    /// inaccessible.
+    ///
     /// Operational visibility: Read
     #[serde(skip_serializing)]
     pub kid: Option<String>,

--- a/sdk/keyvault/azure_security_keyvault_keys/src/resource.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/resource.rs
@@ -123,7 +123,7 @@ fn deconstruct(url: &Url) -> Result<ResourceId> {
 }
 
 mod private {
-    use crate::models::{DeletedKey, DeletedKeyProperties, Key, KeyProperties};
+    use crate::models::{DeletedKey, DeletedKeyProperties, Key, KeyOperationResult, KeyProperties};
 
     pub trait AsId {
         fn as_id(&self) -> Option<&String>;
@@ -148,6 +148,12 @@ mod private {
     }
 
     impl AsId for DeletedKeyProperties {
+        fn as_id(&self) -> Option<&String> {
+            self.kid.as_ref()
+        }
+    }
+
+    impl AsId for KeyOperationResult {
         fn as_id(&self) -> Option<&String> {
             self.kid.as_ref()
         }

--- a/sdk/keyvault/azure_security_keyvault_keys/tests/key_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/tests/key_client.rs
@@ -5,7 +5,8 @@ use azure_core::{http::StatusCode, Result};
 use azure_core_test::{recorded, TestContext, TestMode};
 use azure_security_keyvault_keys::{
     models::{
-        CreateKeyParameters, CurveName, EncryptionAlgorithm, KeyClientGetKeyOptions,
+        CreateKeyParameters, CurveName, EncryptionAlgorithm, KeyClientEncryptOptions,
+        KeyClientGetKeyOptions, KeyClientSignOptions, KeyClientWrapKeyOptions,
         KeyOperationParameters, KeyType, SignParameters, SignatureAlgorithm,
         UpdateKeyPropertiesParameters, VerifyParameters,
     },
@@ -247,7 +248,14 @@ async fn encrypt_decrypt(ctx: TestContext) -> Result<()> {
         ..Default::default()
     };
     let encrypted = client
-        .encrypt(NAME, &key_version, parameters.clone().try_into()?, None)
+        .encrypt(
+            NAME,
+            parameters.clone().try_into()?,
+            Some(KeyClientEncryptOptions {
+                key_version: Some(key_version.clone()),
+                ..Default::default()
+            }),
+        )
         .await?
         .into_model()?;
     assert!(matches!(encrypted.result.as_ref(), Some(ciphertext) if !ciphertext.is_empty()));
@@ -306,7 +314,7 @@ async fn encrypt_decrypt_latest_key_version(ctx: TestContext) -> Result<()> {
         ..Default::default()
     };
     let encrypted = client
-        .encrypt(NAME, "", parameters.clone().try_into()?, None)
+        .encrypt(NAME, parameters.clone().try_into()?, None)
         .await?
         .into_model()?;
     assert!(matches!(encrypted.result.as_ref(), Some(ciphertext) if !ciphertext.is_empty()));
@@ -362,7 +370,14 @@ async fn sign_verify(ctx: TestContext) -> Result<()> {
         value: Some(digest.clone()),
     };
     let signed = client
-        .sign(NAME, &key_version, parameters.try_into()?, None)
+        .sign(
+            NAME,
+            parameters.try_into()?,
+            Some(KeyClientSignOptions {
+                key_version: Some(key_version.clone()),
+                ..Default::default()
+            }),
+        )
         .await?
         .into_model()?;
     assert!(matches!(signed.result.as_ref(), Some(signature) if !signature.is_empty()));
@@ -421,7 +436,14 @@ async fn wrap_key_unwrap_key(ctx: TestContext) -> Result<()> {
         ..Default::default()
     };
     let wrapped = client
-        .wrap_key(NAME, &key_version, parameters.clone().try_into()?, None)
+        .wrap_key(
+            NAME,
+            parameters.clone().try_into()?,
+            Some(KeyClientWrapKeyOptions {
+                key_version: Some(key_version.clone()),
+                ..Default::default()
+            }),
+        )
         .await?
         .into_model()?;
     assert!(matches!(wrapped.result.as_ref(), Some(result) if !result.is_empty()));

--- a/sdk/keyvault/azure_security_keyvault_keys/tsp-location.yaml
+++ b/sdk/keyvault/azure_security_keyvault_keys/tsp-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/keyvault/data-plane/Keys
-commit: 54b4984cab282ddd55aac3ae75d06c55b558157d
+commit: dea82a7b4059bc4577f19168c4d4171f54ab4a63
 repo: Azure/azure-rest-api-specs


### PR DESCRIPTION
After talking with the Key Vault and Managed HSM teams, we want to promote using the latest key version for encrypting, sign, and wrapping DEKs;
however, encourage passing a version to their reverse operations.

Requires Azure/azure-rest-api-specs#42571
