### PR TITLE
Add per-operation latency tracking for perf tests

### DIFF
--- a/sdk/core/azure_core_test/src/perf/config_tests.rs
+++ b/sdk/core/azure_core_test/src/perf/config_tests.rs
@@ -119,6 +119,7 @@ fn test_perf_runner_new_with_empty_tests() {
     assert_eq!(runner.options.warmup, Duration::seconds(5));
     assert_eq!(runner.options.test_results_filename, "./results.json");
     assert!(!runner.options.no_cleanup);
+    assert!(!runner.options.latency);
 }
 
 #[test]
@@ -685,4 +686,39 @@ async fn test_perf_runner_with_test_functions() {
         .cleanup(test_context.clone())
         .await
         .expect("Cleanup failed");
+}
+
+#[test]
+fn test_perf_runner_latency_flag() {
+    let tests = vec![create_basic_test_metadata()];
+
+    // Defaults to false.
+    let runner = PerfRunner::with_command_line(
+        env!("CARGO_MANIFEST_DIR"),
+        file!(),
+        tests.clone(),
+        vec!["perf-tests"],
+    )
+    .unwrap();
+    assert!(!runner.options.latency);
+
+    // Long form.
+    let runner = PerfRunner::with_command_line(
+        env!("CARGO_MANIFEST_DIR"),
+        file!(),
+        tests.clone(),
+        vec!["perf-tests", "--latency"],
+    )
+    .unwrap();
+    assert!(runner.options.latency);
+
+    // Short form.
+    let runner = PerfRunner::with_command_line(
+        env!("CARGO_MANIFEST_DIR"),
+        file!(),
+        tests,
+        vec!["perf-tests", "-l"],
+    )
+    .unwrap();
+    assert!(runner.options.latency);
 }

--- a/sdk/core/azure_core_test/src/perf/framework_tests.rs
+++ b/sdk/core/azure_core_test/src/perf/framework_tests.rs
@@ -96,3 +96,89 @@ async fn test_perf_runner_with_single_test() {
     println!("Result: {:?}", result);
     assert!(result.is_ok());
 }
+
+#[tokio::test]
+async fn test_latency_collection_returns_values() {
+    let args = vec![
+        "perf_test",
+        "--parallel",
+        "2",
+        "--duration",
+        "1",
+        "--warmup",
+        "0",
+        "--test-results",
+        "",
+        "--latency",
+        "fibonacci1",
+        "-c",
+        "5",
+    ];
+    let runner = PerfRunner::with_command_line(
+        env!("CARGO_MANIFEST_DIR"),
+        file!(),
+        vec![PerfTestMetadata {
+            name: "fibonacci1",
+            description: "A basic test for testing purposes",
+            options: vec![PerfTestOption {
+                name: "count",
+                mandatory: true,
+                short_activator: Some('c'),
+                expected_args_len: 1,
+                display_message: "The Fibonacci number to compute",
+                option_type: PerfTestOptionKind::Uint32,
+                ..Default::default()
+            }],
+            create_test: create_fibonacci1_test,
+        }],
+        args,
+    )
+    .unwrap();
+
+    // Run directly via run_test_for to inspect the returned latencies.
+    let test_mode = crate::TestMode::current_opt()
+        .unwrap()
+        .unwrap_or(crate::TestMode::Live);
+    let mut test_instances: Vec<Arc<dyn PerfTest>> = Vec::new();
+    let mut test_contexts: Vec<Arc<TestContext>> = Vec::new();
+    for _ in 0..runner.options.parallel {
+        let instance = (runner.tests[0].create_test)(runner.clone()).await.unwrap();
+        let instance: Arc<dyn PerfTest> = Arc::from(instance);
+        let context = Arc::new(
+            crate::recorded::start(
+                test_mode,
+                runner.package_dir,
+                runner.module_name,
+                runner.tests[0].name,
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+        instance.setup(context.clone()).await.unwrap();
+        test_instances.push(instance);
+        test_contexts.push(context);
+    }
+
+    let (ops_per_second, latencies) = runner
+        .run_test_for(&test_instances, &test_contexts, Duration::seconds(1), true)
+        .await
+        .unwrap();
+
+    assert!(
+        ops_per_second > 0.0,
+        "Should have completed some operations"
+    );
+    assert!(
+        !latencies.is_empty(),
+        "Latencies should be collected when track_latency is true"
+    );
+
+    // Every latency should be non-zero.
+    for lat in &latencies {
+        assert!(
+            !lat.is_zero(),
+            "Each latency measurement should be non-zero"
+        );
+    }
+}

--- a/sdk/core/azure_core_test/src/perf/mod.rs
+++ b/sdk/core/azure_core_test/src/perf/mod.rs
@@ -138,6 +138,7 @@ struct PerfRunnerOptions {
     duration: Duration,
     warmup: Duration,
     disable_progress: bool,
+    latency: bool,
     test_results_filename: String,
 }
 
@@ -145,13 +146,14 @@ impl Display for PerfRunnerOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "PerfRunnerOptions {{ no_cleanup: {}, iterations: {}, parallel: {}, duration: {}, warmup: {}, disable_progress: {}, test_results_filename: '{}' }}",
+            "PerfRunnerOptions {{ no_cleanup: {}, iterations: {}, parallel: {}, duration: {}, warmup: {}, disable_progress: {}, latency: {}, test_results_filename: '{}' }}",
             self.no_cleanup,
             self.iterations,
             self.parallel,
             self.duration,
             self.warmup,
             self.disable_progress,
+            self.latency,
             self.test_results_filename
         )
     }
