### PR TITLE
Use internal crate feed in Azure Pipelines

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[registries]
+azure-sdk = { index = "sparse+https://pkgs.dev.azure.com/azure-sdk/_packaging/azure-sdk-for-rust/Cargo/index/" }
+
+[source.crates-io]
+# replace-with = "azure-sdk"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [registries]
-azure-sdk = { index = "sparse+https://pkgs.dev.azure.com/azure-sdk/_packaging/azure-sdk-for-rust/Cargo/index/" }
+azure-sdk-for-rust = { index = "sparse+https://pkgs.dev.azure.com/azure-sdk/_packaging/azure-sdk-for-rust/Cargo/index/" }
 
-[source.crates-io]
-# replace-with = "azure-sdk"
+# To use the Azure Artifacts feed, run `eng/scripts/use-registry.rs azure`.
+# [source.crates-io]
+# replace-with = "azure-sdk-for-rust"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,4 +22,11 @@
     "editor.defaultFormatter": "ms-vscode.powershell",
   },
   "cmake.ignoreCMakeListsMissing": true,
+  "yaml.schemas": {
+    "file:///c%3A/Users/heaths/.vscode/extensions/docsmsft.docs-yaml-1.0.5/dist/toc.schema.json": "/toc\\.yml/i",
+    "https://raw.githubusercontent.com/microsoft/azure-pipelines-vscode/master/service-schema.json": [
+      "file:///home/heaths/src/azure-sdk-for-rust2/eng/pipelines/templates/jobs/fetch.yml",
+      "file:///home/heaths/src/azure-sdk-for-rust2/eng/pipelines/fetch.yml"
+    ]
+  },
 }

