### PR TITLE
Updated default parallelism and chunk size to match .NET SDK

### DIFF
--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Default `parallel` and `partition_size` for blob upload and download now match the Azure Storage SDK for .NET. Parallelism scales with CPU count (8 to 32 workers). Upload partition size is 4 MiB for content under 100 MiB and 8 MiB for larger content. Download partition size is 4 MiB. Explicitly provided values still take precedence and are silently clamped at service maximums (4000 MiB per uploaded block, 256 MiB per download range). Upload now rejects content that would require more than 50,000 blocks at the chosen partition size.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -10,7 +10,7 @@ use crate::{
         http_ranges::IntoRangeHeader, BlobClientDownloadOptions, BlobClientDownloadResult,
         BlobClientUploadOptions, BlobClientUploadResult, StorageErrorCode,
     },
-    partitioned_transfer::{self, PartitionedDownloadBehavior},
+    partitioned_transfer::{self, defaults, PartitionedDownloadBehavior},
     AppendBlobClient, BlockBlobClient, PageBlobClient,
 };
 use async_trait::async_trait;
@@ -24,7 +24,7 @@ use azure_core::{
     },
     tracing, Bytes, Result,
 };
-use std::{num::NonZero, ops::Range, sync::Arc};
+use std::{ops::Range, sync::Arc};
 
 impl BlobClient {
     /// Creates a new BlobClient, using Entra ID authentication.
@@ -205,10 +205,13 @@ impl BlobClient {
         options: Option<BlobClientDownloadOptions<'_>>,
     ) -> Result<BlobClientDownloadResult> {
         let options = options.unwrap_or_default();
-        let parallel = options.parallel.unwrap_or(DEFAULT_DOWNLOAD_PARALLEL);
+        let parallel = options
+            .parallel
+            .unwrap_or_else(defaults::default_concurrency);
         let partition_size = options
             .partition_size
-            .unwrap_or(DEFAULT_DOWNLOAD_PARTITION_SIZE);
+            .map(defaults::clamp_download_partition_size)
+            .unwrap_or_else(defaults::default_download_partition_size);
         // Construct exhaustively to catch new options.
         let get_range_options = BlobClientDownloadInternalOptions {
             encryption_algorithm: options.encryption_algorithm,
@@ -288,10 +291,6 @@ impl BlobClient {
         }
     }
 }
-
-// unwrap evaluated at compile time
-const DEFAULT_DOWNLOAD_PARALLEL: NonZero<usize> = NonZero::new(4).unwrap();
-const DEFAULT_DOWNLOAD_PARTITION_SIZE: NonZero<usize> = NonZero::new(4 * 1024 * 1024).unwrap();
 
 struct BlobClientDownloadBehavior<'a> {
     client: GeneratedBlobClient,

--- a/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
@@ -12,7 +12,7 @@ use crate::{
         method_options::BlockBlobClientUploadOptions, BlockBlobClientCommitBlockListOptions,
         BlockBlobClientStageBlockOptions, BlockBlobClientUploadResult, BlockLookupList,
     },
-    partitioned_transfer::{self, PartitionedUploadBehavior},
+    partitioned_transfer::{self, defaults, PartitionedUploadBehavior},
 };
 use async_trait::async_trait;
 use azure_core::{
@@ -24,7 +24,7 @@ use azure_core::{
     tracing, Bytes, Result, Uuid,
 };
 use futures::lock::Mutex;
-use std::{num::NonZero, sync::Arc};
+use std::sync::Arc;
 
 impl BlockBlobClient {
     /// Creates a new BlockBlobClient, using Entra ID authentication.
@@ -125,8 +125,14 @@ impl BlockBlobClient {
         options: Option<BlockBlobClientUploadOptions<'_>>,
     ) -> Result<BlockBlobClientUploadResult> {
         let options = options.unwrap_or_default();
-        let parallel = options.parallel.unwrap_or(DEFAULT_PARALLEL);
-        let partition_size = options.partition_size.unwrap_or(DEFAULT_PARTITION_SIZE);
+        let body: Body = content.into();
+        let parallel = options
+            .parallel
+            .unwrap_or_else(defaults::default_concurrency);
+        let partition_size = options
+            .partition_size
+            .map(defaults::clamp_upload_partition_size)
+            .unwrap_or_else(|| defaults::default_upload_partition_size(body.len()));
         // Construct exhaustively to catch new options.
         let oneshot_options = BlockBlobClientUploadInternalOptions {
             blob_cache_control: options.blob_cache_control.clone(),
@@ -205,7 +211,7 @@ impl BlockBlobClient {
             stage_block_options,
             commit_block_list_options,
         );
-        partitioned_transfer::upload(content.into(), parallel, partition_size, &behavior).await?;
+        partitioned_transfer::upload(body, parallel, partition_size, &behavior).await?;
         behavior.result.into_inner().ok_or_else(|| {
             azure_core::Error::with_message(
                 azure_core::error::ErrorKind::Other,
@@ -214,10 +220,6 @@ impl BlockBlobClient {
         })
     }
 }
-
-// unwrap evaluated at compile time
-const DEFAULT_PARALLEL: NonZero<usize> = NonZero::new(4).unwrap();
-const DEFAULT_PARTITION_SIZE: NonZero<u64> = NonZero::new(4 * 1024 * 1024).unwrap();
 
 struct BlockInfo {
     offset: u64,

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/defaults.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/defaults.rs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Default values for `parallel` and `partition_size` on blob upload and download.
+//!
+//! These match the Azure Storage SDK for .NET (`Azure.Storage.Blobs`):
+//! - Concurrency: `min(max(CPUs * 2, 8), 32)`
+//! - Upload partition size: 4 MiB when content is under 100 MiB, otherwise 8 MiB
+//! - Download partition size: 4 MiB
+//! - Service caps: 4000 MiB per uploaded block, 256 MiB per download range, 50 000 blocks per block blob
+
+use std::num::NonZero;
+
+pub(crate) const DEFAULT_BUFFER_SIZE: u64 = 4 * 1024 * 1024;
+pub(crate) const LARGE_BUFFER_SIZE: u64 = 8 * 1024 * 1024;
+pub(crate) const LARGE_UPLOAD_THRESHOLD: u64 = 100 * 1024 * 1024;
+pub(crate) const MAX_STAGE_BYTES: u64 = 4_000 * 1024 * 1024;
+pub(crate) const MAX_DOWNLOAD_BYTES: usize = 256 * 1024 * 1024;
+pub(crate) const MAX_BLOCKS: u64 = 50_000;
+
+pub(crate) fn default_concurrency() -> NonZero<usize> {
+    let cpus = std::thread::available_parallelism()
+        .map(NonZero::get)
+        .unwrap_or(1);
+    let n = cpus.saturating_mul(2).clamp(8, 32);
+    NonZero::new(n).unwrap()
+}
+
+pub(crate) fn default_upload_partition_size(content_len: Option<u64>) -> NonZero<u64> {
+    let n = match content_len {
+        Some(len) if len >= LARGE_UPLOAD_THRESHOLD => LARGE_BUFFER_SIZE,
+        _ => DEFAULT_BUFFER_SIZE,
+    };
+    NonZero::new(n).unwrap()
+}
+
+pub(crate) fn default_download_partition_size() -> NonZero<usize> {
+    NonZero::new(DEFAULT_BUFFER_SIZE as usize).unwrap()
+}
+
+pub(crate) fn clamp_upload_partition_size(p: NonZero<u64>) -> NonZero<u64> {
+    NonZero::new(p.get().min(MAX_STAGE_BYTES)).unwrap()
+}
+
+pub(crate) fn clamp_download_partition_size(p: NonZero<usize>) -> NonZero<usize> {
+    NonZero::new(p.get().min(MAX_DOWNLOAD_BYTES)).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn concurrency_is_within_8_to_32() {
+        let c = default_concurrency().get();
+        assert!((8..=32).contains(&c), "expected 8..=32, got {c}");
+    }
+
+    #[test]
+    fn upload_partition_unknown_length_is_4_mib() {
+        assert_eq!(default_upload_partition_size(None).get(), DEFAULT_BUFFER_SIZE);
+    }
+
+    #[test]
+    fn upload_partition_below_threshold_is_4_mib() {
+        let below = LARGE_UPLOAD_THRESHOLD - 1;
+        assert_eq!(
+            default_upload_partition_size(Some(below)).get(),
+            DEFAULT_BUFFER_SIZE,
+        );
+    }
+
+    #[test]
+    fn upload_partition_at_threshold_is_8_mib() {
+        assert_eq!(
+            default_upload_partition_size(Some(LARGE_UPLOAD_THRESHOLD)).get(),
+            LARGE_BUFFER_SIZE,
+        );
+    }
+
+    #[test]
+    fn upload_partition_well_above_threshold_is_8_mib() {
+        let large = 1024 * 1024 * 1024;
+        assert_eq!(
+            default_upload_partition_size(Some(large)).get(),
+            LARGE_BUFFER_SIZE,
+        );
+    }
+
+    #[test]
+    fn download_partition_default_is_4_mib() {
+        assert_eq!(
+            default_download_partition_size().get() as u64,
+            DEFAULT_BUFFER_SIZE,
+        );
+    }
+
+    #[test]
+    fn clamp_upload_passes_through_under_max() {
+        let under = NonZero::new(LARGE_BUFFER_SIZE).unwrap();
+        assert_eq!(clamp_upload_partition_size(under), under);
+    }
+
+    #[test]
+    fn clamp_upload_caps_at_max() {
+        let over = NonZero::new(MAX_STAGE_BYTES + 1).unwrap();
+        assert_eq!(clamp_upload_partition_size(over).get(), MAX_STAGE_BYTES);
+    }
+
+    #[test]
+    fn clamp_download_passes_through_under_max() {
+        let under = NonZero::new(DEFAULT_BUFFER_SIZE as usize).unwrap();
+        assert_eq!(clamp_download_partition_size(under), under);
+    }
+
+    #[test]
+    fn clamp_download_caps_at_max() {
+        let over = NonZero::new(MAX_DOWNLOAD_BYTES + 1).unwrap();
+        assert_eq!(clamp_download_partition_size(over).get(), MAX_DOWNLOAD_BYTES);
+    }
+}

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/mod.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+pub(crate) mod defaults;
 mod download;
 mod upload;
 

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/upload.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/upload.rs
@@ -1,13 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use azure_core::http::Body;
+use azure_core::{
+    error::{Error, ErrorKind},
+    http::Body,
+};
 use bytes::Bytes;
 
 use async_trait::async_trait;
 use azure_core::stream::SeekableStream;
 use futures::StreamExt;
 
+use crate::partitioned_transfer::defaults;
 use crate::streams::{
     multi_bytes_stream::MultiBytesStream,
     partitioned_stream::{self, stream_multi_buffer_partitions, stream_single_buffer_partitions},
@@ -30,6 +34,19 @@ pub(crate) async fn upload(
     client: &impl PartitionedUploadBehavior,
 ) -> AzureResult<()> {
     if let Some(content_len) = content.len() {
+        let required_min = content_len.div_ceil(defaults::MAX_BLOCKS);
+        if partition_size.get() < required_min {
+            return Err(Error::with_message(
+                ErrorKind::Other,
+                format!(
+                    "partition_size {} is too small for content length {}; \
+                     a block blob cannot exceed {} blocks",
+                    partition_size.get(),
+                    content_len,
+                    defaults::MAX_BLOCKS,
+                ),
+            ));
+        }
         if content_len <= partition_size.get() {
             client.transfer_oneshot(content).await?;
             return Ok(());
@@ -315,6 +332,37 @@ mod tests {
         .await;
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejects_partition_size_that_would_exceed_50000_blocks() {
+        // With partition_size == 1 and content_len == 50_001, required minimum
+        // partition_size is ceil(50_001 / 50_000) == 2, so partition_size of 1 is
+        // too small and upload() must refuse before contacting the service.
+        let content_len: usize = defaults::MAX_BLOCKS as usize + 1;
+        let partition_size: u64 = 1;
+        let concurrency: usize = 2;
+
+        let mock = MockPartitionedUploadBehavior::new();
+        let src_data = vec![0u8; content_len];
+
+        let result = upload(
+            Body::Bytes(Bytes::from(src_data)),
+            NonZero::new(concurrency).unwrap(),
+            NonZero::new(partition_size).unwrap(),
+            &mock,
+        )
+        .await;
+
+        let err = result.expect_err("expected 50,000-block check to fail");
+        assert!(
+            err.to_string().contains("50000") || err.to_string().contains("50_000"),
+            "error should reference the 50,000-block limit: {err}"
+        );
+        assert!(
+            mock.invocations.lock().await.is_empty(),
+            "no transfer calls should happen when the check fails"
+        );
     }
 
     async fn assert_upload_oneshot_invocations(


### PR DESCRIPTION
# Match .NET blob SDK's parallelism & chunk-size behavior

## Context

Today the Rust blob SDK uses static defaults: `parallel = 4`, `partition_size = 4 MiB` for both upload and download. The .NET SDK (`Azure.Storage.Blobs`) picks these dynamically based on CPU count and content length, which produces materially better throughput on modern machines and large blobs. This PR ports **the functional behavior** (default values + one safety check), without restructuring existing APIs or internal signatures. The two public knobs remain `parallel` and `partition_size` — no new fields, no renames, no signature changes in `partitioned_transfer::upload`/`download`.

Authoritative .NET references:
- Concurrency formula: `PartitionedUploader.cs:209`
- Dynamic block size: `PartitionedUploader.cs:433-439`
- 50k-block enforcement: `PartitionedUploader.cs:900-910`
- Numeric constants: `Constants.cs:34,39,44,50,243,254,256`

## Behavior changes

### 1. Default `parallel` (upload & download)

When `options.parallel` is `None`:

```
parallel = min(max(available_parallelism() * 2, 8), 32)
```

Uses `std::thread::available_parallelism()`, falling back to `1` on `Err`. Matches .NET's `Math.Min(Math.Max(Environment.ProcessorCount * 2, 8), 32)`. Replaces today's fixed `4`.

Skip .NET's opt-in legacy switch (`UseLegacyDefaultConcurrency = 5`); no counterpart in Rust.

### 2. Default `partition_size` (upload only)

When `options.partition_size` is `None` on upload, pick based on the `Body`'s known content length:

```
if content.len() is Some(n) and n >= 100 MiB:  8 MiB   // LargeBufferSize
else:                                           4 MiB   // DefaultBufferSize
```

Matches .NET's `GetActualBlockSize`. When length is unknown (non-seekable stream), use 4 MiB (same as .NET's fallback).

### 3. Default `partition_size` (download)

Remains 4 MiB. No behavior change — this already matches .NET's subsequent-range size. Moved the literal into the same helper module for consistency.

### 4. 50,000-block safety check (upload)

Inside `partitioned_transfer::upload`, after inspecting `content.len()`:

```
if let Some(len) = content.len() {
    let required_min = len.div_ceil(50_000);
    if partition_size.get() < required_min {
        return Err(... "partition_size too small for content length; \
                       a block blob cannot exceed 50,000 blocks");
    }
}
```

Matches .NET's `InsufficientStorageTransferOptions`. Prevents the service from returning a confusing 400 when the caller picks too small a block size for a very large blob.

### 5. Silently clamp user-provided sizes at service maximums

- Upload `partition_size` clamped to `4000 MiB` (`MaxStageBytes`).
- Download `partition_size` clamped to `256 MiB` (`MaxDownloadBytes`).

.NET caps silently via `Math.Min`; match that.

## Files changed

### New: `sdk/storage/azure_storage_blob/src/partitioned_transfer/defaults.rs`

Pure helpers — unit-testable, no dependencies on the transfer layer:

- `DEFAULT_BUFFER_SIZE` (4 MiB), `LARGE_BUFFER_SIZE` (8 MiB), `LARGE_UPLOAD_THRESHOLD` (100 MiB), `MAX_STAGE_BYTES` (4000 MiB), `MAX_DOWNLOAD_BYTES` (256 MiB), `MAX_BLOCKS` (50,000)
- `default_concurrency() -> NonZero<usize>`
- `default_upload_partition_size(content_len: Option<u64>) -> NonZero<u64>`
- `default_download_partition_size() -> NonZero<usize>`
- `clamp_upload_partition_size(p: NonZero<u64>) -> NonZero<u64>`
- `clamp_download_partition_size(p: NonZero<usize>) -> NonZero<usize>`

Registered via `mod defaults;` in `partitioned_transfer/mod.rs`.

### `sdk/storage/azure_storage_blob/src/clients/blob_client.rs`

Deleted `DEFAULT_DOWNLOAD_PARALLEL` and `DEFAULT_DOWNLOAD_PARTITION_SIZE` constants. `download()` now resolves defaults via the `defaults::*` helpers and clamps user-provided partition sizes.

### `sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs`

Deleted `DEFAULT_PARALLEL` and `DEFAULT_PARTITION_SIZE` constants. `upload()` converts to `Body` early so `body.len()` is reachable for default selection, then resolves defaults via the `defaults::*` helpers and clamps user-provided partition sizes.

### `sdk/storage/azure_storage_blob/src/partitioned_transfer/upload.rs`

Signature of `pub(crate) async fn upload` unchanged. Added the 50k-block check just before the existing single-shot branch so that oversized content is rejected before any service call.

### `sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs`

No changes — signature unchanged, all clamping and default selection happens in the caller.

## Tests

- **10 new unit tests in `defaults.rs`** covering: concurrency range, upload partition size for unknown/below-threshold/at-threshold/well-above-threshold content lengths, default download partition size, and both clamp helpers.
- **New unit test in `upload.rs`** (`rejects_partition_size_that_would_exceed_50000_blocks`): uses the existing mock `PartitionedUploadBehavior` pattern; passes 50,001 bytes with `partition_size = 1` and asserts `upload()` returns an error referencing the 50,000-block limit and does not invoke any behavior methods.
- **Existing tests unchanged**: signatures of `partitioned_transfer::upload` and `::download` stayed the same, so the four existing upload tests and the concurrency tests in `mod.rs` continue to pass as-is.

## CHANGELOG

Entry added to `sdk/storage/azure_storage_blob/CHANGELOG.md` under 0.13.0 (Unreleased) → Features Added.