### PR TITLE
Ignore clippy::style lint group

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ zip = { version = "8.2", default-features = false, features = ["deflate"] }
 
 [workspace.lints.clippy]
 large_futures = "deny"
+style = { level = "allow", priority = -1 }
 uninlined_format_args = "allow"
 
 [workspace.lints.rust]


### PR DESCRIPTION
We've had a number of toolchain updates - especially nightly - that have blocked PRs from merging
    due to stylistic clippy lints, as well as some other lints that are worth considering.

    We should be more thoughtful about when and how we update long-term, but for now we can at least reduce the noise.
