### PR TITLE
[Storage] APIView Feedback pre-initial GA

### DIFF
--- a/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
@@ -9,8 +9,8 @@ use crate::{
         BlockBlobClientUploadInternalResultHeaders,
     },
     models::{
-        method_options::BlockBlobClientUploadOptions, BlockBlobClientCommitBlockListOptions,
-        BlockBlobClientStageBlockOptions, BlockBlobClientUploadResult, BlockLookupList,
+        BlockBlobClientCommitBlockListOptions, BlockBlobClientStageBlockOptions,
+        BlockBlobClientUploadOptions, BlockBlobClientUploadResult, BlockLookupList,
     },
     partitioned_transfer::{self, PartitionedUploadBehavior},
 };

--- a/sdk/storage/azure_storage_blob/src/models/extensions.rs
+++ b/sdk/storage/azure_storage_blob/src/models/extensions.rs
@@ -2,10 +2,9 @@
 // Licensed under the MIT License.
 
 use crate::models::{
-    method_options::BlockBlobClientUploadOptions, AccessPolicy, AppendBlobClientCreateOptions,
-    BlobTag, BlobTags, BlockBlobClientCommitBlockListOptions,
-    BlockBlobClientUploadBlobFromUrlOptions, PageBlobClientCreateOptions, SignedIdentifier,
-    SignedIdentifiers,
+    AccessPolicy, AppendBlobClientCreateOptions, BlobTag, BlobTags,
+    BlockBlobClientCommitBlockListOptions, BlockBlobClientUploadBlobFromUrlOptions,
+    BlockBlobClientUploadOptions, PageBlobClientCreateOptions, SignedIdentifier, SignedIdentifiers,
 };
 use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 use std::collections::HashMap;

--- a/sdk/storage/azure_storage_blob/src/models/mod.rs
+++ b/sdk/storage/azure_storage_blob/src/models/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod drains;
 pub(crate) mod error;
 pub(crate) mod extensions;
 pub(crate) mod http_ranges;
-pub mod method_options;
+mod method_options;
 
 pub use http_ranges::HttpRange;
 pub(crate) mod response_ext;
@@ -123,7 +123,7 @@ impl Serialize for BlobMetadata {
 ///     name: Option<String>,
 /// }
 /// ```
-pub mod blob_name {
+pub(crate) mod blob_name {
     use super::BlobName;
     use percent_encoding::percent_decode_str;
     use serde::{de::Error, Deserialize, Deserializer};


### PR DESCRIPTION
Flatten model imports: types are now reachable from `models::` only, not via duplicate `models::method_options::` or `models::blob_name::` paths.