### PR TITLE
Cosmos: Changelog and release prep for v0.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
  "async-lock",
  "async-trait",
  "azure_core 0.35.0",
- "azure_data_cosmos_macros",
+ "azure_data_cosmos_macros 0.1.0",
  "azure_identity 0.35.0",
  "base64 0.22.1",
  "bytes",
@@ -485,6 +485,17 @@ dependencies = [
  "url",
  "uuid",
  "windows 0.62.2",
+]
+
+[[package]]
+name = "azure_data_cosmos_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d950637b4229226b5d4a41d71d777b8193ebe86abcbf57e564d5a4bb95e7562"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,13 +99,15 @@ default-features = false
 version = "0.2.0"
 path = "sdk/cosmos/azure_data_cosmos_driver"
 
+[workspace.dependencies.azure_data_cosmos_macros]
+version = "0.1.0"
+
 [workspace.dependencies]
 async-lock = "3.4"
 async-stream = { version = "0.3.6" }
 async-trait = "0.1"
 base64 = "0.22"
 arc-swap = "1.7"
-azure_data_cosmos_macros = { version = "0.2.0", path = "sdk/cosmos/azure_data_cosmos_macros" }
 bytes = "1.11.1"
 cargo_metadata = "0.23.1"
 clap = { version = "4.5.58", features = ["derive"] }

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.33.0 (Unreleased)
+## 0.33.0 (2026-04-24)
 
 ### Features Added
 
@@ -19,8 +19,6 @@
 - `ContainerClient::create_item()` and `ContainerClient::upsert_item()` now require an `item_id: &str` parameter (same pattern as `replace_item` and `read_item`). The item id is passed to the driver via `ItemReference` so the body never needs to be parsed to extract the document id.
 - Renamed `replace_throughput` to `begin_replace_throughput` on `ContainerClient` and `DatabaseClient`. The return type changed from `ResourceResponse<ThroughputProperties>` to `ThroughputPoller`. ([#4096](https://github.com/Azure/azure-sdk-for-rust/pull/4096))
 - Removed `CreateDatabaseOptions::with_throughput()`. Database-level shared throughput provisioning is no longer supported through the SDK. Use container-level throughput instead. ([#4147](https://github.com/Azure/azure-sdk-for-rust/pull/4147))
-
-### Bugs Fixed
 
 ### Other Changes
 

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.2.0 (Unreleased)
+## 0.2.0 (2026-04-24)
 
 ### Features Added
 
@@ -9,12 +9,6 @@
 - Added `rustls` feature flag (enabled by default) that configures reqwest with rustls as the TLS stack. ([#4252](https://github.com/Azure/azure-sdk-for-rust/pull/4252))
 - Added `native_tls` feature flag that configures reqwest with native-tls as the TLS stack. Disable default features and enable `native_tls` to use the platform TLS stack. ([#4252](https://github.com/Azure/azure-sdk-for-rust/pull/4252))
 - Added `SessionToken::merge()` for merging two session tokens by partition key range ID. ([#4214](https://github.com/Azure/azure-sdk-for-rust/pull/4214))
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 0.1.0 (2026-04-09)
 


### PR DESCRIPTION
Updates the CHANGELOG for Cosmos 0.33, and changes reference to `azure_data_cosmos_macros` to 0.1.0, since there are no changes in this release and it's not shipping.