@@ -168,6 +170,7 @@ impl From<&ArgMatches> for PerfRunnerOptions {
                 .get_one::<u32>("parallel")
                 .expect("defaulted by clap"),
             disable_progress: matches.get_flag("no-progress"),
+            latency: matches.get_flag("latency"),
             duration: Duration::seconds(
                 *matches
                     .get_one::<i64>("duration")
@@ -375,7 +378,7 @@ impl PerfRunner {
                 self.options.warmup
             );
 
-            self.run_test_for(&test_instances, &test_contexts, self.options.warmup)
+            self.run_test_for(&test_instances, &test_contexts, self.options.warmup, false)
                 .await?;
 
             println!(
@@ -383,9 +386,17 @@ impl PerfRunner {
                 self.options.duration
             );
 
-            let operations_per_second = self
-                .run_test_for(&test_instances, &test_contexts, self.options.duration)
+            let (operations_per_second, latencies) = self
+                .run_test_for(
+                    &test_instances,
+                    &test_contexts,
+                    self.options.duration,
+                    self.options.latency,
+                )
                 .await?;
+            if self.options.latency {
+                Self::print_latencies("Latency Distribution", latencies);
+            }
             if !self.options.no_cleanup {
                 println!("========== Starting test cleanup ==========");
                 for (instance, context) in test_instances.iter().zip(test_contexts.iter()) {
@@ -434,18 +445,21 @@ impl PerfRunner {
     /// * `test_instances` - One test instance per parallel task.
     /// * `test_contexts` - The test contexts to use for each parallel task.
     /// * `duration` - The duration to run the test for.
+    /// * `track_latency` - Whether to track per-operation latency.
     ///
     /// # Returns
-    /// The operations per second achieved during the test.
+    /// A tuple of (operations per second, per-operation latencies). Latencies is empty if `track_latency` is false.
     pub async fn run_test_for(
         &self,
         test_instances: &[Arc<dyn PerfTest>],
         test_contexts: &[Arc<TestContext>],
         duration: Duration,
-    ) -> azure_core::Result<f64> {
+        track_latency: bool,
+    ) -> azure_core::Result<(f64, Vec<tokio::time::Duration>)> {
         // Reset the performance measurements before starting the test.
         self.progress.store(0, Ordering::SeqCst);
-        let mut tasks: JoinSet<Result<(i64, tokio::time::Duration)>> = JoinSet::new();
+        let mut tasks: JoinSet<Result<(i64, tokio::time::Duration, Vec<tokio::time::Duration>)>> =
+            JoinSet::new();
         (0..self.options.parallel).for_each(|i| {
             let test_instance = Arc::clone(&test_instances[i as usize]);
             let progress = self.progress.clone();
@@ -453,34 +467,47 @@ impl PerfRunner {
             tasks.spawn(async move {
                 let start = tokio::time::Instant::now();
                 let mut count = 0i64;
+                let mut latencies = Vec::new();
                 let timeout = tokio::time::Duration::from_secs_f64(duration.as_seconds_f64());
                 loop {
+                    let op_start = if track_latency {
+                        Some(tokio::time::Instant::now())
+                    } else {
+                        None
+                    };
                     test_instance.run(test_context.clone()).await?;
+                    if let Some(op_start) = op_start {
+                        latencies.push(op_start.elapsed());
+                    }
                     progress.fetch_add(1, Ordering::SeqCst);
                     count += 1;
                     if start.elapsed() >= timeout {
                         break;
                     }
                 }
-                Ok((count, start.elapsed()))
+                Ok((count, start.elapsed(), latencies))
             });
         });
         let start = tokio::time::Instant::now();
 
-        let operations_per_second = select!(
+        let (operations_per_second, all_latencies) = select!(
                 results = tasks.join_all() =>  {
                     println!("All test tasks completed: {:?}", start.elapsed());
-                    // Collect the results of the test tasks.
                     let collected_results: Result<Vec<_>> = results.into_iter().collect();
+                    let collected = collected_results?;
 
-                    // Calculate the operations/second for each of the tasks and sum them to a single result.
-                    let total_ops:f64 = collected_results?
-                        .into_iter()
-                        .map(|(count, duration)| {count as f64 / duration.as_secs_f64()})
+                    let total_ops:f64 = collected
+                        .iter()
+                        .map(|(count, duration, _)| {*count as f64 / duration.as_secs_f64()})
                         .sum();
 
+                    let all_latencies: Vec<tokio::time::Duration> = collected
+                        .into_iter()
+                        .flat_map(|(_, _, latencies)| latencies)
+                        .collect();
+
                     println!("Total operations per second: {total_ops}");
-                    Ok(total_ops)
+                    Ok((total_ops, all_latencies))
                 },
                 _ = async {
                         let mut last_count = 0;
@@ -502,7 +529,26 @@ impl PerfRunner {
                         "Progress reporting task exited unexpectedly.",
                     ))},
         )?;
-        Ok(operations_per_second)
+        Ok((operations_per_second, all_latencies))
+    }
+
+    fn print_latencies(header: &str, mut latencies: Vec<tokio::time::Duration>) {
+        if latencies.is_empty() {
+            return;
+        }
+        latencies.sort();
+        println!("=== {} ===", header);
+        let percentiles = [0.5, 0.75, 0.9, 0.99, 0.999, 0.9999, 0.99999, 1.0];
+        for percentile in percentiles {
+            let index = ((latencies.len() as f64 * percentile) as usize).saturating_sub(1);
+            let latency = latencies[index];
+            println!(
+                "{:>9.3}%   {:>8.2}ms",
+                percentile * 100.0,
+                latency.as_secs_f64() * 1000.0
+            );
+        }
+        println!();
     }
 
     // Future command line switches:
@@ -511,7 +557,6 @@ impl PerfRunner {
     //   * Allow untrusted TLS certificates
     // * Advanced options
     //   * Print job statistics (?)
-    //   * Track latency and print per-operation latency statistics
     //   * Target throughput (operations/second) (?)
     // * Language specific options
     //   * Max I/O completion threads
@@ -570,6 +615,8 @@ impl PerfRunner {
                     .global(false),
             )
             .arg(clap::arg!(--"no-cleanup" "Disable test cleanup")
+            .required(false).global(true))
+            .arg(clap::arg!(-l --latency "Track and print per-operation latency statistics")
             .required(false).global(true))
         ;
         for test in tests {


### PR DESCRIPTION
Adds per-operation latency tracking to individual perf tests via the `--latency -l` flags. This will track the latency of each individual test run and aggregate them all across all threads. A latency distribution will be displayed at the end. This mirrors the .NET and Python of this feature.

This is the first of a couple of changes I will be making to enable the PerfAutomation tool to do "advanced stats" tracking with Rust. Next up these latencies will be written to a results file.

This change is mostly Copilot generated.