### PR TITLE
Fix new clippy lints

### DIFF
--- a/sdk/core/azure_core/src/error/error_response.rs
+++ b/sdk/core/azure_core/src/error/error_response.rs
@@ -403,7 +403,7 @@ mod tests {
             .expect("Parse success.");
         err.error.as_ref().expect("error should be set");
 
-        println!("{:?}", &err);
+        println!("{:?}", err);
         assert_eq!(
             err.error.as_ref().unwrap().code,
             Some("InvalidRequest".to_string())
@@ -496,7 +496,7 @@ mod tests {
             });
             let error_response = ErrorResponse::try_from(err).expect("expected an ErrorResponse");
             error_response.error.as_ref().expect("error should be set");
-            println!("{:?}", &error_response);
+            println!("{:?}", error_response);
             assert_eq!(
                 error_response.error.as_ref().unwrap().code,
                 Some("InvalidRequest".to_string())
@@ -520,7 +520,7 @@ mod tests {
                 .json()
                 .expect("expected an ErrorResponse");
             error_response.error.as_ref().expect("error should be set");
-            println!("{:?}", &error_response);
+            println!("{:?}", error_response);
             assert_eq!(
                 error_response.error.as_ref().unwrap().code,
                 Some("InvalidRequest".to_string())
@@ -553,7 +553,7 @@ mod tests {
     async fn deserialize_to_error_response_internal() {
         let err :ErrorResponseInternal = serde_json::from_slice (br#"{"error":{"code":"InvalidRequest","message":"The request object is not recognized.","innererror":{"code":"InvalidKey","key":"foo"}}}"#)
             .expect("Parse success.");
-        println!("{:?}", &err);
+        println!("{:?}", err);
 
         assert_eq!(err.error.code, Some("InvalidRequest"));
         assert_eq!(

--- a/sdk/core/azure_core_test/src/proxy/bootstrap.rs
+++ b/sdk/core/azure_core_test/src/proxy/bootstrap.rs
@@ -283,7 +283,7 @@ fn extract_test_proxy(
         let message = format!(
             "failed to extract {}: {:?}",
             archive_file_path.display(),
-            &err
+            err
         );
         azure_core::Error::with_error(ErrorKind::Io, err, message)
     })

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -251,7 +251,7 @@ impl ConsumerClient {
             self.endpoint
         );
 
-        let source_url = format!("{}/Partitions/{}", &self.endpoint, &partition_id);
+        let source_url = format!("{}/Partitions/{}", self.endpoint, partition_id);
         let source_url = Url::parse(&source_url).map_err(azure_core::Error::from)?;
 
         let message_source = AmqpSource::builder()


### PR DESCRIPTION
We've had a number of toolchain updates - especially nightly - that have blocked PRs from merging due to stylistic clippy lints, as well as some other lints that are worth considering.

We should be more thoughtful about when and how we update long-term, but for now we can at least reduce the noise.