### PR TITLE
Require TLS for test-proxy

### DIFF
--- a/sdk/core/azure_core_opentelemetry/tests/telemetry_service_implementation.rs
+++ b/sdk/core/azure_core_opentelemetry/tests/telemetry_service_implementation.rs
@@ -254,7 +254,7 @@ async fn test_service_client_new(ctx: TestContext) -> Result<()> {
     let mut options = TestServiceClientOptions {
         ..Default::default()
     };
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = TestServiceClient::new(endpoint, credential, Some(options)).unwrap();
     assert_eq!(client.endpoint().as_str(), "https://www.microsoft.com/");
@@ -270,7 +270,7 @@ async fn test_service_client_get(ctx: TestContext) -> Result<()> {
     let endpoint = "https://azuresdkforcpp.azurewebsites.net";
     let credential = recording.credential().clone();
     let mut options = TestServiceClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = TestServiceClient::new(endpoint, credential, Some(options)).unwrap();
     let response = client.get("get", None).await;
@@ -302,7 +302,7 @@ async fn test_service_client_get_with_tracing(ctx: TestContext) -> Result<()> {
         },
         ..Default::default()
     };
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = TestServiceClient::new(endpoint, credential, Some(options)).unwrap();
     let response = client.get("get", None).await;
@@ -357,7 +357,7 @@ async fn test_service_client_get_tracing_error(ctx: TestContext) -> Result<()> {
         },
         ..Default::default()
     };
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = TestServiceClient::new(endpoint, credential.clone(), Some(options)).unwrap();
     let response = client.get("failing_url", None).await;
@@ -418,7 +418,7 @@ async fn test_service_client_get_with_function_tracing(ctx: TestContext) -> Resu
         },
         ..Default::default()
     };
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = TestServiceClient::new(endpoint, credential, Some(options)).unwrap();
     let response = client.get_with_function_tracing("get", None).await;
@@ -481,7 +481,7 @@ async fn test_service_client_get_with_function_tracing_error(ctx: TestContext) -
         },
         ..Default::default()
     };
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = TestServiceClient::new(endpoint, credential, Some(options)).unwrap();
     let response = client.get_with_function_tracing("failing_url", None).await;

--- a/sdk/core/azure_core_opentelemetry/tests/telemetry_service_macros.rs
+++ b/sdk/core/azure_core_opentelemetry/tests/telemetry_service_macros.rs
@@ -219,7 +219,7 @@ mod tests {
             },
             ..Default::default()
         };
-        recording.instrument(&mut options.client_options);
+        recording.instrument(&mut options.client_options, None);
 
         TestServiceClientWithMacros::new(endpoint, credential, Some(options)).unwrap()
     }
