### PR TITLE
[Storage] Patch trust boundary in `partitioned_stream`

### DIFF
--- a/sdk/storage/azure_storage_blob/src/buffers/mod.rs
+++ b/sdk/storage/azure_storage_blob/src/buffers/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+pub(crate) mod read_buf;
+pub(crate) mod read_buf_ext;

--- a/sdk/storage/azure_storage_blob/src/buffers/read_buf.rs
+++ b/sdk/storage/azure_storage_blob/src/buffers/read_buf.rs
@@ -61,6 +61,10 @@ impl ReadBuf {
         self.buf.len()
     }
 
+    pub fn remaining(&self) -> usize {
+        self.capacity() - self.len()
+    }
+
     /// Gets a mutable reference to the slice of bytes between `len()` and `capacity()`.
     pub fn spare_capacity_mut(&mut self) -> &mut [u8] {
         &mut self.buf[self.cursor..]

--- a/sdk/storage/azure_storage_blob/src/buffers/read_buf.rs
+++ b/sdk/storage/azure_storage_blob/src/buffers/read_buf.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/// Buffer wrapper to support read-style APIs, e.g. `AsyncReadExt::read()`.
+///
+/// # Safety
+///
+/// This type implements the minimum viable API to achieve its goal, marking appropriate
+/// methods as unsafe to ensure proper use. To avoid bypassing these markers, any larger
+/// functionality should be built in `ReadBufExt`, outside this module.
+///
+/// # Remarks
+///
+/// Most other buffer APIs that support a running cursor across multiple writes do not support
+/// direct writes to the underlying data via `&mut [u8]`. This interface is to support such
+/// cursor functionality for APIs that directly access the target slice. Such APIs are harder
+/// to prove correctness with, trusting an implicit contract that whoever accesses that memory
+/// is writing to it as intended and communicating the number of bytes written accordingly.
+/// This type forces callers to make those decisions. An extension trait contains common
+/// implementations.
+///
+/// To get the owned data back out, a `finalize()` must be written based on the implementing
+/// type to properly truncate the data before returning ownership.
+#[derive(Default)]
+pub(crate) struct ReadBuf {
+    buf: Vec<u8>,
+    cursor: usize,
+}
+
+impl ReadBuf {
+    /// Creates a new ReadBuf with a zeroed Vec of the given capacity.
+    pub fn zeroed(capacity: usize) -> Self {
+        Self {
+            buf: vec![0; capacity],
+            cursor: 0,
+        }
+    }
+
+    /// Extends the capacity of this buf and zeroes the new capacity.
+    pub fn extend_zeroed(&mut self, additional: usize) {
+        self.buf.resize(self.buf.len() + additional, 0);
+    }
+
+    /// Returns the inner vec, truncated to len().
+    pub fn finalize(mut self) -> Vec<u8> {
+        self.buf.truncate(self.cursor);
+        self.buf
+    }
+
+    /// Gets the length of written bytes.
+    pub fn len(&self) -> usize {
+        self.cursor
+    }
+    /// Gets if there are no written bytes.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Gets the capacity of the underlying buffer.
+    pub fn capacity(&self) -> usize {
+        self.buf.len()
+    }
+
+    /// Gets a mutable reference to the slice of bytes between `len()` and `capacity()`.
+    pub fn spare_capacity_mut(&mut self) -> &mut [u8] {
+        &mut self.buf[self.cursor..]
+    }
+
+    /// Set the length of this buffer.
+    ///
+    /// # Safety
+    ///
+    /// This method updates the internal cursor of the length without any checks.
+    /// It is the caller's responsibility to ensure this is is within the buffer's capacity.
+    pub unsafe fn set_len(&mut self, position: usize) {
+        self.cursor = position;
+    }
+}

--- a/sdk/storage/azure_storage_blob/src/buffers/read_buf.rs
+++ b/sdk/storage/azure_storage_blob/src/buffers/read_buf.rs
@@ -76,7 +76,7 @@ impl ReadBuf {
     ///
     /// This method updates the internal cursor of the length without any checks.
     /// It is the caller's responsibility to ensure this is within the buffer's capacity.
-    pub unsafe fn set_len(&mut self, position: usize) {
+    pub unsafe fn set_len_unchecked(&mut self, position: usize) {
         self.cursor = position;
     }
 }

--- a/sdk/storage/azure_storage_blob/src/buffers/read_buf.rs
+++ b/sdk/storage/azure_storage_blob/src/buffers/read_buf.rs
@@ -75,7 +75,7 @@ impl ReadBuf {
     /// # Safety
     ///
     /// This method updates the internal cursor of the length without any checks.
-    /// It is the caller's responsibility to ensure this is is within the buffer's capacity.
+    /// It is the caller's responsibility to ensure this is within the buffer's capacity.
     pub unsafe fn set_len(&mut self, position: usize) {
         self.cursor = position;
     }

--- a/sdk/storage/azure_storage_blob/src/buffers/read_buf.rs
+++ b/sdk/storage/azure_storage_blob/src/buffers/read_buf.rs
@@ -76,7 +76,7 @@ impl ReadBuf {
     ///
     /// This method updates the internal cursor of the length without any checks.
     /// It is the caller's responsibility to ensure this is within the buffer's capacity.
-    pub unsafe fn set_len_unchecked(&mut self, position: usize) {
+    pub unsafe fn unchecked_set_len(&mut self, position: usize) {
         self.cursor = position;
     }
 }

--- a/sdk/storage/azure_storage_blob/src/buffers/read_buf_ext.rs
+++ b/sdk/storage/azure_storage_blob/src/buffers/read_buf_ext.rs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use std::io::Write;
+
+use azure_core::{error::ErrorKind, Error, Result};
+use futures::{AsyncRead, AsyncReadExt};
+
+use crate::buffers::read_buf::ReadBuf;
+
+/// Extensions for `ReadBuf`.
+pub(crate) trait ReadBufExt {
+    fn extend_from_slice(&mut self, data: &[u8]) -> Result<()>;
+    async fn read_from<R>(&mut self, read: &mut R) -> Result<usize>
+    where
+        R: AsyncRead + Unpin;
+}
+
+impl ReadBufExt for ReadBuf {
+    fn extend_from_slice(&mut self, mut data: &[u8]) -> Result<()> {
+        while !data.is_empty() {
+            let remaining = self.capacity() - self.len();
+            if remaining < data.len() {
+                self.extend_zeroed(data.len() - remaining);
+            }
+            let mut dst = self.spare_capacity_mut();
+            let written = dst.write(data)?;
+            // SAFETY: We trust values returned from std::io::impls.
+            unsafe { self.set_len(self.len() + written) };
+            data = &data[written..];
+        }
+        Ok(())
+    }
+
+    async fn read_from<R>(&mut self, read: &mut R) -> Result<usize>
+    where
+        R: AsyncRead + Unpin,
+    {
+        let dst = self.spare_capacity_mut();
+        let count = read.read(dst).await?;
+        let new_len = self.len() + count;
+
+        if new_len <= self.capacity() {
+            // SAFETY: This is being performed immediately after the length is proven
+            // to be within capacity.
+            unsafe { self.set_len(new_len) };
+            Ok(count)
+        } else {
+            // The AsyncRead implementation returned an impossible byte read count.
+            // Whether through a bug or through malice, it can't be trusted.
+            Err(Error::with_message(
+                ErrorKind::Io,
+                "AsyncRead::read returned an impossible byte read count.",
+            ))
+        }
+    }
+}

--- a/sdk/storage/azure_storage_blob/src/buffers/read_buf_ext.rs
+++ b/sdk/storage/azure_storage_blob/src/buffers/read_buf_ext.rs
@@ -1,21 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use std::io::Write;
+use std::{cmp::min, io::Write};
 
+use async_trait::async_trait;
 use azure_core::{error::ErrorKind, Error, Result};
 use futures::{AsyncRead, AsyncReadExt};
 
 use crate::buffers::read_buf::ReadBuf;
 
 /// Extensions for `ReadBuf`.
+#[async_trait]
 pub(crate) trait ReadBufExt {
     fn extend_from_slice(&mut self, data: &[u8]) -> Result<()>;
     async fn read_from<R>(&mut self, read: &mut R) -> Result<usize>
     where
-        R: AsyncRead + Unpin;
+        R: AsyncRead + Unpin + Send;
+    async fn read_exactly_from<R>(&mut self, read: &mut R, amount: usize) -> Result<usize>
+    where
+        R: AsyncRead + Unpin + Send;
 }
 
+#[async_trait]
 impl ReadBufExt for ReadBuf {
     fn extend_from_slice(&mut self, mut data: &[u8]) -> Result<()> {
         while !data.is_empty() {
@@ -32,12 +38,12 @@ impl ReadBufExt for ReadBuf {
         Ok(())
     }
 
-    async fn read_from<R>(&mut self, read: &mut R) -> Result<usize>
+    async fn read_from<R>(&mut self, stream: &mut R) -> Result<usize>
     where
-        R: AsyncRead + Unpin,
+        R: AsyncRead + Unpin + Send,
     {
         let dst = self.spare_capacity_mut();
-        let count = read.read(dst).await?;
+        let count = stream.read(dst).await?;
         let new_len = self.len() + count;
 
         if new_len <= self.capacity() {
@@ -53,5 +59,36 @@ impl ReadBufExt for ReadBuf {
                 "AsyncRead::read returned an impossible byte read count.",
             ))
         }
+    }
+    async fn read_exactly_from<R>(&mut self, stream: &mut R, amount: usize) -> Result<usize>
+    where
+        R: AsyncRead + Unpin + Send,
+    {
+        let mut total_read = 0;
+        while total_read < amount {
+            let to_read = min(self.remaining(), amount.saturating_sub(total_read));
+            let dst = &mut self.spare_capacity_mut()[..to_read];
+            let count = stream.read(dst).await?;
+            if count == 0 {
+                return Ok(total_read);
+            }
+            total_read += count;
+            let new_len = self.len() + count;
+
+            if new_len <= self.capacity() {
+                // SAFETY: This is being performed immediately after the length is proven
+                // to be within capacity.
+                unsafe { self.set_len(new_len) };
+            } else {
+                // The AsyncRead implementation returned an impossible byte read count.
+                // Whether through a bug or through malice, it can't be trusted.
+                return Err(Error::with_message(
+                    ErrorKind::Io,
+                    "AsyncRead::read returned an impossible byte read count.",
+                ));
+            }
+        }
+
+        Ok(total_read)
     }
 }

--- a/sdk/storage/azure_storage_blob/src/buffers/read_buf_ext.rs
+++ b/sdk/storage/azure_storage_blob/src/buffers/read_buf_ext.rs
@@ -107,7 +107,7 @@ mod tests {
         ) -> std::task::Poll<std::io::Result<usize>> {
             Poll::Ready(
                 self.count
-                    .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "mock error")),
+                    .ok_or_else(|| std::io::Error::other("mock error")),
             )
         }
     }

--- a/sdk/storage/azure_storage_blob/src/buffers/read_buf_ext.rs
+++ b/sdk/storage/azure_storage_blob/src/buffers/read_buf_ext.rs
@@ -10,6 +10,7 @@ use futures::{AsyncRead, AsyncReadExt};
 use crate::buffers::read_buf::ReadBuf;
 
 /// Extensions for `ReadBuf`.
+/// Enforces modification of internal cursor go through unsafe methods defined on the type.
 #[async_trait]
 pub(crate) trait ReadBufExt {
     fn extend_from_slice(&mut self, data: &[u8]) -> Result<()>;
@@ -47,13 +48,13 @@ impl ReadBufExt for ReadBuf {
         unsafe { self.set_len(self.len() + count) };
         Ok(count)
     }
-    async fn read_exactly_from<R>(&mut self, stream: &mut R, amount: usize) -> Result<usize>
+    async fn read_exactly_from<R>(&mut self, stream: &mut R, len: usize) -> Result<usize>
     where
         R: AsyncRead + Unpin + Send,
     {
         let mut total_read = 0;
-        while total_read < amount {
-            let to_read = min(self.remaining(), amount.saturating_sub(total_read));
+        while total_read < len {
+            let to_read = min(self.remaining(), len.saturating_sub(total_read));
             let dst = &mut self.spare_capacity_mut()[..to_read];
             let count = validated_read(dst, stream).await?;
             // SAFETY: `count` has been validated as <= `dst.len()`, a slice of `self.spare_capacity_mut()`

--- a/sdk/storage/azure_storage_blob/src/buffers/read_buf_ext.rs
+++ b/sdk/storage/azure_storage_blob/src/buffers/read_buf_ext.rs
@@ -89,3 +89,77 @@ where
     }
     Ok(count)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::task::Poll;
+
+    use super::*;
+
+    struct MockAsyncRead {
+        count: Option<usize>,
+    }
+    impl AsyncRead for MockAsyncRead {
+        fn poll_read(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            _buf: &mut [u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
+            Poll::Ready(
+                self.count
+                    .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "mock error")),
+            )
+        }
+    }
+
+    #[tokio::test]
+    async fn validated_read_success() {
+        for (slice_len, async_read_count) in [
+            (0, 0),
+            (1, 0),
+            (1, 1),
+            (1024, 1024),
+            (12345, 1024),
+            (12345, 123),
+        ] {
+            // sanity check we're testing the right thing
+            assert!(slice_len >= async_read_count);
+
+            let mut buf = vec![0; slice_len];
+            let mut async_read = MockAsyncRead {
+                count: Some(async_read_count),
+            };
+            assert_eq!(
+                validated_read(&mut buf, &mut async_read).await.unwrap(),
+                async_read_count
+            )
+        }
+    }
+
+    #[tokio::test]
+    async fn validated_read_propagates_error() {
+        let mut buf = vec![0; 1024];
+        let mut async_read = MockAsyncRead { count: None };
+        assert_eq!(
+            validated_read(&mut buf, &mut async_read)
+                .await
+                .unwrap_err()
+                .to_string(),
+            "mock error"
+        )
+    }
+
+    #[tokio::test]
+    async fn validated_read_detects_bad_count() {
+        for (slice_len, async_read_count) in [(0, 1), (1, 2), (1024, 1234), (123, 12345)] {
+            // sanity check we're testing the right thing
+            assert!(slice_len < async_read_count);
+
+            let mut buf = vec![0; slice_len];
+            let mut async_read = MockAsyncRead {
+                count: Some(async_read_count),
+            };
+            assert!(validated_read(&mut buf, &mut async_read).await.is_err())
+        }
+    }
+}

--- a/sdk/storage/azure_storage_blob/src/buffers/read_buf_ext.rs
+++ b/sdk/storage/azure_storage_blob/src/buffers/read_buf_ext.rs
@@ -42,23 +42,10 @@ impl ReadBufExt for ReadBuf {
     where
         R: AsyncRead + Unpin + Send,
     {
-        let dst = self.spare_capacity_mut();
-        let count = stream.read(dst).await?;
-        let new_len = self.len() + count;
-
-        if new_len <= self.capacity() {
-            // SAFETY: This is being performed immediately after the length is proven
-            // to be within capacity.
-            unsafe { self.set_len(new_len) };
-            Ok(count)
-        } else {
-            // The AsyncRead implementation returned an impossible byte read count.
-            // Whether through a bug or through malice, it can't be trusted.
-            Err(Error::with_message(
-                ErrorKind::Io,
-                "AsyncRead::read returned an impossible byte read count.",
-            ))
-        }
+        let count = validated_read(self.spare_capacity_mut(), stream).await?;
+        // SAFETY: `count` has been validated as <= `self.spare_capacity_mut().len()`
+        unsafe { self.set_len(self.len() + count) };
+        Ok(count)
     }
     async fn read_exactly_from<R>(&mut self, stream: &mut R, amount: usize) -> Result<usize>
     where
@@ -68,27 +55,37 @@ impl ReadBufExt for ReadBuf {
         while total_read < amount {
             let to_read = min(self.remaining(), amount.saturating_sub(total_read));
             let dst = &mut self.spare_capacity_mut()[..to_read];
-            let count = stream.read(dst).await?;
+            let count = validated_read(dst, stream).await?;
+            // SAFETY: `count` has been validated as <= `dst.len()`, a slice of `self.spare_capacity_mut()`
+            unsafe { self.set_len(self.len() + count) };
+
             if count == 0 {
                 return Ok(total_read);
             }
             total_read += count;
-            let new_len = self.len() + count;
-
-            if new_len <= self.capacity() {
-                // SAFETY: This is being performed immediately after the length is proven
-                // to be within capacity.
-                unsafe { self.set_len(new_len) };
-            } else {
-                // The AsyncRead implementation returned an impossible byte read count.
-                // Whether through a bug or through malice, it can't be trusted.
-                return Err(Error::with_message(
-                    ErrorKind::Io,
-                    "AsyncRead::read returned an impossible byte read count.",
-                ));
-            }
         }
 
         Ok(total_read)
     }
+}
+
+/// Performs a read into the given slice.
+/// Validates that the count returned is accurate to the buffer provided.
+///
+/// # Returns
+///
+/// - Err if `stream.read(buf).await?` > `buf.len()`
+/// - Otherwise, the `Result` of `stream.read(buf).await`
+async fn validated_read<R>(buf: &mut [u8], stream: &mut R) -> Result<usize>
+where
+    R: AsyncRead + Unpin,
+{
+    let count = stream.read(buf).await?;
+    if count > buf.len() {
+        return Err(Error::with_message(
+            ErrorKind::Io,
+            "AsyncRead::read returned an impossible byte read count.",
+        ));
+    }
+    Ok(count)
 }

--- a/sdk/storage/azure_storage_blob/src/buffers/read_buf_ext.rs
+++ b/sdk/storage/azure_storage_blob/src/buffers/read_buf_ext.rs
@@ -33,7 +33,7 @@ impl ReadBufExt for ReadBuf {
             let mut dst = self.spare_capacity_mut();
             let written = dst.write(data)?;
             // SAFETY: We trust values returned from std::io::impls.
-            unsafe { self.set_len(self.len() + written) };
+            unsafe { self.unchecked_set_len(self.len() + written) };
             data = &data[written..];
         }
         Ok(())
@@ -45,7 +45,7 @@ impl ReadBufExt for ReadBuf {
     {
         let count = validated_read(self.spare_capacity_mut(), stream).await?;
         // SAFETY: `count` has been validated as <= `self.spare_capacity_mut().len()`
-        unsafe { self.set_len(self.len() + count) };
+        unsafe { self.unchecked_set_len(self.len() + count) };
         Ok(count)
     }
     async fn read_exactly_from<R>(&mut self, stream: &mut R, len: usize) -> Result<usize>
@@ -58,7 +58,7 @@ impl ReadBufExt for ReadBuf {
             let dst = &mut self.spare_capacity_mut()[..to_read];
             let count = validated_read(dst, stream).await?;
             // SAFETY: `count` has been validated as <= `dst.len()`, a slice of `self.spare_capacity_mut()`
-            unsafe { self.set_len(self.len() + count) };
+            unsafe { self.unchecked_set_len(self.len() + count) };
 
             if count == 0 {
                 return Ok(total_read);

--- a/sdk/storage/azure_storage_blob/src/lib.rs
+++ b/sdk/storage/azure_storage_blob/src/lib.rs
@@ -7,6 +7,7 @@
 #![allow(dead_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+pub(crate) mod buffers;
 pub mod clients;
 #[allow(unused_imports)]
 mod generated;

--- a/sdk/storage/azure_storage_blob/src/streams/partitioned_stream.rs
+++ b/sdk/storage/azure_storage_blob/src/streams/partitioned_stream.rs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 use async_stream::try_stream;
-use std::{cmp::min, mem, num::NonZero, slice};
+use std::{cmp::min, mem, num::NonZero};
 
 use azure_core::stream::SeekableStream;
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use futures::{AsyncReadExt, Stream};
 
 use crate::buffers::{read_buf::ReadBuf, read_buf_ext::ReadBufExt};
@@ -90,7 +90,7 @@ pub(crate) fn stream_single_buffer_partitions(
 struct MultiBufferPartition {
     completed_buffers: Vec<Bytes>,
     completed_buffers_total_bytes: u64,
-    current_buffer: BytesMut,
+    current_buffer: ReadBuf,
     buffer_len: usize,
 }
 
@@ -99,29 +99,26 @@ impl MultiBufferPartition {
         Self {
             completed_buffers: Vec::with_capacity(expected_buffers),
             completed_buffers_total_bytes: 0,
-            current_buffer: BytesMut::with_capacity(buffer_len),
+            current_buffer: ReadBuf::zeroed(buffer_len),
             buffer_len,
         }
     }
     fn len(&self) -> u64 {
         self.current_buffer.len() as u64 + self.completed_buffers_total_bytes
     }
-    fn buf(&mut self) -> &mut BytesMut {
+    fn buf(&mut self) -> &mut ReadBuf {
         if self.current_buffer.spare_capacity_mut().is_empty() {
-            let bytes = mem::replace(
-                &mut self.current_buffer,
-                BytesMut::with_capacity(self.buffer_len),
-            )
-            .freeze();
-            self.completed_buffers_total_bytes += bytes.len() as u64;
-            self.completed_buffers.push(bytes);
+            let vec =
+                mem::replace(&mut self.current_buffer, ReadBuf::zeroed(self.buffer_len)).finalize();
+            self.completed_buffers_total_bytes += vec.len() as u64;
+            self.completed_buffers.push(vec.into());
         }
         &mut self.current_buffer
     }
     fn freeze(mut self) -> Vec<Bytes> {
         if !self.current_buffer.is_empty() {
             self.completed_buffers
-                .push(mem::take(&mut self.current_buffer).freeze());
+                .push(mem::take(&mut self.current_buffer).finalize().into());
         }
         self.completed_buffers
     }
@@ -136,9 +133,12 @@ pub(crate) fn stream_multi_buffer_partitions(
     partition_len: NonZero<u64>,
 ) -> impl Stream<Item = Result<Vec<Bytes>>> {
     let partition_len = partition_len.get();
-    // supports a partition_len up to MAX_CONTIGUOUS_ELEMENT * MULTI_BUF_PARTITION_BUF_LEN (= 8 petabytes)
+    // supports a partition_len up to MAX_CONTIGUOUS_ELEMENT * MULTI_BUF_PARTITION_BUF_LEN (= 8 petabytes on 32-bit systems)
     let vec_len = partition_len
         .div_ceil(MULTI_BUF_PARTITION_BUF_LEN as u64)
+        // try_into is casting (down, on 32 bit systems) from u64 to usize.
+        // This should never actually fail under Storage-supported maximums,
+        // but unwrap_or safely caps at the max supported length for MultiBufferPartition
         .try_into()
         .unwrap_or(MAX_CONTIGUOUS_ELEMENTS);
     try_stream! {
@@ -153,31 +153,14 @@ pub(crate) fn stream_multi_buffer_partitions(
             let remaining_partition_space = remaining_partition_space; // un-mut this variable
 
             // Read from inner stream
-            // SAFETY: spare_capacity_mut() returns allocated memory without initialized value.
-            // We want to read directly into that memory. We are responsible for correctly
-            // updating `buf` with its new length using the memory we've now initialized.
-            unsafe {
-                let buf = partition.buf();
-                let spare_capacity = buf.spare_capacity_mut();
-                let mut spare_capacity = slice::from_raw_parts_mut(
-                    spare_capacity.as_mut_ptr() as *mut u8,
-                    spare_capacity.len(),
-                );
-                // Reserved capacity may go beyond the partition length. Cap it.
-                if let Ok(remaining_usize) = remaining_partition_space.try_into() {
-                    if spare_capacity.len() > remaining_usize {
-                        spare_capacity = &mut spare_capacity[..remaining_usize];
-                    }
+            let buf = partition.buf();
+            let count = buf.read_exactly_from(&mut inner, min(remaining_partition_space, buf.remaining() as u64) as usize).await?;
+            if count == 0 {
+                // stream finished! yield existing bytes and complete
+                if partition.len() > 0 {
+                    yield mem::take(&mut partition).freeze();
                 }
-                let count = inner.read(spare_capacity).await?;
-                if count == 0 {
-                    // stream finished! yield existing bytes and complete
-                    if partition.len() > 0 {
-                        yield mem::take(&mut partition).freeze();
-                    }
-                    break;
-                }
-                buf.set_len(buf.len() + count);
+                break;
             }
         }
     }

--- a/sdk/storage/azure_storage_blob/src/streams/partitioned_stream.rs
+++ b/sdk/storage/azure_storage_blob/src/streams/partitioned_stream.rs
@@ -5,8 +5,10 @@ use async_stream::try_stream;
 use std::{cmp::min, mem, num::NonZero, slice};
 
 use azure_core::stream::SeekableStream;
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::{Bytes, BytesMut};
 use futures::{AsyncReadExt, Stream};
+
+use crate::buffers::{read_buf::ReadBuf, read_buf_ext::ReadBufExt};
 
 type Result<T> = azure_core::Result<T>;
 
@@ -22,16 +24,19 @@ pub(crate) fn stream_single_buffer_partitions(
     try_stream! {
         let mut len_hint = inner.len();
         let mut total_read = 0;
-        let new_partition = |len_hint: Option<u64>, total_read: u64| BytesMut::with_capacity(len_hint
-            .map(|len| min(len.saturating_sub(total_read), partition_len as u64) as usize)
-            .unwrap_or(partition_len));
+        let new_partition = |len_hint: Option<u64>, total_read: u64| {
+            let capacity = len_hint
+                .map(|len| min(len.saturating_sub(total_read), partition_len as u64) as usize)
+                .unwrap_or(partition_len);
+            ReadBuf::zeroed(capacity)
+        };
         let mut partition = new_partition(len_hint, total_read);
         loop {
             // If partition is at partition_len, yield it
             // Do NOT consider the len_hint. We handle that later.
             let mut remaining_partition_space = partition_len.saturating_sub(partition.len());
             if remaining_partition_space == 0 {
-                yield mem::replace(&mut partition, new_partition(len_hint, total_read)).freeze();
+                yield mem::replace(&mut partition, new_partition(len_hint, total_read)).finalize().into();
                 remaining_partition_space = partition_len;
             }
             let remaining_partition_space = remaining_partition_space; // un-mut this variable
@@ -46,46 +51,30 @@ pub(crate) fn stream_single_buffer_partitions(
                 let count = inner.read(&mut small_buf).await?;
                 if count == 0 {
                     if !partition.is_empty() {
-                        yield mem::take(&mut partition).freeze();
+                        yield mem::take(&mut partition).finalize().into();
                     }
                     break;
                 }
                 let remaining = &small_buf[..count];
                 // len_hint proven inaccurate. discard and reallocate
                 len_hint = None;
-                partition.reserve(partition_len.saturating_sub(partition.capacity()));
-                partition.put(remaining);
+                partition.extend_zeroed(partition_len.saturating_sub(partition.capacity()));
+                partition.extend_from_slice(remaining)?;
                 total_read += count as u64;
                 // after special-case read, loop back around to recalculate next steps
                 continue;
             }
 
             // Read from inner stream
-            // SAFETY: spare_capacity_mut() returns allocated memory without initialized value.
-            // We want to read directly into that memory. We are responsible for correctly
-            // updating `buf` with its new length using the memory we've now initialized.
-            unsafe {
-                let spare_capacity = partition.spare_capacity_mut();
-                let mut spare_capacity = slice::from_raw_parts_mut(
-                    spare_capacity.as_mut_ptr() as *mut u8,
-                    spare_capacity.len(),
-                );
-                // Reserved capacity may go beyond the partition length. Cap it.
-                // The resulting capped slice may go beyond what len_hint suggests. Good.
-                if spare_capacity.len() > remaining_partition_space {
-                    spare_capacity = &mut spare_capacity[..remaining_partition_space];
+            let count = partition.read_from(&mut inner).await?;
+            if count == 0 {
+                // stream finished! yield existing bytes and complete
+                if !partition.is_empty() {
+                    yield mem::take(&mut partition).finalize().into();
                 }
-                let count = inner.read(spare_capacity).await?;
-                if count == 0 {
-                    // stream finished! yield existing bytes and complete
-                    if !partition.is_empty() {
-                        yield mem::take(&mut partition).freeze();
-                    }
-                    break;
-                }
-                partition.set_len(partition.len() + count);
-                total_read += count as u64;
+                break;
             }
+            total_read += count as u64;
 
             // If len_hint has been exceeded, discard as inaccurate
             if let Some(expected_total_len) = len_hint {

--- a/sdk/storage/azure_storage_blob/src/streams/partitioned_stream.rs
+++ b/sdk/storage/azure_storage_blob/src/streams/partitioned_stream.rs
@@ -133,7 +133,7 @@ pub(crate) fn stream_multi_buffer_partitions(
     partition_len: NonZero<u64>,
 ) -> impl Stream<Item = Result<Vec<Bytes>>> {
     let partition_len = partition_len.get();
-    // supports a partition_len up to MAX_CONTIGUOUS_ELEMENT * MULTI_BUF_PARTITION_BUF_LEN (= 8 petabytes on 32-bit systems)
+    // supports a partition_len up to MAX_CONTIGUOUS_ELEMENTS * MULTI_BUF_PARTITION_BUF_LEN (= 8 petabytes on 32-bit systems)
     let vec_len = partition_len
         .div_ceil(MULTI_BUF_PARTITION_BUF_LEN as u64)
         // try_into is casting (down, on 32 bit systems) from u64 to usize.


### PR DESCRIPTION
Chunking stream assumed a `Box<dyn SeekableStream>` supplied by the application was trustworthy. While this object was supplied by an application consuming this library in the first place, the application developer is not necessarily the stream implementor. We should protect the user from buggy or malicious stream implementations and treat the stream object as untrustworthy.

This patches two issues:
1. Feeding length from the stream object directly into `unsafe` code.
2. Allowing the stream object access to uninitialized memory.

Rather than use `bytes::BytesMut` as a cursor for multi-reads sequentially into a buffer, this fix introduces a new type `ReadBuf` has been introduced to handle this functionality. Unlike `BytesMut`, `ReadBuf` is entirely initialized upfront, ensuring no access is given to uninitialized memory.

Due to the nature of reading directly into supplied memory, `ReadBuf` still must provide method to update the cursor position based on the count returned by `read()`. But, the input value is now verified before use to ensure it does not go past the provided amount. This update method is marked `unsafe` with comments about this exact issue, to ensure values are always checked before their updating.

The only way the cursor in the `ReadBuf` can update is through that `unsafe` method. No other code with access touches the value. To help enforce this, the type implements a minimum required API surface to use the type. Other functionality is left to an extension trait, whose implementation does not have direct access to the cursor, forcing a maintainer to interact with `unsafe` methods and justify their usage.

There is an expected perf hit now that memory is initialized upfront. Since we must initialize any memory we pass across this trust boundary, this is unavoidable.