### PR TITLE
Cosmos: Forward user_agent_suffix to CosmosDriverRuntime (#4367)

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed `with_user_agent_suffix()` not being forwarded to the driver runtime. Requests made by the driver (PKRange resolution, container metadata, etc.) now include the configured user-agent suffix.
+
 ### Other Changes
 
 - Per-partition automatic failover (PPAF) and per-partition circuit breaker (PPCB) are now driven by the `azure_data_cosmos_driver` crate, replacing the SDK's prior implementation. Behavior is unchanged from a configuration standpoint — the existing `AZURE_COSMOS_PER_PARTITION_CIRCUIT_BREAKER_ENABLED` environment variable continues to work — but routing is now per-`(partition_key_range_id, region)` instead of per-region. Driver-level changes are described in [`azure_data_cosmos_driver` 0.3.0](https://github.com/Azure/azure-sdk-for-rust/blob/main/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md). ([#4156](https://github.com/Azure/azure-sdk-for-rust/pull/4156))

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client_builder.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client_builder.rs
@@ -330,8 +330,11 @@ impl CosmosClientBuilder {
         // Create Cosmos headers policy to override User-Agent with Cosmos-specific value.
         // This runs as a per-call policy after azure_core's UserAgentPolicy.
         let crate_version = option_env!("CARGO_PKG_VERSION").unwrap_or("unknown");
+        // Extract before self.options is moved into GatewayPipeline so we can
+        // also forward it to the driver runtime builder below.
+        let user_agent_suffix = self.options.user_agent_suffix.clone();
         let cosmos_headers_policy: Arc<dyn azure_core::http::policies::Policy> = Arc::new(
-            CosmosHeadersPolicy::new(crate_version, self.options.user_agent_suffix.as_deref()),
+            CosmosHeadersPolicy::new(crate_version, user_agent_suffix.as_deref()),
         );
 
         let pipeline_core = azure_core::http::Pipeline::new(
@@ -414,6 +417,25 @@ impl CosmosClientBuilder {
         #[allow(unused_mut)]
         let mut driver_runtime_builder = CosmosDriverRuntimeBuilder::new();
 
+        // Forward the user-agent suffix so requests made by the driver
+        // (PKRange resolution, container metadata, etc.) carry the same
+        // identifier as requests made through the SDK pipeline.
+        if let Some(ref suffix) = user_agent_suffix {
+            if let Some(driver_suffix) =
+                azure_data_cosmos_driver::options::UserAgentSuffix::try_new(suffix.as_str())
+            {
+                driver_runtime_builder =
+                    driver_runtime_builder.with_user_agent_suffix(driver_suffix);
+            } else {
+                tracing::warn!(
+                    suffix = %suffix,
+                    "user_agent_suffix is too long or contains invalid characters for the \
+                     driver runtime (max 25 chars, alphanumeric/hyphen/underscore/dot/tilde); \
+                     it will not be set on the driver"
+                );
+            }
+        }
+
         // Forward SDK connection settings to the driver's connection pool.
         let mut pool_builder = ConnectionPoolOptions::builder();
         if self.allow_proxy {
@@ -480,3 +502,80 @@ fn build_driver_account(
 // CosmosClient::builder().build() now eagerly creates a CosmosDriver,
 // which requires a real endpoint. Re-add once fault injection is linked
 // from the SDK to the driver.
+
+#[cfg(test)]
+mod tests {
+    use azure_data_cosmos_driver::options::UserAgentSuffix;
+
+    use crate::CosmosClientOptions;
+
+    #[test]
+    fn user_agent_suffix_valid_forwards_to_driver() {
+        let options = CosmosClientOptions {
+            user_agent_suffix: Some("my-app".to_string()),
+            ..Default::default()
+        };
+
+        let driver_suffix = options
+            .user_agent_suffix
+            .as_deref()
+            .and_then(UserAgentSuffix::try_new);
+
+        assert!(
+            driver_suffix.is_some(),
+            "valid suffix should convert to UserAgentSuffix"
+        );
+        assert_eq!(driver_suffix.unwrap().as_str(), "my-app");
+    }
+
+    #[test]
+    fn user_agent_suffix_too_long_does_not_forward_to_driver() {
+        // UserAgentSuffix has a 25-char max; build a string that exceeds it.
+        let long_suffix = "a".repeat(26);
+        let options = CosmosClientOptions {
+            user_agent_suffix: Some(long_suffix),
+            ..Default::default()
+        };
+
+        let driver_suffix = options
+            .user_agent_suffix
+            .as_deref()
+            .and_then(UserAgentSuffix::try_new);
+
+        assert!(
+            driver_suffix.is_none(),
+            "suffix exceeding 25 chars should not convert"
+        );
+    }
+
+    #[test]
+    fn user_agent_suffix_invalid_chars_does_not_forward_to_driver() {
+        // Spaces are not allowed in UserAgentSuffix.
+        let options = CosmosClientOptions {
+            user_agent_suffix: Some("my app".to_string()),
+            ..Default::default()
+        };
+
+        let driver_suffix = options
+            .user_agent_suffix
+            .as_deref()
+            .and_then(UserAgentSuffix::try_new);
+
+        assert!(
+            driver_suffix.is_none(),
+            "suffix with invalid characters should not convert"
+        );
+    }
+
+    #[test]
+    fn user_agent_suffix_none_does_not_forward_to_driver() {
+        let options = CosmosClientOptions::default();
+
+        let driver_suffix = options
+            .user_agent_suffix
+            .as_deref()
+            .and_then(UserAgentSuffix::try_new);
+
+        assert!(driver_suffix.is_none(), "no suffix set should yield None");
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/runtime.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/runtime.rs
@@ -722,6 +722,63 @@ mod tests {
     use super::*;
     use url::Url;
 
+    /// Verifies that `with_user_agent_suffix` is stored in the built runtime.
+    #[tokio::test]
+    async fn user_agent_suffix_is_forwarded_to_runtime() {
+        let suffix = UserAgentSuffix::try_new("test-app").expect("valid suffix");
+        let runtime = CosmosDriverRuntimeBuilder::new()
+            .with_user_agent_suffix(suffix)
+            .build()
+            .await
+            .unwrap();
+
+        assert_eq!(runtime.user_agent().suffix(), Some("test-app"));
+    }
+
+    /// Verifies that the user-agent suffix set on the runtime appears in the
+    /// `User-Agent` HTTP header that the driver attaches to outgoing requests.
+    ///
+    /// This mirrors how `fetch_account_properties_with_runtime` (and other
+    /// driver internals) build the header value: they call
+    /// `runtime.user_agent().as_str()` and pass it to `apply_cosmos_headers`.
+    #[tokio::test]
+    async fn user_agent_suffix_appears_in_request_headers() {
+        use crate::driver::transport::{
+            cosmos_headers::apply_cosmos_headers, cosmos_transport_client::HttpRequest,
+        };
+        use azure_core::http::headers::{HeaderValue, Headers, USER_AGENT};
+        use azure_core::http::Method;
+
+        let suffix = UserAgentSuffix::try_new("test-app").expect("valid suffix");
+        let runtime = CosmosDriverRuntimeBuilder::new()
+            .with_user_agent_suffix(suffix)
+            .build()
+            .await
+            .unwrap();
+
+        // Replicate the header construction used in driver request paths.
+        let user_agent_hv = HeaderValue::from(runtime.user_agent().as_str().to_owned());
+        let mut request = HttpRequest {
+            url: Url::parse("https://test.documents.azure.com/").unwrap(),
+            method: Method::Get,
+            headers: Headers::new(),
+            body: None,
+            timeout: None,
+            #[cfg(feature = "fault_injection")]
+            evaluation_collector: None,
+        };
+        apply_cosmos_headers(&mut request, &user_agent_hv);
+
+        let header_value = request
+            .headers
+            .get_optional_str(&USER_AGENT)
+            .expect("User-Agent header should be set by apply_cosmos_headers");
+        assert!(
+            header_value.contains("test-app"),
+            "User-Agent header '{header_value}' should contain the suffix 'test-app'"
+        );
+    }
+
     #[tokio::test]
     async fn get_or_create_driver_removes_failed_initialization_from_registry() {
         let runtime = CosmosDriverRuntimeBuilder::new().build().await.unwrap();


### PR DESCRIPTION
with_user_agent_suffix() was stored in CosmosClientOptions and forwarded to CosmosHeadersPolicy (the SDK pipeline), but was never plumbed through to CosmosDriverRuntimeBuilder.  Requests made by the driver runtime for PKRange resolution and container metadata therefore never carried the configured user-agent suffix.

Extract the suffix into a local variable before self.options is moved into GatewayPipeline, then call UserAgentSuffix::try_new() and pass it to CosmosDriverRuntimeBuilder::with_user_agent_suffix() when valid. If the suffix is too long or contains characters that are not permitted by the driver (max 25, alphanumeric/hyphen/underscore/dot/tilde), a tracing::warn is emitted and the driver suffix is left unset rather than panicking.