@@ -283,7 +283,7 @@ mod tests {
         let mut options = TestServiceClientWithMacrosOptions {
             ..Default::default()
         };
-        recording.instrument(&mut options.client_options);
+        recording.instrument(&mut options.client_options, None);
 
         let client = TestServiceClientWithMacros::new(endpoint, credential, Some(options)).unwrap();
         assert_eq!(client.endpoint().as_str(), "https://microsoft.com/");

--- a/sdk/core/azure_core_test/Cargo.toml
+++ b/sdk/core/azure_core_test/Cargo.toml
@@ -15,12 +15,16 @@ rust-version.workspace = true
 publish = false
 
 [features]
-default = []
+default = ["azure_core/default"]
 tracing = ["tracing-subscriber"]
 
 [dependencies]
 async-trait.workspace = true
-azure_core = { workspace = true, features = ["test"] }
+azure_core = { workspace = true, features = [
+  "reqwest",
+  "reqwest_rustls",
+  "test",
+] }
 azure_core_test_macros.workspace = true
 azure_identity.workspace = true
 clap.workspace = true

--- a/sdk/core/azure_core_test/examples/test_proxy.rs
+++ b/sdk/core/azure_core_test/examples/test_proxy.rs
@@ -85,6 +85,7 @@ impl From<Args> for azure_core_test::proxy::ProxyOptions {
     fn from(args: Args) -> Self {
         Self {
             auto: args.auto,
+            https: true,
             insecure: args.insecure,
             auto_shutdown_in_seconds: args.auto_shutdown_in_seconds,
         }

--- a/sdk/core/azure_core_test/src/proxy/bootstrap.rs
+++ b/sdk/core/azure_core_test/src/proxy/bootstrap.rs
@@ -19,10 +19,7 @@ pub use tokio::{
 pub use tracing::Level;
 use tracing::Span;
 
-// cspell:ignore aspnetcore devcert teamprojectid testproxy
-pub const KESTREL_CERT_PATH_ENV: &str = "ASPNETCORE_Kestrel__Certificates__Default__Path";
-pub const KESTREL_CERT_PASSWORD_ENV: &str = "ASPNETCORE_Kestrel__Certificates__Default__Password";
-pub const KESTREL_CERT_PASSWORD: &str = "password";
+// cspell:ignore teamprojectid testproxy
 pub const MIN_VERSION: Version = Version {
     major: 20241213,
     minor: 1,
@@ -40,23 +37,23 @@ pub async fn start(
     crate_dir: impl AsRef<Path>,
     options: Option<ProxyOptions>,
 ) -> Result<Proxy> {
+    // Find root of git repo or work tree: a ".git" directory or file will exist either way.
+    let git_dir = crate::find_ancestor_file(crate_dir.as_ref(), ".git")?;
+    let git_dir = git_dir.parent().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::NotFound, "parent git repository not found")
+    })?;
+
     if env::var(PROXY_MANUAL_START).is_ok_and(|v| v.eq_ignore_ascii_case("true")) {
         tracing::warn!(
             "environment variable {PROXY_MANUAL_START} is 'true'; not starting test-proxy"
         );
-        let proxy = Proxy::existing()?;
+        let proxy = Proxy::existing(git_dir)?;
 
         // Set up default matchers and sanitizers.
         proxy.initialize().await?;
 
         return Ok(proxy);
     }
-
-    // Find root of git repo or work tree: a ".git" directory or file will exist either way.
-    let git_dir = crate::find_ancestor_file(crate_dir.as_ref(), ".git")?;
-    let git_dir = git_dir.parent().ok_or_else(|| {
-        io::Error::new(io::ErrorKind::NotFound, "parent git repository not found")
-    })?;
 
     let executable_file_path = ensure_test_proxy(git_dir).await?;
 

--- a/sdk/core/azure_core_test/src/proxy/client.rs
+++ b/sdk/core/azure_core_test/src/proxy/client.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+use crate::InstrumentOptions;
+
 use super::{
     matchers::Matcher,
     models::{
@@ -11,14 +13,87 @@ use super::{
     RecordingId, RECORDING_ID,
 };
 use azure_core::{
+    error::{ErrorKind, ResultExt},
     http::{
         headers::{AsHeaders, ACCEPT, CONTENT_TYPE},
         request::{Request, RequestContent},
-        ClientMethodOptions, ClientOptions, Method, Pipeline, PipelineSendOptions, Response, Url,
+        ClientMethodOptions, ClientOptions, HttpClient, Method, Pipeline, PipelineSendOptions,
+        Response, Transport, Url,
     },
     Bytes, Result,
 };
-use tracing::Span;
+use reqwest::Certificate;
+use std::{io::Read, path::Path, sync::Arc, time::Duration};
+use tracing::{debug, Span};
+
+static CA_PEM: std::sync::OnceLock<Vec<u8>> = std::sync::OnceLock::new();
+
+/// Options [`Recording::instrument()`].
+///
+/// This should be a subset of [`azure_core::http::HttpClientOptions`].
+#[derive(Clone, Debug)]
+pub struct HttpClientOptions {
+    /// Automatically decompress responses if the `content-encoding` header indicates a supported compression encoding.
+    /// Defaults to `true`.
+    pub automatic_decompression: bool,
+}
+
+impl Default for HttpClientOptions {
+    fn default() -> Self {
+        Self {
+            automatic_decompression: true,
+        }
+    }
+}
+
+impl From<InstrumentOptions> for HttpClientOptions {
+    fn from(options: InstrumentOptions) -> Self {
+        Self {
+            automatic_decompression: options.automatic_decompression,
+        }
+    }
+}
+
+/// Creates a new [`reqwest::Client`] configured to test-proxy.
+///
+/// This should work like [`azure_core::http::new_http_client()`] but with appropriate TLS configuration for self-signed TLS certificates.
+pub fn new_http_client(options: Option<HttpClientOptions>) -> Result<Arc<dyn HttpClient>> {
+    // TODO: As we design https://github.com/Azure/azure-sdk-for-rust/issues/4217 we should consider how we can use some sort of callback or `#[cfg(test)]`-guarded field to obviate this function.
+
+    debug!("creating an http client using `reqwest`");
+    let options = options.unwrap_or_default();
+
+    const DEFAULT_CONNECTION_TIMEOUT: Duration = Duration::from_secs(20);
+    const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(60);
+
+    let pem = CA_PEM.get().ok_or_else(|| {
+        azure_core::Error::new(
+            ErrorKind::Other,
+            "expected self-signed CA to be initialized",
+        )
+    })?;
+    let ca = Certificate::from_pem(pem)
+        .with_context(ErrorKind::Other, "failed to decode self-signed CA")?;
+
+    let client = ::reqwest::ClientBuilder::new()
+        .connect_timeout(DEFAULT_CONNECTION_TIMEOUT)
+        .read_timeout(DEFAULT_READ_TIMEOUT)
+        .gzip(options.automatic_decompression)
+        .deflate(options.automatic_decompression)
+        // By default, reqwest will chase 3xx redirects up to 10 links. REST API guidelines
+        // discourage services from using 3xx redirects, so disabling the reqwest redirect logic
+        // simplifies the client logic.
+        .redirect(::reqwest::redirect::Policy::none())
+        // Accept self-signed CA for test-proxy on localhost.
+        .tls_backend_rustls()
+        .tls_certs_merge([ca])
+        // BUGBUG: reqwest/rustls does not accept self-signed CAs for TLS: https://github.com/seanmonstar/reqwest/issues/1554
+        .tls_danger_accept_invalid_certs(true)
+        .build()
+        .with_context(ErrorKind::Other, "failed to build test-proxy client")?;
+
+    Ok(Arc::new(client))
+}
 
 /// The test-proxy client.
 ///
@@ -32,13 +107,29 @@ pub struct Client {
 
 #[allow(dead_code)]
 impl Client {
-    pub fn new(endpoint: Url) -> Result<Self> {
+    pub fn new(endpoint: Url, ca_path: &Path, options: Option<HttpClientOptions>) -> Result<Self> {
+        let _ = CA_PEM.get_or_init(|| {
+            let mut pem = Vec::new();
+            std::fs::File::open(ca_path)
+                .unwrap_or_else(|_| panic!("failed to open '{}'", ca_path.display()))
+                .read_to_end(&mut pem)
+                .unwrap_or_else(|_| panic!("failed to read '{}'", ca_path.display()));
+            pem
+        });
+
+        let client = new_http_client(options)?;
+        let transport = Transport::new(client.clone());
+
+        let options = ClientOptions {
+            transport: Some(transport),
+            ..Default::default()
+        };
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(
                 option_env!("CARGO_PKG_NAME"),
                 option_env!("CARGO_PKG_VERSION"),
-                ClientOptions::default(),
+                options,
                 Vec::default(),
                 Vec::default(),
                 None,

--- a/sdk/core/azure_core_test/src/proxy/mod.rs
+++ b/sdk/core/azure_core_test/src/proxy/mod.rs
@@ -33,6 +33,13 @@ const RECORDING_MODE: HeaderName = HeaderName::from_static("x-recording-mode");
 const RECORDING_UPSTREAM_BASE_URI: HeaderName =
     HeaderName::from_static("x-recording-upstream-base-uri");
 
+// cspell:ignore aspnetcore
+const KESTREL_CERT_PATH: &str = "eng/common/testproxy/dotnet-devcert.pfx";
+const KESTREL_CERT_CA_PATH: &str = "eng/common/testproxy/dotnet-devcert.crt";
+const KESTREL_CERT_PATH_ENV: &str = "ASPNETCORE_Kestrel__Certificates__Default__Path";
+const KESTREL_CERT_PASSWORD_ENV: &str = "ASPNETCORE_Kestrel__Certificates__Default__Password";
+const KESTREL_CERT_PASSWORD: &str = "password";
+
 pub use bootstrap::start;
 
 /// Represents the running `test-proxy` service.
@@ -55,7 +62,7 @@ impl Proxy {
             .env(
                 KESTREL_CERT_PATH_ENV,
                 // cspell:ignore testproxy devcert
-                git_dir.join("eng/common/testproxy/dotnet-devcert.pfx"),
+                git_dir.join(KESTREL_CERT_PATH),
             )
             .env(KESTREL_CERT_PASSWORD_ENV, KESTREL_CERT_PASSWORD)
             .stdout(Stdio::piped())
@@ -90,8 +97,9 @@ impl Proxy {
             }
         });
 
+        let ca_path = git_dir.join(KESTREL_CERT_CA_PATH);
         if let Some(endpoint) = &self.endpoint {
-            self.client = Some(Client::new(endpoint.clone())?);
+            self.client = Some(Client::new(endpoint.clone(), &ca_path, None)?);
         }
 
         Ok(())
@@ -181,12 +189,14 @@ impl Proxy {
 
 impl Proxy {
     /// Gets a proxy representing an existing test-proxy process.
-    pub fn existing() -> Result<Self> {
-        let endpoint: Url = "http://localhost:5000".parse()?;
+    pub fn existing(git_dir: &Path) -> Result<Self> {
+        // Always bind over TLS. See https://github.com/Azure/azure-sdk-for-rust/issues/4348.
+        let endpoint: Url = "https://localhost:5001".parse()?;
+        let ca_path = git_dir.join(KESTREL_CERT_CA_PATH);
         Ok(Self {
             command: None,
             endpoint: Some(endpoint.clone()),
-            client: Some(Client::new(endpoint)?),
+            client: Some(Client::new(endpoint, &ca_path, None)?),
         })
     }
 
@@ -211,17 +221,17 @@ impl Drop for Proxy {
 }
 
 pub(crate) trait ProxyExt<'a> {
-    fn client(&'a self) -> Option<&'a Client>;
+    fn client_ref(&'a self) -> Option<&'a Client>;
 }
 
 impl<'a> ProxyExt<'a> for Arc<Proxy> {
-    fn client(&'a self) -> Option<&'a Client> {
+    fn client_ref(&'a self) -> Option<&'a Client> {
         self.client.as_ref()
     }
 }
 
 impl<'a> ProxyExt<'a> for Option<Arc<Proxy>> {
-    fn client(&'a self) -> Option<&'a Client> {
+    fn client_ref(&'a self) -> Option<&'a Client> {
         self.as_ref().and_then(|proxy| proxy.client.as_ref())
     }
 }
@@ -231,6 +241,9 @@ impl<'a> ProxyExt<'a> for Option<Arc<Proxy>> {
 pub struct ProxyOptions {
     /// `true` to bind to any available port; otherwise, bind to only the default port `:5000`.
     pub auto: bool,
+
+    /// Bind only to an HTTPS endpoint i.e., `https://localhost`. The default is `true`.
+    pub https: bool,
 
     /// Allow insecure upstream SSL certs.
     pub insecure: bool,
@@ -250,9 +263,18 @@ impl ProxyOptions {
             self.auto_shutdown_in_seconds.to_string(),
         ]);
 
+        let endpoint = format!("{}://0.0.0.0:0", self.scheme());
         if self.auto {
-            args.extend_from_slice(&["--", "--urls", "http://0.0.0.0:0"].map(Into::into));
+            args.extend_from_slice(&["--", "--urls", &endpoint].map(Into::into));
         }
+    }
+
+    fn scheme(&self) -> &'static str {
+        if self.https {
+            return "https";
+        }
+
+        "http"
     }
 }
 
@@ -260,6 +282,7 @@ impl Default for ProxyOptions {
     fn default() -> Self {
         Self {
             auto: true,
+            https: true,
             insecure: false,
             auto_shutdown_in_seconds: 300,
         }

--- a/sdk/core/azure_core_test/src/recorded.rs
+++ b/sdk/core/azure_core_test/src/recorded.rs
@@ -51,7 +51,7 @@ pub async fn start(
                         // Work around change to query parameter ordering introduced in https://github.com/Azure/azure-sdk-for-rust/pull/3437.
                         // Tracking reversion: https://github.com/Azure/azure-sdk-for-rust/issues/3438.
                         proxy
-                            .client()
+                            .client_ref()
                             .expect("expected test-proxy Client")
                             .set_matcher(
                                 CustomDefaultMatcher {

--- a/sdk/core/azure_core_test/src/recording.rs
+++ b/sdk/core/azure_core_test/src/recording.rs
@@ -10,7 +10,8 @@ use crate::{
     credentials::{self, MockCredential},
     proxy::{
         client::{
-            ClientAddSanitizerOptions, ClientRemoveSanitizersOptions, ClientSetMatcherOptions,
+            new_http_client, ClientAddSanitizerOptions, ClientRemoveSanitizersOptions,
+            ClientSetMatcherOptions,
         },
         models::{SanitizerList, StartPayload, VariablePayload},
         policy::RecordingPolicy,
@@ -25,7 +26,7 @@ use azure_core::{
     error::ErrorKind,
     http::{
         headers::{AsHeaders, Header, HeaderName, HeaderValue},
-        ClientOptions,
+        ClientOptions, Transport,
     },
     test::TestMode,
 };
@@ -72,7 +73,7 @@ impl Recording {
         S: Sanitizer,
         azure_core::Error: From<<S as AsHeaders>::Error>,
     {
-        let Some(client) = self.proxy.client() else {
+        let Some(client) = self.proxy.client_ref() else {
             return Ok(());
         };
 
@@ -117,14 +118,18 @@ impl Recording {
     ///     let recording = ctx.recording();
     ///
     ///     let mut options = MyClientOptions::default();
-    ///     recording.instrument(&mut options.client_options);
+    ///     recording.instrument(&mut options.client_options, None);
     ///
     ///     let client = MyClient::new("https://azure.net", Some(options));
     ///     client.invoke().await
     /// }
     /// ```
-    pub fn instrument(&self, options: &mut ClientOptions) {
-        let Some(client) = self.proxy.client() else {
+    pub fn instrument(
+        &self,
+        client_options: &mut ClientOptions,
+        options: Option<InstrumentOptions>,
+    ) {
+        let Some(client) = self.proxy.client_ref() else {
             return;
         };
 
@@ -140,7 +145,7 @@ impl Recording {
                 })
                 .clone();
 
-            options.per_call_policies.push(test_mode_policy);
+            client_options.per_call_policies.push(test_mode_policy);
         }
 
         let recording_policy = self
@@ -155,7 +160,11 @@ impl Recording {
             })
             .clone();
 
-        options.per_try_policies.push(recording_policy);
+        client_options.per_try_policies.push(recording_policy);
+
+        let client =
+            new_http_client(options.map(Into::into)).expect("failed to create HTTP client");
+        client_options.transport = Some(Transport::new(client));
     }
 
     /// Update a recording with settings appropriate for a performance test.
@@ -182,7 +191,7 @@ impl Recording {
     ///     let recording = ctx.recording();
     ///
     ///     let mut options = MyServiceClientOptions::default();
-    ///     recording.instrument_perf(&mut options.client_options)?;
+    ///     recording.instrument_perf(&mut options.client_options, None)?;
     ///
     ///     let client = MyServiceClient::new("https://azure.net", Some(options));
     ///     client.invoke().await
@@ -195,8 +204,12 @@ impl Recording {
     /// Note that this function is a no-op for live tests - it only affects recorded tests
     /// in playback mode.
     ///
-    pub fn instrument_perf(&self, options: &mut ClientOptions) -> azure_core::Result<()> {
-        self.instrument(options);
+    pub fn instrument_perf(
+        &self,
+        client_options: &mut ClientOptions,
+        options: Option<InstrumentOptions>,
+    ) -> azure_core::Result<()> {
+        self.instrument(client_options, options);
         self.remove_recording(false)
     }
 
@@ -308,7 +321,7 @@ impl Recording {
     ///
     /// You can find a list of default sanitizers in [source code](https://github.com/Azure/azure-sdk-tools/blob/main/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs).
     pub async fn remove_sanitizers(&self, sanitizers: &[&str]) -> azure_core::Result<()> {
-        let Some(client) = self.proxy.client() else {
+        let Some(client) = self.proxy.client_ref() else {
             return Ok(());
         };
 
@@ -328,7 +341,7 @@ impl Recording {
 
     /// Sets a [`Matcher`] to compare requests and/or responses.
     pub async fn set_matcher(&self, matcher: Matcher) -> azure_core::Result<()> {
-        let Some(client) = self.proxy.client() else {
+        let Some(client) = self.proxy.client_ref() else {
             return Ok(());
         };
 
@@ -527,7 +540,7 @@ impl Recording {
     ///
     /// If playing back a recording, environment variable that were recorded will be reloaded.
     pub(crate) async fn start(&mut self) -> azure_core::Result<()> {
-        let Some(client) = self.proxy.client() else {
+        let Some(client) = self.proxy.client_ref() else {
             // Assumes running live test.
             return Ok(());
         };
@@ -563,7 +576,7 @@ impl Recording {
     ///
     /// If recording, environment variables that were retrieved will be recorded.
     pub(crate) async fn stop(&self) -> azure_core::Result<()> {
-        let Some(client) = self.proxy.client() else {
+        let Some(client) = self.proxy.client_ref() else {
             // Assumes running live test.
             return Ok(());
         };
@@ -599,6 +612,24 @@ impl Drop for Recording {
     /// Stops the recording or playback.
     fn drop(&mut self) {
         futures::executor::block_on(self.stop()).unwrap_or_else(|err| panic!("{err}"));
+    }
+}
+
+/// Options [`Recording::instrument()`].
+///
+/// This should be a subset of [`HttpClientOptions`](azure_core::http::HttpClientOptions).
+#[derive(Clone, Debug)]
+pub struct InstrumentOptions {
+    /// Automatically decompress responses if the `content-encoding` header indicates a supported compression encoding.
+    /// Defaults to `true`.
+    pub automatic_decompression: bool,
+}
+
+impl Default for InstrumentOptions {
+    fn default() -> Self {
+        Self {
+            automatic_decompression: true,
+        }
     }
 }
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
@@ -32,7 +32,9 @@ rustc_version.workspace = true
 
 [dev-dependencies]
 azure_core_amqp = { workspace = true, features = ["test"] }
-azure_core_test = { workspace = true, features = ["tracing"] }
+azure_core_test = { workspace = true, features = [
+  "tracing",
+] }
 azure_identity.workspace = true
 azure_messaging_eventhubs = { path = ".", features = [
   "in_memory_checkpoint_store",

--- a/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/tests/checkpoint_unit_tests.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/tests/checkpoint_unit_tests.rs
@@ -4,7 +4,9 @@
 //! Unit tests for the blob checkpoint store models and utilities.
 
 use azure_core::Result;
-use azure_core_test::{recorded, CustomDefaultMatcher, Matcher, Recording, TestContext};
+use azure_core_test::{
+    recorded, CustomDefaultMatcher, InstrumentOptions, Matcher, Recording, TestContext,
+};
 use azure_messaging_eventhubs::{models::Checkpoint, CheckpointStore};
 use azure_messaging_eventhubs_checkpointstore_blob::BlobCheckpointStore;
 use azure_storage_blob::{BlobContainerClient, BlobContainerClientOptions};
@@ -14,7 +16,13 @@ use tracing::trace;
 pub fn create_test_checkpoint_store(recording: &Recording) -> Result<Arc<BlobCheckpointStore>> {
     let credential = recording.credential();
     let mut options = BlobContainerClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(
+        &mut options.client_options,
+        Some(InstrumentOptions {
+            // Storage does not use automatic decompression by default.
+            automatic_decompression: false,
+        }),
+    );
     let blob_container_client = BlobContainerClient::new(
         &recording.var("AZURE_STORAGE_BLOB_ENDPOINT", None),
         &recording.var("AZURE_STORAGE_BLOB_CONTAINER", None),
@@ -178,11 +186,7 @@ async fn update_checkpoint_empty_values(ctx: TestContext) -> Result<()> {
     };
 
     // Update the checkpoint - should still work even with empty metadata
-    let result = checkpoint_store.update_checkpoint(checkpoint).await;
-    assert!(
-        result.is_ok(),
-        "Updating checkpoint with empty values should succeed"
-    );
+    checkpoint_store.update_checkpoint(checkpoint).await?;
 
     Ok(())
 }
@@ -209,22 +213,23 @@ async fn update_checkpoint_multiple_updates(ctx: TestContext) -> Result<()> {
     };
 
     // First update
-    let result1 = checkpoint_store.update_checkpoint(checkpoint.clone()).await;
-    assert!(result1.is_ok(), "First checkpoint update should succeed");
+    checkpoint_store
+        .update_checkpoint(checkpoint.clone())
+        .await?;
 
     // Update the same checkpoint with new values
     checkpoint.offset = Some("200".to_string());
     checkpoint.sequence_number = Some(20);
 
-    let result2 = checkpoint_store.update_checkpoint(checkpoint.clone()).await;
-    assert!(result2.is_ok(), "Second checkpoint update should succeed");
+    checkpoint_store
+        .update_checkpoint(checkpoint.clone())
+        .await?;
 
     // Third update with different values
     checkpoint.offset = Some("300".to_string());
     checkpoint.sequence_number = Some(30);
 
-    let result3 = checkpoint_store.update_checkpoint(checkpoint).await;
-    assert!(result3.is_ok(), "Third checkpoint update should succeed");
+    checkpoint_store.update_checkpoint(checkpoint).await?;
 
     Ok(())
 }
@@ -261,8 +266,7 @@ async fn update_checkpoint_verify_in_list_checkpoints(ctx: TestContext) -> Resul
     };
 
     // Update the checkpoint
-    let update_result = checkpoint_store.update_checkpoint(checkpoint).await;
-    assert!(update_result.is_ok(), "Updating checkpoint should succeed");
+    checkpoint_store.update_checkpoint(checkpoint).await?;
 
     // Now list checkpoints and verify our update is there
     let checkpoints = checkpoint_store

--- a/sdk/keyvault/azure_security_keyvault_certificates/tests/certificate_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/tests/certificate_client.rs
@@ -46,7 +46,7 @@ async fn certificate_roundtrip(ctx: TestContext) -> Result<()> {
     recording.remove_sanitizers(&[SANITIZE_BODY_NAME]).await?;
 
     let mut options = CertificateClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = CertificateClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -79,7 +79,7 @@ async fn certificate_validate_instrumentation(ctx: TestContext) -> Result<()> {
     recording.remove_sanitizers(&[SANITIZE_BODY_NAME]).await?;
 
     let mut options = CertificateClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     azure_core_test::tracing::assert_instrumentation_information(
         |tracer_provider| {
@@ -144,7 +144,7 @@ async fn update_certificate_properties(ctx: TestContext) -> Result<()> {
     recording.remove_sanitizers(&[SANITIZE_BODY_NAME]).await?;
 
     let mut options = CertificateClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = CertificateClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -200,7 +200,7 @@ async fn list_certificates(ctx: TestContext) -> Result<()> {
     recording.remove_sanitizers(&[SANITIZE_BODY_NAME]).await?;
 
     let mut options = CertificateClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = CertificateClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -241,7 +241,7 @@ async fn purge_certificate(ctx: TestContext) -> Result<()> {
     recording.remove_sanitizers(&[SANITIZE_BODY_NAME]).await?;
 
     let mut options = CertificateClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = CertificateClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -296,7 +296,7 @@ async fn sign_jwt_with_ec_certificate(ctx: TestContext) -> Result<()> {
     recording.remove_sanitizers(&[SANITIZE_BODY_NAME]).await?;
 
     let mut options = CertificateClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = CertificateClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -338,7 +338,7 @@ async fn sign_jwt_with_ec_certificate(ctx: TestContext) -> Result<()> {
         .expect("certificate version required");
 
     let mut key_options = KeyClientOptions::default();
-    recording.instrument(&mut key_options.client_options);
+    recording.instrument(&mut key_options.client_options, None);
 
     // Sign a JWT.
     let key_client = KeyClient::new(
@@ -380,7 +380,7 @@ async fn create_invalid_certificate(ctx: TestContext) -> Result<()> {
     recording.remove_sanitizers(&[SANITIZE_BODY_NAME]).await?;
 
     let mut options = CertificateClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = CertificateClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),

--- a/sdk/keyvault/azure_security_keyvault_certificates/tests/readme.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/tests/readme.rs
@@ -13,7 +13,7 @@ async fn readme(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
 
     let mut options = CertificateClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = CertificateClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -22,7 +22,7 @@ async fn readme(ctx: TestContext) -> Result<()> {
     )?;
 
     let mut key_options = KeyClientOptions::default();
-    recording.instrument(&mut key_options.client_options);
+    recording.instrument(&mut key_options.client_options, None);
 
     let key_client = KeyClient::new(
         client.endpoint().as_str(),

--- a/sdk/keyvault/azure_security_keyvault_keys/perf/create_key.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/perf/create_key.rs
@@ -72,7 +72,7 @@ impl PerfTest for CreateKey {
         let credential = recording.credential();
 
         let mut client_options = KeyClientOptions::default();
-        recording.instrument_perf(&mut client_options.client_options)?;
+        recording.instrument_perf(&mut client_options.client_options, None)?;
 
         let vault_url = self
             .vault_url

--- a/sdk/keyvault/azure_security_keyvault_keys/perf/get_key.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/perf/get_key.rs
@@ -72,7 +72,7 @@ impl PerfTest for GetKey {
         let credential = recording.credential();
 
         let mut client_options = KeyClientOptions::default();
-        recording.instrument_perf(&mut client_options.client_options)?;
+        recording.instrument_perf(&mut client_options.client_options, None)?;
 
         let vault_url = self
             .vault_url

--- a/sdk/keyvault/azure_security_keyvault_keys/tests/key_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/tests/key_client.rs
@@ -21,7 +21,7 @@ async fn key_roundtrip(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
 
     let mut options = KeyClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = KeyClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -63,7 +63,7 @@ async fn update_key_properties(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
 
     let mut options = KeyClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = KeyClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -111,7 +111,7 @@ async fn list_keys(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
 
     let mut options = KeyClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = KeyClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -160,7 +160,7 @@ async fn purge_key(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
 
     let mut options = KeyClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = KeyClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -217,7 +217,7 @@ async fn encrypt_decrypt(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
 
     let mut options = KeyClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = KeyClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -284,7 +284,7 @@ async fn encrypt_decrypt_latest_key_version(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
 
     let mut options = KeyClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = KeyClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -337,7 +337,7 @@ async fn sign_verify(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
 
     let mut options = KeyClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = KeyClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -402,7 +402,7 @@ async fn wrap_key_unwrap_key(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
 
     let mut options = KeyClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = KeyClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),

--- a/sdk/keyvault/azure_security_keyvault_keys/tests/readme.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/tests/readme.rs
@@ -13,7 +13,7 @@ async fn readme(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
 
     let mut options = KeyClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = KeyClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),

--- a/sdk/keyvault/azure_security_keyvault_secrets/perf/get_secret.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/perf/get_secret.rs
@@ -77,7 +77,7 @@ impl PerfTest for GetSecrets {
         let credential = recording.credential();
 
         let mut client_options = SecretClientOptions::default();
-        recording.instrument_perf(&mut client_options.client_options)?;
+        recording.instrument_perf(&mut client_options.client_options, None)?;
 
         let vault_url = self
             .vault_url

--- a/sdk/keyvault/azure_security_keyvault_secrets/tests/readme.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/tests/readme.rs
@@ -13,7 +13,7 @@ async fn readme(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
 
     let mut options = SecretClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = SecretClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),

--- a/sdk/keyvault/azure_security_keyvault_secrets/tests/secret_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/tests/secret_client.rs
@@ -26,7 +26,7 @@ async fn secret_roundtrip(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
 
     let mut options = SecretClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = SecretClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -67,7 +67,7 @@ async fn update_secret_properties(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
 
     let mut options = SecretClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = SecretClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -115,7 +115,7 @@ async fn list_secrets(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
 
     let mut options = SecretClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = SecretClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -164,7 +164,7 @@ async fn purge_secret(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
 
     let mut options = SecretClientOptions::default();
-    recording.instrument(&mut options.client_options);
+    recording.instrument(&mut options.client_options, None);
 
     let client = SecretClient::new(
         recording.var("AZURE_KEYVAULT_URL", None).as_str(),
@@ -228,7 +228,7 @@ async fn round_trip_secret_verify_telemetry(ctx: TestContext) -> Result<()> {
     azure_core_test::tracing::assert_instrumentation_information(
         |tracer_provider| {
             let mut options = SecretClientOptions::default();
-            recording.instrument(&mut options.client_options);
+            recording.instrument(&mut options.client_options, None);
             options.client_options.instrumentation = InstrumentationOptions {
                 tracer_provider: Some(tracer_provider),
             };
@@ -316,7 +316,7 @@ async fn list_secrets_verify_telemetry(ctx: TestContext) -> Result<()> {
 
         let secret_client = {
             let mut options = SecretClientOptions::default();
-            recording.instrument(&mut options.client_options);
+            recording.instrument(&mut options.client_options, None);
             SecretClient::new(
                 recording.var("AZURE_KEYVAULT_URL", None).as_str(),
                 recording.credential(),
@@ -346,7 +346,7 @@ async fn list_secrets_verify_telemetry(ctx: TestContext) -> Result<()> {
     let validate_result = azure_core_test::tracing::assert_instrumentation_information(
         |tracer_provider| {
             let mut options = SecretClientOptions::default();
-            recording.instrument(&mut options.client_options);
+            recording.instrument(&mut options.client_options, None);
             options.client_options.instrumentation = InstrumentationOptions {
                 tracer_provider: Some(tracer_provider),
             };
@@ -406,7 +406,7 @@ async fn list_secrets_by_pages_verify_telemetry(ctx: TestContext) -> Result<()> 
 
         let secret_client = {
             let mut options = SecretClientOptions::default();
-            recording.instrument(&mut options.client_options);
+            recording.instrument(&mut options.client_options, None);
             SecretClient::new(
                 recording.var("AZURE_KEYVAULT_URL", None).as_str(),
                 recording.credential(),
@@ -436,7 +436,7 @@ async fn list_secrets_by_pages_verify_telemetry(ctx: TestContext) -> Result<()> 
     let validate_result = azure_core_test::tracing::assert_instrumentation_information(
         |tracer_provider| {
             let mut options = SecretClientOptions::default();
-            recording.instrument(&mut options.client_options);
+            recording.instrument(&mut options.client_options, None);
             options.client_options.instrumentation = InstrumentationOptions {
                 tracer_provider: Some(tracer_provider),
             };
@@ -499,7 +499,7 @@ async fn list_secrets_verify_telemetry_rehydrated(ctx: TestContext) -> Result<()
 
         let secret_client = {
             let mut options = SecretClientOptions::default();
-            recording.instrument(&mut options.client_options);
+            recording.instrument(&mut options.client_options, None);
             SecretClient::new(
                 recording.var("AZURE_KEYVAULT_URL", None).as_str(),
                 recording.credential(),
@@ -529,7 +529,7 @@ async fn list_secrets_verify_telemetry_rehydrated(ctx: TestContext) -> Result<()
     let validate_result = azure_core_test::tracing::assert_instrumentation_information(
         |tracer_provider| {
             let mut options = SecretClientOptions::default();
-            recording.instrument(&mut options.client_options);
+            recording.instrument(&mut options.client_options, None);
             options.client_options.instrumentation = InstrumentationOptions {
                 tracer_provider: Some(tracer_provider),
             };

--- a/sdk/storage/azure_storage_blob/tests/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client.rs
@@ -22,8 +22,8 @@ use azure_storage_blob::{
     BlobClient, BlobClientOptions, BlobContainerClient, BlobContainerClientOptions, StorageError,
 };
 use azure_storage_blob_test::{
-    create_test_blob, get_blob_name, get_container_client, get_container_name, ClientOptionsExt,
-    StorageAccount, TestPolicy,
+    create_test_blob, get_blob_name, get_container_client, get_container_name, recorded_test_setup,
+    ClientOptionsExt, StorageAccount, TestPolicy,
 };
 use bytes::{BufMut, BytesMut};
 use flate2::{write::GzEncoder, Compression};
@@ -524,7 +524,7 @@ async fn test_encoding_edge_cases(ctx: TestContext) -> Result<(), Box<dyn Error>
     // Recording Setup
     let recording = ctx.recording();
     let mut client_options = ClientOptions::default();
-    recording.instrument(&mut client_options);
+    let endpoint = recorded_test_setup(recording, StorageAccount::Standard, &mut client_options);
 
     // ContainerClient Options
     let container_client_options = BlobContainerClientOptions {
@@ -537,12 +537,6 @@ async fn test_encoding_edge_cases(ctx: TestContext) -> Result<(), Box<dyn Error>
         client_options: client_options.clone(),
         ..Default::default()
     };
-
-    // Endpoint
-    let endpoint = format!(
-        "https://{}.blob.core.windows.net/",
-        recording.var("AZURE_STORAGE_ACCOUNT_NAME", None).as_str()
-    );
 
     let container_name = get_container_name(recording);
     // Create Container & Container Client

--- a/sdk/storage/azure_storage_blob_test/src/lib.rs
+++ b/sdk/storage/azure_storage_blob_test/src/lib.rs
@@ -20,7 +20,7 @@ use azure_core::{
     },
     Bytes, Result,
 };
-use azure_core_test::Recording;
+use azure_core_test::{InstrumentOptions, Recording};
 use azure_storage_blob::{
     models::{
         BlockBlobClientUploadOptions, BlockBlobClientUploadResult, BlockLookupList,
@@ -111,7 +111,13 @@ pub fn recorded_test_setup(
     account_type: StorageAccount,
     client_options: &mut ClientOptions,
 ) -> String {
-    recording.instrument(client_options);
+    recording.instrument(
+        client_options,
+        Some(InstrumentOptions {
+            // Storage does not use automatic decompression by default.
+            automatic_decompression: false,
+        }),
+    );
 
     let account_name_var = match account_type {
         StorageAccount::Standard => "AZURE_STORAGE_ACCOUNT_NAME",

--- a/sdk/storage/azure_storage_queue/tests/common/mod.rs
+++ b/sdk/storage/azure_storage_queue/tests/common/mod.rs
@@ -22,7 +22,7 @@ pub fn get_queue_name(recording: &Recording) -> String {
 /// * `recording` - A reference to a Recording instance.
 pub fn recorded_test_setup(recording: &Recording) -> (ClientOptions, String, String) {
     let mut client_options = ClientOptions::default();
-    recording.instrument(&mut client_options);
+    recording.instrument(&mut client_options, None);
     let account_name = recording.var("AZURE_STORAGE_ACCOUNT_NAME", None);
     let endpoint = format!("https://{}.queue.core.windows.net/", account_name.as_str());
     let secondary_endpoint = format!(


### PR DESCRIPTION
Switches the default binding to HTTPS for test-proxy and allows self-signed CAs, working around an issue in `reqwest` that rejected self-signed CAs as TLS certificates.

Limits blast radius to tests.

Resolves #4345
