### PR TITLE
[DO NOT MERGE / DO NOT REVIEW] PKR cache memory micro-benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +383,7 @@ dependencies = [
  "azure_core",
  "azure_identity",
  "base64",
+ "dhat",
  "futures",
  "reqwest",
  "serde",
@@ -612,6 +622,21 @@ dependencies = [
  "time",
  "tokio",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -1103,6 +1128,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,6 +1520,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gloo-timers"
@@ -2009,6 +2056,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,6 +2111,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2406,7 +2468,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -2427,7 +2489,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2740,6 +2802,18 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3254,6 +3328,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/sdk/cosmos/azure_data_cosmos_driver/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_driver/Cargo.toml
@@ -32,6 +32,7 @@ uuid = { workspace = true, features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
 azure_identity.workspace = true
+dhat = "0.3"
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 uuid = { workspace = true, features = ["v4", "fast-rng"] }
@@ -42,3 +43,7 @@ workspace = true
 
 [features]
 default = []
+
+[[bench]]
+name = "pk_range_cache_memory"
+harness = false

--- a/sdk/cosmos/azure_data_cosmos_driver/benches/README.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/benches/README.md
@@ -1,0 +1,56 @@
+# `pk_range_cache_memory` — PartitionKeyRange cache memory micro-benchmark
+
+> ⚠️ **DO NOT MERGE / DO NOT REVIEW.** This branch exists solely to collect
+> retained-heap numbers comparable to the Python PR
+> [Azure/azure-sdk-for-python#46297](https://github.com/Azure/azure-sdk-for-python/pull/46297),
+> which strips unused fields from the Python PKR cache.
+
+## What it measures
+
+Retained-heap delta after building a 100,000-entry partition-key-range vector,
+mirroring the `tracemalloc` methodology used in the Python PR. Variants:
+
+| Variant | Fields retained |
+|---------|-----------------|
+| **A** | All 13 fields currently on `PartitionKeyRange` |
+| **B** | Minimum: `id`, `min_inclusive`, `max_exclusive`, `parents` |
+| **C** | B + `status` + `throughputFraction` (cross-SDK recommendation) |
+
+Field shapes use **bytes-for-bytes equivalents** of the driver crate's types:
+`Option<ETag>` (`Cow<'static, str>` newtype) and `EffectivePartitionKey`
+(`String` newtype). The bench declares local newtype copies because
+`PartitionKeyRange` is `pub(crate)` in the driver.
+
+## Tool
+
+[`dhat-rs`](https://docs.rs/dhat) is the closest Rust analog of Python's
+`tracemalloc` — it reports retained bytes and live heap blocks via a global
+allocator wrapper.
+
+## Run
+
+```bash
+cargo bench --bench pk_range_cache_memory -p azure_data_cosmos_driver -- --nocapture
+```
+
+A `dhat-heap.json` viewer file is dropped in the repo root.
+
+## Latest results (M-series Mac, release build)
+
+| Variant | Retained MiB | Bytes/entry | Reduction vs A |
+|---------|-------------:|------------:|---------------:|
+| A: current (all 13 fields) | 43.90 | 460 | — |
+| B: stripped (id/min/max/parents) | 14.05 | 147 | −68.0% |
+| C: stripped + status + throughputFraction | 15.57 | 163 | −64.5% |
+
+These align (within methodology error) with Python PR #46297 results
+(854 → 452 B/entry, −47%) — the larger Rust reduction reflects the heavier
+struct on Rust today (more `Option<String>` fields populated).
+
+## Why a benchmark, not a code change
+
+This branch is intentionally measurement-only. The actual field-stripping
+decision should land as a separate, reviewable PR after we agree on which
+fields to drop. The cross-SDK analysis (Java drops these fields entirely;
+.NET v3 inherits them but doesn't read them on PKR) supports variant **C**
+as the safest cut.

--- a/sdk/cosmos/azure_data_cosmos_driver/benches/pk_range_cache_memory.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/benches/pk_range_cache_memory.rs
@@ -1,0 +1,361 @@
+//! Rust analog of the Python tracemalloc PKR-cache micro-benchmark from PR #46297.
+//!
+//! Builds 100,000 synthetic PartitionKeyRange entries in three variants and reports
+//! retained heap bytes via dhat (Rust's closest analog to Python's tracemalloc).
+//!
+//! Variants:
+//!   A. Current — exact struct from sdk/cosmos/azure_data_cosmos/src/routing/partition_key_range.rs
+//!   B. Stripped — id, min, max, parents only (Python PKRange-equivalent)
+//!   C. Stripped + 2 — adds status + throughputFraction (cross-SDK middle ground)
+//!
+//! Run:
+//!   cargo run --release -- --variant a   # or b, c, all
+//!
+//! Apples-to-apples with Python's `tracemalloc.get_traced_memory()` "current" reading.
+
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+const N_RANGES: usize = 100_000;
+
+
+// Driver-equivalent newtypes: bytes-for-bytes layout match for memory accounting.
+// `EtagLocal` mirrors `azure_data_cosmos_driver::models::ETag(Cow<'static, str>)`.
+// `EpkLocal` mirrors `azure_data_cosmos_driver::models::EffectivePartitionKey(String)`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EtagLocal(pub Cow<'static, str>);
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EpkLocal(pub String);
+
+// =========================================================================
+// Variant A — current PartitionKeyRange (verbatim from azure_data_cosmos)
+// =========================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PartitionKeyRangeStatus {
+    #[default]
+    Online,
+    Splitting,
+    Offline,
+    Split,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PartitionKeyRangeFull {
+    #[serde(rename = "id")]
+    pub id: String,
+    #[serde(rename = "_rid", skip_serializing_if = "Option::is_none")]
+    pub resource_id: Option<String>,
+    #[serde(rename = "_self", skip_serializing_if = "Option::is_none")]
+    pub self_link: Option<String>,
+    #[serde(rename = "_etag", skip_serializing_if = "Option::is_none")]
+    pub etag: Option<EtagLocal>,
+    #[serde(rename = "_ts", skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<i64>,
+    #[serde(rename = "minInclusive")]
+    pub min_inclusive: EpkLocal,
+    #[serde(rename = "maxExclusive")]
+    pub max_exclusive: EpkLocal,
+    #[serde(rename = "ridPrefix", skip_serializing_if = "Option::is_none")]
+    pub rid_prefix: Option<i32>,
+    #[serde(rename = "throughputFraction", default)]
+    pub throughput_fraction: f64,
+    #[serde(rename = "targetThroughput", skip_serializing_if = "Option::is_none")]
+    pub target_throughput: Option<f64>,
+    #[serde(rename = "status", default)]
+    pub status: PartitionKeyRangeStatus,
+    #[serde(rename = "_lsn", default)]
+    pub lsn: i64,
+    #[serde(rename = "parents", skip_serializing_if = "Option::is_none")]
+    pub parents: Option<Vec<String>>,
+    #[serde(
+        rename = "ownedArchivalPKRangeIds",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub owned_archival_pk_range_ids: Option<Vec<String>>,
+}
+
+// =========================================================================
+// Variant B — stripped (Python PKRange shape: id + min + max + parents)
+// =========================================================================
+#[derive(Debug, Clone)]
+pub struct PartitionKeyRangeStripped {
+    pub id: String,
+    pub min_inclusive: String,
+    pub max_exclusive: String,
+    pub parents: Option<Vec<String>>,
+}
+
+// =========================================================================
+// Variant C — stripped + status + throughputFraction (cross-SDK middle ground)
+// =========================================================================
+#[derive(Debug, Clone)]
+pub struct PartitionKeyRangeStrippedKeep2 {
+    pub id: String,
+    pub min_inclusive: String,
+    pub max_exclusive: String,
+    pub parents: Option<Vec<String>>,
+    pub status: PartitionKeyRangeStatus,
+    pub throughput_fraction: f64,
+}
+
+// =========================================================================
+// Synthetic generator — realistic field shapes mirroring service responses
+// =========================================================================
+
+/// Hex-style 16-char EPK (matches typical Cosmos effective-partition-key width).
+fn epk_for(i: usize) -> String {
+    // 16 hex chars; deterministic but distinct per-range so strings can't share storage.
+    format!("{:016X}", (i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15))
+}
+
+/// 24-char base64-like rid string (mirrors Cosmos rid widths).
+fn rid_for(i: usize) -> String {
+    // Deterministic, 24 chars. Ends in == like real base64 padding.
+    format!("3FIlAOzjvyg{:010X}AA==", i as u64)
+}
+
+/// Build N full-shape PartitionKeyRange entries with realistic field values.
+fn gen_full(n: usize) -> Vec<PartitionKeyRangeFull> {
+    let mut v = Vec::with_capacity(n);
+    for i in 0..n {
+        let min_inc = if i == 0 { String::new() } else { epk_for(i) };
+        let max_exc = if i == n - 1 { "FF".to_string() } else { epk_for(i + 1) };
+        let rid = rid_for(i);
+        v.push(PartitionKeyRangeFull {
+            id: i.to_string(),
+            resource_id: Some(rid.clone()),
+            self_link: Some(format!(
+                "dbs/3FIlAA==/colls/3FIlAOzjvyg=/pkranges/{}/",
+                rid
+            )),
+            etag: Some(EtagLocal(Cow::Owned(format!("\"{:08x}-0000-0800-0000-{:012x}0000\"", i, i)))),
+            timestamp: Some(1_700_000_000 + i as i64),
+            min_inclusive: EpkLocal(min_inc),
+            max_exclusive: EpkLocal(max_exc),
+            rid_prefix: Some((i % 256) as i32),
+            throughput_fraction: 1.0 / n as f64,
+            target_throughput: Some(400.0),
+            status: PartitionKeyRangeStatus::Online,
+            lsn: 100 + i as i64,
+            parents: if i % 2 == 0 {
+                None
+            } else {
+                Some(vec![(i / 2).to_string()])
+            },
+            owned_archival_pk_range_ids: None,
+        });
+    }
+    v
+}
+
+/// Convert a full-shape vec into the stripped variant — same string contents
+/// would be allocated freshly anyway in the wire-deserialization path, so we
+/// just rebuild from scratch for an isolated measurement.
+fn gen_stripped(n: usize) -> Vec<PartitionKeyRangeStripped> {
+    let mut v = Vec::with_capacity(n);
+    for i in 0..n {
+        let min_inc = if i == 0 { String::new() } else { epk_for(i) };
+        let max_exc = if i == n - 1 { "FF".to_string() } else { epk_for(i + 1) };
+        v.push(PartitionKeyRangeStripped {
+            id: i.to_string(),
+            min_inclusive: min_inc,
+            max_exclusive: max_exc,
+            parents: if i % 2 == 0 {
+                None
+            } else {
+                Some(vec![(i / 2).to_string()])
+            },
+        });
+    }
+    v
+}
+
+fn gen_stripped_keep2(n: usize) -> Vec<PartitionKeyRangeStrippedKeep2> {
+    let mut v = Vec::with_capacity(n);
+    for i in 0..n {
+        let min_inc = if i == 0 { String::new() } else { epk_for(i) };
+        let max_exc = if i == n - 1 { "FF".to_string() } else { epk_for(i + 1) };
+        v.push(PartitionKeyRangeStrippedKeep2 {
+            id: i.to_string(),
+            min_inclusive: min_inc,
+            max_exclusive: max_exc,
+            parents: if i % 2 == 0 {
+                None
+            } else {
+                Some(vec![(i / 2).to_string()])
+            },
+            status: PartitionKeyRangeStatus::Online,
+            throughput_fraction: 1.0 / n as f64,
+        });
+    }
+    v
+}
+
+// =========================================================================
+// Measurement helpers
+// =========================================================================
+
+#[derive(Debug, Clone, Copy)]
+struct Snapshot {
+    curr_bytes: u64,
+    curr_blocks: u64,
+    max_bytes: u64,
+}
+
+fn snapshot() -> Snapshot {
+    let s = dhat::HeapStats::get();
+    Snapshot {
+        curr_bytes: s.curr_bytes as u64,
+        curr_blocks: s.curr_blocks as u64,
+        max_bytes: s.max_bytes as u64,
+    }
+}
+
+fn delta(before: Snapshot, after: Snapshot) -> (i64, i64, i64) {
+    (
+        after.curr_bytes as i64 - before.curr_bytes as i64,
+        after.curr_blocks as i64 - before.curr_blocks as i64,
+        after.max_bytes as i64 - before.max_bytes as i64,
+    )
+}
+
+fn mib(bytes: i64) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+#[derive(Debug)]
+struct Result {
+    label: &'static str,
+    retained_bytes: i64,
+    retained_blocks: i64,
+    peak_delta_bytes: i64,
+    n_entries: usize,
+}
+
+fn measure_full(n: usize) -> Result {
+    // Pre-snapshot baseline — only the cache vec contributes to the delta.
+    let before = snapshot();
+    let v = gen_full(n);
+    let after = snapshot();
+    let (rb, blocks, peak) = delta(before, after);
+    // Keep alive until we've snapshot.
+    std::hint::black_box(&v);
+    drop(v);
+    Result {
+        label: "A: current (all 13 fields)",
+        retained_bytes: rb,
+        retained_blocks: blocks,
+        peak_delta_bytes: peak,
+        n_entries: n,
+    }
+}
+
+fn measure_stripped(n: usize) -> Result {
+    let before = snapshot();
+    let v = gen_stripped(n);
+    let after = snapshot();
+    let (rb, blocks, peak) = delta(before, after);
+    std::hint::black_box(&v);
+    drop(v);
+    Result {
+        label: "B: stripped (id, min, max, parents)",
+        retained_bytes: rb,
+        retained_blocks: blocks,
+        peak_delta_bytes: peak,
+        n_entries: n,
+    }
+}
+
+fn measure_stripped_keep2(n: usize) -> Result {
+    let before = snapshot();
+    let v = gen_stripped_keep2(n);
+    let after = snapshot();
+    let (rb, blocks, peak) = delta(before, after);
+    std::hint::black_box(&v);
+    drop(v);
+    Result {
+        label: "C: stripped + status + throughputFraction",
+        retained_bytes: rb,
+        retained_blocks: blocks,
+        peak_delta_bytes: peak,
+        n_entries: n,
+    }
+}
+
+fn print_results(results: &[Result]) {
+    println!();
+    println!("# Rust PKR-cache memory micro-benchmark");
+    println!();
+    println!("Tool: dhat-rs (Rust analog of Python tracemalloc, retained-heap delta)");
+    println!("Entries per scenario: {}", N_RANGES);
+    println!();
+    println!("| Variant | Retained MiB | Bytes / entry | Heap blocks | Peak delta MiB |");
+    println!("|---------|-------------:|--------------:|------------:|---------------:|");
+    for r in results {
+        println!(
+            "| {} | {:.2} | {:.0} | {} | {:.2} |",
+            r.label,
+            mib(r.retained_bytes),
+            r.retained_bytes as f64 / r.n_entries as f64,
+            r.retained_blocks,
+            mib(r.peak_delta_bytes),
+        );
+    }
+    println!();
+    if results.len() >= 2 {
+        let baseline = results[0].retained_bytes;
+        println!("## Reductions vs Variant A");
+        println!();
+        for r in &results[1..] {
+            let saved = baseline - r.retained_bytes;
+            let pct = (saved as f64 / baseline as f64) * 100.0;
+            println!(
+                "- {}: {:.2} MiB saved per cache ({:.1}% reduction)",
+                r.label,
+                mib(saved),
+                pct
+            );
+        }
+        println!();
+        println!("## 150-cache cluster projection (mirrors Python PR #46297)");
+        println!();
+        println!("| Scenario | Total memory |");
+        println!("|----------|-------------:|");
+        for r in results {
+            let total = (r.retained_bytes as f64) * 150.0;
+            println!(
+                "| 150 caches × per-cache: {} | {:.2} GiB |",
+                r.label,
+                total / (1024.0 * 1024.0 * 1024.0)
+            );
+        }
+        println!(
+            "| Single shared cache (any variant) | {:.2} MiB |",
+            mib(baseline)
+        );
+    }
+}
+
+fn main() {
+    let _profiler = dhat::Profiler::builder().testing().build();
+
+    // Run each variant in its own scope, dropping between to isolate deltas.
+    println!("Generating Variant A (current)...");
+    let r_a = measure_full(N_RANGES);
+    println!("  retained: {:.2} MiB", mib(r_a.retained_bytes));
+
+    println!("Generating Variant B (stripped)...");
+    let r_b = measure_stripped(N_RANGES);
+    println!("  retained: {:.2} MiB", mib(r_b.retained_bytes));
+
+    println!("Generating Variant C (stripped + 2)...");
+    let r_c = measure_stripped_keep2(N_RANGES);
+    println!("  retained: {:.2} MiB", mib(r_c.retained_bytes));
+
+    print_results(&[r_a, r_b, r_c]);
+}


### PR DESCRIPTION
## ⚠️ DO NOT MERGE / DO NOT REVIEW

This PR is **measurement-only**. It exists to collect retained-heap numbers for the driver's `PartitionKeyRange` cache, comparable to the Python PR [Azure/azure-sdk-for-python#46297](https://github.com/Azure/azure-sdk-for-python/pull/46297).

> Note: a "Do Not Review" label does not exist in this repo, so the convention is captured in the title.

## What this adds

- `sdk/cosmos/azure_data_cosmos_driver/benches/pk_range_cache_memory.rs` — `dhat-rs` heap micro-benchmark with three variants:
  - **A** — current shape (all 13 fields)
  - **B** — minimum (`id`, `min`, `max`, `parents`)
  - **C** — B + `status` + `throughputFraction`
- `dhat = "0.3"` dev-dependency on the driver crate.
- A `[[bench]] harness = false` entry.
- A README explaining methodology and how to run.

The benchmark declares **local newtype copies** of `EffectivePartitionKey` and `ETag` (bytes-for-bytes equivalent) because `PartitionKeyRange` is `pub(crate)` in the driver crate and cannot be imported from a `benches/` target.

## Why dhat-rs

It is the closest Rust analog of Python's `tracemalloc` — it reports retained-heap deltas via a global allocator wrapper, so the methodology is symmetric with the Python experiment.

## Latest local results (M-series Mac, release build, 100,000 ranges)

| Variant | Retained MiB | Bytes/entry | Reduction vs A |
|---|---:|---:|---:|
| A: current (all 13 fields) | 43.90 | 460 | — |
| B: stripped (id/min/max/parents) | 14.05 | 147 | **−68.0%** |
| C: stripped + status + throughputFraction | 15.57 | 163 | **−64.5%** |

These align with the Python PR's projection (854 → 452 B/entry, ~−47%); the larger Rust delta reflects the heavier struct on Rust today.

## Run

```
cargo bench --bench pk_range_cache_memory -p azure_data_cosmos_driver -- --nocapture
```