--- a/eng/pipelines/fetch.yml
+++ b/eng/pipelines/fetch.yml
@@ -1,0 +1,26 @@
+# Manually-triggered pipeline to pull crates from upstream into feed.
+
+trigger: none
+pr: none
+
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+    - stage: Fetch
+      variables:
+      - template: /eng/pipelines/templates/variables/image.yml
+      - template: /eng/pipelines/templates/variables/rust.yml
+      jobs:
+      - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+        parameters:
+          JobTemplatePath: /eng/pipelines/templates/jobs/fetch.yml
+          MatrixConfigs:
+          - Name: rust_fetch
+            Path: /eng/pipelines/templates/stages/platform-matrix.json
+            Selection: all
+            GenerateVMJobs: true
+          CloudConfig:
+            Cloud: public
+          SparseCheckoutPaths:
+          - /*

--- a/eng/pipelines/fetch.yml
+++ b/eng/pipelines/fetch.yml
@@ -7,20 +7,18 @@ extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
     stages:
-    - stage: Fetch
-      variables:
-      - template: /eng/pipelines/templates/variables/image.yml
-      - template: /eng/pipelines/templates/variables/rust.yml
-      jobs:
-      - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
-        parameters:
-          JobTemplatePath: /eng/pipelines/templates/jobs/fetch.yml
-          MatrixConfigs:
-          - Name: rust_fetch
-            Path: /eng/pipelines/templates/stages/platform-matrix.json
-            Selection: all
-            GenerateVMJobs: true
-          CloudConfig:
-            Cloud: public
-          SparseCheckoutPaths:
-          - /*
+      - stage: Fetch
+        variables:
+          - template: /eng/pipelines/templates/variables/image.yml
+          - template: /eng/pipelines/templates/variables/rust.yml
+        jobs:
+          - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+            parameters:
+              JobTemplatePath: /eng/pipelines/templates/jobs/fetch.yml
+              AdditionalParameters: {}
+              MatrixConfigs:
+                - Name: rust_fetch
+                  Path: eng/pipelines/templates/stages/platform-matrix.json
+                  Selection: all
+                  NonSparseParameters: RustToolchainName
+                  GenerateVMJobs: true

--- a/eng/pipelines/templates/jobs/fetch.yml
+++ b/eng/pipelines/templates/jobs/fetch.yml
@@ -1,0 +1,43 @@
+parameters:
+# Required parameters from generate-job-matrix.yml
+- name: UsePlatformContainer
+  type: boolean
+- name: OSName
+  type: string
+- name: Matrix
+  type: object
+- name: DependsOn
+  type: string
+- name: CloudConfig
+  type: object
+  default: {}
+
+jobs:
+- job:
+  displayName: Fetch
+  condition: and(succeeded(), ne(${{ parameters.Matrix }}, '{}'))
+  dependsOn: ${{ parameters.DependsOn }}
+  strategy:
+    matrix: $[ ${{ parameters.Matrix }} ]
+  variables:
+    CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS: artifacts-cargo-credprovider
+  pool:
+    name: $(Pool)
+    # 1es pipeline templates converts `image` to demands: ImageOverride under the hood
+    # which is incompatible with image selection in the default non-1es hosted pools
+    ${{ if eq(parameters.OSName, 'macOS') }}:
+      vmImage: $(OSVmImage)
+    ${{ else }}:
+      image: $(OSVmImage)
+    os: ${{ parameters.OSName }}
+  steps:
+  - checkout: self
+  - template: /eng/pipelines/templates/steps/use-rust.yml@self
+    parameters:
+      Toolchain: $(RustToolchainName)
+  - pwsh: cargo install --locked --index sparse+https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/Cargo/index/ artifacts-cargo-credprovider
+    displayName: Install cargo credential provider
+  - pwsh: cargo login --registry azure-sdk
+    displayName: Login to azure-sdk registry
+  - pwsh: cargo --config='source.crates-io.replace-with="azure-sdk"' fetch
+    displayName: Fetch dependencies

--- a/eng/pipelines/templates/jobs/fetch.yml
+++ b/eng/pipelines/templates/jobs/fetch.yml
@@ -39,5 +39,7 @@ jobs:
     displayName: Install cargo credential provider
   - pwsh: cargo login --registry azure-sdk
     displayName: Login to azure-sdk registry
-  - pwsh: cargo --config='source.crates-io.replace-with="azure-sdk"' fetch
+  - pwsh: eng/scripts/use-registry.rs azure
+    displayName: Configure azure-sdk registry
+  - pwsh: cargo fetch
     displayName: Fetch dependencies

--- a/eng/pipelines/templates/jobs/fetch.yml
+++ b/eng/pipelines/templates/jobs/fetch.yml
@@ -32,14 +32,19 @@ jobs:
     os: ${{ parameters.OSName }}
   steps:
   - checkout: self
+  - ${{ if ne(RustToolchainName, 'nightly') }}:
+      - template: /eng/pipelines/templates/steps/use-rust.yml@self
+        parameters:
+          Toolchain: nightly
+
   - template: /eng/pipelines/templates/steps/use-rust.yml@self
     parameters:
       Toolchain: $(RustToolchainName)
   - pwsh: cargo install --locked --index sparse+https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/Cargo/index/ artifacts-cargo-credprovider
     displayName: Install cargo credential provider
-  - pwsh: cargo login --registry azure-sdk
-    displayName: Login to azure-sdk registry
-  - pwsh: eng/scripts/use-registry.rs azure
-    displayName: Configure azure-sdk registry
+  - pwsh: cargo login --registry azure-sdk-for-rust
+    displayName: Login to azure-sdk-for-rust registry
+  - pwsh: cargo +nightly -Zscript eng/scripts/use-registry.rs azure
+    displayName: Configure azure-sdk-for-rust registry
   - pwsh: cargo fetch
     displayName: Fetch dependencies

--- a/eng/pipelines/templates/jobs/fetch.yml
+++ b/eng/pipelines/templates/jobs/fetch.yml
@@ -1,50 +1,52 @@
 parameters:
-# Required parameters from generate-job-matrix.yml
-- name: UsePlatformContainer
-  type: boolean
-- name: OSName
-  type: string
-- name: Matrix
-  type: object
-- name: DependsOn
-  type: string
-- name: CloudConfig
-  type: object
-  default: {}
+  # Required parameters from generate-job-matrix.yml
+  - name: UsePlatformContainer
+    type: boolean
+  - name: OSName
+    type: string
+  - name: Matrix
+    type: object
+  - name: DependsOn
+    type: string
+  - name: CloudConfig
+    type: object
+    default: {}
 
 jobs:
-- job:
-  displayName: Fetch
-  condition: and(succeeded(), ne(${{ parameters.Matrix }}, '{}'))
-  dependsOn: ${{ parameters.DependsOn }}
-  strategy:
-    matrix: $[ ${{ parameters.Matrix }} ]
-  variables:
-    CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS: artifacts-cargo-credprovider
-  pool:
-    name: $(Pool)
-    # 1es pipeline templates converts `image` to demands: ImageOverride under the hood
-    # which is incompatible with image selection in the default non-1es hosted pools
-    ${{ if eq(parameters.OSName, 'macOS') }}:
-      vmImage: $(OSVmImage)
-    ${{ else }}:
-      image: $(OSVmImage)
-    os: ${{ parameters.OSName }}
-  steps:
-  - checkout: self
-  - ${{ if ne(RustToolchainName, 'nightly') }}:
+  - job:
+    displayName: Fetch
+    condition: and(succeeded(), ne(${{ parameters.Matrix }}, '{}'))
+    dependsOn: ${{ parameters.DependsOn }}
+    strategy:
+      matrix: $[ ${{ parameters.Matrix }} ]
+    variables:
+      CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS: artifacts-cargo-credprovider
+    pool:
+      name: $(Pool)
+      # 1es pipeline templates converts `image` to demands: ImageOverride under the hood
+      # which is incompatible with image selection in the default non-1es hosted pools
+      ${{ if eq(parameters.OSName, 'macOS') }}:
+        vmImage: $(OSVmImage)
+      ${{ else }}:
+        image: $(OSVmImage)
+      os: ${{ parameters.OSName }}
+    steps:
+      - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+        parameters:
+          paths:
+            - "/*"
       - template: /eng/pipelines/templates/steps/use-rust.yml@self
         parameters:
           Toolchain: nightly
-
-  - template: /eng/pipelines/templates/steps/use-rust.yml@self
-    parameters:
-      Toolchain: $(RustToolchainName)
-  - pwsh: cargo install --locked --index sparse+https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/Cargo/index/ artifacts-cargo-credprovider
-    displayName: Install cargo credential provider
-  - pwsh: cargo login --registry azure-sdk-for-rust
-    displayName: Login to azure-sdk-for-rust registry
-  - pwsh: cargo +nightly -Zscript eng/scripts/use-registry.rs azure
-    displayName: Configure azure-sdk-for-rust registry
-  - pwsh: cargo fetch
-    displayName: Fetch dependencies
+          Condition: and(succeeded(), ne('$(RustToolchainName)', 'nightly'))
+      - template: /eng/pipelines/templates/steps/use-rust.yml@self
+        parameters:
+          Toolchain: $(RustToolchainName)
+      - pwsh: cargo install --locked --index sparse+https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/Cargo/index/ artifacts-cargo-credprovider
+        displayName: Install cargo credential provider
+      - pwsh: cargo login --registry azure-sdk-for-rust
+        displayName: Login to azure-sdk-for-rust registry
+      - pwsh: cargo +nightly -Zscript eng/scripts/use-registry.rs azure
+        displayName: Configure azure-sdk-for-rust registry
+      - pwsh: cargo fetch
+        displayName: Fetch dependencies

--- a/eng/pipelines/templates/steps/use-rust.yml
+++ b/eng/pipelines/templates/steps/use-rust.yml
@@ -15,6 +15,9 @@ parameters:
   - name: SetDefault
     type: boolean
     default: true
+  - name: Condition
+    type: string
+    default: succeeded()
 
 steps:
 - pwsh: |
@@ -97,4 +100,5 @@ steps:
     Invoke-LoggedCommand "rustup show"
 
   displayName: "Use Rust ${{ parameters.Toolchain }}"
+  condition: ${{ parameters.Condition }}
   workingDirectory: ${{ parameters.WorkingDirectory }}

--- a/eng/scripts/update-cratenames.rs
+++ b/eng/scripts/update-cratenames.rs
@@ -4,8 +4,8 @@
 edition = "2021"
 
 [dependencies]
-cargo-util-schemas = "0.1.0"
-toml = "0.8.10"
+cargo-util-schemas = "0.13.0"
+toml = "1.1.2"
 ---
 
 use cargo_util_schemas::manifest::{InheritableDependency, TomlManifest};

--- a/eng/scripts/update-pathversions.rs
+++ b/eng/scripts/update-pathversions.rs
@@ -5,8 +5,8 @@ edition = "2021"
 description = "In all Cargo.toml files in the repo, for all dependencies that have both path and version properties, update the version property to the version in the package."
 
 [dependencies]
-regex = "1.5"
-toml_edit = "0.22"
+regex = "1.12.3"
+toml_edit = "0.25.10"
 ---
 
 use regex::Regex;
@@ -15,11 +15,12 @@ use std::{env, error::Error, fs, path::PathBuf};
 use toml_edit::{value, DocumentMut, Item, Table};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let add_mode = env::args().nth(1)
+    let add_mode = env::args()
+        .nth(1)
         .map(|arg| match arg.as_str() {
             "add" => true,
             "update" => false,
-            _ => panic!("Invalid mode. Use 'add' or 'update'.")
+            _ => panic!("Invalid mode. Use 'add' or 'update'."),
         })
         .expect("requires 'add' or 'update' mode argument");
 
@@ -27,10 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let repo_root = script_root.join("../..").canonicalize()?;
 
     // find all Cargo.toml files in the repo_root directory
-    let exclude_dirs = vec![
-        repo_root.join("eng"),
-        repo_root.join("target")
-    ];
+    let exclude_dirs = vec![repo_root.join("eng"), repo_root.join("target")];
 
     let toml_files = load_cargo_toml_files(&repo_root, &exclude_dirs)?;
 
@@ -39,7 +37,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for mut toml_file in toml_files {
         let should_add = add_mode && !toml_file.is_publish_disabled;
 
-        update_package_versions(toml_file.document.as_table_mut(), &package_versions, should_add);
+        update_package_versions(
+            toml_file.document.as_table_mut(),
+            &package_versions,
+            should_add,
+        );
 
         // if the toml file has a workspace table, update the workspace table
         if let Some(workspace) = toml_file.document.get_mut("workspace") {
@@ -56,7 +58,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn load_cargo_toml_files(repo_root: &PathBuf, exclude_dirs: &Vec<PathBuf>) -> Result<Vec<TomlInfo>, Box<dyn Error>> {
+fn load_cargo_toml_files(
+    repo_root: &PathBuf,
+    exclude_dirs: &Vec<PathBuf>,
+) -> Result<Vec<TomlInfo>, Box<dyn Error>> {
     let mut toml_paths = Vec::new();
     find_cargo_toml_files(repo_root, exclude_dirs, &mut toml_paths)?;
 
@@ -65,23 +70,33 @@ fn load_cargo_toml_files(repo_root: &PathBuf, exclude_dirs: &Vec<PathBuf>) -> Re
         let content = fs::read_to_string(&path)?;
         let doc = content.parse::<DocumentMut>()?;
         let package_table = doc.get("package").and_then(Item::as_table);
-        let publish_property = package_table.and_then(|table| table.get("publish")).and_then(Item::as_bool);
-        let package_name = package_table.and_then(|table| table.get("name")).and_then(Item::as_str);
-        let package_version = package_table.and_then(|table| table.get("version")).and_then(Item::as_str);
+        let publish_property = package_table
+            .and_then(|table| table.get("publish"))
+            .and_then(Item::as_bool);
+        let package_name = package_table
+            .and_then(|table| table.get("name"))
+            .and_then(Item::as_str);
+        let package_version = package_table
+            .and_then(|table| table.get("version"))
+            .and_then(Item::as_str);
 
         toml_files.push(TomlInfo {
             path,
             package_name: package_name.map(|s| s.to_string()),
             package_version: package_version.map(|s| s.to_string()),
             is_publish_disabled: publish_property == Some(false),
-            document: doc
+            document: doc,
         });
     }
 
     Ok(toml_files)
 }
 
-fn find_cargo_toml_files(dir: &PathBuf, exclude_dirs: &Vec<PathBuf>, toml_paths: &mut Vec<PathBuf>) -> Result<(), Box<dyn Error>> {
+fn find_cargo_toml_files(
+    dir: &PathBuf,
+    exclude_dirs: &Vec<PathBuf>,
+    toml_paths: &mut Vec<PathBuf>,
+) -> Result<(), Box<dyn Error>> {
     for entry in fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
@@ -103,13 +118,21 @@ fn get_package_versions(toml_files: &Vec<TomlInfo>) -> Vec<(String, String, bool
             continue;
         }
 
-        package_versions.push((toml_file.package_name.clone().unwrap(), toml_file.package_version.clone().unwrap(), toml_file.is_publish_disabled));
+        package_versions.push((
+            toml_file.package_name.clone().unwrap(),
+            toml_file.package_version.clone().unwrap(),
+            toml_file.is_publish_disabled,
+        ));
     }
 
     package_versions
 }
 
-fn update_package_versions(toml: &mut Table, package_versions: &Vec<(String, String, bool)>, add: bool) {
+fn update_package_versions(
+    toml: &mut Table,
+    package_versions: &Vec<(String, String, bool)>,
+    add: bool,
+) {
     // for each dependency table, for each package in package_versions
     // if the package is in the dependency table
     //   if the dependency has both path and version properties, update the version property
@@ -124,7 +147,10 @@ fn update_package_versions(toml: &mut Table, package_versions: &Vec<(String, Str
         for (package, version, is_publish_disabled) in package_versions {
             if let Some(dependency) = table.get_mut(package) {
                 // azure_idenentity will only be a transitive dev-dependency
-                let should_add = add && table_name != "dev-dependencies" && !is_publish_disabled && package != "azure_identity";
+                let should_add = add
+                    && table_name != "dev-dependencies"
+                    && !is_publish_disabled
+                    && package != "azure_identity";
 
                 let has_path_property = dependency.get("path").is_some();
                 let has_version_property = dependency.get("version").is_some();

--- a/eng/scripts/use-registry.rs
+++ b/eng/scripts/use-registry.rs
@@ -1,0 +1,121 @@
+#!/usr/bin/env -S cargo +nightly -Zscript
+---
+[package]
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+toml = "1.1.2"
+---
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, path::PathBuf, process};
+
+fn main() {
+    let mode = match std::env::args().nth(1).as_deref() {
+        Some("azure") => Mode::Azure,
+        Some("crates.io") => Mode::CratesIo,
+        Some(other) => {
+            eprintln!("error: unknown registry \"{other}\", expected \"azure\" or \"crates.io\"");
+            process::exit(1);
+        }
+        None => {
+            eprintln!("usage: use-registry.rs <azure|crates.io>");
+            process::exit(1);
+        }
+    };
+
+    let config_path = find_config();
+    let content = std::fs::read_to_string(&config_path).unwrap_or_else(|err| {
+        eprintln!("error: failed to read {}: {err}", config_path.display());
+        process::exit(1);
+    });
+
+    let mut config: CargoConfig = toml::from_str(&content).unwrap_or_else(|err| {
+        eprintln!("error: failed to parse {}: {err}", config_path.display());
+        process::exit(1);
+    });
+
+    // Find the name of the other registry defined under [registries].
+    let registry_name = match config.registries.keys().next() {
+        Some(name) => name.clone(),
+        None => {
+            eprintln!("error: no registries defined in {}", config_path.display());
+            process::exit(1);
+        }
+    };
+
+    let crates_io = config
+        .source
+        .entry("crates-io".to_string())
+        .or_insert_with(Source::default);
+
+    match mode {
+        Mode::Azure => {
+            if crates_io.replace_with.as_deref() == Some(&registry_name) {
+                // Already pointing to the registry; nothing to do.
+                return;
+            }
+            crates_io.replace_with = Some(registry_name);
+        }
+        Mode::CratesIo => {
+            if crates_io.replace_with.is_none() {
+                // Already using crates.io; nothing to do.
+                return;
+            }
+            crates_io.replace_with = None;
+        }
+    }
+
+    let output = toml::to_string(&config).unwrap_or_else(|err| {
+        eprintln!("error: failed to serialize config: {err}");
+        process::exit(1);
+    });
+
+    std::fs::write(&config_path, output).unwrap_or_else(|err| {
+        eprintln!("error: failed to write {}: {err}", config_path.display());
+        process::exit(1);
+    });
+
+    eprintln!("updated {}", config_path.display());
+}
+
+fn find_config() -> PathBuf {
+    let dir = std::env::current_dir().expect("current directory");
+    for ancestor in dir.ancestors() {
+        let path = ancestor.join(".cargo/config.toml");
+        if path.exists() {
+            return path;
+        }
+    }
+    eprintln!("error: .cargo/config.toml not found");
+    process::exit(1);
+}
+
+enum Mode {
+    Azure,
+    CratesIo,
+}
+
+#[derive(Deserialize, Serialize)]
+struct CargoConfig {
+    #[serde(default)]
+    registries: BTreeMap<String, Registry>,
+    #[serde(default)]
+    source: BTreeMap<String, Source>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct Registry {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    index: Option<String>,
+}
+
+#[derive(Default, Deserialize, Serialize)]
+struct Source {
+    #[serde(rename = "replace-with", skip_serializing_if = "Option::is_none")]
+    replace_with: Option<String>,
+}

--- a/eng/scripts/use-registry.rs
+++ b/eng/scripts/use-registry.rs
@@ -4,15 +4,18 @@
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
-toml = "1.1.2"
+toml_edit = "0.25.10"
 ---
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, path::PathBuf, process};
+use std::{fs, path::PathBuf, process};
+use toml_edit::{value, DocumentMut, InlineTable, Item, Table, Value};
+
+const REGISTRY: &str = "azure-sdk-for-rust";
+const INDEX: &str =
+    "sparse+https://pkgs.dev.azure.com/azure-sdk/_packaging/azure-sdk-for-rust/Cargo/index/";
 
 fn main() {
     let mode = match std::env::args().nth(1).as_deref() {
@@ -28,54 +31,37 @@ fn main() {
         }
     };
 
-    let config_path = find_config();
-    let content = std::fs::read_to_string(&config_path).unwrap_or_else(|err| {
-        eprintln!("error: failed to read {}: {err}", config_path.display());
+    let cargo_home = std::env::var("CARGO_HOME").unwrap_or_else(|_| {
+        eprintln!("error: CARGO_HOME is not set");
         process::exit(1);
     });
+    let config_path = PathBuf::from(cargo_home).join("config.toml");
 
-    let mut config: CargoConfig = toml::from_str(&content).unwrap_or_else(|err| {
+    let content = if config_path.exists() {
+        fs::read_to_string(&config_path).unwrap_or_else(|err| {
+            eprintln!("error: failed to read {}: {err}", config_path.display());
+            process::exit(1);
+        })
+    } else {
+        String::new()
+    };
+
+    let mut doc: DocumentMut = content.parse().unwrap_or_else(|err| {
         eprintln!("error: failed to parse {}: {err}", config_path.display());
         process::exit(1);
     });
 
-    // Find the name of the other registry defined under [registries].
-    let registry_name = match config.registries.keys().next() {
-        Some(name) => name.clone(),
-        None => {
-            eprintln!("error: no registries defined in {}", config_path.display());
-            process::exit(1);
-        }
-    };
-
-    let crates_io = config
-        .source
-        .entry("crates-io".to_string())
-        .or_insert_with(Source::default);
-
     match mode {
         Mode::Azure => {
-            if crates_io.replace_with.as_deref() == Some(&registry_name) {
-                // Already pointing to the registry; nothing to do.
-                return;
-            }
-            crates_io.replace_with = Some(registry_name);
+            ensure_registry(&mut doc);
+            set_replace_with(&mut doc);
         }
         Mode::CratesIo => {
-            if crates_io.replace_with.is_none() {
-                // Already using crates.io; nothing to do.
-                return;
-            }
-            crates_io.replace_with = None;
+            remove_replace_with(&mut doc);
         }
     }
 
-    let output = toml::to_string(&config).unwrap_or_else(|err| {
-        eprintln!("error: failed to serialize config: {err}");
-        process::exit(1);
-    });
-
-    std::fs::write(&config_path, output).unwrap_or_else(|err| {
+    fs::write(&config_path, doc.to_string()).unwrap_or_else(|err| {
         eprintln!("error: failed to write {}: {err}", config_path.display());
         process::exit(1);
     });
@@ -83,39 +69,52 @@ fn main() {
     eprintln!("updated {}", config_path.display());
 }
 
-fn find_config() -> PathBuf {
-    let dir = std::env::current_dir().expect("current directory");
-    for ancestor in dir.ancestors() {
-        let path = ancestor.join(".cargo/config.toml");
-        if path.exists() {
-            return path;
+/// Add the azure-sdk-for-rust registry to [registries] if not already present.
+fn ensure_registry(doc: &mut DocumentMut) {
+    let registries = doc
+        .entry("registries")
+        .or_insert_with(|| Item::Table(Table::new()))
+        .as_table_mut()
+        .expect("[registries] should be a table");
+
+    if registries.get(REGISTRY).is_none() {
+        let mut entry = InlineTable::new();
+        entry.insert("index", Value::from(INDEX));
+        registries.insert(REGISTRY, Item::Value(Value::InlineTable(entry)));
+    }
+}
+
+/// Add [source.crates-io] if needed and set replace-with.
+fn set_replace_with(doc: &mut DocumentMut) {
+    let source = doc
+        .entry("source")
+        .or_insert_with(|| {
+            let mut t = Table::new();
+            t.set_implicit(true);
+            Item::Table(t)
+        })
+        .as_table_mut()
+        .expect("[source] should be a table");
+
+    let crates_io = source
+        .entry("crates-io")
+        .or_insert_with(|| Item::Table(Table::new()))
+        .as_table_mut()
+        .expect("[source.crates-io] should be a table");
+
+    crates_io.insert("replace-with", value(REGISTRY));
+}
+
+/// Remove replace-with from [source.crates-io] if present.
+fn remove_replace_with(doc: &mut DocumentMut) {
+    if let Some(source) = doc.get_mut("source").and_then(|s| s.as_table_mut()) {
+        if let Some(crates_io) = source.get_mut("crates-io").and_then(|c| c.as_table_mut()) {
+            crates_io.remove("replace-with");
         }
     }
-    eprintln!("error: .cargo/config.toml not found");
-    process::exit(1);
 }
 
 enum Mode {
     Azure,
     CratesIo,
-}
-
-#[derive(Deserialize, Serialize)]
-struct CargoConfig {
-    #[serde(default)]
-    registries: BTreeMap<String, Registry>,
-    #[serde(default)]
-    source: BTreeMap<String, Source>,
-}
-
-#[derive(Deserialize, Serialize)]
-struct Registry {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    index: Option<String>,
-}
-
-#[derive(Default, Deserialize, Serialize)]
-struct Source {
-    #[serde(rename = "replace-with", skip_serializing_if = "Option::is_none")]
-    replace_with: Option<String>,
 }

--- a/eng/scripts/verify-dependencies.rs
+++ b/eng/scripts/verify-dependencies.rs
@@ -5,9 +5,9 @@ edition = "2021"
 
 [dependencies]
 cargo-util-schemas = "0.11.0"
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.114"
-toml = "1.0.1"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+toml = "1.1.2"
 ---
 
 use cargo_util_schemas::manifest::{InheritableDependency, TomlDependency, TomlManifest};

--- a/eng/scripts/verify-keywords.rs
+++ b/eng/scripts/verify-keywords.rs
@@ -4,8 +4,8 @@
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.114"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
 ---
 
 // Copyright (c) Microsoft Corporation. All rights reserved.


### PR DESCRIPTION
Allows contributors to pull from crates.io without having to authenticate with the internal feed, but the registry can easily be switched. Azure Pipelines will use this internal feed to pull crates.

Resolves #2397