### PR TITLE
feat(cosmos-perf): record server-reported request duration as backend latency

### DIFF
--- a/sdk/cosmos/azure_data_cosmos_perf/src/operations/create_item.rs
+++ b/sdk/cosmos/azure_data_cosmos_perf/src/operations/create_item.rs
@@ -4,6 +4,7 @@
 //! Create operation.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use azure_data_cosmos::clients::ContainerClient;
@@ -11,7 +12,7 @@ use azure_data_cosmos::options::ItemWriteOptions;
 use rand::RngExt;
 use uuid::Uuid;
 
-use super::{Operation, PerfItem};
+use super::{extract_backend_duration, Operation, PerfItem};
 use crate::seed::{SeededItem, SharedItems};
 
 /// Creates a new item with a unique ID and partition key.
@@ -36,7 +37,7 @@ impl Operation for CreateItemOperation {
         "CreateItem"
     }
 
-    async fn execute(&self, container: &ContainerClient) -> azure_core::Result<()> {
+    async fn execute(&self, container: &ContainerClient) -> azure_core::Result<Option<Duration>> {
         let id = Uuid::new_v4().to_string();
         let partition_key = Uuid::new_v4().to_string();
         let value = rand::rng().random_range(0..u64::MAX);
@@ -48,11 +49,12 @@ impl Operation for CreateItemOperation {
             payload: "perf-test-created".to_string(),
         };
 
-        container
+        let response = container
             .create_item(&item.partition_key, &item, self.options.clone())
             .await?;
+        let backend = extract_backend_duration(response.headers());
 
         self.items.push(SeededItem { id, partition_key });
-        Ok(())
+        Ok(backend)
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_perf/src/operations/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos_perf/src/operations/mod.rs
@@ -14,6 +14,7 @@ mod read_item;
 mod upsert_item;
 
 use async_trait::async_trait;
+use azure_core::http::headers::{HeaderName, Headers};
 use azure_data_cosmos::clients::ContainerClient;
 use azure_data_cosmos::options::{
     ExcludedRegions, ItemReadOptions, ItemWriteOptions, OperationOptions,
@@ -21,6 +22,7 @@ use azure_data_cosmos::options::{
 use azure_data_cosmos::regions::Region;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::config::{Config, ExcludeRegionsScope};
 pub use crate::operations::create_item::CreateItemOperation;
@@ -28,6 +30,23 @@ pub use crate::operations::query_items::QueryItemsOperation;
 pub use crate::operations::read_item::ReadItemOperation;
 pub use crate::operations::upsert_item::UpsertItemOperation;
 use crate::seed::SharedItems;
+
+/// `x-ms-request-duration-ms` — server-reported request processing time in
+/// milliseconds (floating-point string).
+const REQUEST_DURATION_MS: HeaderName = HeaderName::from_static("x-ms-request-duration-ms");
+
+/// Extracts the server-reported request duration from a Cosmos response.
+///
+/// Returns `None` when the header is missing (e.g., on responses served
+/// from cache or when the gateway omitted the diagnostic header) or when
+/// the value cannot be parsed as `f64`.
+pub(crate) fn extract_backend_duration(headers: &Headers) -> Option<Duration> {
+    headers
+        .get_optional_str(&REQUEST_DURATION_MS)
+        .and_then(|s| s.parse::<f64>().ok())
+        .filter(|ms| ms.is_finite() && *ms >= 0.0)
+        .map(|ms| Duration::from_secs_f64(ms / 1000.0))
+}
 
 /// A single executable perf test operation.
 ///
@@ -39,7 +58,14 @@ pub trait Operation: Send + Sync {
     fn name(&self) -> &'static str;
 
     /// Executes one instance of the operation.
-    async fn execute(&self, container: &ContainerClient) -> azure_core::Result<()>;
+    ///
+    /// Returns `Ok(Some(d))` when the server reported a processing duration
+    /// via the `x-ms-request-duration-ms` response header (this is the
+    /// backend latency surfaced separately from the client-observed
+    /// wall-clock latency). Returns `Ok(None)` when no backend duration
+    /// could be observed (multi-page query streams may aggregate, see
+    /// individual implementations).
+    async fn execute(&self, container: &ContainerClient) -> azure_core::Result<Option<Duration>>;
 }
 
 /// The item type used for seeding, reading, querying, and upserting.

--- a/sdk/cosmos/azure_data_cosmos_perf/src/operations/query_items.rs
+++ b/sdk/cosmos/azure_data_cosmos_perf/src/operations/query_items.rs
@@ -4,13 +4,14 @@
 //! Single-partition query operation.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use azure_data_cosmos::clients::ContainerClient;
 use azure_data_cosmos::Query;
 use futures::StreamExt;
 
-use super::Operation;
+use super::{extract_backend_duration, Operation};
 use crate::seed::SharedItems;
 
 /// Runs a single-partition query against a random seeded partition key.
@@ -31,18 +32,28 @@ impl Operation for QueryItemsOperation {
         "QueryItems"
     }
 
-    async fn execute(&self, container: &ContainerClient) -> azure_core::Result<()> {
+    async fn execute(&self, container: &ContainerClient) -> azure_core::Result<Option<Duration>> {
         let item = self.items.random();
         let pk = &item.partition_key;
 
         let query =
             Query::from("SELECT * FROM c WHERE c.partition_key = @pk").with_parameter("@pk", pk)?;
 
-        let mut stream = container.query_items::<serde_json::Value>(query, pk, None)?;
+        let mut stream = container
+            .query_items::<serde_json::Value>(query, pk, None)?
+            .into_pages();
+
+        // Sum backend durations across pages so a multi-page query reports
+        // the total server processing time, mirroring how the client-observed
+        // elapsed wraps the entire stream consumption.
+        let mut backend_total: Option<Duration> = None;
         while let Some(result) = stream.next().await {
-            result?;
+            let page = result?;
+            if let Some(d) = extract_backend_duration(page.headers()) {
+                backend_total = Some(backend_total.unwrap_or_default() + d);
+            }
         }
 
-        Ok(())
+        Ok(backend_total)
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_perf/src/operations/read_item.rs
+++ b/sdk/cosmos/azure_data_cosmos_perf/src/operations/read_item.rs
@@ -4,12 +4,13 @@
 //! Point read operation.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use azure_data_cosmos::clients::ContainerClient;
 use azure_data_cosmos::options::ItemReadOptions;
 
-use super::Operation;
+use super::{extract_backend_duration, Operation};
 use crate::seed::SharedItems;
 
 /// Reads a random seeded item by ID and partition key.
@@ -31,12 +32,12 @@ impl Operation for ReadItemOperation {
         "ReadItem"
     }
 
-    async fn execute(&self, container: &ContainerClient) -> azure_core::Result<()> {
+    async fn execute(&self, container: &ContainerClient) -> azure_core::Result<Option<Duration>> {
         let item = self.items.random();
 
-        container
+        let response = container
             .read_item::<serde_json::Value>(&item.partition_key, &item.id, self.options.clone())
             .await?;
-        Ok(())
+        Ok(extract_backend_duration(response.headers()))
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_perf/src/operations/upsert_item.rs
+++ b/sdk/cosmos/azure_data_cosmos_perf/src/operations/upsert_item.rs
@@ -4,13 +4,14 @@
 //! Upsert operation.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use azure_data_cosmos::clients::ContainerClient;
 use azure_data_cosmos::options::ItemWriteOptions;
 use rand::RngExt;
 
-use super::{Operation, PerfItem};
+use super::{extract_backend_duration, Operation, PerfItem};
 use crate::seed::SharedItems;
 
 /// Upserts an item into a random seeded partition.
@@ -32,7 +33,7 @@ impl Operation for UpsertItemOperation {
         "UpsertItem"
     }
 
-    async fn execute(&self, container: &ContainerClient) -> azure_core::Result<()> {
+    async fn execute(&self, container: &ContainerClient) -> azure_core::Result<Option<Duration>> {
         let seeded = self.items.random();
         let value = rand::rng().random_range(0..u64::MAX);
 
@@ -43,9 +44,9 @@ impl Operation for UpsertItemOperation {
             payload: "perf-test-payload".to_string(),
         };
 
-        container
+        let response = container
             .upsert_item(&item.partition_key, &item, self.options.clone())
             .await?;
-        Ok(())
+        Ok(extract_backend_duration(response.headers()))
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_perf/src/runner.rs
+++ b/sdk/cosmos/azure_data_cosmos_perf/src/runner.rs
@@ -51,6 +51,21 @@ struct PerfResult {
     p50_ms: f64,
     p90_ms: f64,
     p99_ms: f64,
+    /// Server-reported request processing latency parsed from
+    /// `x-ms-request-duration-ms` response header. `None` for intervals
+    /// without backend samples.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    backend_min_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    backend_max_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    backend_mean_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    backend_p50_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    backend_p90_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    backend_p99_ms: Option<f64>,
     cpu_percent: f32,
     memory_bytes: u64,
     system_cpu_percent: f32,
@@ -279,8 +294,8 @@ pub async fn run(config: RunConfig) {
 
                 let op_start = Instant::now();
                 match op.execute(&container).await {
-                    Ok(()) => {
-                        stats.record_latency(op.name(), op_start.elapsed());
+                    Ok(backend) => {
+                        stats.record_latency(op.name(), op_start.elapsed(), backend);
                     }
                     Err(e) => {
                         stats.record_error(op.name());
@@ -374,6 +389,12 @@ async fn upsert_results(
             p50_ms: s.p50.as_secs_f64() * 1000.0,
             p90_ms: s.p90.as_secs_f64() * 1000.0,
             p99_ms: s.p99.as_secs_f64() * 1000.0,
+            backend_min_ms: s.backend_min.map(|d| d.as_secs_f64() * 1000.0),
+            backend_max_ms: s.backend_max.map(|d| d.as_secs_f64() * 1000.0),
+            backend_mean_ms: s.backend_mean.map(|d| d.as_secs_f64() * 1000.0),
+            backend_p50_ms: s.backend_p50.map(|d| d.as_secs_f64() * 1000.0),
+            backend_p90_ms: s.backend_p90.map(|d| d.as_secs_f64() * 1000.0),
+            backend_p99_ms: s.backend_p99.map(|d| d.as_secs_f64() * 1000.0),
             cpu_percent: cpu,
             memory_bytes: mem,
             system_cpu_percent: sys_cpu,

--- a/sdk/cosmos/azure_data_cosmos_perf/src/stats.rs
+++ b/sdk/cosmos/azure_data_cosmos_perf/src/stats.rs
@@ -26,7 +26,9 @@ pub struct Stats {
 ///
 /// Uses an [`hdrhistogram::Histogram`] for percentile estimation with constant
 /// memory. Exact count, min, max, and sum are tracked separately so the mean
-/// is always precise.
+/// is always precise. Two parallel histograms are tracked: one for the
+/// client-observed wall-clock latency, and one for the server-reported
+/// processing duration parsed from `x-ms-request-duration-ms`.
 struct OperationStats {
     /// HdrHistogram for percentile estimation (values in microseconds).
     histogram: Histogram<u64>,
@@ -40,6 +42,13 @@ struct OperationStats {
     sum: Duration,
     /// Number of failed operations.
     errors: u64,
+    /// Histogram for backend-reported request duration.
+    backend_histogram: Histogram<u64>,
+    /// Number of operations that contributed a backend duration sample.
+    backend_count: u64,
+    backend_min: Duration,
+    backend_max: Duration,
+    backend_sum: Duration,
 }
 
 /// Upper bound for the histogram: 1 hour in microseconds.
@@ -56,13 +65,20 @@ impl Default for OperationStats {
             max: Duration::ZERO,
             sum: Duration::ZERO,
             errors: 0,
+            backend_histogram: Histogram::new_with_bounds(1, MAX_LATENCY_US, 3)
+                .expect("valid histogram bounds"),
+            backend_count: 0,
+            backend_min: Duration::MAX,
+            backend_max: Duration::ZERO,
+            backend_sum: Duration::ZERO,
         }
     }
 }
 
 impl OperationStats {
-    /// Records a latency sample into the histogram.
-    fn record(&mut self, latency: Duration) {
+    /// Records a client-observed latency sample, plus an optional
+    /// server-reported backend duration when available.
+    fn record(&mut self, latency: Duration, backend: Option<Duration>) {
         self.count += 1;
         self.sum += latency;
         if latency < self.min {
@@ -76,6 +92,19 @@ impl OperationStats {
         // Clamp to histogram bounds; values above MAX_LATENCY_US are recorded
         // at the max and still counted.
         let _ = self.histogram.record(micros.clamp(1, MAX_LATENCY_US));
+
+        if let Some(b) = backend {
+            self.backend_count += 1;
+            self.backend_sum += b;
+            if b < self.backend_min {
+                self.backend_min = b;
+            }
+            if b > self.backend_max {
+                self.backend_max = b;
+            }
+            let bm = b.as_micros() as u64;
+            let _ = self.backend_histogram.record(bm.clamp(1, MAX_LATENCY_US));
+        }
     }
 
     /// Resets all counters and returns a fresh default instance.
@@ -95,6 +124,14 @@ pub struct Summary {
     pub p50: Duration,
     pub p90: Duration,
     pub p99: Duration,
+    /// Server-reported processing latency (`x-ms-request-duration-ms`).
+    /// `None` when the interval contained zero samples carrying the header.
+    pub backend_min: Option<Duration>,
+    pub backend_max: Option<Duration>,
+    pub backend_mean: Option<Duration>,
+    pub backend_p50: Option<Duration>,
+    pub backend_p90: Option<Duration>,
+    pub backend_p99: Option<Duration>,
 }
 
 impl Stats {
@@ -110,10 +147,11 @@ impl Stats {
     /// Records a successful operation latency.
     ///
     /// Only locks the mutex for this specific operation — no cross-operation
-    /// contention.
-    pub fn record_latency(&self, operation: &str, latency: Duration) {
+    /// contention. Pass `backend = Some(d)` when the underlying response
+    /// included an `x-ms-request-duration-ms` header.
+    pub fn record_latency(&self, operation: &str, latency: Duration, backend: Option<Duration>) {
         if let Some(m) = self.shards.get(operation) {
-            m.lock().unwrap().record(latency);
+            m.lock().unwrap().record(latency, backend);
         }
     }
 
@@ -159,6 +197,12 @@ fn compute_summary(name: String, stats: OperationStats) -> Summary {
             p50: Duration::ZERO,
             p90: Duration::ZERO,
             p99: Duration::ZERO,
+            backend_min: None,
+            backend_max: None,
+            backend_mean: None,
+            backend_p50: None,
+            backend_p90: None,
+            backend_p99: None,
         };
     }
 
@@ -166,6 +210,26 @@ fn compute_summary(name: String, stats: OperationStats) -> Summary {
     let p50 = Duration::from_micros(stats.histogram.value_at_quantile(0.50));
     let p90 = Duration::from_micros(stats.histogram.value_at_quantile(0.90));
     let p99 = Duration::from_micros(stats.histogram.value_at_quantile(0.99));
+
+    let (backend_min, backend_max, backend_mean, backend_p50, backend_p90, backend_p99) =
+        if stats.backend_count > 0 {
+            let bmean = Duration::from_secs_f64(
+                stats.backend_sum.as_secs_f64() / stats.backend_count as f64,
+            );
+            let bp50 = Duration::from_micros(stats.backend_histogram.value_at_quantile(0.50));
+            let bp90 = Duration::from_micros(stats.backend_histogram.value_at_quantile(0.90));
+            let bp99 = Duration::from_micros(stats.backend_histogram.value_at_quantile(0.99));
+            (
+                Some(stats.backend_min),
+                Some(stats.backend_max),
+                Some(bmean),
+                Some(bp50),
+                Some(bp90),
+                Some(bp99),
+            )
+        } else {
+            (None, None, None, None, None, None)
+        };
 
     Summary {
         name,
@@ -177,6 +241,12 @@ fn compute_summary(name: String, stats: OperationStats) -> Summary {
         p50,
         p90,
         p99,
+        backend_min,
+        backend_max,
+        backend_mean,
+        backend_p50,
+        backend_p90,
+        backend_p99,
     }
 }
 
@@ -188,14 +258,18 @@ pub fn print_report(summaries: &[Summary]) {
     }
 
     println!(
-        "  {:<15} {:>8} {:>8} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}",
-        "Operation", "Count", "Errors", "Min", "Max", "Mean", "P50", "P90", "P99"
+        "  {:<15} {:>8} {:>8} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}",
+        "Operation", "Count", "Errors", "Min", "Max", "Mean", "P50", "P90", "P99", "BackendP99"
     );
-    println!("  {}", "-".repeat(103));
+    println!("  {}", "-".repeat(114));
 
     for s in summaries {
+        let backend_p99 = s
+            .backend_p99
+            .map(format_duration)
+            .unwrap_or_else(|| "—".to_string());
         println!(
-            "  {:<15} {:>8} {:>8} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}",
+            "  {:<15} {:>8} {:>8} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}",
             s.name,
             s.count,
             s.errors,
@@ -205,6 +279,7 @@ pub fn print_report(summaries: &[Summary]) {
             format_duration(s.p50),
             format_duration(s.p90),
             format_duration(s.p99),
+            backend_p99,
         );
     }
 }
@@ -290,9 +365,9 @@ mod tests {
     #[test]
     fn record_and_drain() {
         let stats = Stats::new(&["read"]);
-        stats.record_latency("read", Duration::from_millis(10));
-        stats.record_latency("read", Duration::from_millis(20));
-        stats.record_latency("read", Duration::from_millis(30));
+        stats.record_latency("read", Duration::from_millis(10), None);
+        stats.record_latency("read", Duration::from_millis(20), None);
+        stats.record_latency("read", Duration::from_millis(30), None);
         stats.record_error("read");
 
         let summaries = stats.drain_summaries();
@@ -301,6 +376,7 @@ mod tests {
         assert_eq!(summaries[0].errors, 1);
         assert_eq!(summaries[0].min, Duration::from_millis(10));
         assert_eq!(summaries[0].max, Duration::from_millis(30));
+        assert!(summaries[0].backend_p99.is_none());
 
         // After drain, should be empty
         let summaries = stats.drain_summaries();
@@ -324,7 +400,7 @@ mod tests {
         let stats = Stats::new(&["write"]);
         // Record 1ms through 100ms — p50 ≈ 50ms, p99 ≈ 99ms
         for i in 1..=100u64 {
-            stats.record_latency("write", Duration::from_millis(i));
+            stats.record_latency("write", Duration::from_millis(i), None);
         }
         let summaries = stats.drain_summaries();
         assert_eq!(summaries.len(), 1);
@@ -345,7 +421,7 @@ mod tests {
     fn high_volume_recording() {
         let stats = Stats::new(&["write"]);
         for i in 0..20_000u64 {
-            stats.record_latency("write", Duration::from_micros(i));
+            stats.record_latency("write", Duration::from_micros(i), None);
         }
         let summaries = stats.drain_summaries();
         assert_eq!(summaries.len(), 1);
@@ -357,9 +433,68 @@ mod tests {
     #[test]
     fn unknown_operation_ignored() {
         let stats = Stats::new(&["read"]);
-        stats.record_latency("unknown", Duration::from_millis(10));
+        stats.record_latency("unknown", Duration::from_millis(10), None);
         stats.record_error("unknown");
         let summaries = stats.drain_summaries();
         assert!(summaries.is_empty());
+    }
+
+    #[test]
+    fn backend_durations_aggregate_separately_from_client() {
+        let stats = Stats::new(&["read"]);
+        // Mix of samples: some carry a backend duration, some don't.
+        // Client latencies span 10..=30ms, backend latencies span 5..=15ms
+        // for the subset that have one — verifies the two histograms are
+        // independent.
+        stats.record_latency(
+            "read",
+            Duration::from_millis(10),
+            Some(Duration::from_millis(5)),
+        );
+        stats.record_latency(
+            "read",
+            Duration::from_millis(20),
+            Some(Duration::from_millis(10)),
+        );
+        stats.record_latency(
+            "read",
+            Duration::from_millis(30),
+            Some(Duration::from_millis(15)),
+        );
+        stats.record_latency("read", Duration::from_millis(25), None);
+
+        let summaries = stats.drain_summaries();
+        assert_eq!(summaries.len(), 1);
+        let s = &summaries[0];
+
+        assert_eq!(s.count, 4, "all 4 client samples count");
+        assert_eq!(s.min, Duration::from_millis(10));
+        assert_eq!(s.max, Duration::from_millis(30));
+
+        let bmin = s.backend_min.expect("3 backend samples were recorded");
+        let bmax = s.backend_max.expect("3 backend samples were recorded");
+        let bp99 = s.backend_p99.expect("3 backend samples were recorded");
+        assert_eq!(bmin, Duration::from_millis(5));
+        assert_eq!(bmax, Duration::from_millis(15));
+        // p99 of {5,10,15} is the max (15ms), within hdrhistogram tolerance.
+        let bp99_ms = bp99.as_millis();
+        assert!((14..=16).contains(&bp99_ms), "backend p99 was {bp99_ms}ms");
+    }
+
+    #[test]
+    fn backend_summary_is_none_when_no_samples() {
+        let stats = Stats::new(&["read"]);
+        for i in 1..=10u64 {
+            stats.record_latency("read", Duration::from_millis(i), None);
+        }
+        let summaries = stats.drain_summaries();
+        assert_eq!(summaries.len(), 1);
+        let s = &summaries[0];
+        assert!(s.backend_min.is_none());
+        assert!(s.backend_max.is_none());
+        assert!(s.backend_mean.is_none());
+        assert!(s.backend_p50.is_none());
+        assert!(s.backend_p90.is_none());
+        assert!(s.backend_p99.is_none());
     }
 }


### PR DESCRIPTION
## Summary

Reads the `x-ms-request-duration-ms` response header on every Cosmos request in the perf binary and emits `backend_{min,max,mean,p50,p90,p99}_ms` per operation per reporting interval. This surfaces server-side processing time separately from client-observed wall-clock latency so network + client-queue overhead can be isolated in ADX/Grafana dashboards.

## Changes

- **`operations/mod.rs`**: New `extract_backend_duration()` helper parses header value → `Duration`
- **`Operation::execute`** return type changed from `Result<()>` → `Result<Option<Duration>>`; each op implementation reads the header
- **`operations/query_items.rs`**: Iterates by-page via `into_pages()` and sums backend durations across pages
- **`stats.rs`**: Parallel `HdrHistogram` for backend durations; new fields on `Summary`
- **`runner.rs`**: `PerfResult` struct gains 6 `Option<f64>` fields (`skip_serializing_if = None`)

## Testing

- `backend_durations_aggregate_separately_from_client` — verifies the two histograms are independent
- `backend_summary_is_none_when_no_samples` — verifies the all-None path when header is absent
- All 7 unit tests pass; clippy clean

## Backwards Compatibility

- Existing JSON keys unchanged
- Payloads without `backend_*` keys ingest cleanly into ADX (null columns)
