### PR TITLE
Fixing live test regression

### DIFF
--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/operation_pipeline.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/operation_pipeline.rs
@@ -157,6 +157,14 @@ pub(crate) async fn execute_operation_pipeline(
             location_state_store.endpoint_unavailability_ttl(),
         );
 
+        // Emit one structured debug record per attempt with the chosen
+        // routing decision. Tests and SREs filter on this to verify which
+        // region/endpoint each operation actually went to. Keep the field
+        // name (`routing_decision`) and message (`routing decision made`)
+        // stable -- `azure_data_cosmos`'s multi-write integration tests grep
+        // for them.
+        tracing::debug!(routing_decision = %routing, "routing decision made");
+
         // ── STAGE 3: Build transport request ───────────────────────────
         let execution_context = compute_execution_context(&retry_state);
 


### PR DESCRIPTION
Fixes a live test regression in 

```
waiting for container to be created in satellite region (westus3): failed to resolve container metadata for 'auto-test-7ebc7df443f648ff9e0d123dc36e6bf2/MultiWritePreferredLocations'
waiting for container to be created in satellite region (westus3): failed to resolve container metadata for 'auto-test-7ebc7df443f648ff9e0d123dc36e6bf2/MultiWritePreferredLocations'
Deleting left-over database: auto-test-7ebc7df443f648ff9e0d123dc36e6bf2
Hub region upsert logs: []
thread 'multi_write_tests::cosmos_multi_write::multi_write_preferred_locations' (47551) panicked at sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write.rs:150:9:
Expected to find upsert document log entries
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

inrtroduced when https://github.com/Azure/azure-sdk-for-rust/pull/4156/files#diff-49e478ecf1eb33d42d8601a44859ee1c7c4063f5792a7700aac6f925235cf8e1 removed a debug trace