### PR TITLE
Transition to GitHub App auth, remove azuresdk-github-pat usage

### DIFF
--- a/eng/pipelines/prepare-pipelines.yml
+++ b/eng/pipelines/prepare-pipelines.yml
@@ -1,7 +1,7 @@
 trigger: none
 
 variables:
-- template: /eng/pipelines/templates/variables/image.yml
+  - template: /eng/pipelines/templates/variables/image.yml
 
 extends:
   template: /eng/common/pipelines/templates/jobs/prepare-pipelines.yml

--- a/eng/pipelines/templates/stages/archetype-rust-release.yml
+++ b/eng/pipelines/templates/stages/archetype-rust-release.yml
@@ -58,6 +58,7 @@ stages:
                 PackageRepository: Crates.io
                 ReleaseSha: $(Build.SourceVersion)
                 WorkingDirectory: $(Pipeline.Workspace)/_work
+                AuthToken: ''
 
         - deployment: PublishPackage
           displayName: "Publish to Crates.io"
@@ -196,5 +197,6 @@ stages:
               CommitMsg: "Increment package version after release of ${{ join(', ', parameters.Artifacts.*.name) }}"
               PRTitle: "Increment versions for ${{parameters.ServiceDirectory}} releases"
               CloseAfterOpenForTesting: '${{parameters.TestPipeline}}'
+              AuthToken: ''
               ${{ if startsWith(variables['Build.SourceBranch'], 'refs/pull/') }}:
                 BaseBranchName: main


### PR DESCRIPTION
This pull request makes minor updates to the pipeline configuration files to explicitly set the `AuthToken` parameter to an empty string in several jobs and stages. This clarifies authentication handling and ensures consistent behavior across pipeline steps.

Most important changes:

**Pipeline authentication configuration:**

* Added `AuthToken: ''` to the parameters in the `prepare-pipelines.yml` job template, making the authentication token parameter explicit.
* Set `AuthToken: ''` in the `BuildPackage` and `CreatePullRequest` jobs in `archetype-rust-release.yml`, ensuring no authentication token is passed by default. [[1]](diffhunk://#diff-947a9cd6baf7f4a33dbba26387027a2b2aece6f2a6eea485a4be13880b314297R61) [[2]](diffhunk://#diff-947a9cd6baf7f4a33dbba26387027a2b2aece6f2a6eea485a4be13880b314297R200)

Related to Azure/azure-sdk-tools#9842

[prepare-pipelines](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6371870&view=results)
[rust - canary](https://dev.azure.com/azure-sdk/internal/_build?definitionId=7442)