### PR TITLE
Cosmos: Additional response headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,13 +268,37 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966f75417a6779ea221531960d9d46fe630879606501aa5277312ad4ae38587"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core_macros 0.8.0",
+ "bytes",
+ "futures",
+ "hmac",
+ "openssl",
+ "pin-project",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "tracing",
+ "typespec 0.14.0",
+ "typespec_client_core 0.14.0",
+]
+
+[[package]]
+name = "azure_core"
 version = "0.36.0"
 dependencies = [
  "async-lock",
  "async-trait",
  "azure_core_macros 0.8.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 0.36.0",
  "azure_security_keyvault_certificates",
  "azure_security_keyvault_secrets",
  "bytes",
@@ -296,7 +320,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "typespec 0.14.0",
- "typespec_client_core",
+ "typespec_client_core 0.15.0",
  "ureq",
 ]
 
@@ -305,7 +329,7 @@ name = "azure_core_amqp"
 version = "0.15.0"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.36.0",
  "fe2o3-amqp",
  "fe2o3-amqp-cbs",
  "fe2o3-amqp-ext",
@@ -350,10 +374,10 @@ dependencies = [
 name = "azure_core_opentelemetry"
 version = "0.10.0"
 dependencies = [
- "azure_core",
+ "azure_core 0.36.0",
  "azure_core_test",
  "azure_core_test_macros",
- "azure_identity",
+ "azure_identity 0.36.0",
  "opentelemetry",
  "opentelemetry_sdk",
  "tokio",
@@ -366,9 +390,9 @@ name = "azure_core_test"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.36.0",
  "azure_core_test_macros",
- "azure_identity",
+ "azure_identity 0.36.0",
  "azure_security_keyvault_secrets",
  "clap",
  "dotenvy",
@@ -391,7 +415,7 @@ dependencies = [
 name = "azure_core_test_macros"
 version = "0.1.0"
 dependencies = [
- "azure_core",
+ "azure_core 0.36.0",
  "azure_core_test",
  "proc-macro2",
  "quote",
@@ -405,10 +429,10 @@ version = "0.33.0"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 0.35.0",
  "azure_core_test",
  "azure_data_cosmos_driver",
- "azure_identity",
+ "azure_identity 0.35.0",
  "base64 0.22.1",
  "clap",
  "futures",
@@ -428,7 +452,7 @@ name = "azure_data_cosmos_benchmarks"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.35.0",
  "azure_data_cosmos_driver",
  "criterion",
  "tokio",
@@ -442,9 +466,9 @@ dependencies = [
  "arc-swap",
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 0.35.0",
  "azure_data_cosmos_macros",
- "azure_identity",
+ "azure_identity 0.35.0",
  "base64 0.22.1",
  "bytes",
  "crossbeam-epoch",
@@ -478,9 +502,9 @@ name = "azure_data_cosmos_perf"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.35.0",
  "azure_data_cosmos",
- "azure_identity",
+ "azure_identity 0.35.0",
  "clap",
  "console-subscriber",
  "futures",
@@ -498,11 +522,29 @@ dependencies = [
 
 [[package]]
 name = "azure_identity"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385e4426c01965149a002a72c54c43d6f1b9d2244179e70647df48e3b28f8c32"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core 0.35.0",
+ "futures",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "azure_identity"
 version = "0.36.0"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 0.36.0",
  "azure_core_test",
  "azure_security_keyvault_secrets",
  "clap",
@@ -528,10 +570,10 @@ dependencies = [
  "async-lock",
  "async-stream",
  "async-trait",
- "azure_core",
+ "azure_core 0.36.0",
  "azure_core_amqp",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 0.36.0",
  "azure_messaging_eventhubs",
  "criterion",
  "fe2o3-amqp",
@@ -549,10 +591,10 @@ name = "azure_messaging_eventhubs_checkpointstore_blob"
 version = "0.9.0"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.36.0",
  "azure_core_opentelemetry",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 0.36.0",
  "azure_messaging_eventhubs",
  "azure_storage_blob",
  "futures",
@@ -575,10 +617,10 @@ dependencies = [
  "async-lock",
  "async-stream",
  "async-trait",
- "azure_core",
+ "azure_core 0.36.0",
  "azure_core_amqp",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 0.36.0",
  "azure_messaging_servicebus",
  "futures",
  "rand 0.10.1",
@@ -597,9 +639,9 @@ version = "0.14.0"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 0.36.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 0.36.0",
  "azure_security_keyvault_keys",
  "azure_security_keyvault_test",
  "futures",
@@ -619,9 +661,9 @@ version = "0.15.0"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 0.36.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 0.36.0",
  "azure_security_keyvault_test",
  "criterion",
  "futures",
@@ -642,9 +684,9 @@ version = "0.15.0"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 0.36.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 0.36.0",
  "azure_security_keyvault_test",
  "futures",
  "include-file",
@@ -670,10 +712,10 @@ version = "0.13.0"
 dependencies = [
  "async-stream",
  "async-trait",
- "azure_core",
+ "azure_core 0.36.0",
  "azure_core_opentelemetry",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 0.36.0",
  "azure_storage_blob_test",
  "bytes",
  "clap",
@@ -698,7 +740,7 @@ name = "azure_storage_blob_test"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.36.0",
  "azure_core_test",
  "azure_storage_blob",
  "bytes",
@@ -711,10 +753,10 @@ name = "azure_storage_queue"
 version = "0.7.0"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.36.0",
  "azure_core_opentelemetry",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 0.36.0",
  "clap",
  "futures",
  "opentelemetry-stdout",
@@ -1858,6 +1900,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2968,9 +3026,11 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2979,6 +3039,7 @@ dependencies = [
  "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
@@ -3999,6 +4060,31 @@ dependencies = [
 
 [[package]]
 name = "typespec_client_core"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4714a935f6aa74724775f07291390e8f07df0a1804544cd4106ac3b75c0478d2"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "pin-project",
+ "rand 0.10.1",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tracing",
+ "typespec 0.14.0",
+ "typespec_macros 0.13.0",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "typespec_client_core"
 version = "0.15.0"
 dependencies = [
  "async-trait",
@@ -4047,7 +4133,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.117",
  "tokio",
- "typespec_client_core",
+ "typespec_client_core 0.15.0",
 ]
 
 [[package]]

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `ThroughputPoller` type that implements `IntoFuture` and `Stream` for tracking asynchronous throughput replacement operations.
 - Added `FeedRange` type with `ContainerClient::read_feed_ranges()` and `ContainerClient::feed_range_from_partition_key()` - supports hierarchical partition keys (MultiHash) including prefix partition keys that return multiple feed ranges. ([#4149](https://github.com/Azure/azure-sdk-for-rust/pull/4149))
 - Added `lsn()` and `item_lsn()` accessors on `ItemResponse<T>` exposing the `lsn` and `x-ms-item-lsn` Cosmos DB response headers. ([#4176](https://github.com/Azure/azure-sdk-for-rust/pull/4176))
+- Added `partition_key_range_id` and `internal_partition_id` response headers to the driver bridge, making them accessible on SDK response types. ([#4278](https://github.com/Azure/azure-sdk-for-rust/pull/4278))
 - Added `rustls` feature flag (enabled by default) that configures reqwest with rustls as the TLS stack. ([#4252](https://github.com/Azure/azure-sdk-for-rust/pull/4252))
 - Added `native_tls` feature flag that configures reqwest with native-tls as the TLS stack. Disable default features and enable `native_tls` to use the platform TLS stack. ([#4252](https://github.com/Azure/azure-sdk-for-rust/pull/4252))
 - The `allow_invalid_certificates` feature now works with any TLS backend (`rustls` or `native_tls`). ([#4252](https://github.com/Azure/azure-sdk-for-rust/pull/4252))

--- a/sdk/cosmos/azure_data_cosmos/src/driver_bridge.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/driver_bridge.rs
@@ -15,9 +15,9 @@ use azure_data_cosmos_driver::models::{CosmosResponse as DriverResponse, CosmosR
 
 use crate::{
     constants::{
-        ACTIVITY_ID, CONTINUATION, INDEX_METRICS, ITEM_COUNT, OFFER_REPLACE_PENDING,
-        PARTITION_KEY_RANGE_ID, QUERY_METRICS, REQUEST_CHARGE, REQUEST_DURATION_MS, SESSION_TOKEN,
-        SUB_STATUS,
+        ACTIVITY_ID, CONTINUATION, COSMOS_INTERNAL_PARTITION_ID, INDEX_METRICS, ITEM_COUNT,
+        OFFER_REPLACE_PENDING, PARTITION_KEY_RANGE_ID, QUERY_METRICS, REQUEST_CHARGE,
+        REQUEST_DURATION_MS, SESSION_TOKEN, SUB_STATUS,
     },
     models::CosmosResponse,
 };
@@ -86,6 +86,9 @@ fn driver_response_headers_to_headers(cosmos_headers: &CosmosResponseHeaders) ->
     }
     if let Some(pk_range_id) = &cosmos_headers.partition_key_range_id {
         headers.insert(PARTITION_KEY_RANGE_ID, pk_range_id.clone());
+    }
+    if let Some(internal_id) = &cosmos_headers.internal_partition_id {
+        headers.insert(COSMOS_INTERNAL_PARTITION_ID, internal_id.clone());
     }
 
     headers
@@ -232,6 +235,7 @@ mod tests {
         h.substatus = Some(SubStatusCode::new(0));
         h.offer_replace_pending = Some(true);
         h.partition_key_range_id = Some("5".to_string());
+        h.internal_partition_id = Some("int-part-99".to_string());
         h
     }
 
@@ -275,6 +279,10 @@ mod tests {
         assert_eq!(headers.get_optional_str(&SUB_STATUS), None);
         assert_eq!(headers.get_optional_str(&OFFER_REPLACE_PENDING), None);
         assert_eq!(headers.get_optional_str(&PARTITION_KEY_RANGE_ID), None);
+        assert_eq!(
+            headers.get_optional_str(&COSMOS_INTERNAL_PARTITION_ID),
+            None
+        );
     }
 
     /// Regression test: index_metrics (base64-decoded by the driver) must survive

--- a/sdk/cosmos/azure_data_cosmos/src/driver_bridge.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/driver_bridge.rs
@@ -261,6 +261,10 @@ mod tests {
             Some("true")
         );
         assert_eq!(headers.get_optional_str(&PARTITION_KEY_RANGE_ID), Some("5"));
+        assert_eq!(
+            headers.get_optional_str(&COSMOS_INTERNAL_PARTITION_ID),
+            Some("int-part-99")
+        );
     }
 
     #[test]

--- a/sdk/cosmos/azure_data_cosmos/src/driver_bridge.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/driver_bridge.rs
@@ -15,8 +15,9 @@ use azure_data_cosmos_driver::models::{CosmosResponse as DriverResponse, CosmosR
 
 use crate::{
     constants::{
-        ACTIVITY_ID, CONTINUATION, INDEX_METRICS, ITEM_COUNT, OFFER_REPLACE_PENDING, QUERY_METRICS,
-        REQUEST_CHARGE, REQUEST_DURATION_MS, SESSION_TOKEN, SUB_STATUS,
+        ACTIVITY_ID, CONTINUATION, INDEX_METRICS, ITEM_COUNT, OFFER_REPLACE_PENDING,
+        PARTITION_KEY_RANGE_ID, QUERY_METRICS, REQUEST_CHARGE, REQUEST_DURATION_MS, SESSION_TOKEN,
+        SUB_STATUS,
     },
     models::CosmosResponse,
 };
@@ -82,6 +83,9 @@ fn driver_response_headers_to_headers(cosmos_headers: &CosmosResponseHeaders) ->
     }
     if let Some(pending) = cosmos_headers.offer_replace_pending {
         headers.insert(OFFER_REPLACE_PENDING, pending.to_string());
+    }
+    if let Some(pk_range_id) = &cosmos_headers.partition_key_range_id {
+        headers.insert(PARTITION_KEY_RANGE_ID, pk_range_id.clone());
     }
 
     headers
@@ -227,6 +231,7 @@ mod tests {
         h.item_count = Some(42);
         h.substatus = Some(SubStatusCode::new(0));
         h.offer_replace_pending = Some(true);
+        h.partition_key_range_id = Some("5".to_string());
         h
     }
 
@@ -251,6 +256,7 @@ mod tests {
             headers.get_optional_str(&OFFER_REPLACE_PENDING),
             Some("true")
         );
+        assert_eq!(headers.get_optional_str(&PARTITION_KEY_RANGE_ID), Some("5"));
     }
 
     #[test]
@@ -268,6 +274,7 @@ mod tests {
         assert_eq!(headers.get_optional_str(&ITEM_COUNT), None);
         assert_eq!(headers.get_optional_str(&SUB_STATUS), None);
         assert_eq!(headers.get_optional_str(&OFFER_REPLACE_PENDING), None);
+        assert_eq!(headers.get_optional_str(&PARTITION_KEY_RANGE_ID), None);
     }
 
     /// Regression test: index_metrics (base64-decoded by the driver) must survive

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Added `item_lsn` field to `CosmosResponseHeaders` for the `x-ms-item-lsn` response header.
+- Added `partition_key_range_id` and `internal_partition_id` fields to `CosmosResponseHeaders` for the `x-ms-documentdb-partitionkeyrangeid` and `x-ms-cosmos-internal-partition-id` response headers. ([#4278](https://github.com/Azure/azure-sdk-for-rust/pull/4278))
 - Added `rustls` feature flag (enabled by default) that configures reqwest with rustls as the TLS stack. ([#4252](https://github.com/Azure/azure-sdk-for-rust/pull/4252))
 - Added `native_tls` feature flag that configures reqwest with native-tls as the TLS stack. Disable default features and enable `native_tls` to use the platform TLS stack. ([#4252](https://github.com/Azure/azure-sdk-for-rust/pull/4252))
 

--- a/sdk/cosmos/azure_data_cosmos_driver/src/models/cosmos_headers.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/models/cosmos_headers.rs
@@ -45,6 +45,7 @@ pub(crate) mod response_header_names {
     pub const OWNER_ID: &str = "x-ms-content-path";
     pub const OFFER_REPLACE_PENDING: &str = "x-ms-offer-replace-pending";
     pub const PARTITION_KEY_RANGE_ID: &str = "x-ms-documentdb-partitionkeyrangeid";
+    pub const INTERNAL_PARTITION_ID: &str = "x-ms-cosmos-internal-partition-id";
 }
 
 /// Header names used by the fault injection framework.
@@ -254,6 +255,12 @@ pub struct CosmosResponseHeaders {
     ///
     /// Identifies which physical partition handled the operation.
     pub partition_key_range_id: Option<String>,
+
+    /// Internal partition ID (`x-ms-cosmos-internal-partition-id`).
+    ///
+    /// For informational purposes only. This value is an opaque identifier
+    /// assigned by the service and may change without notice.
+    pub internal_partition_id: Option<String>,
 }
 
 impl CosmosResponseHeaders {
@@ -345,6 +352,9 @@ impl CosmosResponseHeaders {
                 response_header_names::PARTITION_KEY_RANGE_ID => {
                     result.partition_key_range_id = Some(value.as_str().to_owned());
                 }
+                response_header_names::INTERNAL_PARTITION_ID => {
+                    result.internal_partition_id = Some(value.as_str().to_owned());
+                }
                 _ => {}
             }
         }
@@ -381,6 +391,7 @@ mod tests {
         headers.insert("lsn", "42");
         headers.insert("x-ms-item-lsn", "37");
         headers.insert("x-ms-documentdb-partitionkeyrangeid", "3");
+        headers.insert("x-ms-cosmos-internal-partition-id", "abc-internal-123");
 
         let cosmos_headers = CosmosResponseHeaders::from_headers(&headers);
 
@@ -418,6 +429,10 @@ mod tests {
         assert_eq!(cosmos_headers.lsn, Some(42));
         assert_eq!(cosmos_headers.item_lsn, Some(37));
         assert_eq!(cosmos_headers.partition_key_range_id.as_deref(), Some("3"));
+        assert_eq!(
+            cosmos_headers.internal_partition_id.as_deref(),
+            Some("abc-internal-123")
+        );
     }
 
     #[test]
@@ -460,6 +475,7 @@ mod tests {
             owner_id: Some("rid1".to_string()),
             offer_replace_pending: None,
             partition_key_range_id: Some("3".to_string()),
+            internal_partition_id: Some("int-part-1".to_string()),
         };
 
         assert_eq!(
@@ -494,6 +510,7 @@ mod tests {
         assert!(headers.lsn.is_none());
         assert!(headers.item_lsn.is_none());
         assert!(headers.partition_key_range_id.is_none());
+        assert!(headers.internal_partition_id.is_none());
     }
 
     #[test]

--- a/sdk/cosmos/azure_data_cosmos_driver/src/models/cosmos_headers.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/models/cosmos_headers.rs
@@ -44,6 +44,7 @@ pub(crate) mod response_header_names {
     pub const OWNER_FULL_NAME: &str = "x-ms-alt-content-path";
     pub const OWNER_ID: &str = "x-ms-content-path";
     pub const OFFER_REPLACE_PENDING: &str = "x-ms-offer-replace-pending";
+    pub const PARTITION_KEY_RANGE_ID: &str = "x-ms-documentdb-partitionkeyrangeid";
 }
 
 /// Header names used by the fault injection framework.
@@ -248,6 +249,11 @@ pub struct CosmosResponseHeaders {
     ///
     /// When `true`, a throughput change is still being processed asynchronously.
     pub offer_replace_pending: Option<bool>,
+
+    /// Partition key range ID that served this request (`x-ms-documentdb-partitionkeyrangeid`).
+    ///
+    /// Identifies which physical partition handled the operation.
+    pub partition_key_range_id: Option<String>,
 }
 
 impl CosmosResponseHeaders {
@@ -336,6 +342,9 @@ impl CosmosResponseHeaders {
                 response_header_names::OFFER_REPLACE_PENDING => {
                     result.offer_replace_pending = value.as_str().parse::<bool>().ok();
                 }
+                response_header_names::PARTITION_KEY_RANGE_ID => {
+                    result.partition_key_range_id = Some(value.as_str().to_owned());
+                }
                 _ => {}
             }
         }
@@ -371,6 +380,7 @@ mod tests {
         headers.insert("x-ms-request-duration-ms", "4.56");
         headers.insert("lsn", "42");
         headers.insert("x-ms-item-lsn", "37");
+        headers.insert("x-ms-documentdb-partitionkeyrangeid", "3");
 
         let cosmos_headers = CosmosResponseHeaders::from_headers(&headers);
 
@@ -407,6 +417,7 @@ mod tests {
         assert!((cosmos_headers.server_duration_ms.unwrap() - 4.56).abs() < f64::EPSILON);
         assert_eq!(cosmos_headers.lsn, Some(42));
         assert_eq!(cosmos_headers.item_lsn, Some(37));
+        assert_eq!(cosmos_headers.partition_key_range_id.as_deref(), Some("3"));
     }
 
     #[test]
@@ -448,6 +459,7 @@ mod tests {
             owner_full_name: Some("dbs/db1/colls/c1".to_string()),
             owner_id: Some("rid1".to_string()),
             offer_replace_pending: None,
+            partition_key_range_id: Some("3".to_string()),
         };
 
         assert_eq!(
@@ -481,6 +493,7 @@ mod tests {
         assert!(headers.server_duration_ms.is_none());
         assert!(headers.lsn.is_none());
         assert!(headers.item_lsn.is_none());
+        assert!(headers.partition_key_range_id.is_none());
     }
 
     #[test]


### PR DESCRIPTION
We'll do a full scan across SDKs for response headers later, but for now, we've got a specific request to add the Partition Key Range ID response header.