### PR TITLE
Storage Stress Framework [DO NOT MERGE]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,7 +590,10 @@ dependencies = [
  "azure_core_test",
  "azure_storage_blob",
  "bytes",
+ "clap",
  "futures",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,6 +595,9 @@ dependencies = [
  "crc-fast",
  "futures",
  "rand 0.10.1",
+ "reqwest",
+ "serde",
+ "serde_json",
  "tokio",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "azure_storage_blob_stress"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "azure_core",
+ "azure_core_test",
+ "azure_identity",
+ "azure_storage_blob",
+ "azure_storage_blob_test",
+ "clap",
+ "crc-fast",
+ "futures",
+ "rand 0.10.1",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "azure_storage_blob_test"
 version = "0.1.0"
 dependencies = [
@@ -591,7 +609,10 @@ dependencies = [
  "azure_storage_blob",
  "bytes",
  "clap",
+ "crc-fast",
  "futures",
+ "pin-project",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "tokio",
@@ -962,6 +983,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest",
+ "spin",
 ]
 
 [[package]]
@@ -3128,6 +3159,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
   "sdk/canary/azure_canary_core",
   "sdk/canary/azure_canary",
   "sdk/storage/azure_storage_blob",
+  "sdk/storage/azure_storage_blob_stress",
   "sdk/storage/azure_storage_queue",
 ]
 exclude = [

--- a/sdk/storage/.cspell.json
+++ b/sdk/storage/.cspell.json
@@ -29,6 +29,7 @@
     "mycontainer",
     "myqueue",
     "numofmessages",
+    "nvme",
     "pagelist",
     "peekonly",
     "policyid",

--- a/sdk/storage/azure_storage_blob_stress/Cargo.toml
+++ b/sdk/storage/azure_storage_blob_stress/Cargo.toml
@@ -1,31 +1,26 @@
 [package]
-name = "azure_storage_blob_test"
+name = "azure_storage_blob_stress"
 version = "0.1.0"
-description = "Common utilities for Key Vault tests"
-readme = "README.md"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-homepage = "https://github.com/azure/azure-sdk-for-rust"
-keywords = ["sdk", "cloud", "rest"]
-categories = ["development-tools"]
 publish = false
 
 [dependencies]
 async-trait.workspace = true
-azure_core = { workspace = true, features = ["xml"] }
+azure_core.workspace = true
 azure_core_test.workspace = true
+azure_identity.workspace = true
 azure_storage_blob.path = "../azure_storage_blob"
-bytes.workspace = true
+azure_storage_blob_test.path = "../azure_storage_blob_test"
 clap = { workspace = true, features = ["derive"] }
 crc-fast = "1.9.0"
 futures.workspace = true
 rand.workspace = true
-serde.workspace = true
-serde_json.workspace = true
 tokio = { workspace = true, features = ["rt"] }
+uuid.workspace = true
 
 [lints]
 workspace = true

--- a/sdk/storage/azure_storage_blob_stress/Cargo.toml
+++ b/sdk/storage/azure_storage_blob_stress/Cargo.toml
@@ -19,6 +19,9 @@ clap = { workspace = true, features = ["derive"] }
 crc-fast = "1.9.0"
 futures.workspace = true
 rand.workspace = true
+reqwest = { workspace = true, features = ["rustls"] }
+serde.workspace = true
+serde_json.workspace = true
 tokio = { workspace = true, features = ["rt"] }
 uuid.workspace = true
 

--- a/sdk/storage/azure_storage_blob_stress/src/clients.rs
+++ b/sdk/storage/azure_storage_blob_stress/src/clients.rs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use azure_core::{
+    error::{ErrorKind, ResultExt},
+    http::Url,
+    Result,
+};
+use azure_storage_blob::BlobContainerClient;
+
+pub fn get_container_client() -> Result<BlobContainerClient> {
+    let account_name = std::env::var("AZURE_STORAGE_ACCOUNT_NAME").with_context(
+        ErrorKind::Other,
+        "Configure `AZURE_STORAGE_ACCOUNT_NAME` environment variable.",
+    )?;
+    let container_name = uuid::Uuid::new_v4().to_string();
+    BlobContainerClient::from_url(
+        Url::parse(
+            format!(
+                "https://{}.blob.core.windows.net/{}",
+                account_name, container_name
+            )
+            .as_str(),
+        )?,
+        Some(azure_core_test::credentials::from_env(None)?),
+        None,
+    )
+}

--- a/sdk/storage/azure_storage_blob_stress/src/clients.rs
+++ b/sdk/storage/azure_storage_blob_stress/src/clients.rs
@@ -1,19 +1,45 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+use std::{
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
+
 use azure_core::{
     error::{ErrorKind, ResultExt},
-    http::Url,
+    http::{ClientOptions, Transport, Url},
     Result,
 };
-use azure_storage_blob::BlobContainerClient;
+use azure_storage_blob::{BlobContainerClient, BlobContainerClientOptions};
+use azure_storage_blob_test::fault_injection::{FaultInjectionPolicy, FaultInjectionProbabilities};
+use rand::rngs::SmallRng;
 
-pub fn get_container_client() -> Result<BlobContainerClient> {
+pub fn get_container_client(
+    fault_options: &FaultInjectionProbabilities,
+) -> Result<BlobContainerClient> {
     let account_name = std::env::var("AZURE_STORAGE_ACCOUNT_NAME").with_context(
         ErrorKind::Other,
         "Configure `AZURE_STORAGE_ACCOUNT_NAME` environment variable.",
     )?;
     let container_name = uuid::Uuid::new_v4().to_string();
+
+    let client_options = if fault_options.is_zero() {
+        None
+    } else {
+        Some(BlobContainerClientOptions {
+            client_options: ClientOptions {
+                per_try_policies: vec![Arc::new(FaultInjectionPolicy::<SmallRng>::new(
+                    Url::parse("https://127.0.0.1:7778").unwrap(),
+                    fault_options.clone(),
+                )?)],
+                transport: Some(FAULT_HTTP_CLIENT.clone()),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    };
+
     BlobContainerClient::from_url(
         Url::parse(
             format!(
@@ -23,6 +49,23 @@ pub fn get_container_client() -> Result<BlobContainerClient> {
             .as_str(),
         )?,
         Some(azure_core_test::credentials::from_env(None)?),
-        None,
+        client_options,
     )
 }
+
+// Build a custom reqwest client that accepts the fault injector's
+// self-signed TLS certificate and disables automatic decompression
+// (required for partitioned downloads to work correctly).
+static FAULT_HTTP_CLIENT: LazyLock<Transport> = LazyLock::new(|| {
+    Transport::new(Arc::new(
+        ::reqwest::ClientBuilder::new()
+            .danger_accept_invalid_certs(true)
+            .read_timeout(Duration::from_secs(10))
+            .no_gzip()
+            .no_brotli()
+            .no_deflate()
+            .no_zstd()
+            .build()
+            .expect("build reqwest client"),
+    ))
+});

--- a/sdk/storage/azure_storage_blob_stress/src/download_blobs_test.rs
+++ b/sdk/storage/azure_storage_blob_stress/src/download_blobs_test.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use azure_core::{error::ErrorKind, http::Body, Error, Result};
 use azure_storage_blob::{models::BlobClientDownloadOptions, BlobClient, BlobContainerClient};
 use azure_storage_blob_test::{
+    fault_injection::FaultInjectionProbabilities,
     stress::{
         data,
         value_parsers::{non_zero_usize, simple_non_zero_len_u64, simple_non_zero_len_usize},
@@ -41,9 +42,12 @@ pub(crate) struct DownloadBlobsTestArgs {
 }
 
 impl DownloadBlobsTestArgs {
-    pub fn as_test(&self) -> Result<Box<dyn StressTest>> {
+    pub fn as_test(
+        &self,
+        fault_options: &FaultInjectionProbabilities,
+    ) -> Result<Box<dyn StressTest>> {
         Ok(Box::new(DownloadBlobsTest {
-            container_client: crate::clients::get_container_client()?,
+            container_client: crate::clients::get_container_client(fault_options)?,
             download_targets: self.targets,
             download_targets_len: self.data_len,
             download_target_name_queue: Arc::new(Mutex::new(VecDeque::with_capacity(self.targets))),

--- a/sdk/storage/azure_storage_blob_stress/src/download_blobs_test.rs
+++ b/sdk/storage/azure_storage_blob_stress/src/download_blobs_test.rs
@@ -51,11 +51,12 @@ impl DownloadBlobsTestArgs {
 
 impl std::fmt::Display for DownloadBlobsTestArgs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "DownloadOptions: {{ targets: {}, concurrency: {}, block_len: {}, data_len: {} }}",
-            self.targets, self.concurrency, self.block_len, self.data_len,
-        )
+        writeln!(f, "=== Download Blobs Configuration ===")?;
+        writeln!(f, "block_len: {}", self.block_len)?;
+        writeln!(f, "concurrency: {}", self.concurrency)?;
+        writeln!(f, "data_len: {}", self.data_len)?;
+        writeln!(f, "targets: {}", self.targets)?;
+        Ok(())
     }
 }
 

--- a/sdk/storage/azure_storage_blob_stress/src/download_blobs_test.rs
+++ b/sdk/storage/azure_storage_blob_stress/src/download_blobs_test.rs
@@ -1,15 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use std::{collections::VecDeque, num::NonZero, sync::Arc};
+use std::{collections::VecDeque, num::NonZero, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use azure_core::{error::ErrorKind, http::Body, Error, Result};
 use azure_storage_blob::{models::BlobClientDownloadOptions, BlobClient, BlobContainerClient};
-use azure_storage_blob_test::stress::{
-    data,
-    value_parsers::{non_zero_u64, non_zero_usize},
-    StressRunOutput, StressTest, StressTestOperation,
+use azure_storage_blob_test::{
+    stress::{
+        data,
+        value_parsers::{non_zero_u64, non_zero_usize},
+        StressRunOutput, StressTest, StressTestOperation,
+    },
+    OptionalTimeoutFutureExt,
 };
 use clap::Args;
 use crc_fast::{CrcAlgorithm, Digest};
@@ -149,10 +152,14 @@ struct DownloadOperation {
 
 #[async_trait]
 impl StressTestOperation for DownloadOperation {
-    async fn run(&mut self, mut result_sender: UnboundedSender<StressRunOutput>) {
+    async fn run(
+        &mut self,
+        timeout: Option<Duration>,
+        mut result_sender: UnboundedSender<StressRunOutput>,
+    ) {
         let mut digest = Digest::new(CRC_ALGORITHM);
 
-        let result: std::result::Result<(), Error> = async {
+        let download_op = async {
             let mut download_body = self
                 .client
                 .download(Some(BlobClientDownloadOptions {
@@ -165,19 +172,19 @@ impl StressTestOperation for DownloadOperation {
             while let Some(bytes) = download_body.try_next().await? {
                 digest.update(&bytes);
             }
-            Ok(())
-        }
-        .await;
+            Ok::<_, Error>(())
+        };
 
-        let output = match result {
-            Ok(()) => {
+        let output = match download_op.timeout(timeout).await {
+            Ok(Ok(())) => {
                 if digest.finalize() == self.expected_content_crc {
                     StressRunOutput::Success
                 } else {
                     StressRunOutput::DataCorruption
                 }
             }
-            Err(e) => StressRunOutput::GracefulError(e),
+            Ok(Err(op_error)) => StressRunOutput::GracefulError(op_error),
+            Err(_timeout) => StressRunOutput::Timeout,
         };
         let _ = result_sender
             .send(output)

--- a/sdk/storage/azure_storage_blob_stress/src/download_blobs_test.rs
+++ b/sdk/storage/azure_storage_blob_stress/src/download_blobs_test.rs
@@ -1,13 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use std::{collections::VecDeque, num::NonZero, sync::Arc, time::Duration};
+use std::{
+    collections::VecDeque,
+    num::NonZero,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 
 use async_trait::async_trait;
-use azure_core::{error::ErrorKind, http::Body, Error, Result};
-use azure_storage_blob::{models::BlobClientDownloadOptions, BlobClient, BlobContainerClient};
+use azure_core::{
+    error::ErrorKind,
+    http::{Body, ClientMethodOptions, Context},
+    Error, Result,
+};
+use azure_storage_blob::{
+    models::{
+        BlobClientDownloadOptions, BlobClientUploadOptions, BlobContainerClientCreateOptions,
+        BlobContainerClientDeleteOptions,
+    },
+    BlobClient, BlobContainerClient,
+};
 use azure_storage_blob_test::{
-    fault_injection::FaultInjectionProbabilities,
+    fault_injection::{self, FaultInjectionProbabilities},
     stress::{
         data,
         value_parsers::{non_zero_usize, simple_non_zero_len_u64, simple_non_zero_len_usize},
@@ -85,11 +100,24 @@ struct DownloadBlobsTest {
     chunk_len: NonZero<usize>,
 }
 
+static NO_FAULT: LazyLock<Context> = LazyLock::new(|| {
+    let mut c = Context::new();
+    c.insert(fault_injection::NoFault);
+    c
+});
+
 #[async_trait]
 impl StressTest for DownloadBlobsTest {
     async fn global_setup(&self) -> Result<()> {
         println!("Creating container...");
-        self.container_client.create(None).await?;
+        self.container_client
+            .create(Some(BlobContainerClientCreateOptions {
+                method_options: ClientMethodOptions {
+                    context: NO_FAULT.clone(),
+                },
+                ..Default::default()
+            }))
+            .await?;
         println!("Container created.");
 
         let mut create_blob_tasks = Vec::with_capacity(self.download_targets);
@@ -107,7 +135,15 @@ impl StressTest for DownloadBlobsTest {
 
             create_blob_tasks.push(async move {
                 client
-                    .upload(Body::SeekableStream(Box::new(stream)).into(), None)
+                    .upload(
+                        Body::SeekableStream(Box::new(stream)).into(),
+                        Some(BlobClientUploadOptions {
+                            method_options: ClientMethodOptions {
+                                context: NO_FAULT.clone(),
+                            },
+                            ..Default::default()
+                        }),
+                    )
                     .await
             });
         }
@@ -139,7 +175,14 @@ impl StressTest for DownloadBlobsTest {
 
     async fn global_cleanup(&self) -> Result<()> {
         println!("Deleting container...");
-        self.container_client.delete(None).await?;
+        self.container_client
+            .delete(Some(BlobContainerClientDeleteOptions {
+                method_options: ClientMethodOptions {
+                    context: NO_FAULT.clone(),
+                },
+                ..Default::default()
+            }))
+            .await?;
         println!("Deleting created.");
         Ok(())
     }

--- a/sdk/storage/azure_storage_blob_stress/src/download_blobs_test.rs
+++ b/sdk/storage/azure_storage_blob_stress/src/download_blobs_test.rs
@@ -9,7 +9,7 @@ use azure_storage_blob::{models::BlobClientDownloadOptions, BlobClient, BlobCont
 use azure_storage_blob_test::{
     stress::{
         data,
-        value_parsers::{non_zero_u64, non_zero_usize},
+        value_parsers::{non_zero_usize, simple_non_zero_len_u64, simple_non_zero_len_usize},
         StressRunOutput, StressTest, StressTestOperation,
     },
     OptionalTimeoutFutureExt,
@@ -24,18 +24,19 @@ const CRC_ALGORITHM: CrcAlgorithm = CrcAlgorithm::Crc64Nvme;
 #[derive(Args, Debug)]
 pub(crate) struct DownloadBlobsTestArgs {
     /// Number of blobs used across download operations.
-    #[arg(long, default_value_t = 1, value_parser = non_zero_usize)]
+    #[arg(long, default_value_t = 1, value_parser = non_zero_usize, value_name = "COUNT")]
     targets: usize,
 
     /// Concurrency value for download options.
-    #[arg(long, default_value_t = 2, value_parser = non_zero_usize)]
+    #[arg(long, default_value_t = 2, value_parser = non_zero_usize, value_name = "NUM WORKERS")]
     concurrency: usize,
 
     /// Block length for download options.
-    #[arg(long, default_value_t = 4 << 20, value_parser = non_zero_usize)]
+    #[arg(long, default_value_t = 4 << 20, value_parser = simple_non_zero_len_usize)]
     block_len: usize,
 
-    #[arg(long, value_parser = non_zero_u64)]
+    /// Data length of blob(s) to download.
+    #[arg(long, value_parser = simple_non_zero_len_u64)]
     data_len: u64,
 }
 

--- a/sdk/storage/azure_storage_blob_stress/src/download_blobs_test.rs
+++ b/sdk/storage/azure_storage_blob_stress/src/download_blobs_test.rs
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use std::{collections::VecDeque, num::NonZero, sync::Arc};
+
+use async_trait::async_trait;
+use azure_core::{error::ErrorKind, http::Body, Error, Result};
+use azure_storage_blob::{models::BlobClientDownloadOptions, BlobClient, BlobContainerClient};
+use azure_storage_blob_test::stress::{
+    data,
+    value_parsers::{non_zero_u64, non_zero_usize},
+    StressRunOutput, StressTest, StressTestOperation,
+};
+use clap::Args;
+use crc_fast::{CrcAlgorithm, Digest};
+use futures::{channel::mpsc::UnboundedSender, future, lock::Mutex, SinkExt, TryStreamExt};
+use uuid::Uuid;
+
+const CRC_ALGORITHM: CrcAlgorithm = CrcAlgorithm::Crc64Nvme;
+
+#[derive(Args, Debug)]
+pub(crate) struct DownloadBlobsTestArgs {
+    /// Number of blobs used across download operations.
+    #[arg(long, default_value_t = 1, value_parser = non_zero_usize)]
+    targets: usize,
+
+    /// Concurrency value for download options.
+    #[arg(long, default_value_t = 2, value_parser = non_zero_usize)]
+    concurrency: usize,
+
+    /// Block length for download options.
+    #[arg(long, default_value_t = 4 << 20, value_parser = non_zero_usize)]
+    block_len: usize,
+
+    #[arg(long, value_parser = non_zero_u64)]
+    data_len: u64,
+}
+
+impl DownloadBlobsTestArgs {
+    pub fn as_test(&self) -> Result<Box<dyn StressTest>> {
+        Ok(Box::new(DownloadBlobsTest {
+            container_client: crate::clients::get_container_client()?,
+            download_targets: self.targets,
+            download_targets_len: self.data_len,
+            download_target_name_queue: Arc::new(Mutex::new(VecDeque::with_capacity(self.targets))),
+            parallel: NonZero::new(self.concurrency).ok_or_else(non_zero_err)?,
+            chunk_len: NonZero::new(self.block_len).ok_or_else(non_zero_err)?,
+        }))
+    }
+}
+
+impl std::fmt::Display for DownloadBlobsTestArgs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "DownloadOptions: {{ targets: {}, concurrency: {}, block_len: {}, data_len: {} }}",
+            self.targets, self.concurrency, self.block_len, self.data_len,
+        )
+    }
+}
+
+struct DownloadBlobsTest {
+    /// Container client to operate within.
+    /// This container will be created on setup and deleted on cleanup.
+    container_client: BlobContainerClient,
+    /// Number of blobs to setup for test.
+    download_targets: usize,
+    /// Length for the blobs being setup in bytes.
+    download_targets_len: u64,
+
+    /// Rotating queue of download target names to configure for the next operation.
+    download_target_name_queue: Arc<Mutex<VecDeque<BlobInfo>>>,
+
+    // Download options.
+    parallel: NonZero<usize>,
+    chunk_len: NonZero<usize>,
+}
+
+#[async_trait]
+impl StressTest for DownloadBlobsTest {
+    async fn global_setup(&self) -> Result<()> {
+        println!("Creating container...");
+        self.container_client.create(None).await?;
+        println!("Container created.");
+
+        let mut create_blob_tasks = Vec::with_capacity(self.download_targets);
+        for i in 0..self.download_targets {
+            println!("Creating blob {i}...");
+            let (stream, data_crc) =
+                data::random_data_stream_with_checksum(self.download_targets_len, CRC_ALGORITHM);
+
+            let name = Uuid::new_v4().to_string();
+            let client = self.container_client.blob_client(name.as_str());
+            self.download_target_name_queue
+                .lock()
+                .await
+                .push_back(BlobInfo { name, data_crc });
+
+            create_blob_tasks.push(async move {
+                client
+                    .upload(Body::SeekableStream(Box::new(stream)).into(), None)
+                    .await
+            });
+        }
+        for (i, res) in future::join_all(create_blob_tasks)
+            .await
+            .into_iter()
+            .enumerate()
+        {
+            res?;
+            println!("Created blob {i}.");
+        }
+        Ok(())
+    }
+
+    async fn get_operation(&self) -> Result<Box<dyn StressTestOperation>> {
+        let mut queue = self.download_target_name_queue.lock().await;
+        let next_blob = queue
+            .pop_front()
+            .ok_or_else(|| Error::with_message(ErrorKind::Other, "No configured blobs."))?;
+        let op = DownloadOperation {
+            client: self.container_client.blob_client(&next_blob.name),
+            parallel: self.parallel,
+            chunk_len: self.chunk_len,
+            expected_content_crc: next_blob.data_crc,
+        };
+        queue.push_back(next_blob);
+        Ok(Box::new(op))
+    }
+
+    async fn global_cleanup(&self) -> Result<()> {
+        self.container_client.delete(None).await?;
+        Ok(())
+    }
+}
+
+struct BlobInfo {
+    name: String,
+    data_crc: u64,
+}
+
+struct DownloadOperation {
+    client: BlobClient,
+    parallel: NonZero<usize>,
+    chunk_len: NonZero<usize>,
+    expected_content_crc: u64,
+}
+
+#[async_trait]
+impl StressTestOperation for DownloadOperation {
+    async fn run(&mut self, mut result_sender: UnboundedSender<StressRunOutput>) {
+        let mut digest = Digest::new(CRC_ALGORITHM);
+
+        let result: std::result::Result<(), Error> = async {
+            let mut download_body = self
+                .client
+                .download(Some(BlobClientDownloadOptions {
+                    parallel: Some(self.parallel),
+                    partition_size: Some(self.chunk_len),
+                    ..Default::default()
+                }))
+                .await?
+                .body;
+            while let Some(bytes) = download_body.try_next().await? {
+                digest.update(&bytes);
+            }
+            Ok(())
+        }
+        .await;
+
+        let output = match result {
+            Ok(()) => {
+                if digest.finalize() == self.expected_content_crc {
+                    StressRunOutput::Success
+                } else {
+                    StressRunOutput::DataCorruption
+                }
+            }
+            Err(e) => StressRunOutput::GracefulError(e),
+        };
+        let _ = result_sender
+            .send(output)
+            .await
+            .inspect_err(|_| println!("Failed to report status."));
+    }
+}
+
+fn non_zero_err() -> Error {
+    Error::with_message(ErrorKind::DataConversion, "Tried to wrap 0 as a NonZero.")
+}

--- a/sdk/storage/azure_storage_blob_stress/src/main.rs
+++ b/sdk/storage/azure_storage_blob_stress/src/main.rs
@@ -7,7 +7,9 @@ mod roundtrip_blobs_test;
 
 use std::process::exit;
 
-use azure_storage_blob_test::stress::{Result, StressRunner, StressTest, StressTestFactory};
+use azure_storage_blob_test::stress::{
+    args::StressRunnerOptions, Result, StressRunner, StressTest, StressTestFactory,
+};
 use clap::Subcommand;
 
 use crate::{
@@ -34,10 +36,12 @@ enum StressTests {
 }
 
 impl StressTestFactory for StressTests {
-    fn build_test(&self) -> Result<Box<dyn StressTest>> {
-        match self {
-            StressTests::Download(args) => args.as_test(),
-            StressTests::Roundtrip(args) => args.as_test(),
+    fn build_test(options: &StressRunnerOptions<Self>) -> Result<Box<dyn StressTest>> {
+        match &options.command {
+            StressTests::Download(download_args) => download_args.as_test(options.fault_options()),
+            StressTests::Roundtrip(roundtrip_args) => {
+                roundtrip_args.as_test(options.fault_options())
+            }
         }
     }
 }

--- a/sdk/storage/azure_storage_blob_stress/src/main.rs
+++ b/sdk/storage/azure_storage_blob_stress/src/main.rs
@@ -16,7 +16,7 @@ async fn main() {
     let runner = StressRunner::<StressTests>::new(env!("CARGO_MANIFEST_DIR"), file!());
 
     if let Err(e) = runner.run().await {
-        eprintln!("{:#}", e);
+        eprintln!("{}", e);
         exit(1);
     }
 }

--- a/sdk/storage/azure_storage_blob_stress/src/main.rs
+++ b/sdk/storage/azure_storage_blob_stress/src/main.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+pub(crate) mod clients;
+mod download_blobs_test;
+
+use std::process::exit;
+
+use azure_storage_blob_test::stress::{Result, StressRunner, StressTest, StressTestFactory};
+use clap::Subcommand;
+
+use crate::download_blobs_test::DownloadBlobsTestArgs;
+
+#[tokio::main]
+async fn main() {
+    let runner = StressRunner::<StressTests>::new(env!("CARGO_MANIFEST_DIR"), file!());
+
+    if let Err(e) = runner.run().await {
+        eprintln!("{:#}", e);
+        exit(1);
+    }
+}
+
+#[derive(Debug, Subcommand)]
+enum StressTests {
+    /// Continuously download from a set of blobs.
+    Download(DownloadBlobsTestArgs),
+}
+
+impl StressTestFactory for StressTests {
+    fn build_test(&self) -> Result<Box<dyn StressTest>> {
+        match self {
+            StressTests::Download(args) => args.as_test(),
+        }
+    }
+}
+
+impl std::fmt::Display for StressTests {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Download(args) => args.fmt(f),
+        }
+    }
+}

--- a/sdk/storage/azure_storage_blob_stress/src/main.rs
+++ b/sdk/storage/azure_storage_blob_stress/src/main.rs
@@ -38,9 +38,11 @@ enum StressTests {
 impl StressTestFactory for StressTests {
     fn build_test(options: &StressRunnerOptions<Self>) -> Result<Box<dyn StressTest>> {
         match &options.command {
-            StressTests::Download(download_args) => download_args.as_test(options.fault_options()),
+            StressTests::Download(download_args) => {
+                download_args.as_test(&options.fault_options()?)
+            }
             StressTests::Roundtrip(roundtrip_args) => {
-                roundtrip_args.as_test(options.fault_options())
+                roundtrip_args.as_test(&options.fault_options()?)
             }
         }
     }

--- a/sdk/storage/azure_storage_blob_stress/src/main.rs
+++ b/sdk/storage/azure_storage_blob_stress/src/main.rs
@@ -3,13 +3,16 @@
 
 pub(crate) mod clients;
 mod download_blobs_test;
+mod roundtrip_blobs_test;
 
 use std::process::exit;
 
 use azure_storage_blob_test::stress::{Result, StressRunner, StressTest, StressTestFactory};
 use clap::Subcommand;
 
-use crate::download_blobs_test::DownloadBlobsTestArgs;
+use crate::{
+    download_blobs_test::DownloadBlobsTestArgs, roundtrip_blobs_test::RoundtripBlobsTestArgs,
+};
 
 #[tokio::main]
 async fn main() {
@@ -25,12 +28,16 @@ async fn main() {
 enum StressTests {
     /// Continuously download from a set of blobs.
     Download(DownloadBlobsTestArgs),
+
+    /// Continuously upload blobs.
+    Roundtrip(RoundtripBlobsTestArgs),
 }
 
 impl StressTestFactory for StressTests {
     fn build_test(&self) -> Result<Box<dyn StressTest>> {
         match self {
             StressTests::Download(args) => args.as_test(),
+            StressTests::Roundtrip(args) => args.as_test(),
         }
     }
 }
@@ -39,6 +46,7 @@ impl std::fmt::Display for StressTests {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Download(args) => args.fmt(f),
+            Self::Roundtrip(args) => args.fmt(f),
         }
     }
 }

--- a/sdk/storage/azure_storage_blob_stress/src/roundtrip_blobs_test.rs
+++ b/sdk/storage/azure_storage_blob_stress/src/roundtrip_blobs_test.rs
@@ -1,16 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use std::{num::NonZero, time::Duration};
+use std::{num::NonZero, sync::LazyLock, time::Duration};
 
 use async_trait::async_trait;
-use azure_core::{error::ErrorKind, http::Body, Error, Result};
+use azure_core::{
+    error::ErrorKind,
+    http::{Body, ClientMethodOptions, Context},
+    Error, Result,
+};
 use azure_storage_blob::{
-    models::{BlobClientDownloadOptions, BlobClientUploadOptions},
+    models::{
+        BlobClientDownloadOptions, BlobClientUploadOptions, BlobContainerClientCreateOptions,
+        BlobContainerClientDeleteOptions,
+    },
     BlobClient, BlobContainerClient,
 };
 use azure_storage_blob_test::{
-    fault_injection::FaultInjectionProbabilities,
+    fault_injection::{self, FaultInjectionProbabilities},
     stress::{
         data,
         value_parsers::{non_zero_usize, simple_non_zero_len_u64},
@@ -91,11 +98,24 @@ struct RoundtripBlobsTest {
     chunk_len: NonZero<usize>,
 }
 
+static NO_FAULT: LazyLock<Context> = LazyLock::new(|| {
+    let mut c = Context::new();
+    c.insert(fault_injection::NoFault);
+    c
+});
+
 #[async_trait]
 impl StressTest for RoundtripBlobsTest {
     async fn global_setup(&self) -> Result<()> {
         println!("Creating container...");
-        self.container_client.create(None).await?;
+        self.container_client
+            .create(Some(BlobContainerClientCreateOptions {
+                method_options: ClientMethodOptions {
+                    context: NO_FAULT.clone(),
+                },
+                ..Default::default()
+            }))
+            .await?;
         println!("Container created.");
         Ok(())
     }
@@ -132,7 +152,14 @@ impl StressTest for RoundtripBlobsTest {
 
     async fn global_cleanup(&self) -> Result<()> {
         println!("Deleting container...");
-        self.container_client.delete(None).await?;
+        self.container_client
+            .delete(Some(BlobContainerClientDeleteOptions {
+                method_options: ClientMethodOptions {
+                    context: NO_FAULT.clone(),
+                },
+                ..Default::default()
+            }))
+            .await?;
         println!("Deleting created.");
         Ok(())
     }

--- a/sdk/storage/azure_storage_blob_stress/src/roundtrip_blobs_test.rs
+++ b/sdk/storage/azure_storage_blob_stress/src/roundtrip_blobs_test.rs
@@ -10,6 +10,7 @@ use azure_storage_blob::{
     BlobClient, BlobContainerClient,
 };
 use azure_storage_blob_test::{
+    fault_injection::FaultInjectionProbabilities,
     stress::{
         data,
         value_parsers::{non_zero_usize, simple_non_zero_len_u64},
@@ -53,9 +54,12 @@ enum DataSourceType {
 }
 
 impl RoundtripBlobsTestArgs {
-    pub fn as_test(&self) -> Result<Box<dyn StressTest>> {
+    pub fn as_test(
+        &self,
+        fault_options: &FaultInjectionProbabilities,
+    ) -> Result<Box<dyn StressTest>> {
         Ok(Box::new(RoundtripBlobsTest {
-            container_client: crate::clients::get_container_client()?,
+            container_client: crate::clients::get_container_client(fault_options)?,
             data_len: self.data_len,
             data_type: self.data_source,
             parallel: NonZero::new(self.concurrency).ok_or_else(non_zero_err)?,

--- a/sdk/storage/azure_storage_blob_stress/src/roundtrip_blobs_test.rs
+++ b/sdk/storage/azure_storage_blob_stress/src/roundtrip_blobs_test.rs
@@ -1,80 +1,86 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use std::{collections::VecDeque, num::NonZero, sync::Arc, time::Duration};
+use std::{num::NonZero, time::Duration};
 
 use async_trait::async_trait;
 use azure_core::{error::ErrorKind, http::Body, Error, Result};
-use azure_storage_blob::{models::BlobClientDownloadOptions, BlobClient, BlobContainerClient};
+use azure_storage_blob::{
+    models::{BlobClientDownloadOptions, BlobClientUploadOptions},
+    BlobClient, BlobContainerClient,
+};
 use azure_storage_blob_test::{
     stress::{
         data,
-        value_parsers::{non_zero_usize, simple_non_zero_len_u64, simple_non_zero_len_usize},
+        value_parsers::{non_zero_usize, simple_non_zero_len_u64},
         StressRunOutput, StressTest, StressTestOperation,
     },
     OptionalTimeoutFutureExt,
 };
-use clap::Args;
+use clap::{Args, ValueEnum};
 use crc_fast::{CrcAlgorithm, Digest};
-use futures::{channel::mpsc::UnboundedSender, future, lock::Mutex, SinkExt, TryStreamExt};
+use futures::{channel::mpsc::UnboundedSender, SinkExt, TryStreamExt};
 use uuid::Uuid;
 
 const CRC_ALGORITHM: CrcAlgorithm = CrcAlgorithm::Crc64Nvme;
 
 #[derive(Args, Debug)]
-pub(crate) struct DownloadBlobsTestArgs {
-    /// Number of blobs used across download operations.
-    #[arg(long, default_value_t = 1, value_parser = non_zero_usize, value_name = "COUNT")]
-    targets: usize,
-
+pub(crate) struct RoundtripBlobsTestArgs {
     /// Concurrency value for download options.
     #[arg(long, default_value_t = 2, value_parser = non_zero_usize, value_name = "NUM WORKERS")]
     concurrency: usize,
 
     /// Block length for download options.
-    #[arg(long, default_value_t = 4 << 20, value_parser = simple_non_zero_len_usize)]
+    #[arg(long, default_value_t = 4 << 20, value_parser = simple_non_zero_len_u64)]
     block_len: usize,
 
     /// Data length of blob(s) to download.
     #[arg(long, value_parser = simple_non_zero_len_u64)]
     data_len: u64,
+
+    /// Type of data source to upload from.
+    #[arg(value_enum)]
+    data_source: DataSourceType,
 }
 
-impl DownloadBlobsTestArgs {
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, ValueEnum)]
+enum DataSourceType {
+    /// A stream which uploads in-memory data through a stream interface.
+    GeneratedStream,
+
+    /// Direct contiguous memory access.
+    DirectMemory,
+}
+
+impl RoundtripBlobsTestArgs {
     pub fn as_test(&self) -> Result<Box<dyn StressTest>> {
-        Ok(Box::new(DownloadBlobsTest {
+        Ok(Box::new(RoundtripBlobsTest {
             container_client: crate::clients::get_container_client()?,
-            download_targets: self.targets,
-            download_targets_len: self.data_len,
-            download_target_name_queue: Arc::new(Mutex::new(VecDeque::with_capacity(self.targets))),
+            data_len: self.data_len,
+            data_type: self.data_source,
             parallel: NonZero::new(self.concurrency).ok_or_else(non_zero_err)?,
             chunk_len: NonZero::new(self.block_len).ok_or_else(non_zero_err)?,
         }))
     }
 }
 
-impl std::fmt::Display for DownloadBlobsTestArgs {
+impl std::fmt::Display for RoundtripBlobsTestArgs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "=== Download Blobs Configuration ===")?;
+        writeln!(f, "=== Upload Blobs Configuration ===")?;
         writeln!(f, "block_len: {}", self.block_len)?;
         writeln!(f, "concurrency: {}", self.concurrency)?;
         writeln!(f, "data_len: {}", self.data_len)?;
-        writeln!(f, "targets: {}", self.targets)?;
         Ok(())
     }
 }
 
-struct DownloadBlobsTest {
+struct RoundtripBlobsTest {
     /// Container client to operate within.
     /// This container will be created on setup and deleted on cleanup.
     container_client: BlobContainerClient,
-    /// Number of blobs to setup for test.
-    download_targets: usize,
-    /// Length for the blobs being setup in bytes.
-    download_targets_len: u64,
 
-    /// Rotating queue of download target names to configure for the next operation.
-    download_target_name_queue: Arc<Mutex<VecDeque<BlobInfo>>>,
+    data_len: u64,
+    data_type: DataSourceType,
 
     // Download options.
     parallel: NonZero<usize>,
@@ -82,55 +88,42 @@ struct DownloadBlobsTest {
 }
 
 #[async_trait]
-impl StressTest for DownloadBlobsTest {
+impl StressTest for RoundtripBlobsTest {
     async fn global_setup(&self) -> Result<()> {
         println!("Creating container...");
         self.container_client.create(None).await?;
         println!("Container created.");
-
-        let mut create_blob_tasks = Vec::with_capacity(self.download_targets);
-        for i in 0..self.download_targets {
-            println!("Creating blob {i}...");
-            let (stream, data_crc) =
-                data::random_data_stream_with_checksum(self.download_targets_len, CRC_ALGORITHM);
-
-            let name = Uuid::new_v4().to_string();
-            let client = self.container_client.blob_client(name.as_str());
-            self.download_target_name_queue
-                .lock()
-                .await
-                .push_back(BlobInfo { name, data_crc });
-
-            create_blob_tasks.push(async move {
-                client
-                    .upload(Body::SeekableStream(Box::new(stream)).into(), None)
-                    .await
-            });
-        }
-        for (i, res) in future::join_all(create_blob_tasks)
-            .await
-            .into_iter()
-            .enumerate()
-        {
-            res?;
-            println!("Created blob {i}.");
-        }
         Ok(())
     }
 
     async fn get_operation(&self) -> Result<Box<dyn StressTestOperation>> {
-        let mut queue = self.download_target_name_queue.lock().await;
-        let next_blob = queue
-            .pop_front()
-            .ok_or_else(|| Error::with_message(ErrorKind::Other, "No configured blobs."))?;
-        let op = DownloadOperation {
-            client: self.container_client.blob_client(&next_blob.name),
+        let body: Body;
+        let crc;
+        match self.data_type {
+            DataSourceType::GeneratedStream => {
+                let (stream, stream_crc) =
+                    data::random_data_stream_with_checksum(self.data_len, CRC_ALGORITHM);
+                body = Body::SeekableStream(Box::new(stream));
+                crc = stream_crc;
+            }
+            DataSourceType::DirectMemory => {
+                let (vec, vec_crc) =
+                    data::random_data_memory_with_checksum(self.data_len as usize, CRC_ALGORITHM);
+                body = vec.into();
+                crc = vec_crc;
+            }
+        }
+
+        let name = Uuid::new_v4().to_string();
+        let client = self.container_client.blob_client(name.as_str());
+
+        Ok(Box::new(RoundtripOperation {
+            client,
             parallel: self.parallel,
             chunk_len: self.chunk_len,
-            expected_content_crc: next_blob.data_crc,
-        };
-        queue.push_back(next_blob);
-        Ok(Box::new(op))
+            data: body,
+            data_crc: crc,
+        }))
     }
 
     async fn global_cleanup(&self) -> Result<()> {
@@ -141,20 +134,16 @@ impl StressTest for DownloadBlobsTest {
     }
 }
 
-struct BlobInfo {
-    name: String,
-    data_crc: u64,
-}
-
-struct DownloadOperation {
+struct RoundtripOperation {
     client: BlobClient,
     parallel: NonZero<usize>,
     chunk_len: NonZero<usize>,
-    expected_content_crc: u64,
+    data: Body,
+    data_crc: u64,
 }
 
 #[async_trait]
-impl StressTestOperation for DownloadOperation {
+impl StressTestOperation for RoundtripOperation {
     async fn run(
         &mut self,
         timeout: Option<Duration>,
@@ -162,7 +151,19 @@ impl StressTestOperation for DownloadOperation {
     ) {
         let mut digest = Digest::new(CRC_ALGORITHM);
 
-        let download_op = async {
+        let roundtrip_op = async {
+            // Upload
+            self.client
+                .upload(
+                    self.data.clone().into(),
+                    Some(BlobClientUploadOptions {
+                        parallel: Some(self.parallel),
+                        ..Default::default()
+                    }),
+                )
+                .await?;
+
+            // Download
             let mut download_body = self
                 .client
                 .download(Some(BlobClientDownloadOptions {
@@ -175,12 +176,13 @@ impl StressTestOperation for DownloadOperation {
             while let Some(bytes) = download_body.try_next().await? {
                 digest.update(&bytes);
             }
+
             Ok::<_, Error>(())
         };
 
-        let output = match download_op.timeout(timeout).await {
+        let output = match roundtrip_op.timeout(timeout).await {
             Ok(Ok(())) => {
-                if digest.finalize() == self.expected_content_crc {
+                if digest.finalize() == self.data_crc {
                     StressRunOutput::Success
                 } else {
                     StressRunOutput::DataCorruption

--- a/sdk/storage/azure_storage_blob_test/Cargo.toml
+++ b/sdk/storage/azure_storage_blob_test/Cargo.toml
@@ -19,7 +19,10 @@ azure_core = { workspace = true, features = ["xml"] }
 azure_core_test.workspace = true
 azure_storage_blob.path = "../azure_storage_blob"
 bytes.workspace = true
+clap = { workspace = true, features = ["derive"] }
 futures.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 tokio = { workspace = true, features = ["rt"] }
 
 [lints]

--- a/sdk/storage/azure_storage_blob_test/Cargo.toml
+++ b/sdk/storage/azure_storage_blob_test/Cargo.toml
@@ -22,6 +22,7 @@ bytes.workspace = true
 clap = { workspace = true, features = ["derive"] }
 crc-fast = "1.9.0"
 futures.workspace = true
+pin-project.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/sdk/storage/azure_storage_blob_test/src/data_streams.rs
+++ b/sdk/storage/azure_storage_blob_test/src/data_streams.rs
@@ -10,6 +10,7 @@ use std::{fmt, iter::Cycle, ops::Range, pin::Pin, task::Poll};
 #[derive(Clone)]
 pub struct GeneratedStream<I> {
     generator: Cycle<I>,
+    generator_reset_src: Cycle<I>,
     bytes_read: u64,
     len: u64,
     chunk: usize,
@@ -19,6 +20,7 @@ impl GeneratedStream<Range<u8>> {
     pub fn new(len: u64, chunk: Option<usize>) -> GeneratedStream<Range<u8>> {
         GeneratedStream {
             generator: (0..u8::MAX).cycle(),
+            generator_reset_src: (0..u8::MAX).cycle(),
             bytes_read: 0,
             len,
             chunk: chunk.unwrap_or(1024),
@@ -33,7 +35,8 @@ where
     #[allow(clippy::should_implement_trait)]
     pub fn from_iter(iter: I, len: u64, chunk: Option<usize>) -> Self {
         GeneratedStream {
-            generator: iter.cycle(),
+            generator: iter.clone().cycle(),
+            generator_reset_src: iter.cycle(),
             bytes_read: 0,
             len,
             chunk: chunk.unwrap_or(1024),
@@ -51,8 +54,8 @@ impl<I> fmt::Debug for GeneratedStream<I> {
 
 impl<I> AsyncRead for GeneratedStream<I>
 where
-    I: Clone,
-    Cycle<I>: Iterator<Item = u8> + Unpin,
+    I: Clone + Unpin,
+    Cycle<I>: Iterator<Item = u8>,
 {
     fn poll_read(
         self: Pin<&mut Self>,
@@ -111,11 +114,12 @@ where
 #[async_trait::async_trait]
 impl<I> SeekableStream for GeneratedStream<I>
 where
-    I: Clone + Send + Sync,
+    I: Clone + Send + Sync + Unpin,
     Cycle<I>: Iterator<Item = u8> + Unpin,
 {
     async fn reset(&mut self) -> azure_core::Result<()> {
         self.bytes_read = 0;
+        self.generator = self.generator_reset_src.clone();
         Ok(())
     }
 
@@ -126,7 +130,7 @@ where
 
 impl<I> From<GeneratedStream<I>> for Body
 where
-    for<'a> I: Clone + Send + Sync + 'a,
+    for<'a> I: Clone + Send + Sync + Unpin + 'a,
     Cycle<I>: Iterator<Item = u8> + Unpin,
 {
     fn from(stream: GeneratedStream<I>) -> Self {
@@ -136,7 +140,7 @@ where
 
 impl<I> From<GeneratedStream<I>> for RequestContent<Bytes, NoFormat>
 where
-    for<'a> I: Clone + Send + Sync + 'a,
+    for<'a> I: Clone + Send + Sync + Unpin + 'a,
     Cycle<I>: Iterator<Item = u8> + Unpin,
 {
     fn from(stream: GeneratedStream<I>) -> Self {

--- a/sdk/storage/azure_storage_blob_test/src/data_streams.rs
+++ b/sdk/storage/azure_storage_blob_test/src/data_streams.rs
@@ -1,0 +1,145 @@
+use azure_core::{
+    http::{Body, NoFormat, RequestContent},
+    stream::SeekableStream,
+};
+use bytes::Bytes;
+use futures::{io::AsyncRead, stream::Stream};
+use std::{fmt, iter::Cycle, ops::Range, pin::Pin, task::Poll};
+
+/// Implements a [`Stream`] over an endless cycle of bytes.
+#[derive(Clone)]
+pub struct GeneratedStream<I> {
+    generator: Cycle<I>,
+    bytes_read: u64,
+    len: u64,
+    chunk: usize,
+}
+
+impl GeneratedStream<Range<u8>> {
+    pub fn new(len: u64, chunk: Option<usize>) -> GeneratedStream<Range<u8>> {
+        GeneratedStream {
+            generator: (0..u8::MAX).cycle(),
+            bytes_read: 0,
+            len,
+            chunk: chunk.unwrap_or(1024),
+        }
+    }
+}
+
+impl<I> GeneratedStream<I>
+where
+    I: Iterator<Item = u8> + Clone,
+{
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_iter(iter: I, len: u64, chunk: Option<usize>) -> Self {
+        GeneratedStream {
+            generator: iter.cycle(),
+            bytes_read: 0,
+            len,
+            chunk: chunk.unwrap_or(1024),
+        }
+    }
+}
+
+impl<I> fmt::Debug for GeneratedStream<I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GeneratedStream")
+            .field("bytes_read", &self.bytes_read)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<I> AsyncRead for GeneratedStream<I>
+where
+    I: Clone,
+    Cycle<I>: Iterator<Item = u8> + Unpin,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let self_mut = self.get_mut();
+
+        if self_mut.bytes_read >= self_mut.len {
+            return Poll::Ready(Ok(0));
+        }
+
+        let remaining_bytes = self_mut.len - self_mut.bytes_read;
+        let bytes_to_read = std::cmp::min(remaining_bytes, buf.len() as u64) as usize;
+
+        for byte_slot in buf.iter_mut().take(bytes_to_read) {
+            *byte_slot = self_mut.generator.next().unwrap();
+            self_mut.bytes_read += 1;
+        }
+
+        Poll::Ready(Ok(bytes_to_read))
+    }
+}
+
+impl<I> Stream for GeneratedStream<I>
+where
+    I: Clone,
+    Cycle<I>: Iterator<Item = u8> + Unpin,
+{
+    type Item = std::io::Result<Vec<u8>>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let self_mut = self.get_mut();
+
+        if self_mut.bytes_read >= self_mut.len {
+            return Poll::Ready(None);
+        }
+
+        let remaining_bytes = self_mut.len - self_mut.bytes_read;
+        let bytes_to_read = std::cmp::min(remaining_bytes, self_mut.chunk as u64);
+
+        let chunk: Vec<u8> = (0..bytes_to_read)
+            .map(|_| {
+                self_mut.bytes_read += 1;
+                self_mut.generator.next().unwrap()
+            })
+            .collect();
+
+        Poll::Ready(Some(Ok(chunk)))
+    }
+}
+
+#[async_trait::async_trait]
+impl<I> SeekableStream for GeneratedStream<I>
+where
+    I: Clone + Send + Sync,
+    Cycle<I>: Iterator<Item = u8> + Unpin,
+{
+    async fn reset(&mut self) -> azure_core::Result<()> {
+        self.bytes_read = 0;
+        Ok(())
+    }
+
+    fn len(&self) -> Option<u64> {
+        Some(self.len)
+    }
+}
+
+impl<I> From<GeneratedStream<I>> for Body
+where
+    for<'a> I: Clone + Send + Sync + 'a,
+    Cycle<I>: Iterator<Item = u8> + Unpin,
+{
+    fn from(stream: GeneratedStream<I>) -> Self {
+        Body::SeekableStream(Box::new(stream))
+    }
+}
+
+impl<I> From<GeneratedStream<I>> for RequestContent<Bytes, NoFormat>
+where
+    for<'a> I: Clone + Send + Sync + 'a,
+    Cycle<I>: Iterator<Item = u8> + Unpin,
+{
+    fn from(stream: GeneratedStream<I>) -> Self {
+        Body::from(stream).into()
+    }
+}

--- a/sdk/storage/azure_storage_blob_test/src/fault_injection.rs
+++ b/sdk/storage/azure_storage_blob_test/src/fault_injection.rs
@@ -11,6 +11,7 @@ use azure_core::http::{
 };
 use futures::lock::Mutex;
 use rand::{distr::StandardUniform, RngExt};
+use serde::Deserialize;
 
 const FAULT_INJECTION_HEADER: HeaderName =
     HeaderName::from_static("x-ms-faultinjector-response-option");
@@ -31,6 +32,8 @@ pub struct FaultInjectionPolicy<Rng> {
     injector: Arc<Mutex<ProbabilityHeaderInjector<Rng>>>,
 }
 
+pub struct NoFault;
+
 impl<Rng: rand::SeedableRng + Debug + Send + Sync> FaultInjectionPolicy<Rng> {
     pub fn new(
         fault_injector_endpoint: Url,
@@ -47,14 +50,8 @@ impl<Rng: rand::SeedableRng + Debug + Send + Sync> FaultInjectionPolicy<Rng> {
     }
 }
 
-#[async_trait]
-impl<Rng: rand::Rng + Debug + Send + Sync> Policy for FaultInjectionPolicy<Rng> {
-    async fn send(
-        &self,
-        ctx: &Context,
-        request: &mut Request,
-        next: &[Arc<dyn Policy>],
-    ) -> PolicyResult {
+impl<Rng: rand::Rng> FaultInjectionPolicy<Rng> {
+    async fn inject_fault(&self, request: &mut Request) -> azure_core::Result<()> {
         if request.headers().get_str(&UPSTREAM_HEADER).is_err() {
             let f = Url::parse(&format!(
                 "{}://{}{}",
@@ -84,11 +81,28 @@ impl<Rng: rand::Rng + Debug + Send + Sync> Policy for FaultInjectionPolicy<Rng> 
 
         self.injector.lock().await.inject(request);
 
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<Rng: rand::Rng + Debug + Send + Sync> Policy for FaultInjectionPolicy<Rng> {
+    async fn send(
+        &self,
+        ctx: &Context,
+        request: &mut Request,
+        next: &[Arc<dyn Policy>],
+    ) -> PolicyResult {
+        // If caller didn't make an exception, perform fault injection.
+        if ctx.value::<NoFault>().is_none() {
+            self.inject_fault(request).await?;
+        }
+
         next[0].send(ctx, request, &next[1..]).await
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct FaultInjectionProbabilities {
     pub partial_response_hang: f32,
     pub partial_response_close: f32,

--- a/sdk/storage/azure_storage_blob_test/src/fault_injection.rs
+++ b/sdk/storage/azure_storage_blob_test/src/fault_injection.rs
@@ -1,0 +1,204 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use std::{fmt::Debug, sync::Arc};
+
+use async_trait::async_trait;
+use azure_core::http::{
+    headers::HeaderName,
+    policies::{Policy, PolicyResult},
+    Context, Request, Url,
+};
+use futures::lock::Mutex;
+use rand::{distr::StandardUniform, RngExt};
+
+const FAULT_INJECTION_HEADER: HeaderName =
+    HeaderName::from_static("x-ms-faultinjector-response-option");
+const UPSTREAM_HEADER: HeaderName = HeaderName::from_static("x-upstream-base-uri");
+
+const FULL_RESPONSE: &str = "f";
+const PARTIAL_RESPONSE_HANG: &str = "p";
+const PARTIAL_RESPONSE_CLOSE: &str = "pc";
+const PARTIAL_RESPONSE_ABORT: &str = "pa";
+const PARTIAL_RESPONSE_NORMAL: &str = "pn";
+const NO_RESPONSE_HANG: &str = "n";
+const NO_RESPONSE_CLOSE: &str = "nc";
+const NO_RESPONSE_ABORT: &str = "na";
+
+#[derive(Debug)]
+pub struct FaultInjectionPolicy<Rng> {
+    fault_injector_endpoint: Url,
+    injector: Arc<Mutex<ProbabilityHeaderInjector<Rng>>>,
+}
+
+impl<Rng: rand::SeedableRng + Debug + Send + Sync> FaultInjectionPolicy<Rng> {
+    pub fn new(
+        fault_injector_endpoint: Url,
+        probabilities: FaultInjectionProbabilities,
+    ) -> azure_core::Result<Self> {
+        Ok(Self {
+            fault_injector_endpoint,
+            injector: Arc::new(Mutex::new(ProbabilityHeaderInjector {
+                header_name: FAULT_INJECTION_HEADER,
+                header_value_probabilities: probabilities.try_into()?,
+                rng: rand::make_rng(),
+            })),
+        })
+    }
+}
+
+#[async_trait]
+impl<Rng: rand::Rng + Debug + Send + Sync> Policy for FaultInjectionPolicy<Rng> {
+    async fn send(
+        &self,
+        ctx: &Context,
+        request: &mut Request,
+        next: &[Arc<dyn Policy>],
+    ) -> PolicyResult {
+        if request.headers().get_str(&UPSTREAM_HEADER).is_err() {
+            let f = Url::parse(&format!(
+                "{}://{}{}",
+                request.url().scheme(),
+                request.url().host_str().unwrap(),
+                request
+                    .url()
+                    .port()
+                    .map(|port| format!(":{port}"))
+                    .unwrap_or_default(),
+            ))?;
+            request.headers_mut().insert(UPSTREAM_HEADER, f.to_string());
+        }
+
+        request
+            .url_mut()
+            .set_scheme(self.fault_injector_endpoint.scheme())
+            .unwrap();
+        request
+            .url_mut()
+            .set_host(self.fault_injector_endpoint.host_str())
+            .unwrap();
+        request
+            .url_mut()
+            .set_port(self.fault_injector_endpoint.port())
+            .unwrap();
+
+        self.injector.lock().await.inject(request);
+
+        next[0].send(ctx, request, &next[1..]).await
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct FaultInjectionProbabilities {
+    pub partial_response_hang: f32,
+    pub partial_response_close: f32,
+    pub partial_response_abort: f32,
+    pub partial_response_normal: f32,
+    pub no_response_hang: f32,
+    pub no_response_close: f32,
+    pub no_response_abort: f32,
+}
+
+impl FaultInjectionProbabilities {
+    pub fn is_zero(&self) -> bool {
+        self.partial_response_hang == 0.0
+            && self.partial_response_close == 0.0
+            && self.partial_response_abort == 0.0
+            && self.partial_response_normal == 0.0
+            && self.no_response_hang == 0.0
+            && self.no_response_close == 0.0
+            && self.no_response_abort == 0.0
+    }
+}
+
+impl TryFrom<FaultInjectionProbabilities> for Vec<(f32, &'static str)> {
+    type Error = azure_core::Error;
+    fn try_from(value: FaultInjectionProbabilities) -> Result<Self, Self::Error> {
+        let mut vec = Vec::new();
+        let non_negative = |value: f32, name: &str| {
+            if value < 0.0 {
+                Err(azure_core::Error::with_message(
+                    azure_core::error::ErrorKind::Other,
+                    format!("{name} must be a non-negative value."),
+                ))
+            } else {
+                Ok(value)
+            }
+        };
+
+        for (prob, name, header_value) in [
+            (
+                value.partial_response_hang,
+                "partial_response_hang",
+                PARTIAL_RESPONSE_HANG,
+            ),
+            (
+                value.partial_response_close,
+                "partial_response_close",
+                PARTIAL_RESPONSE_CLOSE,
+            ),
+            (
+                value.partial_response_abort,
+                "partial_response_abort",
+                PARTIAL_RESPONSE_ABORT,
+            ),
+            (
+                value.partial_response_normal,
+                "partial_response_normal",
+                PARTIAL_RESPONSE_NORMAL,
+            ),
+            (value.no_response_hang, "no_response_hang", NO_RESPONSE_HANG),
+            (
+                value.no_response_close,
+                "no_response_close",
+                NO_RESPONSE_CLOSE,
+            ),
+            (
+                value.no_response_abort,
+                "no_response_abort",
+                NO_RESPONSE_ABORT,
+            ),
+        ] {
+            if non_negative(prob, name)? > 0.0 {
+                vec.push((prob, header_value));
+            }
+        }
+
+        if vec.iter().map(|(prob, _)| *prob).sum::<f32>() > 1.0 {
+            return Err(azure_core::Error::with_message(
+                azure_core::error::ErrorKind::Other,
+                "Fault probabilities exceeded 1.0.",
+            ));
+        }
+
+        Ok(vec)
+    }
+}
+
+/// Struct that applies up to one of a list of header values to a request
+/// under a predefined header key.
+#[derive(Debug)]
+struct ProbabilityHeaderInjector<Rng> {
+    header_name: HeaderName,
+    header_value_probabilities: Vec<(f32, &'static str)>,
+    rng: Rng,
+}
+
+impl<Rng: rand::Rng> ProbabilityHeaderInjector<Rng> {
+    fn inject(&mut self, request: &mut Request) {
+        let f: f32 = self.rng.sample(StandardUniform);
+        let mut prob_sum = 0.0;
+        for (prob, value) in self.header_value_probabilities.iter() {
+            prob_sum += *prob;
+            if f < prob_sum {
+                request
+                    .headers_mut()
+                    .insert(self.header_name.clone(), *value);
+                return;
+            }
+        }
+        request
+            .headers_mut()
+            .insert(self.header_name.clone(), FULL_RESPONSE);
+    }
+}

--- a/sdk/storage/azure_storage_blob_test/src/lib.rs
+++ b/sdk/storage/azure_storage_blob_test/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 pub mod data_streams;
+pub mod fault_injection;
 pub mod stress;
 
 use std::{

--- a/sdk/storage/azure_storage_blob_test/src/lib.rs
+++ b/sdk/storage/azure_storage_blob_test/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+pub mod data_streams;
 pub mod stress;
 
 use std::{

--- a/sdk/storage/azure_storage_blob_test/src/lib.rs
+++ b/sdk/storage/azure_storage_blob_test/src/lib.rs
@@ -5,12 +5,16 @@ pub mod data_streams;
 pub mod stress;
 
 use std::{
+    future::Future,
+    pin::Pin,
     slice,
     sync::{
         atomic::{AtomicUsize, Ordering},
         mpsc::Sender,
         Arc,
     },
+    task::Poll,
+    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -33,7 +37,12 @@ use azure_storage_blob::{
     BlobServiceClient, BlobServiceClientOptions,
 };
 use bytes::BytesMut;
-use futures::{AsyncRead, AsyncReadExt};
+use futures::{
+    future::{self, Select},
+    ready, AsyncRead, AsyncReadExt,
+};
+use pin_project::pin_project;
+use tokio::time::{sleep, Sleep};
 
 pub const KB: usize = 1024;
 pub const MB: usize = KB * 1024;
@@ -504,5 +513,61 @@ impl Policy for FailFirstPolicy {
             ));
         }
         next[0].send(ctx, request, &next[1..]).await
+    }
+}
+
+pub trait OptionalTimeoutFutureExt: Sized {
+    fn timeout(self, timeout: Option<Duration>) -> Timeout<Self>;
+}
+
+impl<F: Future> OptionalTimeoutFutureExt for F {
+    fn timeout(self, timeout: Option<Duration>) -> Timeout<Self> {
+        let timeout = timeout.unwrap_or(Duration::MAX);
+        Timeout {
+            fut: future::select(Box::pin(self), Box::pin(sleep(timeout))),
+            timeout_duration: timeout,
+        }
+    }
+}
+
+#[pin_project]
+pub struct Timeout<F> {
+    #[pin]
+    fut: Select<Pin<Box<F>>, Pin<Box<Sleep>>>,
+    timeout_duration: Duration,
+}
+
+impl<T: Future> Future for Timeout<T> {
+    type Output = std::result::Result<T::Output, TimeoutError>;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = self.project();
+        match ready!(this.fut.poll(cx)) {
+            future::Either::Left((output, _)) => Poll::Ready(Ok(output)),
+            future::Either::Right((_timeout, _)) => {
+                // Poll::Ready(Err(azure_core::Error::with_message(
+                //     azure_core::error::ErrorKind::Other,
+                //     "The operation timed out.",
+                // )))
+                Poll::Ready(Err(TimeoutError(*this.timeout_duration)))
+            }
+        }
+    }
+}
+
+pub struct TimeoutError(pub Duration);
+
+impl From<TimeoutError> for azure_core::Error {
+    fn from(value: TimeoutError) -> Self {
+        azure_core::Error::with_message(
+            azure_core::error::ErrorKind::Other,
+            format!(
+                "The operation timed out after {:.2} seconds",
+                value.0.as_secs_f32()
+            ),
+        )
     }
 }

--- a/sdk/storage/azure_storage_blob_test/src/lib.rs
+++ b/sdk/storage/azure_storage_blob_test/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+pub mod stress;
+
 use std::{
     slice,
     sync::{

--- a/sdk/storage/azure_storage_blob_test/src/stress/args.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/args.rs
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use std::time::Duration;
+
+use clap::{Args, Parser};
+
+use crate::{
+    fault_injection::FaultInjectionProbabilities,
+    stress::{value_parsers::simple_duration, StressTest, StressTestFactory},
+};
+
+#[derive(Debug, Clone, Parser)]
+pub struct StressRunnerOptions<T: StressTestFactory> {
+    /// Parallel operations to run.
+    #[arg(long, default_value_t = 1)]
+    pub parallel: usize,
+
+    /// Duration of the stress test, excluding setup and cleanup.
+    #[arg(long, default_value = "10", value_parser = simple_duration, value_name = "SECONDS")]
+    pub duration: Duration,
+
+    /// Optional timeout for one-time test setup.
+    #[arg(long, value_parser = simple_duration, value_name = "SECONDS")]
+    pub setup_timeout: Option<Duration>,
+
+    /// Optional timeout for individual operations during the test.
+    #[arg(long, value_parser = simple_duration, value_name = "SECONDS")]
+    pub operation_timeout: Option<Duration>,
+
+    /// Optional timeout for one-time test cleanup.
+    #[arg(long, value_parser = simple_duration, value_name = "SECONDS")]
+    pub cleanup_timeout: Option<Duration>,
+
+    /// Path to a json config file for fault injection.
+    #[arg(long = "fault-config", value_name = "FILE", group = "fault injection")]
+    pub fault_injection_file: Option<String>,
+
+    /// Use a default configuration for fault injection.
+    #[arg(long = "fault-standard", group = "fault injection")]
+    pub use_default_fault_injection: bool,
+
+    #[command(flatten)]
+    pub fault_injection_inline_overrides: FaultInjectionOverrideOptions,
+
+    #[command(subcommand)]
+    pub command: T,
+}
+
+impl<T: StressTestFactory> StressRunnerOptions<T> {
+    pub fn build_test(&self) -> azure_core::Result<Box<dyn StressTest>> {
+        T::build_test(self)
+    }
+
+    pub fn fault_options(&self) -> &FaultInjectionProbabilities {
+        todo!()
+    }
+}
+
+impl<T: StressTestFactory> std::fmt::Display for StressRunnerOptions<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "=== Stress Runner Configuration ===")?;
+        writeln!(f, "duration: {}", self.duration.as_secs())?;
+        writeln!(f, "parallel: {}", self.parallel)?;
+        writeln!(
+            f,
+            "operation_timeout: {:?}",
+            self.operation_timeout.map(|t| t.as_secs())
+        )?;
+        writeln!(
+            f,
+            "setup_timeout: {:?}",
+            self.setup_timeout.map(|t| t.as_secs())
+        )?;
+        writeln!(
+            f,
+            "cleanup_timeout: {:?}",
+            self.cleanup_timeout.map(|t| t.as_secs())
+        )?;
+        std::fmt::Display::fmt(&self.command, f)
+    }
+}
+
+#[derive(Args, serde::Deserialize, Clone, Debug)]
+#[group(required = false, multiple = true)]
+pub struct FaultInjectionOverrideOptions {
+    /// Override probability for a partial response then hang.
+    #[arg(long = "fault-p", value_name = "PROBABILITY")]
+    pub partial_response_hang: Option<f32>,
+
+    /// Override probability for a partial response then close (TCP FIN).
+    #[arg(long = "fault-pc", value_name = "PROBABILITY")]
+    pub partial_response_close: Option<f32>,
+
+    /// Override probability for a partial response then abort (TCP RST).
+    #[arg(long = "fault-pa", value_name = "PROBABILITY")]
+    pub partial_response_abort: Option<f32>,
+
+    /// Override probability for a partial response then graceful finish.
+    #[arg(long = "fault-pn", value_name = "PROBABILITY")]
+    pub partial_response_normal: Option<f32>,
+
+    /// Override probability for no response then hang.
+    #[arg(long = "fault-n", value_name = "PROBABILITY")]
+    pub no_response_hang: Option<f32>,
+
+    /// Override probability for no response close (TCP FIN)
+    #[arg(long = "fault-nc", value_name = "PROBABILITY")]
+    pub no_response_close: Option<f32>,
+
+    /// Override probability for no response then abort (TCP RST).
+    #[arg(long = "fault-na", value_name = "PROBABILITY")]
+    pub no_response_abort: Option<f32>,
+}
+
+impl From<FaultInjectionOverrideOptions> for crate::fault_injection::FaultInjectionProbabilities {
+    fn from(value: FaultInjectionOverrideOptions) -> Self {
+        Self {
+            partial_response_hang: value.partial_response_hang.unwrap_or_default(),
+            partial_response_close: value.partial_response_close.unwrap_or_default(),
+            partial_response_abort: value.partial_response_abort.unwrap_or_default(),
+            partial_response_normal: value.partial_response_normal.unwrap_or_default(),
+            no_response_hang: value.no_response_hang.unwrap_or_default(),
+            no_response_close: value.no_response_close.unwrap_or_default(),
+            no_response_abort: value.no_response_abort.unwrap_or_default(),
+        }
+    }
+}

--- a/sdk/storage/azure_storage_blob_test/src/stress/args.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/args.rs
@@ -3,6 +3,7 @@
 
 use std::time::Duration;
 
+use azure_core::Result;
 use clap::{Args, Parser};
 
 use crate::{
@@ -41,7 +42,7 @@ pub struct StressRunnerOptions<T: StressTestFactory> {
     pub use_default_fault_injection: bool,
 
     #[command(flatten)]
-    pub fault_injection_inline_overrides: FaultInjectionOverrideOptions,
+    pub fault_overrides: FaultInjectionOverrideOptions,
 
     #[command(subcommand)]
     pub command: T,
@@ -52,8 +53,51 @@ impl<T: StressTestFactory> StressRunnerOptions<T> {
         T::build_test(self)
     }
 
-    pub fn fault_options(&self) -> &FaultInjectionProbabilities {
-        todo!()
+    pub fn fault_options(&self) -> Result<FaultInjectionProbabilities> {
+        let mut base_probabilities = if let Some(file) = &self.fault_injection_file {
+            let json = std::fs::read_to_string(file).map_err(|e| {
+                azure_core::Error::with_error(
+                    azure_core_test::ErrorKind::Io,
+                    e,
+                    "Failed to read file.",
+                )
+            })?;
+            serde_json::from_str(&json).map_err(|e| {
+                azure_core::Error::with_error(
+                    azure_core_test::ErrorKind::DataConversion,
+                    e,
+                    "Failed to serialize file contents.",
+                )
+            })?
+        } else if self.use_default_fault_injection {
+            STD_FAULT_PROBABILITIES
+        } else {
+            Default::default()
+        };
+
+        if let Some(prob) = self.fault_overrides.partial_response_hang {
+            base_probabilities.partial_response_hang = prob;
+        }
+        if let Some(prob) = self.fault_overrides.partial_response_close {
+            base_probabilities.partial_response_close = prob;
+        }
+        if let Some(prob) = self.fault_overrides.partial_response_abort {
+            base_probabilities.partial_response_abort = prob;
+        }
+        if let Some(prob) = self.fault_overrides.partial_response_normal {
+            base_probabilities.partial_response_normal = prob;
+        }
+        if let Some(prob) = self.fault_overrides.no_response_hang {
+            base_probabilities.no_response_hang = prob;
+        }
+        if let Some(prob) = self.fault_overrides.no_response_close {
+            base_probabilities.no_response_close = prob;
+        }
+        if let Some(prob) = self.fault_overrides.no_response_abort {
+            base_probabilities.no_response_abort = prob;
+        }
+
+        Ok(base_probabilities)
     }
 }
 
@@ -126,3 +170,13 @@ impl From<FaultInjectionOverrideOptions> for crate::fault_injection::FaultInject
         }
     }
 }
+
+const STD_FAULT_PROBABILITIES: FaultInjectionProbabilities = FaultInjectionProbabilities {
+    partial_response_hang: 0.03,
+    partial_response_close: 0.03,
+    partial_response_abort: 0.03,
+    partial_response_normal: 0.03,
+    no_response_hang: 0.03,
+    no_response_close: 0.03,
+    no_response_abort: 0.03,
+};

--- a/sdk/storage/azure_storage_blob_test/src/stress/data.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/data.rs
@@ -4,6 +4,7 @@
 use std::cmp::min;
 
 use azure_core::stream::SeekableStream;
+use bytes::BufMut;
 use crc_fast::{CrcAlgorithm, Digest};
 use rand::random;
 
@@ -27,4 +28,17 @@ pub fn random_data_stream_with_checksum(
         GeneratedStream::from_iter(src_bytes.into_iter(), len, None),
         digest.finalize(),
     )
+}
+
+pub fn random_data_memory_with_checksum(len: usize, algorithm: CrcAlgorithm) -> (Vec<u8>, u64) {
+    let buf: [u8; 9999] = random();
+    let mut data = Vec::with_capacity(len);
+
+    for i in (0..len).step_by(buf.len()) {
+        data.put(&buf[..min(buf.len(), i - len)]);
+    }
+
+    let mut digest = Digest::new(algorithm);
+    digest.update(&data);
+    (data, digest.finalize())
 }

--- a/sdk/storage/azure_storage_blob_test/src/stress/data.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/data.rs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use std::cmp::min;
+
+use azure_core::stream::SeekableStream;
+use crc_fast::{CrcAlgorithm, Digest};
+use rand::random;
+
+use crate::data_streams::GeneratedStream;
+
+pub fn random_data_stream_with_checksum(
+    len: u64,
+    algorithm: CrcAlgorithm,
+) -> (impl SeekableStream, u64) {
+    let src_bytes: [u8; 9999] = random();
+
+    let mut digest = Digest::new(algorithm);
+    let mut read = 0;
+    while read < len {
+        let to_digest = min(src_bytes.len(), (len - read) as usize);
+        digest.update(&src_bytes[..to_digest]);
+        read += to_digest as u64;
+    }
+
+    (
+        GeneratedStream::from_iter(src_bytes.into_iter(), len, None),
+        digest.finalize(),
+    )
+}

--- a/sdk/storage/azure_storage_blob_test/src/stress/framework_tests.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/framework_tests.rs
@@ -18,10 +18,10 @@ enum MockStressTestFactory {
 }
 
 impl StressTestFactory for MockStressTestFactory {
-    fn build_test(&self) -> Result<Box<dyn StressTest>> {
-        Ok(match self {
-            Self::TestOne(_args) => Box::new(MockStressTestOne {}),
-            Self::TestTwo(_args) => Box::new(MockStressTestTwo {}),
+    fn build_test(options: &StressRunnerOptions<Self>) -> Result<Box<dyn StressTest>> {
+        Ok(match &options.command {
+            MockStressTestFactory::TestOne(_args_one) => Box::new(MockStressTestOne {}),
+            MockStressTestFactory::TestTwo(_args_two) => Box::new(MockStressTestTwo {}),
         })
     }
 }

--- a/sdk/storage/azure_storage_blob_test/src/stress/framework_tests.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/framework_tests.rs
@@ -18,11 +18,17 @@ enum MockStressTestFactory {
 }
 
 impl StressTestFactory for MockStressTestFactory {
-    fn get_test(&self) -> Result<Box<dyn StressTest>> {
+    fn build_test(&self) -> Result<Box<dyn StressTest>> {
         Ok(match self {
             Self::TestOne(_args) => Box::new(MockStressTestOne {}),
             Self::TestTwo(_args) => Box::new(MockStressTestTwo {}),
         })
+    }
+}
+
+impl std::fmt::Display for MockStressTestFactory {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        todo!()
     }
 }
 
@@ -34,7 +40,7 @@ impl StressTest for MockStressTestOne {
     async fn global_setup(&self) -> Result<()> {
         Ok(())
     }
-    fn get_operation(&self) -> Result<Box<dyn StressTestOperation>> {
+    async fn get_operation(&self) -> Result<Box<dyn StressTestOperation>> {
         Ok(Box::new(MockOperationOne {}))
     }
     async fn global_cleanup(&self) -> Result<()> {
@@ -44,7 +50,7 @@ impl StressTest for MockStressTestOne {
 struct MockOperationOne {}
 #[async_trait]
 impl StressTestOperation for MockOperationOne {
-    async fn run(&self, _result_sender: UnboundedSender<StressRunOutput>) {
+    async fn run(&mut self, _result_sender: UnboundedSender<StressRunOutput>) {
         // todo!()
     }
 }
@@ -66,7 +72,7 @@ impl StressTest for MockStressTestTwo {
     async fn global_setup(&self) -> Result<()> {
         Ok(())
     }
-    fn get_operation(&self) -> Result<Box<dyn StressTestOperation>> {
+    async fn get_operation(&self) -> Result<Box<dyn StressTestOperation>> {
         Ok(Box::new(MockOperationTwo {}))
     }
     async fn global_cleanup(&self) -> Result<()> {
@@ -76,7 +82,7 @@ impl StressTest for MockStressTestTwo {
 struct MockOperationTwo {}
 #[async_trait]
 impl StressTestOperation for MockOperationTwo {
-    async fn run(&self, _result_sender: UnboundedSender<StressRunOutput>) {
+    async fn run(&mut self, _result_sender: UnboundedSender<StressRunOutput>) {
         // todo!()
     }
 }

--- a/sdk/storage/azure_storage_blob_test/src/stress/framework_tests.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/framework_tests.rs
@@ -50,7 +50,11 @@ impl StressTest for MockStressTestOne {
 struct MockOperationOne {}
 #[async_trait]
 impl StressTestOperation for MockOperationOne {
-    async fn run(&mut self, _result_sender: UnboundedSender<StressRunOutput>) {
+    async fn run(
+        &mut self,
+        _timeout: Option<Duration>,
+        _result_sender: UnboundedSender<StressRunOutput>,
+    ) {
         // todo!()
     }
 }
@@ -82,7 +86,11 @@ impl StressTest for MockStressTestTwo {
 struct MockOperationTwo {}
 #[async_trait]
 impl StressTestOperation for MockOperationTwo {
-    async fn run(&mut self, _result_sender: UnboundedSender<StressRunOutput>) {
+    async fn run(
+        &mut self,
+        _timeout: Option<Duration>,
+        _result_sender: UnboundedSender<StressRunOutput>,
+    ) {
         // todo!()
     }
 }

--- a/sdk/storage/azure_storage_blob_test/src/stress/framework_tests.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/framework_tests.rs
@@ -1,0 +1,194 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Tests for functioning of the stress test runner.
+//!
+//! These tests cover various scenarios for running the `StressRunner` with different options and measurements.
+//!
+
+use async_trait::async_trait;
+use clap::Args;
+
+use super::*;
+
+#[derive(Debug, Subcommand)]
+enum MockStressTestFactory {
+    TestOne(MockArgsOne),
+    TestTwo(MockArgsTwo),
+}
+
+impl StressTestFactory for MockStressTestFactory {
+    fn get_test(&self) -> Result<Box<dyn StressTest>> {
+        Ok(match self {
+            Self::TestOne(_args) => Box::new(MockStressTestOne {}),
+            Self::TestTwo(_args) => Box::new(MockStressTestTwo {}),
+        })
+    }
+}
+
+struct MockStressTestOne {}
+#[derive(Args, Debug)]
+struct MockArgsOne {}
+#[async_trait]
+impl StressTest for MockStressTestOne {
+    async fn global_setup(&self) -> Result<()> {
+        Ok(())
+    }
+    fn get_operation(&self) -> Result<Box<dyn StressTestOperation>> {
+        Ok(Box::new(MockOperationOne {}))
+    }
+    async fn global_cleanup(&self) -> Result<()> {
+        Ok(())
+    }
+}
+struct MockOperationOne {}
+#[async_trait]
+impl StressTestOperation for MockOperationOne {
+    async fn run(&self, _result_sender: UnboundedSender<StressRunOutput>) {
+        // todo!()
+    }
+}
+
+struct MockStressTestTwo {}
+#[derive(Args, Debug)]
+struct MockArgsTwo {
+    #[arg(short, long)]
+    a_mandatory: usize,
+    #[arg(short, long, default_value_t = 1)]
+    b_has_default: usize,
+    #[arg(short, long)]
+    c_optional: Option<usize>,
+    #[arg(short, long)]
+    d_flag: bool,
+}
+#[async_trait]
+impl StressTest for MockStressTestTwo {
+    async fn global_setup(&self) -> Result<()> {
+        Ok(())
+    }
+    fn get_operation(&self) -> Result<Box<dyn StressTestOperation>> {
+        Ok(Box::new(MockOperationTwo {}))
+    }
+    async fn global_cleanup(&self) -> Result<()> {
+        Ok(())
+    }
+}
+struct MockOperationTwo {}
+#[async_trait]
+impl StressTestOperation for MockOperationTwo {
+    async fn run(&self, _result_sender: UnboundedSender<StressRunOutput>) {
+        // todo!()
+    }
+}
+
+#[tokio::test]
+async fn test_parse_minimum_runner_args() {
+    let args = vec!["stress_test", "--output", "", "test-one"];
+    let result =
+        StressRunner::<MockStressTestFactory>::from_args(env!("CARGO_MANIFEST_DIR"), file!(), args);
+
+    println!("Result: {:?}", result);
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_parse_missing_required_runner_arg() {
+    let args = vec!["stress_test", "test-one"];
+    let result =
+        StressRunner::<MockStressTestFactory>::from_args(env!("CARGO_MANIFEST_DIR"), file!(), args);
+
+    println!("Result: {:?}", result);
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_parse_unrecognized_runner_arg() {
+    let args = vec!["stress_test", "-o", "", "--bad-arg", "test-one"];
+    let result =
+        StressRunner::<MockStressTestFactory>::from_args(env!("CARGO_MANIFEST_DIR"), file!(), args);
+
+    println!("Result: {:?}", result);
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_parse_all_runner_args() {
+    let args = vec![
+        "stress_test",
+        "--parallel",
+        "5",
+        "--duration",
+        "10",
+        "--timeout",
+        "60",
+        "--output",
+        "",
+        "test-one",
+    ];
+    let result =
+        StressRunner::<MockStressTestFactory>::from_args(env!("CARGO_MANIFEST_DIR"), file!(), args);
+
+    println!("Result: {:?}", result);
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_parse_missing_subcommand() {
+    let args = vec!["stress_test", "--output", ""];
+    let result =
+        StressRunner::<MockStressTestFactory>::from_args(env!("CARGO_MANIFEST_DIR"), file!(), args);
+
+    println!("Result: {:?}", result);
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_parse_subcommand_minimum_args() {
+    let args = vec!["stress_test", "--output", "", "test-two", "-a", "5"];
+    let result =
+        StressRunner::<MockStressTestFactory>::from_args(env!("CARGO_MANIFEST_DIR"), file!(), args);
+
+    println!("Result: {:?}", result);
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_parse_subcommand_all_args() {
+    let args = vec![
+        "stress_test",
+        "--output",
+        "",
+        "test-two",
+        "-a",
+        "5",
+        "-b",
+        "10",
+        "-c",
+        "15",
+        "-d",
+    ];
+    let result =
+        StressRunner::<MockStressTestFactory>::from_args(env!("CARGO_MANIFEST_DIR"), file!(), args);
+
+    println!("Result: {:?}", result);
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_parse_subcommand_unrecognized_arg() {
+    let args = vec![
+        "stress_test",
+        "--output",
+        "",
+        "test-two",
+        "-a",
+        "5",
+        "--bad-arg",
+        "foo",
+    ];
+    let result =
+        StressRunner::<MockStressTestFactory>::from_args(env!("CARGO_MANIFEST_DIR"), file!(), args);
+
+    println!("Result: {:?}", result);
+    assert!(result.is_err());
+}

--- a/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+pub mod args;
 pub mod data;
 pub mod value_parsers;
 
@@ -17,13 +18,13 @@ use futures::{
 use serde::Serialize;
 use std::{fmt::Debug, future::Future, mem, pin::Pin, time::Duration};
 
-use crate::{stress::value_parsers::simple_duration, OptionalTimeoutFutureExt};
+use crate::{stress::args::StressRunnerOptions, OptionalTimeoutFutureExt};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// A [Subcommand] specifier capable of instancing the code for the selected subcommand.
 pub trait StressTestFactory: Subcommand + Debug + std::fmt::Display {
-    fn build_test(&self) -> Result<Box<dyn StressTest>>;
+    fn build_test(options: &StressRunnerOptions<Self>) -> Result<Box<dyn StressTest>>;
 }
 
 #[async_trait::async_trait]
@@ -43,56 +44,6 @@ pub trait StressTestOperation: Send + Sync {
         timeout: Option<Duration>,
         result_sender: UnboundedSender<StressRunOutput>,
     );
-}
-
-#[derive(Debug, Clone, Parser)]
-pub(crate) struct StressRunnerOptions<T: StressTestFactory> {
-    /// Parallel operations to run.
-    #[arg(long, default_value_t = 1)]
-    pub parallel: usize,
-
-    /// Duration of the stress test, excluding setup and cleanup.
-    #[arg(long, default_value = "10", value_parser = simple_duration, value_name = "SECONDS")]
-    duration: Duration,
-
-    /// Optional timeout for one-time test setup.
-    #[arg(long, value_parser = simple_duration, value_name = "SECONDS")]
-    setup_timeout: Option<Duration>,
-
-    /// Optional timeout for individual operations during the test.
-    #[arg(long, value_parser = simple_duration, value_name = "SECONDS")]
-    operation_timeout: Option<Duration>,
-
-    /// Optional timeout for one-time test cleanup.
-    #[arg(long, value_parser = simple_duration, value_name = "SECONDS")]
-    cleanup_timeout: Option<Duration>,
-
-    #[command(subcommand)]
-    pub command: T,
-}
-
-impl<T: StressTestFactory> std::fmt::Display for StressRunnerOptions<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "=== Stress Runner Configuration ===")?;
-        writeln!(f, "duration: {}", self.duration.as_secs())?;
-        writeln!(f, "parallel: {}", self.parallel)?;
-        writeln!(
-            f,
-            "operation_timeout: {:?}",
-            self.operation_timeout.map(|t| t.as_secs())
-        )?;
-        writeln!(
-            f,
-            "setup_timeout: {:?}",
-            self.setup_timeout.map(|t| t.as_secs())
-        )?;
-        writeln!(
-            f,
-            "cleanup_timeout: {:?}",
-            self.cleanup_timeout.map(|t| t.as_secs())
-        )?;
-        std::fmt::Display::fmt(&self.command, f)
-    }
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
@@ -184,7 +135,7 @@ impl<T: StressTestFactory> StressRunner<T> {
     }
 
     pub async fn run(&self) -> Result<()> {
-        let stress_test = self.options.command.build_test()?;
+        let stress_test = self.options.build_test()?;
         let mut totals = StressRunCounts::default();
 
         println!("{}", self.options);

--- a/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
@@ -265,8 +265,9 @@ async fn infinite_stress_loop<T: StressTestFactory>(
         while join_handles.len() >= options.parallel {
             let join_result;
             (join_result, _, join_handles) = future::select_all(mem::take(&mut join_handles)).await;
-            if let Err(_join_error) = join_result {
-                todo!("Handle error joining task")
+            if let Err(join_error) = join_result {
+                totals.loops_panic += 1;
+                eprintln!("{}", join_error);
             }
         }
 
@@ -277,8 +278,8 @@ async fn infinite_stress_loop<T: StressTestFactory>(
                 StressRunOutput::Success => totals.loops_success += 1,
                 StressRunOutput::GracefulError(_error) => totals.loops_graceful_error += 1,
                 StressRunOutput::Timeout => totals.loops_timeout += 1,
-                StressRunOutput::Panic(_panic_msg) => totals.loops_panic += 1,
                 StressRunOutput::DataCorruption => totals.loops_data_corruption += 1,
+                StressRunOutput::Panic(_panic_msg) => {}
             }
             match msg {
                 StressRunOutput::Success | StressRunOutput::GracefulError(_) => {}

--- a/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
@@ -185,6 +185,7 @@ impl<T: StressTestFactory> StressRunner<T> {
 
     pub async fn run(&self) -> Result<()> {
         let stress_test = self.options.command.build_test()?;
+        let mut totals = StressRunCounts::default();
 
         println!("{}", self.options);
 
@@ -203,7 +204,7 @@ impl<T: StressTestFactory> StressRunner<T> {
             // This is acceptable, as the next steps are to execute test cleanup and exit application.
             // If the runs absolutely must be stopped, the [StressTest] implementor can signal to
             // individual test runs in global cleanup.
-            match infinite_stress_loop(stress_test.as_ref(), &self.options)
+            match infinite_stress_loop(stress_test.as_ref(), &mut totals, &self.options)
                 .timeout(Some(self.options.duration))
                 .await
             {
@@ -227,6 +228,14 @@ impl<T: StressTestFactory> StressRunner<T> {
             eprintln!("Stress runner failure. {:#}", e);
         }
 
+        println!(
+            "Final results: {}",
+            serde_json::to_string_pretty(&totals).with_context(
+                ErrorKind::DataConversion,
+                "Failed to serialize test results to JSON.",
+            )?
+        );
+
         println!("=== Begin Cleanup ===");
         stress_test
             .global_cleanup()
@@ -237,9 +246,9 @@ impl<T: StressTestFactory> StressRunner<T> {
 
 async fn infinite_stress_loop<T: StressTestFactory>(
     stress_test: &dyn StressTest,
+    totals: &mut StressRunCounts,
     options: &StressRunnerOptions<T>,
 ) -> Result<()> {
-    let mut totals = StressRunCounts::default();
     let mut join_handles = Vec::with_capacity(options.parallel);
     let (tx, mut rx) = mpsc::unbounded();
 
@@ -264,20 +273,23 @@ async fn infinite_stress_loop<T: StressTestFactory>(
         // non-blocking process run result(s)
         while let Ok(msg) = rx.try_recv() {
             totals.total_loops += 1;
-            match msg {
+            match &msg {
                 StressRunOutput::Success => totals.loops_success += 1,
                 StressRunOutput::GracefulError(_error) => totals.loops_graceful_error += 1,
                 StressRunOutput::Timeout => totals.loops_timeout += 1,
                 StressRunOutput::Panic(_panic_msg) => totals.loops_panic += 1,
                 StressRunOutput::DataCorruption => totals.loops_data_corruption += 1,
             }
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&totals).with_context(
-                    ErrorKind::DataConversion,
-                    "Failed to serialize test results to JSON.",
-                )?
-            );
+            match msg {
+                StressRunOutput::Success | StressRunOutput::GracefulError(_) => {}
+                _ => println!(
+                    "{}",
+                    serde_json::to_string_pretty(&totals).with_context(
+                        ErrorKind::DataConversion,
+                        "Failed to serialize test results to JSON.",
+                    )?
+                ),
+            }
         }
     }
 

--- a/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
@@ -15,7 +15,8 @@ use futures::{
     future,
 };
 use serde::Serialize;
-use std::{fmt::Debug, mem};
+use std::{fmt::Debug, mem, pin::pin, time::Duration};
+use tokio::time::sleep;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -134,50 +135,35 @@ impl<T: StressTestFactory> StressRunner<T> {
         println!("{}", self.options);
 
         let stress_run_result: Result<()> = async {
-            println!("========== Starting global setup ==========");
+            println!("=== Global Setup ===");
             stress_test.global_setup().await?;
 
-            let mut totals = StressRunCounts::default();
-            let mut join_handles = Vec::with_capacity(self.options.parallel);
-            let (tx, mut rx) = mpsc::unbounded();
-            for iteration in 1.. {
-                println!("========== Starting test run {} ==========", iteration);
+            println!("=== Begin Stress ===");
+            // Race an infinite loop of parallel tests against a timeout.
+            // Note that each individual test is spawned into a different worker, and therefore
+            // will NOT cease when the stress loop future is dropped.
+            // This is acceptable, as the next steps are to execute test cleanup and exit application.
+            // If the runs absolutely must be stopped, the [StressTest] implementor can signal to
+            // individual test runs in global cleanup.
+            match future::select(
+                pin!(infinite_stress_loop(stress_test.as_ref(), &self.options)),
+                pin!(sleep(Duration::from_secs(self.options.duration))),
+            )
+            .await
+            {
+                // Test duration completed. This is the expected path.
+                future::Either::Right((_test_duration_timeout, _)) => {}
 
-                let mut operation = stress_test.get_operation().await?;
-                let tx_clone = tx.clone();
-                join_handles.push(get_async_runtime().spawn(Box::pin(async move {
-                    operation.run(tx_clone).await;
-                })));
-
-                // block until free parallel slot
-                while join_handles.len() >= self.options.parallel {
-                    let join_result;
-                    (join_result, _, join_handles) =
-                        future::select_all(mem::take(&mut join_handles)).await;
-                    if let Err(_join_error) = join_result {
-                        todo!("Handle error joining task")
-                    }
-                }
-
-                // non-blocking process run result(s)
-                while let Ok(msg) = rx.try_recv() {
-                    totals.total_loops += 1;
-                    match msg {
-                        StressRunOutput::Success => totals.loops_success += 1,
-                        StressRunOutput::GracefulError(_error) => totals.loops_graceful_error += 1,
-                        StressRunOutput::Timeout => totals.loops_timeout += 1,
-                        StressRunOutput::Panic(_panic_msg) => totals.loops_panic += 1,
-                        StressRunOutput::DataCorruption => totals.loops_data_corruption += 1,
-                    }
-                    println!(
-                        "{}",
-                        serde_json::to_string_pretty(&totals).with_context(
-                            ErrorKind::DataConversion,
-                            "Failed to serialize test results to JSON.",
-                        )?
-                    );
-                }
+                // Infinite run loop exited due to an error managing tests.
+                future::Either::Left((stress_result, _)) => match stress_result {
+                    Ok(()) => Err(Error::with_message(
+                        ErrorKind::Other,
+                        "Infinite stress loop exited with success. This should never happen.",
+                    ))?,
+                    Err(e) => Err(e)?,
+                },
             }
+
             Ok(())
         }
         .await;
@@ -185,9 +171,58 @@ impl<T: StressTestFactory> StressRunner<T> {
             eprintln!("Stress runner failure. {:#}", e);
         }
 
-        println!("========== Starting test cleanup ==========");
+        println!("=== Begin Cleanup ===");
         stress_test.global_cleanup().await
     }
+}
+
+async fn infinite_stress_loop<T: StressTestFactory>(
+    stress_test: &dyn StressTest,
+    options: &StressRunnerOptions<T>,
+) -> Result<()> {
+    let mut totals = StressRunCounts::default();
+    let mut join_handles = Vec::with_capacity(options.parallel);
+    let (tx, mut rx) = mpsc::unbounded();
+
+    for iteration in 1usize.. {
+        println!("Start operation {}", iteration);
+
+        let mut operation = stress_test.get_operation().await?;
+        let tx_clone = tx.clone();
+        join_handles.push(get_async_runtime().spawn(Box::pin(async move {
+            operation.run(tx_clone).await;
+        })));
+
+        // block until free parallel slot
+        while join_handles.len() >= options.parallel {
+            let join_result;
+            (join_result, _, join_handles) = future::select_all(mem::take(&mut join_handles)).await;
+            if let Err(_join_error) = join_result {
+                todo!("Handle error joining task")
+            }
+        }
+
+        // non-blocking process run result(s)
+        while let Ok(msg) = rx.try_recv() {
+            totals.total_loops += 1;
+            match msg {
+                StressRunOutput::Success => totals.loops_success += 1,
+                StressRunOutput::GracefulError(_error) => totals.loops_graceful_error += 1,
+                StressRunOutput::Timeout => totals.loops_timeout += 1,
+                StressRunOutput::Panic(_panic_msg) => totals.loops_panic += 1,
+                StressRunOutput::DataCorruption => totals.loops_data_corruption += 1,
+            }
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&totals).with_context(
+                    ErrorKind::DataConversion,
+                    "Failed to serialize test results to JSON.",
+                )?
+            );
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use azure_core::{
+    async_runtime::get_async_runtime,
+    error::{ErrorKind, ResultExt},
+    Error,
+};
+use clap::{Parser, Subcommand};
+use futures::{
+    channel::mpsc::{self, UnboundedSender},
+    future,
+};
+use serde::Serialize;
+use std::mem;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// A [Subcommand] that is capable of instancing
+pub trait StressTestFactory {
+    fn get_test(&self) -> Result<Box<dyn StressTest>>;
+}
+
+#[async_trait::async_trait]
+pub trait StressTest: Send + Sync {
+    async fn global_setup(&self) -> Result<()>;
+    fn get_operation(&self) -> Result<Box<dyn StressTestOperation>>;
+    async fn global_cleanup(&self) -> Result<()>;
+}
+
+#[async_trait::async_trait]
+pub trait StressTestOperation: Send + Sync {
+    async fn run(&self, result_sender: UnboundedSender<StressRunOutput>);
+}
+
+#[derive(Debug, Clone, Parser)]
+struct StressRunnerOptions<T: StressTestFactory + Subcommand> {
+    /// Parallel operations to run.
+    #[arg(long, default_value_t = 1)]
+    parallel: usize,
+
+    /// Run duration in seconds.
+    #[arg(long, value_name = "SECONDS", default_value_t = 60)]
+    duration: u64,
+
+    /// Optional timeout in seconds for individual operations.
+    #[arg(long, value_name = "SECONDS")]
+    timeout: Option<u64>,
+
+    /// Results output destination.
+    #[arg(short = 'o', long = "output", value_name = "FILE")]
+    results_file: String,
+
+    #[command(subcommand)]
+    command: T,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+struct StressRunCounts {
+    pub total_loops: usize,
+    pub loops_success: usize,
+    pub loops_graceful_error: usize,
+    pub loops_timeout: usize,
+    pub loops_panic: usize,
+    pub loops_data_corruption: usize,
+}
+
+pub enum StressRunOutput {
+    Success,
+    GracefulError(Error),
+    Timeout,
+    Panic(String),
+    DataCorruption,
+}
+
+/// Context information required by performance tests.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct StressRunner<T: StressTestFactory + Subcommand> {
+    options: StressRunnerOptions<T>,
+    package_dir: &'static str,
+    module_name: &'static str,
+}
+
+impl<T: StressTestFactory + Subcommand> StressRunner<T> {
+    /// Construct a stress test runner using one of the provided `tests` based on [`env::args_os`].
+    ///
+    ///
+    /// # Arguments
+    ///
+    /// * package_dir - The directory containing the package with the tests. Typically `env!("CARGO_PACKAGE_DIR")`
+    /// * module_name - The name of the module containing the test, typically `file!()`
+    /// * tests - A set of test definitions.
+    ///
+    pub fn new(package_dir: &'static str, module_name: &'static str) -> Result<Self> {
+        let options = StressRunnerOptions::<T>::try_parse()
+            .with_context(ErrorKind::Other, "Failed to parse command line arguments.")?;
+        Ok(Self {
+            options,
+            package_dir,
+            module_name,
+        })
+    }
+
+    /// Construct a stress test runner using one of the provided `tests` based on provided `args`.
+    pub fn from_args(
+        package_dir: &'static str,
+        module_name: &'static str,
+        args: Vec<&str>,
+    ) -> azure_core::Result<Self> {
+        let options = StressRunnerOptions::<T>::try_parse_from(args)
+            .with_context(ErrorKind::Other, "Failed to parse command line arguments.")?;
+        Ok(Self {
+            options,
+            package_dir,
+            module_name,
+        })
+    }
+
+    pub async fn run(&self) -> azure_core::Result<()> {
+        let stress_test = self.options.command.get_test()?;
+
+        // println!("Test Configuration: {:#}", self.options);
+
+        println!("========== Starting global setup ==========");
+        stress_test.global_setup().await?;
+
+        let mut totals = StressRunCounts::default();
+        let mut join_handles = Vec::with_capacity(self.options.parallel);
+        let (tx, mut rx) = mpsc::unbounded();
+        for iteration in 1.. {
+            println!("========== Starting test run {} ==========", iteration);
+
+            let operation = stress_test.get_operation()?;
+            let tx_clone = tx.clone();
+            join_handles.push(get_async_runtime().spawn(Box::pin(async move {
+                operation.run(tx_clone).await;
+            })));
+
+            // block until free parallel slot
+            while join_handles.len() >= self.options.parallel {
+                let join_result;
+                (join_result, _, join_handles) =
+                    future::select_all(mem::take(&mut join_handles)).await;
+                if let Err(_join_error) = join_result {
+                    todo!("Handle error joining task")
+                }
+            }
+
+            // non-blocking process run result(s)
+            while let Ok(msg) = rx.try_recv() {
+                totals.total_loops += 1;
+                match msg {
+                    StressRunOutput::Success => totals.loops_success += 1,
+                    StressRunOutput::GracefulError(_error) => totals.loops_graceful_error += 1,
+                    StressRunOutput::Timeout => totals.loops_timeout += 1,
+                    StressRunOutput::Panic(_panic_msg) => totals.loops_panic += 1,
+                    StressRunOutput::DataCorruption => totals.loops_data_corruption += 1,
+                }
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&totals).with_context(
+                        ErrorKind::DataConversion,
+                        "Failed to serialize test results to JSON.",
+                    )?
+                );
+            }
+        }
+        println!("========== Starting test cleanup ==========");
+        stress_test.global_cleanup().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod framework_tests;

--- a/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+pub mod data;
+pub mod value_parsers;
+
 use azure_core::{
     async_runtime::get_async_runtime,
     error::{ErrorKind, ResultExt},
@@ -12,29 +15,29 @@ use futures::{
     future,
 };
 use serde::Serialize;
-use std::mem;
+use std::{fmt::Debug, mem};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// A [Subcommand] that is capable of instancing
-pub trait StressTestFactory {
-    fn get_test(&self) -> Result<Box<dyn StressTest>>;
+/// A [Subcommand] specifier capable of instancing the code for the selected subcommand.
+pub trait StressTestFactory: Subcommand + Debug + std::fmt::Display {
+    fn build_test(&self) -> Result<Box<dyn StressTest>>;
 }
 
 #[async_trait::async_trait]
 pub trait StressTest: Send + Sync {
     async fn global_setup(&self) -> Result<()>;
-    fn get_operation(&self) -> Result<Box<dyn StressTestOperation>>;
+    async fn get_operation(&self) -> Result<Box<dyn StressTestOperation>>;
     async fn global_cleanup(&self) -> Result<()>;
 }
 
 #[async_trait::async_trait]
 pub trait StressTestOperation: Send + Sync {
-    async fn run(&self, result_sender: UnboundedSender<StressRunOutput>);
+    async fn run(&mut self, result_sender: UnboundedSender<StressRunOutput>);
 }
 
 #[derive(Debug, Clone, Parser)]
-struct StressRunnerOptions<T: StressTestFactory + Subcommand> {
+struct StressRunnerOptions<T: StressTestFactory> {
     /// Parallel operations to run.
     #[arg(long, default_value_t = 1)]
     parallel: usize,
@@ -47,12 +50,21 @@ struct StressRunnerOptions<T: StressTestFactory + Subcommand> {
     #[arg(long, value_name = "SECONDS")]
     timeout: Option<u64>,
 
-    /// Results output destination.
-    #[arg(short = 'o', long = "output", value_name = "FILE")]
-    results_file: String,
-
+    // /// Results output destination.
+    // #[arg(short = 'o', long = "output", value_name = "FILE")]
+    // results_file: String,
     #[command(subcommand)]
     command: T,
+}
+
+impl<T: StressTestFactory> std::fmt::Display for StressRunnerOptions<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "StressRunnerOptions: {{ parallel: {}, duration: {}, timeout: {:?} }}",
+            self.parallel, self.duration, self.timeout,
+        )
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
@@ -76,13 +88,13 @@ pub enum StressRunOutput {
 /// Context information required by performance tests.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-pub struct StressRunner<T: StressTestFactory + Subcommand> {
+pub struct StressRunner<T: StressTestFactory> {
     options: StressRunnerOptions<T>,
     package_dir: &'static str,
     module_name: &'static str,
 }
 
-impl<T: StressTestFactory + Subcommand> StressRunner<T> {
+impl<T: StressTestFactory> StressRunner<T> {
     /// Construct a stress test runner using one of the provided `tests` based on [`env::args_os`].
     ///
     ///
@@ -92,14 +104,13 @@ impl<T: StressTestFactory + Subcommand> StressRunner<T> {
     /// * module_name - The name of the module containing the test, typically `file!()`
     /// * tests - A set of test definitions.
     ///
-    pub fn new(package_dir: &'static str, module_name: &'static str) -> Result<Self> {
-        let options = StressRunnerOptions::<T>::try_parse()
-            .with_context(ErrorKind::Other, "Failed to parse command line arguments.")?;
-        Ok(Self {
+    pub fn new(package_dir: &'static str, module_name: &'static str) -> Self {
+        let options = StressRunnerOptions::<T>::parse();
+        Self {
             options,
             package_dir,
             module_name,
-        })
+        }
     }
 
     /// Construct a stress test runner using one of the provided `tests` based on provided `args`.
@@ -117,58 +128,65 @@ impl<T: StressTestFactory + Subcommand> StressRunner<T> {
         })
     }
 
-    pub async fn run(&self) -> azure_core::Result<()> {
-        let stress_test = self.options.command.get_test()?;
+    pub async fn run(&self) -> Result<()> {
+        let stress_test = self.options.command.build_test()?;
 
-        // println!("Test Configuration: {:#}", self.options);
+        println!("Test Configuration: {:#}", self.options);
 
-        println!("========== Starting global setup ==========");
-        stress_test.global_setup().await?;
+        let stress_run_result: Result<()> = async {
+            println!("========== Starting global setup ==========");
+            stress_test.global_setup().await?;
 
-        let mut totals = StressRunCounts::default();
-        let mut join_handles = Vec::with_capacity(self.options.parallel);
-        let (tx, mut rx) = mpsc::unbounded();
-        for iteration in 1.. {
-            println!("========== Starting test run {} ==========", iteration);
+            let mut totals = StressRunCounts::default();
+            let mut join_handles = Vec::with_capacity(self.options.parallel);
+            let (tx, mut rx) = mpsc::unbounded();
+            for iteration in 1.. {
+                println!("========== Starting test run {} ==========", iteration);
 
-            let operation = stress_test.get_operation()?;
-            let tx_clone = tx.clone();
-            join_handles.push(get_async_runtime().spawn(Box::pin(async move {
-                operation.run(tx_clone).await;
-            })));
+                let mut operation = stress_test.get_operation().await?;
+                let tx_clone = tx.clone();
+                join_handles.push(get_async_runtime().spawn(Box::pin(async move {
+                    operation.run(tx_clone).await;
+                })));
 
-            // block until free parallel slot
-            while join_handles.len() >= self.options.parallel {
-                let join_result;
-                (join_result, _, join_handles) =
-                    future::select_all(mem::take(&mut join_handles)).await;
-                if let Err(_join_error) = join_result {
-                    todo!("Handle error joining task")
+                // block until free parallel slot
+                while join_handles.len() >= self.options.parallel {
+                    let join_result;
+                    (join_result, _, join_handles) =
+                        future::select_all(mem::take(&mut join_handles)).await;
+                    if let Err(_join_error) = join_result {
+                        todo!("Handle error joining task")
+                    }
+                }
+
+                // non-blocking process run result(s)
+                while let Ok(msg) = rx.try_recv() {
+                    totals.total_loops += 1;
+                    match msg {
+                        StressRunOutput::Success => totals.loops_success += 1,
+                        StressRunOutput::GracefulError(_error) => totals.loops_graceful_error += 1,
+                        StressRunOutput::Timeout => totals.loops_timeout += 1,
+                        StressRunOutput::Panic(_panic_msg) => totals.loops_panic += 1,
+                        StressRunOutput::DataCorruption => totals.loops_data_corruption += 1,
+                    }
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&totals).with_context(
+                            ErrorKind::DataConversion,
+                            "Failed to serialize test results to JSON.",
+                        )?
+                    );
                 }
             }
-
-            // non-blocking process run result(s)
-            while let Ok(msg) = rx.try_recv() {
-                totals.total_loops += 1;
-                match msg {
-                    StressRunOutput::Success => totals.loops_success += 1,
-                    StressRunOutput::GracefulError(_error) => totals.loops_graceful_error += 1,
-                    StressRunOutput::Timeout => totals.loops_timeout += 1,
-                    StressRunOutput::Panic(_panic_msg) => totals.loops_panic += 1,
-                    StressRunOutput::DataCorruption => totals.loops_data_corruption += 1,
-                }
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&totals).with_context(
-                        ErrorKind::DataConversion,
-                        "Failed to serialize test results to JSON.",
-                    )?
-                );
-            }
+            Ok(())
         }
+        .await;
+        if let Err(e) = stress_run_result {
+            eprintln!("Stress runner failure. {:#}", e);
+        }
+
         println!("========== Starting test cleanup ==========");
-        stress_test.global_cleanup().await?;
-        Ok(())
+        stress_test.global_cleanup().await
     }
 }
 

--- a/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
@@ -17,7 +17,7 @@ use futures::{
 use serde::Serialize;
 use std::{fmt::Debug, future::Future, mem, pin::Pin, time::Duration};
 
-use crate::OptionalTimeoutFutureExt;
+use crate::{stress::value_parsers::simple_duration, OptionalTimeoutFutureExt};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -46,38 +46,51 @@ pub trait StressTestOperation: Send + Sync {
 }
 
 #[derive(Debug, Clone, Parser)]
-struct StressRunnerOptions<T: StressTestFactory> {
+pub(crate) struct StressRunnerOptions<T: StressTestFactory> {
     /// Parallel operations to run.
     #[arg(long, default_value_t = 1)]
-    parallel: usize,
+    pub parallel: usize,
 
-    /// Duration of the overall stress test in seconds, excluding setup and cleanup.
-    #[arg(long, value_name = "SECONDS", default_value_t = 60)]
-    duration_s: u64,
+    /// Duration of the stress test, excluding setup and cleanup.
+    #[arg(long, default_value = "10", value_parser = simple_duration, value_name = "SECONDS")]
+    duration: Duration,
 
-    /// Optional timeout in seconds for individual operations.
-    #[arg(long, value_name = "SECONDS")]
-    timeout_s: Option<u64>,
+    /// Optional timeout for one-time test setup.
+    #[arg(long, value_parser = simple_duration, value_name = "SECONDS")]
+    setup_timeout: Option<Duration>,
+
+    /// Optional timeout for individual operations during the test.
+    #[arg(long, value_parser = simple_duration, value_name = "SECONDS")]
+    operation_timeout: Option<Duration>,
+
+    /// Optional timeout for one-time test cleanup.
+    #[arg(long, value_parser = simple_duration, value_name = "SECONDS")]
+    cleanup_timeout: Option<Duration>,
 
     #[command(subcommand)]
-    command: T,
-}
-
-impl<T: StressTestFactory> StressRunnerOptions<T> {
-    fn duration(&self) -> Duration {
-        Duration::from_secs(self.duration_s)
-    }
-    fn timeout(&self) -> Option<Duration> {
-        self.timeout_s.map(Duration::from_secs)
-    }
+    pub command: T,
 }
 
 impl<T: StressTestFactory> std::fmt::Display for StressRunnerOptions<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "=== Stress Runner Configuration ===")?;
-        writeln!(f, "duration: {}", self.duration().as_secs())?;
+        writeln!(f, "duration: {}", self.duration.as_secs())?;
         writeln!(f, "parallel: {}", self.parallel)?;
-        writeln!(f, "timeout: {:?}", self.timeout().map(|t| t.as_secs()))?;
+        writeln!(
+            f,
+            "operation_timeout: {:?}",
+            self.operation_timeout.map(|t| t.as_secs())
+        )?;
+        writeln!(
+            f,
+            "setup_timeout: {:?}",
+            self.setup_timeout.map(|t| t.as_secs())
+        )?;
+        writeln!(
+            f,
+            "cleanup_timeout: {:?}",
+            self.cleanup_timeout.map(|t| t.as_secs())
+        )?;
         std::fmt::Display::fmt(&self.command, f)
     }
 }
@@ -175,9 +188,13 @@ impl<T: StressTestFactory> StressRunner<T> {
 
         println!("{}", self.options);
 
-        let stress_run_result: Result<()> = async {
+        // Catch all Err returns of setup and test run, ensuring we always run cleanup.
+        let setup_and_run_result: Result<()> = async {
             println!("=== Global Setup ===");
-            stress_test.global_setup().await?;
+            stress_test
+                .global_setup()
+                .timeout(self.options.setup_timeout)
+                .await??;
 
             println!("=== Begin Stress ===");
             // Race an infinite loop of parallel tests against a timeout.
@@ -187,7 +204,7 @@ impl<T: StressTestFactory> StressRunner<T> {
             // If the runs absolutely must be stopped, the [StressTest] implementor can signal to
             // individual test runs in global cleanup.
             match infinite_stress_loop(stress_test.as_ref(), &self.options)
-                .timeout(Some(self.options.duration()))
+                .timeout(Some(self.options.duration))
                 .await
             {
                 // Test duration completed. This is the expected path.
@@ -206,12 +223,15 @@ impl<T: StressTestFactory> StressRunner<T> {
             Ok(())
         }
         .await;
-        if let Err(e) = stress_run_result {
+        if let Err(e) = setup_and_run_result {
             eprintln!("Stress runner failure. {:#}", e);
         }
 
         println!("=== Begin Cleanup ===");
-        stress_test.global_cleanup().await
+        stress_test
+            .global_cleanup()
+            .timeout(self.options.cleanup_timeout)
+            .await?
     }
 }
 
@@ -228,7 +248,7 @@ async fn infinite_stress_loop<T: StressTestFactory>(
 
         join_handles.push(get_async_runtime().spawn(operation_wrapper(
             stress_test.get_operation().await?,
-            options.timeout(),
+            options.operation_timeout,
             tx.clone(),
         )));
 

--- a/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
@@ -59,11 +59,11 @@ struct StressRunnerOptions<T: StressTestFactory> {
 
 impl<T: StressTestFactory> std::fmt::Display for StressRunnerOptions<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "StressRunnerOptions: {{ parallel: {}, duration: {}, timeout: {:?} }}",
-            self.parallel, self.duration, self.timeout,
-        )
+        writeln!(f, "=== Stress Runner Configuration ===")?;
+        writeln!(f, "duration: {}", self.duration)?;
+        writeln!(f, "parallel: {}", self.parallel)?;
+        writeln!(f, "timeout: {:?}", self.timeout)?;
+        std::fmt::Display::fmt(&self.command, f)
     }
 }
 
@@ -131,7 +131,7 @@ impl<T: StressTestFactory> StressRunner<T> {
     pub async fn run(&self) -> Result<()> {
         let stress_test = self.options.command.build_test()?;
 
-        println!("Test Configuration: {:#}", self.options);
+        println!("{}", self.options);
 
         let stress_run_result: Result<()> = async {
             println!("========== Starting global setup ==========");

--- a/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
@@ -15,8 +15,9 @@ use futures::{
     future,
 };
 use serde::Serialize;
-use std::{fmt::Debug, mem, pin::pin, time::Duration};
-use tokio::time::sleep;
+use std::{fmt::Debug, future::Future, mem, pin::Pin, time::Duration};
+
+use crate::OptionalTimeoutFutureExt;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -27,14 +28,21 @@ pub trait StressTestFactory: Subcommand + Debug + std::fmt::Display {
 
 #[async_trait::async_trait]
 pub trait StressTest: Send + Sync {
+    /// One-time setup.
     async fn global_setup(&self) -> Result<()>;
+    /// Gets an operation to be ran. Many operations can be run in parallel.
     async fn get_operation(&self) -> Result<Box<dyn StressTestOperation>>;
+    /// One-time cleanup.
     async fn global_cleanup(&self) -> Result<()>;
 }
 
 #[async_trait::async_trait]
 pub trait StressTestOperation: Send + Sync {
-    async fn run(&mut self, result_sender: UnboundedSender<StressRunOutput>);
+    async fn run(
+        &mut self,
+        timeout: Option<Duration>,
+        result_sender: UnboundedSender<StressRunOutput>,
+    );
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -43,24 +51,33 @@ struct StressRunnerOptions<T: StressTestFactory> {
     #[arg(long, default_value_t = 1)]
     parallel: usize,
 
-    /// Duration of the overall stress test, excluding setup and cleanup.
+    /// Duration of the overall stress test in seconds, excluding setup and cleanup.
     #[arg(long, value_name = "SECONDS", default_value_t = 60)]
-    duration: u64,
+    duration_s: u64,
 
     /// Optional timeout in seconds for individual operations.
     #[arg(long, value_name = "SECONDS")]
-    timeout: Option<u64>,
+    timeout_s: Option<u64>,
 
     #[command(subcommand)]
     command: T,
 }
 
+impl<T: StressTestFactory> StressRunnerOptions<T> {
+    fn duration(&self) -> Duration {
+        Duration::from_secs(self.duration_s)
+    }
+    fn timeout(&self) -> Option<Duration> {
+        self.timeout_s.map(Duration::from_secs)
+    }
+}
+
 impl<T: StressTestFactory> std::fmt::Display for StressRunnerOptions<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "=== Stress Runner Configuration ===")?;
-        writeln!(f, "duration: {}", self.duration)?;
+        writeln!(f, "duration: {}", self.duration().as_secs())?;
         writeln!(f, "parallel: {}", self.parallel)?;
-        writeln!(f, "timeout: {:?}", self.timeout)?;
+        writeln!(f, "timeout: {:?}", self.timeout().map(|t| t.as_secs()))?;
         std::fmt::Display::fmt(&self.command, f)
     }
 }
@@ -76,10 +93,32 @@ struct StressRunCounts {
 }
 
 pub enum StressRunOutput {
+    /// The operation completed successfully.
     Success,
+
+    /// The operation failed, but communicated this through [Result::Err].
     GracefulError(Error),
+
+    /// The operation did not complete within the provided timeout.
+    ///
+    /// # Notes
+    ///
+    /// Operation timeout and reporting must be the responsibility of the [StressTestOperation] implementor.
+    /// Since all operations are run in spawned async workers, their work cannot be stopped by
+    /// dropping the join handle, which would lead to the worker reporting a result post-timeout regardless
+    /// of any runner-reported result.
     Timeout,
+
+    /// The operation panicked.
+    ///
+    /// # Notes
+    ///
+    /// Panic unwinding and reporting must be the responsibility of the [StressTestOperation] implementor.
+    /// Unwind safety is not dyn-compatible. Since all operations are dyn in practice, the runner
+    /// can never successfully [std::panic::catch_unwind] the dynamically resolved future.
     Panic(String),
+
+    /// The operation completed successfully, but data integrity checks failed.
     DataCorruption,
 }
 
@@ -147,20 +186,18 @@ impl<T: StressTestFactory> StressRunner<T> {
             // This is acceptable, as the next steps are to execute test cleanup and exit application.
             // If the runs absolutely must be stopped, the [StressTest] implementor can signal to
             // individual test runs in global cleanup.
-            match future::select(
-                pin!(infinite_stress_loop(stress_test.as_ref(), &self.options)),
-                pin!(sleep(Duration::from_secs(self.options.duration))),
-            )
-            .await
+            match infinite_stress_loop(stress_test.as_ref(), &self.options)
+                .timeout(Some(self.options.duration()))
+                .await
             {
                 // Test duration completed. This is the expected path.
-                future::Either::Right((_test_duration_timeout, _)) => {}
+                Err(_timeout_error) => {}
 
                 // Infinite run loop exited due to an error managing tests.
-                future::Either::Left((stress_result, _)) => match stress_result {
+                Ok(stress_result) => match stress_result {
                     Ok(()) => Err(Error::with_message(
                         ErrorKind::Other,
-                        "Infinite stress loop exited with success. This should never happen.",
+                        "Infinite stress loop exited with success. This is a bug.",
                     ))?,
                     Err(e) => Err(e)?,
                 },
@@ -189,11 +226,11 @@ async fn infinite_stress_loop<T: StressTestFactory>(
     for iteration in 1usize.. {
         println!("Start operation {}", iteration);
 
-        let mut operation = stress_test.get_operation().await?;
-        let tx_clone = tx.clone();
-        join_handles.push(get_async_runtime().spawn(Box::pin(async move {
-            operation.run(tx_clone).await;
-        })));
+        join_handles.push(get_async_runtime().spawn(operation_wrapper(
+            stress_test.get_operation().await?,
+            options.timeout(),
+            tx.clone(),
+        )));
 
         // block until free parallel slot
         while join_handles.len() >= options.parallel {
@@ -225,6 +262,14 @@ async fn infinite_stress_loop<T: StressTestFactory>(
     }
 
     Ok(())
+}
+
+fn operation_wrapper(
+    mut operation: Box<dyn StressTestOperation>,
+    timeout: Option<Duration>,
+    tx: UnboundedSender<StressRunOutput>,
+) -> Pin<Box<impl Future<Output = ()>>> {
+    Box::pin(async move { operation.run(timeout, tx.clone()).await })
 }
 
 #[cfg(test)]

--- a/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/mod.rs
@@ -43,7 +43,7 @@ struct StressRunnerOptions<T: StressTestFactory> {
     #[arg(long, default_value_t = 1)]
     parallel: usize,
 
-    /// Run duration in seconds.
+    /// Duration of the overall stress test, excluding setup and cleanup.
     #[arg(long, value_name = "SECONDS", default_value_t = 60)]
     duration: u64,
 
@@ -51,9 +51,6 @@ struct StressRunnerOptions<T: StressTestFactory> {
     #[arg(long, value_name = "SECONDS")]
     timeout: Option<u64>,
 
-    // /// Results output destination.
-    // #[arg(short = 'o', long = "output", value_name = "FILE")]
-    // results_file: String,
     #[command(subcommand)]
     command: T,
 }
@@ -96,15 +93,13 @@ pub struct StressRunner<T: StressTestFactory> {
 }
 
 impl<T: StressTestFactory> StressRunner<T> {
-    /// Construct a stress test runner using one of the provided `tests` based on [`env::args_os`].
-    ///
+    /// Construct a stress test runner with [Subcommand] test factory T, configured through parsed
+    /// arguments from [`std::env::args_os`].
     ///
     /// # Arguments
     ///
     /// * package_dir - The directory containing the package with the tests. Typically `env!("CARGO_PACKAGE_DIR")`
     /// * module_name - The name of the module containing the test, typically `file!()`
-    /// * tests - A set of test definitions.
-    ///
     pub fn new(package_dir: &'static str, module_name: &'static str) -> Self {
         let options = StressRunnerOptions::<T>::parse();
         Self {
@@ -114,7 +109,14 @@ impl<T: StressTestFactory> StressRunner<T> {
         }
     }
 
-    /// Construct a stress test runner using one of the provided `tests` based on provided `args`.
+    /// Construct a stress test runner with [Subcommand] test factory T, configured through parsed
+    /// arguments provided by the caller.
+    ///
+    /// # Arguments
+    ///
+    /// * package_dir - The directory containing the package with the tests. Typically `env!("CARGO_PACKAGE_DIR")`
+    /// * module_name - The name of the module containing the test, typically `file!()`
+    /// * args - The arguments to use for configuring this test run, emulating arguments parsed from the command line.
     pub fn from_args(
         package_dir: &'static str,
         module_name: &'static str,

--- a/sdk/storage/azure_storage_blob_test/src/stress/value_parsers.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/value_parsers.rs
@@ -61,9 +61,9 @@ pub fn simple_duration(s: &str) -> Result<Duration, String> {
 ///
 /// # Suffixes
 /// - `B` - bytes. (Default)
-/// - `KiB` - kibibytes.
-/// - `MiB` - mebibytes.
-/// - `GiB` - gibibytes.
+/// - `KiB` - 1024 bytes.
+/// - `MiB` - 1024 KiB.
+/// - `GiB` - 1024 GiB.
 ///
 /// # Examples
 /// - "10" - 10 bytes.

--- a/sdk/storage/azure_storage_blob_test/src/stress/value_parsers.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/value_parsers.rs
@@ -47,13 +47,21 @@ pub fn non_zero_u64(s: &str) -> Result<u64, String> {
 /// - "10.2a" - Error.
 pub fn simple_duration(s: &str) -> Result<Duration, String> {
     if let Some(s) = s.strip_suffix("s") {
-        Ok(Duration::from_secs_f64(s.parse().map_err(map_float_parse)?))
+        Ok(Duration::from_secs_f64(
+            s.parse::<f64>().map_err(map_float_parse)?,
+        ))
     } else if let Some(s) = s.strip_suffix("m") {
-        Ok(Duration::from_secs_f64(s.parse().map_err(map_float_parse)?))
+        Ok(Duration::from_secs_f64(
+            60.0 * s.parse::<f64>().map_err(map_float_parse)?,
+        ))
     } else if let Some(s) = s.strip_suffix("h") {
-        Ok(Duration::from_secs_f64(s.parse().map_err(map_float_parse)?))
+        Ok(Duration::from_secs_f64(
+            60.0 * 60.0 * s.parse::<f64>().map_err(map_float_parse)?,
+        ))
     } else {
-        Ok(Duration::from_secs_f64(s.parse().map_err(map_float_parse)?))
+        Ok(Duration::from_secs_f64(
+            s.parse::<f64>().map_err(map_float_parse)?,
+        ))
     }
 }
 

--- a/sdk/storage/azure_storage_blob_test/src/stress/value_parsers.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/value_parsers.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const POSITIVE_VALUE: &str = "Value must be positive.";
+
+pub fn non_zero_usize(s: &str) -> Result<usize, String> {
+    let num: usize = s.parse().map_err(|_| POSITIVE_VALUE)?;
+    if num == 0 {
+        Err(POSITIVE_VALUE.to_string())
+    } else {
+        Ok(num)
+    }
+}
+
+pub fn non_zero_u32(s: &str) -> Result<u32, String> {
+    let num: u32 = s.parse().map_err(|_| POSITIVE_VALUE)?;
+    if num == 0 {
+        Err(POSITIVE_VALUE.to_string())
+    } else {
+        Ok(num)
+    }
+}
+
+pub fn non_zero_u64(s: &str) -> Result<u64, String> {
+    let num: u64 = s.parse().map_err(|_| POSITIVE_VALUE)?;
+    if num == 0 {
+        Err(POSITIVE_VALUE.to_string())
+    } else {
+        Ok(num)
+    }
+}

--- a/sdk/storage/azure_storage_blob_test/src/stress/value_parsers.rs
+++ b/sdk/storage/azure_storage_blob_test/src/stress/value_parsers.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+use std::time::Duration;
+
 const POSITIVE_VALUE: &str = "Value must be positive.";
 
 pub fn non_zero_usize(s: &str) -> Result<usize, String> {
@@ -28,4 +30,100 @@ pub fn non_zero_u64(s: &str) -> Result<u64, String> {
     } else {
         Ok(num)
     }
+}
+
+/// Parses a decimal number with an optional suffix to indicate the time unit.
+///
+/// # Suffixes
+/// - `s` - seconds. (Default)
+/// - `m` - minutes.
+/// - `h` - hours.
+///
+/// # Examples
+/// - "10.5" - Duration of 10.5 seconds.
+/// - "10s" - Duration of 10 seconds.
+/// - "10.1m" - Duration of 10.1 minutes.
+/// - "10ss" - Error.
+/// - "10.2a" - Error.
+pub fn simple_duration(s: &str) -> Result<Duration, String> {
+    if let Some(s) = s.strip_suffix("s") {
+        Ok(Duration::from_secs_f64(s.parse().map_err(map_float_parse)?))
+    } else if let Some(s) = s.strip_suffix("m") {
+        Ok(Duration::from_secs_f64(s.parse().map_err(map_float_parse)?))
+    } else if let Some(s) = s.strip_suffix("h") {
+        Ok(Duration::from_secs_f64(s.parse().map_err(map_float_parse)?))
+    } else {
+        Ok(Duration::from_secs_f64(s.parse().map_err(map_float_parse)?))
+    }
+}
+
+/// Parses an integer with an optional suffix to indicate the binary SI unit.
+///
+/// # Suffixes
+/// - `B` - bytes. (Default)
+/// - `KiB` - kibibytes.
+/// - `MiB` - mebibytes.
+/// - `GiB` - gibibytes.
+///
+/// # Examples
+/// - "10" - 10 bytes.
+/// - "10B" - 10 bytes.
+/// - "10KiB" - 10240 bytes.
+/// - "10KB" - Error.
+/// - "1.5GiB" - Error.
+pub fn simple_len_u64(s: &str) -> Result<u64, String> {
+    if let Some(s) = s.to_lowercase().strip_suffix("gib") {
+        Ok(s.parse::<u64>().map_err(map_int_parse)? << 30)
+    } else if let Some(s) = s.to_lowercase().strip_suffix("mib") {
+        Ok(s.parse::<u64>().map_err(map_int_parse)? << 20)
+    } else if let Some(s) = s.to_lowercase().strip_suffix("kib") {
+        Ok(s.parse::<u64>().map_err(map_int_parse)? << 10)
+    } else if let Some(s) = s.to_lowercase().strip_suffix("b") {
+        Ok(s.parse::<u64>().map_err(map_int_parse)?)
+    } else {
+        Ok(s.parse::<u64>().map_err(map_int_parse)?)
+    }
+}
+
+/// [simple_len_u64] but with usize.
+pub fn simple_len_usize(s: &str) -> Result<usize, String> {
+    if let Some(s) = s.to_lowercase().strip_suffix("gib") {
+        Ok(s.parse::<usize>().map_err(map_int_parse)? << 30)
+    } else if let Some(s) = s.to_lowercase().strip_suffix("mib") {
+        Ok(s.parse::<usize>().map_err(map_int_parse)? << 20)
+    } else if let Some(s) = s.to_lowercase().strip_suffix("kib") {
+        Ok(s.parse::<usize>().map_err(map_int_parse)? << 10)
+    } else if let Some(s) = s.to_lowercase().strip_suffix("b") {
+        Ok(s.parse::<usize>().map_err(map_int_parse)?)
+    } else {
+        Ok(s.parse::<usize>().map_err(map_int_parse)?)
+    }
+}
+
+/// [simple_len_u64] but rejects a zero value.
+pub fn simple_non_zero_len_u64(s: &str) -> Result<u64, String> {
+    let num = simple_len_u64(s)?;
+    if num == 0 {
+        Err(POSITIVE_VALUE.to_string())
+    } else {
+        Ok(num)
+    }
+}
+
+/// [simple_len_usize] but rejects a zero value.
+pub fn simple_non_zero_len_usize(s: &str) -> Result<usize, String> {
+    let num = simple_len_usize(s)?;
+    if num == 0 {
+        Err(POSITIVE_VALUE.to_string())
+    } else {
+        Ok(num)
+    }
+}
+
+fn map_float_parse(e: std::num::ParseFloatError) -> String {
+    e.to_string()
+}
+
+fn map_int_parse(e: std::num::ParseIntError) -> String {
+    e.to_string()
 }


### PR DESCRIPTION
_**In progress.**_ Posting a living draft for project status updates.

- Adds stress testing support to azure storage's test utilities crate (`/sdk/storage/azure_storage_blob_test/stress`).
- Adds a stress testing application for azure blob storage (`/sdk/storage/azure_storage_blob_stress`).
  - After building, invoke via `/target/<debug|release>/azure_storage_blob_stress`.
  - `--help` will guide further use.

# How it works

The `StressRunner<T: StressTestFactory>` is the heavy lifter and entry point for a test run. Based on the provided factory, it will instance the appropriate test and run it for a set amount of time. Much like this repo's perf testing framework, it supports universal options as well as test-specific ones.

Each crate that requires stress testing will write a command-line application with a single `StressTestFactory`, a `clap::Subcommand` capable of instancing the correct test object (a dynamic `StressTest`) based on command-line input. The application's main function is as simple as follows:
```rust
#[tokio::main]
async fn main() {
    let runner = StressRunner::<MyStressTestFactory>::new(env!("CARGO_MANIFEST_DIR"), file!());

    if let Err(e) = runner.run().await {
        eprintln!("{}", e);
        exit(1);
    }
}
```

The runner will infinitely retrieve new operations from the stress test and run them until the test duration elapses. Operations are run with a predefined parallelism and may also be configured with an individual timeout.

The runner tracks the outputs of each operation. Outputs are one of the following:
- Success. The operation completed the task successfully.
- Graceful Error. The operation failed. Failure was communicated via `Result::Err`.
- Timeout. The operation did not complete within the allotted time and was cancelled.
- Data corruption. The operation returned as successful, but data integrity checks against the final result failed.

The runner will also track panics by checking the result of joining the spawned worker.