### PR TITLE
Always use rust 1.92 for semver-checks

### DIFF
--- a/eng/pipelines/templates/jobs/pack.yml
+++ b/eng/pipelines/templates/jobs/pack.yml
@@ -49,8 +49,7 @@ jobs:
 
   - template: /eng/pipelines/templates/steps/use-rust.yml@self
     parameters:
-      # 1.93 just came out and bumped the doc version to v57, which cargo-semver-checks does not yet support.
-      Toolchain: '1.92'
+      Toolchain: $(PackToolchain)
 
   - ${{ if eq(parameters.TestPipeline, 'true') }}:
     - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
@@ -80,7 +79,7 @@ jobs:
       inputs:
         pwsh: true
         filePath: $(Build.SourcesDirectory)/eng/scripts/Test-Semver.ps1
-        arguments: -PackageInfoDirectory '$(Build.ArtifactStagingDirectory)/PackageInfo'
+        arguments: -PackageInfoDirectory '$(Build.ArtifactStagingDirectory)/PackageInfo' -Toolchain '$(PackToolchain)'
 
     - task: Powershell@2
       displayName: Pack Crates
@@ -126,7 +125,7 @@ jobs:
       inputs:
         pwsh: true
         filePath: $(Build.SourcesDirectory)/eng/scripts/Test-Semver.ps1
-        arguments: -PackageNames $(PackageNames)
+        arguments: -PackageNames $(PackageNames) -Toolchain '$(PackToolchain)'
 
     - task: Powershell@2
       displayName: Pack Crates

--- a/eng/pipelines/templates/steps/use-rust.yml
+++ b/eng/pipelines/templates/steps/use-rust.yml
@@ -2,7 +2,7 @@ parameters:
   - name: Toolchain
     type: string
     default: active
-    # Expexted values: 'stable', 'nightly', 'msrv', 'active' or a specific toolchain version
+    # Expected values: 'stable', 'nightly', 'msrv', 'active' or a specific toolchain version
     # 'msrv' will read the MSRV from azure_core
     # 'active' will use the active toolchain for the working directory, which will be from rust-toolchain.toml, from a
     #   folder override or the rustup default toolchain

--- a/eng/pipelines/templates/variables/rust.yml
+++ b/eng/pipelines/templates/variables/rust.yml
@@ -1,4 +1,7 @@
 variables:
+  # 1.93 bumped the rustdocs version to v57, which cargo-semver-checks does not yet support.
+  # Affects cargo-semver-checks, check_api_superset, generate_api_report
+  PackToolchain: "1.92"
   RUSTFLAGS: "-Dwarnings"
   RUSTDOCFLAGS: "-Dwarnings"
   RUST_LOG: $[iif(eq(variables['System.Debug'], 'true'), 'trace', 'info')]


### PR DESCRIPTION
This started breaking today, but not entirely sure why. Seems `Test-Semver.ps1` was always using `stable` but `pack.yml` set the default to 1.92.

Seems we did get a new ubuntu image that probably has a newer `rustup`. It's almost as if what `rustup default <toolchain>` did changed how `+stable` resolves. Will investigate after this is fixed to unblock PRs.
