### PR TITLE
Remove explicit version on azure_core_opentelemetry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ path = "sdk/eventhubs/azure_messaging_eventhubs"
 [workspace.dependencies.azure_core_opentelemetry]
 # azure_core_opentelemetry should only ever be in dev-dependencies herein
 path = "sdk/core/azure_core_opentelemetry"
-version = "0.10.0"
 
 [workspace.dependencies.azure_core_test]
 # azure_core_test is not published and only ever a dev-dependency


### PR DESCRIPTION
Since it was only a dev-dependency, we don't actually need the version and it's causing problems when running:

```sh
cargo package --locked --allow-dirty --package azure_storage_blob --package azure_storage_queue --package azure_core --package typespec_client_core
```

Becuase we're not simulating a publish of it, azure_storage_blob would fail.
