### PR TITLE
Increment versions post-GA

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -68,10 +68,10 @@ jobs:
           cargo --version
 
           # Verify core can be built
-          cargo check --package azure_core --all-targets
+          cargo check --manifest-path sdk/core/azure_core/Cargo.toml --all-targets
 
           # Verify that core tests can be discovered
-          cargo test --package azure_core --no-run
+          cargo test --manifest-path sdk/core/azure_core/Cargo.toml --no-run
 
       - name: Environment summary
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ dependencies = [
  "azure_core 1.0.0",
  "azure_core_test_macros",
  "azure_identity 1.0.0",
- "azure_security_keyvault_secrets 1.0.0",
+ "azure_security_keyvault_secrets",
  "clap",
  "dotenvy",
  "flate2",
@@ -478,7 +478,7 @@ dependencies = [
  "async-trait",
  "azure_core 1.0.0",
  "azure_core_test",
- "azure_security_keyvault_secrets 1.1.0-beta.1",
+ "azure_security_keyvault_secrets",
  "clap",
  "futures",
  "include-file",
@@ -607,23 +607,6 @@ dependencies = [
  "sha2",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "azure_security_keyvault_secrets"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b370d75ebb8807cc1ccfc6fe647b1e61e13052cba2e800b95f0cf0bd27d9a"
-dependencies = [
- "async-lock",
- "async-trait",
- "azure_core 1.0.0",
- "futures",
- "rustc_version",
- "serde",
- "serde_json",
- "time",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "azure_core_amqp"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 dependencies = [
  "async-trait",
  "azure_core",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "azure_core_macros"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "azure_core_opentelemetry"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 dependencies = [
  "azure_core",
  "azure_core_test",
@@ -3560,7 +3560,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typespec"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 dependencies = [
  "base64",
  "bytes",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "typespec_client_core"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "typespec_macros"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 dependencies = [
  "cargo_metadata",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,15 +212,37 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6a26a7d374b440015cbbcbf2d9d8be5a133aa940599f5e5dc569504baa262e"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core_macros 1.0.0",
+ "bytes",
+ "futures",
+ "hmac",
+ "openssl",
+ "pin-project",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "tracing",
+ "typespec 1.0.0",
+ "typespec_client_core 1.0.0",
+]
+
+[[package]]
+name = "azure_core"
 version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core_macros",
+ "azure_core_examples",
+ "azure_core_macros 1.0.0",
  "azure_core_test",
- "azure_identity",
- "azure_security_keyvault_certificates",
- "azure_security_keyvault_secrets",
  "bytes",
  "criterion",
  "futures",
@@ -239,9 +261,31 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec",
- "typespec_client_core",
+ "typespec 1.0.0",
+ "typespec_client_core 1.0.0",
  "ureq",
+]
+
+[[package]]
+name = "azure_core_amqp"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15daabffc2fcce01c54333137e40b216f5be8401b3a1bdafe1a633972f7346e9"
+dependencies = [
+ "async-trait",
+ "azure_core 1.0.0",
+ "fe2o3-amqp",
+ "fe2o3-amqp-cbs",
+ "fe2o3-amqp-ext",
+ "fe2o3-amqp-management",
+ "fe2o3-amqp-types",
+ "serde",
+ "serde_amqp",
+ "serde_bytes",
+ "tokio",
+ "tracing",
+ "typespec 1.0.0",
+ "typespec_macros 1.0.0",
 ]
 
 [[package]]
@@ -249,7 +293,7 @@ name = "azure_core_amqp"
 version = "1.1.0-beta.1"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 1.0.0",
  "fe2o3-amqp",
  "fe2o3-amqp-cbs",
  "fe2o3-amqp-ext",
@@ -262,8 +306,32 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec",
- "typespec_macros",
+ "typespec 1.0.0",
+ "typespec_macros 1.0.0",
+]
+
+[[package]]
+name = "azure_core_examples"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "azure_core 1.1.0-beta.1",
+ "base64",
+ "futures",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "azure_core_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b52dba6a345f3ad2d42ff8d0d63df9d0994cfa29657bf18ffdbf149f78a4f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "tracing",
 ]
 
 [[package]]
@@ -280,12 +348,24 @@ dependencies = [
 
 [[package]]
 name = "azure_core_opentelemetry"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71bd721089367eee3399ab7820052421ddb35916327d70d14667303617dfd21"
+dependencies = [
+ "azure_core 1.0.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "tracing",
+]
+
+[[package]]
+name = "azure_core_opentelemetry"
 version = "1.1.0-beta.1"
 dependencies = [
- "azure_core",
+ "azure_core 1.0.0",
  "azure_core_test",
  "azure_core_test_macros",
- "azure_identity",
+ "azure_identity 1.0.0",
  "opentelemetry",
  "opentelemetry_sdk",
  "tokio",
@@ -298,10 +378,10 @@ name = "azure_core_test"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 1.0.0",
  "azure_core_test_macros",
- "azure_identity",
- "azure_security_keyvault_secrets",
+ "azure_identity 1.0.0",
+ "azure_security_keyvault_secrets 1.0.0",
  "clap",
  "dotenvy",
  "flate2",
@@ -323,7 +403,7 @@ dependencies = [
 name = "azure_core_test_macros"
 version = "0.1.0"
 dependencies = [
- "azure_core",
+ "azure_core 1.0.0",
  "azure_core_test",
  "proc-macro2",
  "quote",
@@ -337,9 +417,9 @@ version = "0.31.0"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 1.0.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "clap",
  "futures",
  "pin-project",
@@ -359,8 +439,8 @@ version = "0.1.0"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
- "azure_identity",
+ "azure_core 1.0.0",
+ "azure_identity 1.0.0",
  "base64",
  "futures",
  "reqwest",
@@ -374,13 +454,31 @@ dependencies = [
 
 [[package]]
 name = "azure_identity"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32edf96b356ca7c51d7590c4925cc36efc3947a5da4468e8e0b25c56ecbb3de5"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core 1.0.0",
+ "futures",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "azure_identity"
 version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 1.0.0",
  "azure_core_test",
- "azure_security_keyvault_secrets",
+ "azure_security_keyvault_secrets 1.1.0-beta.1",
  "clap",
  "futures",
  "include-file",
@@ -404,10 +502,10 @@ dependencies = [
  "async-lock",
  "async-stream",
  "async-trait",
- "azure_core",
- "azure_core_amqp",
+ "azure_core 1.0.0",
+ "azure_core_amqp 1.0.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "azure_messaging_eventhubs",
  "criterion",
  "fe2o3-amqp",
@@ -425,10 +523,10 @@ name = "azure_messaging_eventhubs_checkpointstore_blob"
 version = "0.9.0"
 dependencies = [
  "async-trait",
- "azure_core",
- "azure_core_opentelemetry",
+ "azure_core 1.0.0",
+ "azure_core_opentelemetry 1.0.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "azure_messaging_eventhubs",
  "azure_storage_blob",
  "futures",
@@ -451,11 +549,10 @@ dependencies = [
  "async-lock",
  "async-stream",
  "async-trait",
- "azure_core",
- "azure_core_amqp",
+ "azure_core 1.0.0",
+ "azure_core_amqp 1.0.0",
  "azure_core_test",
- "azure_identity",
- "azure_messaging_servicebus",
+ "azure_identity 1.0.0",
  "futures",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
@@ -473,9 +570,9 @@ version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 1.0.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "azure_security_keyvault_keys",
  "azure_security_keyvault_test",
  "futures",
@@ -495,9 +592,9 @@ version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 1.0.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "azure_security_keyvault_test",
  "criterion",
  "futures",
@@ -514,13 +611,30 @@ dependencies = [
 
 [[package]]
 name = "azure_security_keyvault_secrets"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96b370d75ebb8807cc1ccfc6fe647b1e61e13052cba2e800b95f0cf0bd27d9a"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core 1.0.0",
+ "futures",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+]
+
+[[package]]
+name = "azure_security_keyvault_secrets"
 version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 1.0.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "azure_security_keyvault_test",
  "futures",
  "include-file",
@@ -546,10 +660,10 @@ version = "1.1.0-beta.1"
 dependencies = [
  "async-stream",
  "async-trait",
- "azure_core",
- "azure_core_opentelemetry",
+ "azure_core 1.0.0",
+ "azure_core_opentelemetry 1.0.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "azure_storage_blob_test",
  "bytes",
  "clap",
@@ -574,7 +688,7 @@ name = "azure_storage_blob_test"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 1.0.0",
  "azure_core_test",
  "azure_storage_blob",
  "bytes",
@@ -587,10 +701,10 @@ name = "azure_storage_queue"
 version = "1.1.0-beta.1"
 dependencies = [
  "async-trait",
- "azure_core",
- "azure_core_opentelemetry",
+ "azure_core 1.0.0",
+ "azure_core_opentelemetry 1.0.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "clap",
  "futures",
  "opentelemetry-stdout",
@@ -3560,6 +3674,21 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typespec"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21666a31293beab8f41d38c2849ddbc342cd9c7cb4d71a9818868287a8934e53"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "quick-xml",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "typespec"
 version = "1.1.0-beta.1"
 dependencies = [
  "base64",
@@ -3570,6 +3699,32 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "url",
+]
+
+[[package]]
+name = "typespec_client_core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924f0c734e0ac3b881ab99d032bd28fcc969d2bb73ef1b8dd4772fd8e518a382"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "pin-project",
+ "rand 0.10.1",
+ "reqwest",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tracing",
+ "typespec 1.0.0",
+ "typespec_macros 1.0.0",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3592,10 +3747,22 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec",
- "typespec_macros",
+ "typespec 1.0.0",
+ "typespec_macros 1.0.0",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "typespec_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c608f4427943f8adb211abc95c87672b1b98847152783507d54e3246e502f60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3610,7 +3777,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.117",
  "tokio",
- "typespec_client_core",
+ "typespec_client_core 1.0.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "azure_identity"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "azure_storage_blob"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "azure_storage_queue"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 dependencies = [
  "async-trait",
  "azure_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "azure_security_keyvault_certificates"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "azure_security_keyvault_keys"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "azure_security_keyvault_secrets"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "sdk/core/azure_core",
   "sdk/core/azure_core_amqp",
   "sdk/core/azure_core_macros",
+  "sdk/core/azure_core_examples",
   "sdk/core/azure_core_test",
   "sdk/core/azure_core_test_macros",
   "sdk/core/azure_core_opentelemetry",
@@ -40,30 +41,24 @@ rust-version = "1.88"
 
 [workspace.dependencies.typespec]
 default-features = false
-path = "sdk/core/typespec"
-version = "1.1.0-beta.1"
+version = "1.0.0"
 
 [workspace.dependencies.typespec_client_core]
 default-features = false
-path = "sdk/core/typespec_client_core"
-version = "1.1.0-beta.1"
+version = "1.0.0"
 
 [workspace.dependencies.typespec_macros]
-path = "sdk/core/typespec_macros"
-version = "1.1.0-beta.1"
+version = "1.0.0"
 
 [workspace.dependencies.azure_core]
 default-features = false
-version = "1.1.0-beta.1"
-path = "sdk/core/azure_core"
+version = "1.0.0"
 
 [workspace.dependencies.azure_core_macros]
-path = "sdk/core/azure_core_macros"
-version = "1.1.0-beta.1"
+version = "1.0.0"
 
 [workspace.dependencies.azure_core_amqp]
-version = "1.1.0-beta.1"
-path = "sdk/core/azure_core_amqp"
+version = "1.0.0"
 
 [workspace.dependencies.azure_messaging_eventhubs]
 version = "0.15.0"
@@ -71,19 +66,19 @@ path = "sdk/eventhubs/azure_messaging_eventhubs"
 
 [workspace.dependencies.azure_core_opentelemetry]
 # azure_core_opentelemetry should only ever be in dev-dependencies herein
-path = "sdk/core/azure_core_opentelemetry"
+version = "1.0.0"
 
 [workspace.dependencies.azure_core_test]
-# azure_core_test is not published and only ever a dev-dependency
+# azure_core_test is not published and only ever in dev-dependencies herein
 path = "sdk/core/azure_core_test"
 
 [workspace.dependencies.azure_core_test_macros]
-# azure_core_test_macros is not published and only ever a dev-dependency
+# azure_core_test_macros is not published and only ever in dev-dependencies herein
 path = "sdk/core/azure_core_test_macros"
 
 [workspace.dependencies.azure_identity]
 # azure_identity should only ever be in dev-dependencies herein
-path = "sdk/identity/azure_identity"
+version = "1.0.0"
 
 [workspace.dependencies.azure_storage_blob]
 path = "sdk/storage/azure_storage_blob"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,28 +41,28 @@ rust-version = "1.88"
 [workspace.dependencies.typespec]
 default-features = false
 path = "sdk/core/typespec"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 
 [workspace.dependencies.typespec_client_core]
 default-features = false
 path = "sdk/core/typespec_client_core"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 
 [workspace.dependencies.typespec_macros]
 path = "sdk/core/typespec_macros"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 
 [workspace.dependencies.azure_core]
 default-features = false
-version = "1.0.0"
+version = "1.1.0-beta.1"
 path = "sdk/core/azure_core"
 
 [workspace.dependencies.azure_core_macros]
 path = "sdk/core/azure_core_macros"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 
 [workspace.dependencies.azure_core_amqp]
-version = "1.0.0"
+version = "1.1.0-beta.1"
 path = "sdk/core/azure_core_amqp"
 
 [workspace.dependencies.azure_messaging_eventhubs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ path = "sdk/identity/azure_identity"
 
 [workspace.dependencies.azure_storage_blob]
 path = "sdk/storage/azure_storage_blob"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 
 [workspace.dependencies]
 async-lock = "3.4"

--- a/eng/scripts/Analyze-Code.ps1
+++ b/eng/scripts/Analyze-Code.ps1
@@ -40,7 +40,7 @@ $cargoAuditVersionParams = Get-VersionParamsFromCgManifest cargo-audit
 Invoke-LoggedCommand "cargo install cargo-audit --locked $($cargoAuditVersionParams -join ' ')" -GroupOutput
 Invoke-LoggedCommand "cargo audit" -GroupOutput
 
-Invoke-LoggedCommand "cargo check --package azure_core $packageArgs --all-features --all-targets --keep-going" -GroupOutput
+Invoke-LoggedCommand "cargo check --manifest-path sdk/core/azure_core/Cargo.toml $packageArgs --all-features --all-targets --keep-going" -GroupOutput
 
 Invoke-LoggedCommand "cargo fmt $packageArgs -- --check" -GroupOutput
 
@@ -133,7 +133,7 @@ if (!$SkipPackageAnalysis) {
     Invoke-LoggedCommand "&$verifyKeywordsScript $packageManifestPath" -GroupOutput
 
     if ($Toolchain -eq 'nightly') {
-      Invoke-LoggedCommand "cargo +nightly docs-rs --package $($package.Name)" -GroupOutput
+      Invoke-LoggedCommand "cargo +nightly docs-rs --manifest-path $packageManifestPath" -GroupOutput
     }
 
     if ($checkApiSupersetCrates -contains $package.Name) {

--- a/eng/scripts/Pack-Crates.ps1
+++ b/eng/scripts/Pack-Crates.ps1
@@ -97,10 +97,11 @@ function Get-OutputPackageNames($packages) {
 
 function Create-ApiViewFile($package) {
   $packageName = $package.name
-  $command = "cargo run --manifest-path $RepoRoot/eng/tools/generate_api_report/Cargo.toml -- --package $packageName"
+  $manifestPath = $package.manifest_path
+  $command = "cargo run --manifest-path $RepoRoot/eng/tools/generate_api_report/Cargo.toml -- --package $packageName --manifest-path $manifestPath"
   Invoke-LoggedCommand $command -GroupOutput | Out-Host
 
-  $packagePath = Split-Path -Path $package.manifest_path -Parent
+  $packagePath = Split-Path -Path $manifestPath -Parent
 
   "$packagePath/review/$packageName.rust.json"
 }

--- a/eng/scripts/Test-Packages.ps1
+++ b/eng/scripts/Test-Packages.ps1
@@ -13,6 +13,7 @@ Set-StrictMode -Version 2.0
 function Invoke-CargoTestWithJsonOutput (
   [string]$TestParams,
   [string]$PackageName,
+  [string]$ManifestPath,
   [string]$OutputFile
 ) {
   Write-Host "Running tests for $PackageName"
@@ -20,7 +21,7 @@ function Invoke-CargoTestWithJsonOutput (
   # and uploaded to DevOps for display in the Tests tab
   # (requires -Z unstable-options)
   $result = Invoke-LoggedCommand `
-    "cargo +nightly test $TestParams --package $PackageName --all-features --no-fail-fast -- --format json -Z unstable-options" `
+    "cargo +nightly test $TestParams --manifest-path $ManifestPath --all-features --no-fail-fast -- --format json -Z unstable-options" `
     -GroupOutput `
     -DoNotExitOnFailedExitCode
 
@@ -88,21 +89,23 @@ foreach ($package in $packagesToTest) {
   Invoke-LoggedCommand "cargo build --all-features --keep-going" -GroupOutput
   Write-Host "`n`n"
 
+  $manifestPath = [System.IO.Path]::Combine($packageDirectory, 'Cargo.toml')
   $timestamp = Get-Date -Format "yyyyMMdd-HHmmss-fff"
 
   $docTestOutput = ([System.IO.Path]::Combine($testResultsDir, "$($package.Name)-doctest-$timestamp.json"))
   Invoke-CargoTestWithJsonOutput `
     -TestParams "--doc" `
     -PackageName $package.Name `
+    -ManifestPath $manifestPath `
     -OutputFile $docTestOutput
 
   $allTargetsOutput = ([System.IO.Path]::Combine($testResultsDir, "$($package.Name)-alltargets-$timestamp.json"))
   Invoke-CargoTestWithJsonOutput `
     -TestParams "--lib --bins --tests --examples" `
     -PackageName $package.Name `
+    -ManifestPath $manifestPath `
     -OutputFile $allTargetsOutput
 
-  $manifestPath = [System.IO.Path]::Combine($packageDirectory, 'Cargo.toml')
   Invoke-LoggedCommand `
     "cargo test --benches --manifest-path $manifestPath --all-features --no-fail-fast" `
     -GroupOutput

--- a/eng/scripts/Test-Packages.ps1
+++ b/eng/scripts/Test-Packages.ps1
@@ -102,8 +102,9 @@ foreach ($package in $packagesToTest) {
     -PackageName $package.Name `
     -OutputFile $allTargetsOutput
 
+  $manifestPath = [System.IO.Path]::Combine($packageDirectory, 'Cargo.toml')
   Invoke-LoggedCommand `
-    "cargo test --benches --package $($package.Name) --all-features --no-fail-fast" `
+    "cargo test --benches --manifest-path $manifestPath --all-features --no-fail-fast" `
     -GroupOutput
 
   $cleanupScript = ([System.IO.Path]::Combine($packageDirectory, 'Test-Cleanup.ps1'))

--- a/eng/scripts/Test-Semver.ps1
+++ b/eng/scripts/Test-Semver.ps1
@@ -14,35 +14,44 @@ param(
 . ([System.IO.Path]::Combine($PSScriptRoot, '..', 'common', 'scripts', 'common.ps1'))
 . ([System.IO.Path]::Combine($PSScriptRoot, 'shared', 'Cargo.ps1'))
 
-function Get-OutputPackageNames($workspacePackages) {
-  $names = @()
+function Get-OutputPackages($workspacePackages) {
+  $packages = @()
   switch ($PsCmdlet.ParameterSetName) {
     'Named' {
-      $names = $PackageNames
+      Write-Verbose 'Getting named packages form workspace'
+      $packages = $workspacePackages.Where({ $_.name -in $PackageNames })
     }
 
     'PackageInfo' {
-      $names = Get-PackageNamesFromPackageInfo $PackageInfoDirectory
+      Write-Verbose "Getting packages from $PackageInfoDirectory"
+      $packages = Get-PackagesFromPackageInfo $PackageInfoDirectory | ForEach-Object {
+        [pscustomobject] @{
+          name = $_.Name
+          manifest_path = [System.IO.Path]::Combine($_.DirectoryPath, 'Cargo.toml')
+        }
+      }
     }
 
     default {
-      return $workspacePackages.name
+      Write-Verbose 'Getting all workspace packages'
+      return $workspacePackages
 
     }
   }
 
-  foreach ($name in $names) {
+  Write-Verbose "Packages: $($packages.name -join ', ')"
+  foreach ($name in $packages.name) {
     if (-not $workspacePackages.name.Contains($name)) {
       Write-Error "Package '$name' is not in the workspace or does not publish"
       exit 1
     }
   }
 
-  return $names
+  return $packages
 }
 
 $packages = Get-CargoPackages
-$outputPackageNames = Get-OutputPackageNames $packages
+$outputPackages = Get-OutputPackages $packages
 
 $versionParams = @()
 if (!$IgnoreCgManifestVersion) {
@@ -52,8 +61,10 @@ if (!$IgnoreCgManifestVersion) {
 Invoke-LoggedCommand "cargo install cargo-semver-checks --locked $($versionParams -join ' ')" -GroupOutput
 
 $finalExitCode = 0
-foreach ($packageName in $outputPackageNames) {
-  $output = Invoke-LoggedCommand "cargo +$Toolchain semver-checks --package $packageName" -DoNotExitOnFailedExitCode -GroupOutput 2>&1
+foreach ($package in $outputPackages) {
+  $packageName = $package.name
+  $manifestPath = $package.manifest_path
+  $output = Invoke-LoggedCommand "cargo +$Toolchain semver-checks --manifest-path $manifestPath" -DoNotExitOnFailedExitCode -GroupOutput 2>&1
   if ($output -match 'error: no library targets found in package `(?<name>[\w_]+)`' -and $Matches['name'] -eq $packageName) {
     LogWarning "$packageName base version is a placeholder and will be ignored"
     continue

--- a/eng/scripts/shared/Cargo.ps1
+++ b/eng/scripts/shared/Cargo.ps1
@@ -21,15 +21,20 @@ function Get-CargoPackages() {
   return $metadata.packages
 }
 
-function Get-PackageNamesFromPackageInfo($packageInfoDirectory) {
-  $names = @()
+function Get-PackagesFromPackageInfo($packageInfoDirectory) {
+  $packages = @()
   $packageInfoFiles = Get-ChildItem -Path $packageInfoDirectory -Filter '*.json' -File
   foreach ($packageInfoFile in $packageInfoFiles) {
     $packageInfo = Get-Content -Path $packageInfoFile.FullName | ConvertFrom-Json
-    $names += $packageInfo.name
+    $packages += $packageInfo
   }
 
-  return $names
+  return $packages
+}
+
+function Get-PackageNamesFromPackageInfo($packageInfoDirectory) {
+  $packages = Get-PackagesFromPackageInfo($packageInfoDirectory)
+  $packages.name
 }
 
 function Get-VersionParamsFromCgManifest(

--- a/eng/tools/check_api_superset/src/main.rs
+++ b/eng/tools/check_api_superset/src/main.rs
@@ -26,7 +26,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Generate rustdoc JSON for all crates first so we can cross-reference.
     let mut crate_data: Vec<(&str, Crate)> = Vec::new();
+    let service_dir = std::env::current_dir()?.join("sdk/core");
     for crate_name in CRATES {
+        let manifest_path = service_dir.join(crate_name).join("Cargo.toml");
         let mut command = Command::new("cargo");
         command
             .arg(format!("+{channel}"))
@@ -35,8 +37,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             .arg("unstable-options")
             .arg("--output-format")
             .arg("json")
-            .arg("--package")
-            .arg(crate_name)
+            .arg("--manifest-path")
+            .arg(manifest_path)
             .arg("--all-features");
         eprintln!(
             "Running: {} {}",

--- a/eng/tools/generate_api_report/Cargo.toml
+++ b/eng/tools/generate_api_report/Cargo.toml
@@ -14,4 +14,3 @@ toml = { workspace = true }
 [dependencies]
 rustdoc-types = { workspace = true }
 serde_json = { workspace = true }
-toml = { workspace = true }

--- a/eng/tools/generate_api_report/src/main.rs
+++ b/eng/tools/generate_api_report/src/main.rs
@@ -18,14 +18,136 @@ fn main() -> Result<(), Box<dyn Error>> {
         );
     }
 
-    // Get the package name from command-line arguments
+    // Parse command-line arguments: --package <name> [--manifest-path <path>]
     let args: Vec<String> = env::args().collect();
-    if args.len() != 3 || args[1] != "--package" {
-        eprintln!("Usage: {} --package <package_name>", args[0]);
-        std::process::exit(1);
+    let mut package_name: Option<String> = None;
+    let mut manifest_path: Option<String> = None;
+
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--package" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("--package requires a value");
+                    std::process::exit(1);
+                }
+                if package_name.is_some() {
+                    eprintln!("--package specified more than once");
+                    std::process::exit(1);
+                }
+                package_name = Some(args[i].clone());
+            }
+            "--manifest-path" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("--manifest-path requires a value");
+                    std::process::exit(1);
+                }
+                if manifest_path.is_some() {
+                    eprintln!("--manifest-path specified more than once");
+                    std::process::exit(1);
+                }
+                manifest_path = Some(args[i].clone());
+            }
+            arg => {
+                eprintln!("Unknown argument: {}", arg);
+                eprintln!(
+                    "Usage: {} --package <package_name> [--manifest-path <path>]",
+                    args[0]
+                );
+                std::process::exit(1);
+            }
+        }
+        i += 1;
     }
-    let package_name = &args[2];
-    let path_str = format!("./target/doc/{}.json", package_name);
+
+    let package_name = match package_name {
+        Some(name) => name,
+        None => {
+            eprintln!(
+                "Usage: {} --package <package_name> [--manifest-path <path>]",
+                args[0]
+            );
+            std::process::exit(1);
+        }
+    };
+
+    // Resolve the manifest path, querying cargo metadata if not provided.
+    let (manifest_path, crate_name) = if let Some(path) = manifest_path {
+        let crate_name = package_name.replace('-', "_");
+        (path, crate_name)
+    } else {
+        let mut command = Command::new("cargo");
+        command
+            .arg("metadata")
+            .arg("--format-version")
+            .arg("1")
+            .arg("--no-deps")
+            .arg("--manifest-path")
+            .arg("Cargo.toml");
+
+        println!(
+            "Getting manifest path for '{package_name}': {} {}",
+            command.get_program().to_string_lossy(),
+            command
+                .get_args()
+                .collect::<Vec<&OsStr>>()
+                .join(OsStr::new(" "))
+                .to_string_lossy(),
+        );
+
+        let output = command.output()?;
+        if !output.status.success() {
+            eprintln!(
+                "Failed to run cargo metadata: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            std::process::exit(1);
+        }
+
+        let metadata: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+        let pkg = metadata["packages"]
+            .as_array()
+            .and_then(|packages| {
+                packages
+                    .iter()
+                    .find(|pkg| pkg["name"].as_str() == Some(package_name.as_str()))
+            })
+            .ok_or_else(|| {
+                format!(
+                    "Package '{}' not found in cargo metadata output",
+                    package_name
+                )
+            })?;
+
+        let path = pkg["manifest_path"]
+            .as_str()
+            .ok_or("manifest_path not found in cargo metadata output")?
+            .to_string();
+
+        // Derive the lib crate name from the lib target, falling back to the package name.
+        let crate_name = pkg["targets"]
+            .as_array()
+            .and_then(|targets| {
+                targets.iter().find_map(|t| {
+                    let is_lib = t["kind"]
+                        .as_array()
+                        .map(|k| k.iter().any(|v| v.as_str() == Some("lib")))
+                        .unwrap_or(false);
+                    if is_lib {
+                        t["name"].as_str().map(|s| s.replace('-', "_"))
+                    } else {
+                        None
+                    }
+                })
+            })
+            .unwrap_or_else(|| package_name.replace('-', "_"));
+
+        (path, crate_name)
+    };
+
+    let path_str = format!("./target/doc/{}.json", crate_name);
     let path = Path::new(&path_str);
 
     // Call cargo +nightly rustdoc to generate the JSON file
@@ -38,8 +160,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .arg("unstable-options")
         .arg("--output-format")
         .arg("json")
-        .arg("--package")
-        .arg(package_name)
+        .arg("--manifest-path")
+        .arg(&manifest_path)
         .arg("--all-features");
     println!(
         "Running: {} {}",
@@ -94,28 +216,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         item.span = Default::default();
     }
 
-    // Navigate to Cargo.toml and get the path for the package
-    let cargo_toml_path = Path::new("Cargo.toml");
-    let cargo_toml_content = std::fs::read_to_string(cargo_toml_path)?;
-    let cargo_toml: toml::Value = toml::from_str(&cargo_toml_content)?;
-
-    let package_path = cargo_toml
-        .get("workspace")
-        .and_then(|ws| ws.get("members"))
-        .and_then(|members| members.as_array())
-        .and_then(|members| {
-            members.iter().find_map(|member| {
-                if member.as_str()?.ends_with(package_name) {
-                    Some(member.as_str()?.to_string())
-                } else {
-                    None
-                }
-            })
-        })
-        .ok_or("Package path not found in Cargo.toml")?;
+    // Derive the package directory from the manifest path.
+    let package_dir = Path::new(&manifest_path)
+        .parent()
+        .ok_or("Cannot determine package directory from manifest path")?;
 
     // Create the review/ folder under the obtained path if it doesn't exist
-    let review_folder_path = Path::new(&package_path).join("review");
+    let review_folder_path = package_dir.join("review");
     if !review_folder_path.exists() {
         std::fs::create_dir_all(&review_folder_path)?;
     }

--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2026-05-11)
 
 ### Features Added

--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -38,11 +38,9 @@ typespec_client_core = { workspace = true, default-features = false, features = 
 rustc_version.workspace = true
 
 [dev-dependencies]
+azure_core_examples.path = "../azure_core_examples"
 azure_core_macros.workspace = true
-azure_core_test.workspace = true
-azure_identity.workspace = true
-azure_security_keyvault_certificates.path = "../../keyvault/azure_security_keyvault_certificates"
-azure_security_keyvault_secrets.path = "../../keyvault/azure_security_keyvault_secrets"
+azure_core_test.path = "../azure_core_test"
 criterion.workspace = true
 http = "1.4.0"
 include-file.workspace = true

--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_core"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Core crate"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/core/azure_core/benches/http_transport_benchmarks.rs
+++ b/sdk/core/azure_core/benches/http_transport_benchmarks.rs
@@ -1,120 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #[cfg_attr(target_os = "macos", allow(unused_imports))]
-use azure_core::{
-    credentials::TokenCredential,
-    fmt::SafeDebug,
-    http::{
-        ClientMethodOptions, ClientOptions, HttpClient, Method, Pipeline, RawResponse, Request,
-        Transport, Url,
-    },
-    Result,
-};
+use azure_core::http::{ClientOptions, HttpClient, Method, Request, Transport, Url};
 #[cfg_attr(target_os = "macos", allow(unused_imports))]
-use azure_identity::DeveloperToolsCredential;
+use azure_core_examples::{
+    client::{TestServiceClient, TestServiceClientOptions, HTTP_ENDPOINT},
+    identity::MockCredential,
+};
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::sync::Arc;
-
-#[cfg_attr(target_os = "macos", allow(dead_code))]
-const HTTP_ENDPOINT: &str = "https://azuresdkforcpp.azurewebsites.net";
-//const HTTP_ENDPOINT: &str = "http://httpbin.org";
-
-#[derive(Clone, SafeDebug)]
-pub struct TestServiceClientOptions {
-    pub client_options: ClientOptions,
-    pub api_version: Option<String>,
-}
-
-impl Default for TestServiceClientOptions {
-    fn default() -> Self {
-        Self {
-            client_options: ClientOptions::default(),
-            api_version: Some("2023-10-01".to_string()),
-        }
-    }
-}
-
-pub struct TestServiceClient {
-    endpoint: Url,
-    api_version: String,
-    pipeline: Pipeline,
-}
-
-#[derive(Default, SafeDebug)]
-pub struct TestServiceClientGetMethodOptions<'a> {
-    pub method_options: ClientMethodOptions<'a>,
-}
-
-impl TestServiceClient {
-    pub fn new(
-        endpoint: &str,
-        _credential: Arc<dyn TokenCredential>,
-        options: Option<TestServiceClientOptions>,
-    ) -> Result<Self> {
-        let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint)?;
-        if !endpoint.scheme().starts_with("http") {
-            return Err(azure_core::Error::with_message(
-                azure_core::error::ErrorKind::Other,
-                format!("{endpoint} must use http(s)"),
-            ));
-        }
-        endpoint.set_query(None);
-
-        Ok(Self {
-            endpoint,
-            api_version: options.api_version.unwrap_or_default(),
-            pipeline: Pipeline::new(
-                option_env!("CARGO_PKG_NAME"),
-                option_env!("CARGO_PKG_VERSION"),
-                options.client_options,
-                Vec::default(),
-                Vec::default(),
-                None,
-            ),
-        })
-    }
-
-    /// Returns the Url associated with this client.
-    pub fn endpoint(&self) -> &Url {
-        &self.endpoint
-    }
-
-    /// Returns the result of a Get verb against the configured endpoint with the specified path.
-    ///
-    /// This method demonstrates a service client which does not have per-method spans but which will create
-    /// HTTP client spans if the `InstrumentationOptions` are configured in the client options.
-    ///
-    pub async fn get(
-        &self,
-        path: &str,
-        options: Option<TestServiceClientGetMethodOptions<'_>>,
-    ) -> Result<RawResponse> {
-        let options = options.unwrap_or_default();
-        let mut url = self.endpoint.clone();
-        url.set_path(path);
-        url.query_pairs_mut()
-            .append_pair("api-version", &self.api_version);
-
-        let mut request = Request::new(url, azure_core::http::Method::Get);
-
-        let response = self
-            .pipeline
-            .send(&options.method_options.context, &mut request, None)
-            .await?;
-        if !response.status().is_success() {
-            return Err(azure_core::Error::with_message(
-                azure_core::error::ErrorKind::HttpResponse {
-                    status: response.status(),
-                    error_code: None,
-                    raw_response: None,
-                },
-                format!("Failed to GET {}: {}", request.url(), response.status()),
-            ));
-        }
-        Ok(response)
-    }
-}
 
 pub fn new_reqwest_client_disable_connection_pool() -> Arc<dyn HttpClient> {
     let client = ::reqwest::ClientBuilder::new()
@@ -141,7 +35,7 @@ pub fn simple_http_transport_test(c: &mut Criterion) {
         let rt = tokio::runtime::Runtime::new().unwrap();
 
         let endpoint = HTTP_ENDPOINT;
-        let credential = DeveloperToolsCredential::new(None).unwrap();
+        let credential = MockCredential::new().unwrap();
         let options = TestServiceClientOptions::default();
 
         let client = TestServiceClient::new(endpoint, credential, Some(options)).unwrap();
@@ -168,7 +62,7 @@ pub fn disable_pooling_http_transport_test(c: &mut Criterion) {
         let rt = tokio::runtime::Runtime::new().unwrap();
 
         let endpoint = HTTP_ENDPOINT;
-        let credential = DeveloperToolsCredential::new(None).unwrap();
+        let credential = MockCredential::new().unwrap();
         let transport = new_reqwest_client_disable_connection_pool();
         let options = TestServiceClientOptions {
             client_options: ClientOptions {

--- a/sdk/core/azure_core/examples/core_error_response.rs
+++ b/sdk/core/azure_core/examples/core_error_response.rs
@@ -6,10 +6,10 @@ use azure_core::{
     http::{StatusCode, Transport},
     json,
 };
-use azure_core_test::ErrorKind;
-use azure_security_keyvault_secrets::{
+use azure_core_examples::secrets::{
     models::SetSecretParameters, SecretClient, SecretClientOptions,
 };
+use azure_core_test::ErrorKind;
 use example::setup;
 
 /// This example demonstrates deserializing a standard Azure error response to get more details.
@@ -91,7 +91,8 @@ mod example {
         credentials::TokenCredential,
         http::{headers::Headers, AsyncRawResponse, HttpClient, StatusCode},
     };
-    use azure_core_test::{credentials::MockCredential, http::MockHttpClient};
+    use azure_core_examples::identity::MockCredential;
+    use azure_core_test::http::MockHttpClient;
     use futures::FutureExt;
     use std::sync::Arc;
 

--- a/sdk/core/azure_core/examples/core_pager.rs
+++ b/sdk/core/azure_core/examples/core_pager.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use azure_core::http::Transport;
-use azure_security_keyvault_secrets::{ResourceExt as _, SecretClient, SecretClientOptions};
+use azure_core_examples::secrets::{ResourceExt as _, SecretClient, SecretClientOptions};
 use example::setup;
 use futures::TryStreamExt as _;
 
@@ -91,7 +91,8 @@ mod example {
         credentials::TokenCredential,
         http::{headers::Headers, AsyncRawResponse, HttpClient, Method, StatusCode},
     };
-    use azure_core_test::{credentials::MockCredential, http::MockHttpClient};
+    use azure_core_examples::identity::MockCredential;
+    use azure_core_test::http::MockHttpClient;
     use futures::FutureExt;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},

--- a/sdk/core/azure_core/examples/core_poller.rs
+++ b/sdk/core/azure_core/examples/core_poller.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use azure_core::http::Transport;
-use azure_security_keyvault_certificates::{
+use azure_core_examples::certificates::{
     models::CreateCertificateParameters, CertificateClient, CertificateClientOptions,
 };
 use example::setup;
@@ -112,7 +112,8 @@ mod example {
             AsyncRawResponse, HttpClient, Method, StatusCode,
         },
     };
-    use azure_core_test::{credentials::MockCredential, http::MockHttpClient};
+    use azure_core_examples::identity::MockCredential;
+    use azure_core_test::http::MockHttpClient;
     use futures::FutureExt as _;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},

--- a/sdk/core/azure_core/examples/core_remove_user_agent.rs
+++ b/sdk/core/azure_core/examples/core_remove_user_agent.rs
@@ -6,7 +6,7 @@ use azure_core::http::{
     policies::{Policy, PolicyResult},
     Context, Request, Transport,
 };
-use azure_security_keyvault_secrets::{SecretClient, SecretClientOptions};
+use azure_core_examples::secrets::{SecretClient, SecretClientOptions};
 use example::setup;
 use std::sync::Arc;
 
@@ -78,7 +78,8 @@ mod example {
         credentials::TokenCredential,
         http::{headers::Headers, AsyncRawResponse, HttpClient, Method, StatusCode},
     };
-    use azure_core_test::{credentials::MockCredential, http::MockHttpClient};
+    use azure_core_examples::identity::MockCredential;
+    use azure_core_test::http::MockHttpClient;
     use futures::FutureExt;
     use std::sync::Arc;
 

--- a/sdk/core/azure_core/examples/core_ureq_client.rs
+++ b/sdk/core/azure_core/examples/core_ureq_client.rs
@@ -4,12 +4,16 @@
 use async_trait::async_trait;
 use azure_core::{
     error::ErrorKind,
-    http::{headers::Headers, AsyncRawResponse, ClientOptions, HttpClient, Request, Transport},
+    http::{
+        headers::Headers, AsyncRawResponse, ClientOptions, HttpClient, Request, StatusCode,
+        Transport,
+    },
 };
-use azure_identity::DeveloperToolsCredential;
-use azure_security_keyvault_secrets::{ResourceExt as _, SecretClient, SecretClientOptions};
-use futures::TryStreamExt;
-use std::{env, sync::Arc};
+use azure_core_examples::{
+    client::{TestServiceClient, TestServiceClientOptions, HTTP_ENDPOINT},
+    identity::MockCredential,
+};
+use std::sync::Arc;
 use typespec::error::ResultExt;
 use ureq::tls::{TlsConfig, TlsProvider};
 
@@ -47,13 +51,8 @@ impl HttpClient for Agent {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let vault_url = env::var("AZURE_KEYVAULT_URL")
-        .map_err(|_| "Environment variable AZURE_KEYVAULT_URL is required")?;
-
-    let credential = DeveloperToolsCredential::new(None)?;
-
     let agent = Arc::new(Agent::default());
-    let options = SecretClientOptions {
+    let options = TestServiceClientOptions {
         client_options: ClientOptions {
             transport: Some(Transport::new(agent)),
             ..Default::default()
@@ -61,12 +60,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ..Default::default()
     };
 
-    let client = SecretClient::new(&vault_url, credential.clone(), Some(options))?;
-    let mut pager = client.list_secret_properties(None)?;
-    while let Some(secret) = pager.try_next().await? {
-        let name = secret.resource_id()?.name;
-        println!("Secret: {name}");
-    }
+    let credential = MockCredential::new()?;
+    let client = TestServiceClient::new(HTTP_ENDPOINT, credential, Some(options))?;
+    let response = client.get("get", None).await?;
+    println!("Response status: {}", response.status());
+    assert_eq!(response.status(), StatusCode::Ok);
 
     Ok(())
 }
@@ -103,7 +101,6 @@ fn into_request(request: &Request) -> azure_core::Result<::http::Request<Vec<u8>
 
 fn into_response(response: ::http::Response<ureq::Body>) -> azure_core::Result<AsyncRawResponse> {
     use ::http::response::Parts;
-    use azure_core::http::StatusCode;
 
     let (
         Parts {

--- a/sdk/core/azure_core/src/http/pager.rs
+++ b/sdk/core/azure_core/src/http/pager.rs
@@ -154,7 +154,7 @@ where
 ///
 /// ```no_run
 /// # use azure_core::{credentials::TokenCredential, http::Transport};
-/// # use azure_security_keyvault_secrets::{ResourceExt, SecretClient, SecretClientOptions};
+/// # use azure_core_examples::secrets::{ResourceExt, SecretClient, SecretClientOptions};
 /// # use futures::TryStreamExt;
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// # let credential: std::sync::Arc<dyn TokenCredential> = unimplemented!();
@@ -176,7 +176,7 @@ where
 ///
 /// ```no_run
 /// # use azure_core::{credentials::TokenCredential, http::Transport};
-/// # use azure_security_keyvault_secrets::{ResourceExt, SecretClient, SecretClientOptions};
+/// # use azure_core_examples::secrets::{ResourceExt, SecretClient, SecretClientOptions};
 /// # use futures::TryStreamExt;
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// # let credential: std::sync::Arc<dyn TokenCredential> = unimplemented!();
@@ -217,6 +217,8 @@ pub struct PagerOptions<'a> {
     /// # Examples
     ///
     /// ``` no_run
+    /// # use azure_core_examples::identity as azure_identity;
+    /// # use azure_core_examples::secrets as azure_security_keyvault_secrets;
     /// use azure_core::http::pager::PagerOptions;
     /// use azure_identity::DeveloperToolsCredential;
     /// use azure_security_keyvault_secrets::{
@@ -280,7 +282,7 @@ impl<'a> Default for PagerOptions<'a> {
 ///
 /// ```no_run
 /// # use azure_core::{credentials::TokenCredential, http::Transport};
-/// # use azure_security_keyvault_secrets::{ResourceExt, SecretClient, SecretClientOptions};
+/// # use azure_core_examples::secrets::{ResourceExt, SecretClient, SecretClientOptions};
 /// # use futures::TryStreamExt;
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// # let credential: std::sync::Arc<dyn TokenCredential> = unimplemented!();
@@ -302,7 +304,7 @@ impl<'a> Default for PagerOptions<'a> {
 ///
 /// ```no_run
 /// # use azure_core::{credentials::TokenCredential, http::Transport};
-/// # use azure_security_keyvault_secrets::{ResourceExt, SecretClient, SecretClientOptions};
+/// # use azure_core_examples::secrets::{ResourceExt, SecretClient, SecretClientOptions};
 /// # use futures::TryStreamExt;
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// # let credential: std::sync::Arc<dyn TokenCredential> = unimplemented!();
@@ -478,7 +480,7 @@ where
     ///
     /// ```no_run
     /// # use azure_core::http::pager::PagerOptions;
-    /// # use azure_security_keyvault_secrets::{SecretClient, models::SecretClientListSecretPropertiesOptions};
+    /// # use azure_core_examples::secrets::{models::SecretClientListSecretPropertiesOptions, SecretClient};
     /// # use futures::stream::TryStreamExt;
     /// # #[tokio::main] async fn main() -> azure_core::Result<()> {
     /// # let client: SecretClient = unimplemented!();
@@ -598,7 +600,7 @@ where
 ///
 /// ```no_run
 /// # use azure_core::{credentials::TokenCredential, http::Transport};
-/// # use azure_security_keyvault_secrets::{ResourceExt, SecretClient, SecretClientOptions};
+/// # use azure_core_examples::secrets::{ResourceExt, SecretClient, SecretClientOptions};
 /// # use futures::TryStreamExt;
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// # let credential: std::sync::Arc<dyn TokenCredential> = unimplemented!();
@@ -757,7 +759,7 @@ where
     ///
     /// ```no_run
     /// # use azure_core::http::pager::PagerOptions;
-    /// # use azure_security_keyvault_secrets::{SecretClient, models::SecretClientListSecretPropertiesOptions};
+    /// # use azure_core_examples::secrets::{models::SecretClientListSecretPropertiesOptions, SecretClient};
     /// # use futures::stream::TryStreamExt;
     /// # #[tokio::main] async fn main() -> azure_core::Result<()> {
     /// # let client: SecretClient = unimplemented!();

--- a/sdk/core/azure_core/src/http/poller.rs
+++ b/sdk/core/azure_core/src/http/poller.rs
@@ -298,7 +298,7 @@ use types::{BoxedCallback, BoxedFuture, BoxedStream};
 ///
 /// ```no_run
 /// # use azure_core::credentials::TokenCredential;
-/// # use azure_security_keyvault_certificates::{CertificateClient, models::CreateCertificateParameters};
+/// # use azure_core_examples::certificates::{CertificateClient, models::CreateCertificateParameters};
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// # let credential: std::sync::Arc<dyn TokenCredential> = unimplemented!();
 /// let client = CertificateClient::new(
@@ -321,7 +321,7 @@ use types::{BoxedCallback, BoxedFuture, BoxedStream};
 ///
 /// ```no_run
 /// # use azure_core::credentials::TokenCredential;
-/// # use azure_security_keyvault_certificates::{CertificateClient, models::CreateCertificateParameters};
+/// # use azure_core_examples::certificates::{CertificateClient, models::CreateCertificateParameters};
 /// # use futures::TryStreamExt;
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// # let credential: std::sync::Arc<dyn TokenCredential> = unimplemented!();

--- a/sdk/core/azure_core/tests/core_error_http_response.rs
+++ b/sdk/core/azure_core/tests/core_error_http_response.rs
@@ -6,8 +6,11 @@ use azure_core::{
     http::{headers::Headers, AsyncRawResponse, ClientOptions, HttpClient, StatusCode, Transport},
     Bytes,
 };
-use azure_core_test::{credentials::MockCredential, http::MockHttpClient};
-use azure_security_keyvault_secrets::{SecretClient, SecretClientOptions};
+use azure_core_examples::{
+    identity::MockCredential,
+    secrets::{SecretClient, SecretClientOptions},
+};
+use azure_core_test::http::MockHttpClient;
 use futures::FutureExt as _;
 use std::{
     str,

--- a/sdk/core/azure_core/tests/readme.rs
+++ b/sdk/core/azure_core/tests/readme.rs
@@ -1,6 +1,13 @@
 // Licensed under the MIT License.
 
 #![allow(dead_code)]
+#![allow(
+    clippy::needless_update,
+    reason = "non_exhaustive prevents struct initialization otherwise"
+)]
+use azure_core_examples::certificates as azure_security_keyvault_certificates;
+use azure_core_examples::identity as azure_identity;
+use azure_core_examples::secrets as azure_security_keyvault_secrets;
 use include_file::include_markdown;
 
 #[ignore = "only compile doc examples"]

--- a/sdk/core/azure_core_amqp/CHANGELOG.md
+++ b/sdk/core/azure_core_amqp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2026-05-11)
 
 ### Features Added

--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -3,7 +3,7 @@
 # AMQP Stack for consumption by packages in the Azure SDK.
 [package]
 name = "azure_core_amqp"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 description = "Rust client library for the AMQP protocol"
 readme = "README.md"
 authors.workspace = true
@@ -19,7 +19,7 @@ edition.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-azure_core = { path = "../azure_core", version = "1.0.0", default-features = false }
+azure_core = { path = "../azure_core", version = "1.1.0-beta.1", default-features = false }
 fe2o3-amqp = { workspace = true, optional = true }
 fe2o3-amqp-cbs = { workspace = true, optional = true }
 fe2o3-amqp-ext = { workspace = true, optional = true }

--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -19,7 +19,7 @@ edition.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-azure_core = { path = "../azure_core", version = "1.1.0-beta.1", default-features = false }
+azure_core = { workspace = true, default-features = false }
 fe2o3-amqp = { workspace = true, optional = true }
 fe2o3-amqp-cbs = { workspace = true, optional = true }
 fe2o3-amqp-ext = { workspace = true, optional = true }

--- a/sdk/core/azure_core_examples/Cargo.toml
+++ b/sdk/core/azure_core_examples/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "azure_core_examples"
+version = "0.1.0"
+description = "Example client implementations for azure_core documentation and tests."
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage = "https://github.com/azure/azure-sdk-for-rust"
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+# cspell:ignore autobenches autoexamples autotests
+autobenches = false
+autoexamples = false
+autotests = false
+
+[dependencies]
+async-trait.workspace = true
+azure_core = { path = "../azure_core", features = [
+  "reqwest",
+  "reqwest_rustls",
+  "tokio",
+] }
+base64.workspace = true
+futures.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/sdk/core/azure_core_examples/README.md
+++ b/sdk/core/azure_core_examples/README.md
@@ -1,0 +1,14 @@
+# Azure client library examples
+
+This crate minimally redefines types in other crates within this workspace to break circular dependencies that resolved to different versions.
+It is not published nor is it supported, and should only redefine types in stable crates for the purpose of non-runnable examples and documentation.
+
+## Contributing
+
+This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit <https://opensource.microsoft.com/cla/>.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct]. For more information see the [Code of Conduct FAQ] or contact <opencode@microsoft.com> with any additional questions or comments.
+
+[Code of Conduct FAQ]: https://opensource.microsoft.com/codeofconduct/faq/

--- a/sdk/core/azure_core_examples/src/certificates/mod.rs
+++ b/sdk/core/azure_core_examples/src/certificates/mod.rs
@@ -1,0 +1,203 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Example certificates client backed by azure_core primitives.
+
+pub mod models;
+
+use crate::certificates::models::{CertificateOperation, CreateCertificateParameters};
+use azure_core::{
+    credentials::TokenCredential,
+    error::ErrorKind,
+    fmt::SafeDebug,
+    http::{
+        headers::{RETRY_AFTER, RETRY_AFTER_MS, X_MS_RETRY_AFTER_MS},
+        policies::{auth::BearerTokenAuthorizationPolicy, Policy},
+        poller::{
+            get_retry_after, Poller, PollerContinuation, PollerResult, PollerState, PollerStatus,
+            StatusMonitor as _,
+        },
+        Body, ClientOptions, Method, Pipeline, RawResponse, Request, RequestContent, Url,
+        UrlExt as _,
+    },
+    json, Result,
+};
+use std::sync::Arc;
+
+const DEFAULT_API_VERSION: &str = "7.5";
+
+/// Options for configuring a [`CertificateClient`].
+#[derive(Clone, SafeDebug)]
+pub struct CertificateClientOptions {
+    /// The API version to use.
+    pub api_version: String,
+    /// Common client options including transport and policies.
+    pub client_options: ClientOptions,
+}
+
+impl Default for CertificateClientOptions {
+    fn default() -> Self {
+        Self {
+            api_version: DEFAULT_API_VERSION.to_owned(),
+            client_options: ClientOptions::default(),
+        }
+    }
+}
+
+/// A minimal certificates client backed by azure_core.
+#[derive(Debug)]
+pub struct CertificateClient {
+    endpoint: Url,
+    api_version: String,
+    pipeline: Pipeline,
+}
+
+impl CertificateClient {
+    /// Creates a new `CertificateClient`.
+    pub fn new(
+        endpoint: &str,
+        credential: Arc<dyn TokenCredential>,
+        options: Option<CertificateClientOptions>,
+    ) -> Result<Self> {
+        let options = options.unwrap_or_default();
+        let endpoint = Url::parse(endpoint)?;
+        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
+            credential,
+            vec!["https://vault.azure.net/.default"],
+        ));
+        Ok(Self {
+            endpoint,
+            api_version: options.api_version,
+            pipeline: Pipeline::new(
+                option_env!("CARGO_PKG_NAME"),
+                option_env!("CARGO_PKG_VERSION"),
+                options.client_options,
+                Vec::new(),
+                vec![auth_policy],
+                None,
+            ),
+        })
+    }
+
+    /// Begins creating a certificate and returns a poller to track the operation.
+    pub fn begin_create_certificate(
+        &self,
+        certificate_name: &str,
+        parameters: RequestContent<CreateCertificateParameters>,
+        _options: Option<()>,
+    ) -> Result<Poller<CertificateOperation>> {
+        let pipeline = self.pipeline.clone();
+        let api_version = self.api_version.clone();
+        let certificate_name = certificate_name.to_owned();
+        let parameters: Body = parameters.into();
+
+        let mut create_url = self.endpoint.clone();
+        create_url.append_path(&format!("/certificates/{certificate_name}/create"));
+        create_url
+            .query_pairs_mut()
+            .append_pair("api-version", &api_version);
+
+        let mut pending_url = self.endpoint.clone();
+        pending_url.append_path(&format!("/certificates/{certificate_name}/pending"));
+        pending_url
+            .query_pairs_mut()
+            .append_pair("api-version", &api_version);
+
+        Ok(Poller::new(
+            move |poller_state: PollerState, poller_options| {
+                let (mut request, next_link) = match poller_state {
+                    PollerState::More(continuation) => {
+                        let next_link = match continuation {
+                            PollerContinuation::Links { next_link, .. } => next_link,
+                            _ => unreachable!("unexpected continuation variant"),
+                        };
+                        // Preserve api-version
+                        let qp: Vec<_> = next_link
+                            .query_pairs()
+                            .filter(|(k, _)| k != "api-version")
+                            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+                            .collect();
+                        let mut next_link = next_link.clone();
+                        next_link.query_pairs_mut().clear().extend_pairs(qp);
+                        next_link
+                            .query_pairs_mut()
+                            .append_pair("api-version", &api_version);
+                        let mut req = Request::new(next_link.clone(), Method::Get);
+                        req.insert_header("accept", "application/json");
+                        (req, next_link)
+                    }
+                    PollerState::Initial => {
+                        let mut req = Request::new(create_url.clone(), Method::Post);
+                        req.insert_header("accept", "application/json");
+                        req.insert_header("content-type", "application/json");
+                        req.set_body(&parameters);
+                        (req, pending_url.clone())
+                    }
+                };
+
+                let pipeline = pipeline.clone();
+                let api_version = api_version.clone();
+                let ctx = poller_options.context.clone();
+                Box::pin(async move {
+                    let rsp = pipeline.send(&ctx, &mut request, None).await?;
+                    let (status, headers, body) = rsp.deconstruct();
+                    let retry_after = get_retry_after(
+                        &headers,
+                        &[RETRY_AFTER_MS, X_MS_RETRY_AFTER_MS, RETRY_AFTER],
+                        &poller_options,
+                    );
+                    let operation: CertificateOperation = json::from_json(&body)?;
+                    let response: azure_core::http::Response<CertificateOperation> =
+                        RawResponse::from_bytes(status, headers, body).into();
+
+                    Ok(match operation.status() {
+                        PollerStatus::InProgress => PollerResult::InProgress {
+                            response,
+                            retry_after,
+                            continuation: PollerContinuation::Links {
+                                next_link,
+                                final_link: None,
+                            },
+                        },
+                        PollerStatus::Succeeded => PollerResult::Succeeded {
+                            response,
+                            target: Box::new(move || {
+                                Box::pin(async move {
+                                    let final_link: Url = operation
+                                        .target
+                                        .ok_or_else(|| {
+                                            azure_core::Error::new(
+                                                ErrorKind::Other,
+                                                "missing target",
+                                            )
+                                        })?
+                                        .parse()
+                                        .map_err(|e| azure_core::Error::new(ErrorKind::Other, e))?;
+
+                                    let qp: Vec<_> = final_link
+                                        .query_pairs()
+                                        .filter(|(k, _)| k != "api-version")
+                                        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+                                        .collect();
+                                    let mut final_link = final_link.clone();
+                                    final_link.query_pairs_mut().clear().extend_pairs(qp);
+                                    final_link
+                                        .query_pairs_mut()
+                                        .append_pair("api-version", &api_version);
+
+                                    let mut req = Request::new(final_link, Method::Get);
+                                    req.insert_header("accept", "application/json");
+                                    let rsp = pipeline.send(&ctx, &mut req, None).await?;
+                                    let (status, headers, body) = rsp.deconstruct();
+                                    Ok(RawResponse::from_bytes(status, headers, body).into())
+                                })
+                            }),
+                        },
+                        _ => PollerResult::Done { response },
+                    })
+                })
+            },
+            None,
+        ))
+    }
+}

--- a/sdk/core/azure_core_examples/src/certificates/mod.rs
+++ b/sdk/core/azure_core_examples/src/certificates/mod.rs
@@ -8,9 +8,17 @@ pub mod models;
 use crate::certificates::models::{CertificateOperation, CreateCertificateParameters};
 use azure_core::{
     credentials::TokenCredential,
+    error::ErrorKind,
     fmt::SafeDebug,
-    http::{poller::Poller, ClientOptions, RequestContent},
-    Result,
+    http::{
+        headers::{RETRY_AFTER, RETRY_AFTER_MS, X_MS_RETRY_AFTER_MS},
+        poller::{
+            get_retry_after, Poller, PollerContinuation, PollerResult, PollerState, PollerStatus,
+            StatusMonitor as _,
+        },
+        Body, ClientOptions, Method, Pipeline, RawResponse, Request, RequestContent, Url,
+    },
+    json, Result,
 };
 use std::sync::Arc;
 
@@ -25,25 +33,117 @@ pub struct CertificateClientOptions {
 
 /// A minimal certificates client backed by azure_core.
 #[derive(Debug)]
-pub struct CertificateClient;
+pub struct CertificateClient {
+    endpoint: Url,
+    pipeline: Pipeline,
+}
 
 impl CertificateClient {
     /// Creates a new `CertificateClient`.
     pub fn new(
-        _endpoint: &str,
+        endpoint: &str,
         _credential: Arc<dyn TokenCredential>,
-        _options: Option<CertificateClientOptions>,
+        options: Option<CertificateClientOptions>,
     ) -> Result<Self> {
-        unimplemented!()
+        let endpoint = Url::parse(endpoint)?;
+        let options = options.unwrap_or_default();
+        Ok(Self {
+            endpoint,
+            pipeline: Pipeline::new(
+                option_env!("CARGO_PKG_NAME"),
+                option_env!("CARGO_PKG_VERSION"),
+                options.client_options,
+                Vec::new(),
+                Vec::new(),
+                None,
+            ),
+        })
     }
 
     /// Begins creating a certificate and returns a poller to track the operation.
     pub fn begin_create_certificate(
         &self,
-        _certificate_name: &str,
-        _parameters: RequestContent<CreateCertificateParameters>,
+        certificate_name: &str,
+        parameters: RequestContent<CreateCertificateParameters>,
         _options: Option<()>,
     ) -> Result<Poller<CertificateOperation>> {
-        unimplemented!()
+        let pipeline = self.pipeline.clone();
+        let certificate_name = certificate_name.to_owned();
+
+        let mut create_url = self.endpoint.clone();
+        create_url.set_path(&format!("certificates/{certificate_name}/create"));
+
+        let mut pending_url = self.endpoint.clone();
+        pending_url.set_path(&format!("certificates/{certificate_name}/pending"));
+
+        let parameters: Body = parameters.into();
+
+        Ok(Poller::new(
+            move |poller_state: PollerState, poller_options| {
+                let (mut request, next_link) = match poller_state {
+                    PollerState::More(continuation) => {
+                        let next_link = match continuation {
+                            PollerContinuation::Links { next_link, .. } => next_link,
+                            _ => unreachable!(),
+                        };
+                        let mut request = Request::new(next_link.clone(), Method::Get);
+                        request.insert_header("accept", "application/json");
+                        (request, next_link)
+                    }
+                    PollerState::Initial => {
+                        let mut request = Request::new(create_url.clone(), Method::Post);
+                        request.insert_header("accept", "application/json");
+                        request.insert_header("content-type", "application/json");
+                        request.set_body(&parameters);
+                        (request, pending_url.clone())
+                    }
+                };
+                let pipeline = pipeline.clone();
+                let ctx = poller_options.context.clone();
+                Box::pin(async move {
+                    let rsp = pipeline.send(&ctx, &mut request, None).await?;
+                    let (status, headers, body) = rsp.deconstruct();
+                    let retry_after = get_retry_after(
+                        &headers,
+                        &[RETRY_AFTER_MS, X_MS_RETRY_AFTER_MS, RETRY_AFTER],
+                        &poller_options,
+                    );
+                    let res: CertificateOperation = json::from_json(&body)?;
+                    let rsp = RawResponse::from_bytes(status, headers, body).into();
+                    Ok(match res.status() {
+                        PollerStatus::InProgress => PollerResult::InProgress {
+                            response: rsp,
+                            retry_after,
+                            continuation: PollerContinuation::Links {
+                                next_link,
+                                final_link: None,
+                            },
+                        },
+                        PollerStatus::Succeeded => {
+                            let target_url: Url = res
+                                .target
+                                .ok_or_else(|| {
+                                    azure_core::Error::new(ErrorKind::Other, "missing target")
+                                })?
+                                .parse()?;
+                            PollerResult::Succeeded {
+                                response: rsp,
+                                target: Box::new(move || {
+                                    Box::pin(async move {
+                                        let mut request = Request::new(target_url, Method::Get);
+                                        request.insert_header("accept", "application/json");
+                                        let rsp = pipeline.send(&ctx, &mut request, None).await?;
+                                        let (status, headers, body) = rsp.deconstruct();
+                                        Ok(RawResponse::from_bytes(status, headers, body).into())
+                                    })
+                                }),
+                            }
+                        }
+                        _ => PollerResult::Done { response: rsp },
+                    })
+                })
+            },
+            None,
+        ))
     }
 }

--- a/sdk/core/azure_core_examples/src/certificates/mod.rs
+++ b/sdk/core/azure_core_examples/src/certificates/mod.rs
@@ -8,26 +8,14 @@ pub mod models;
 use crate::certificates::models::{CertificateOperation, CreateCertificateParameters};
 use azure_core::{
     credentials::TokenCredential,
-    error::ErrorKind,
     fmt::SafeDebug,
-    http::{
-        headers::{RETRY_AFTER, RETRY_AFTER_MS, X_MS_RETRY_AFTER_MS},
-        policies::{auth::BearerTokenAuthorizationPolicy, Policy},
-        poller::{
-            get_retry_after, Poller, PollerContinuation, PollerResult, PollerState, PollerStatus,
-            StatusMonitor as _,
-        },
-        Body, ClientOptions, Method, Pipeline, RawResponse, Request, RequestContent, Url,
-        UrlExt as _,
-    },
-    json, Result,
+    http::{poller::Poller, ClientOptions, RequestContent},
+    Result,
 };
 use std::sync::Arc;
 
-const DEFAULT_API_VERSION: &str = "7.5";
-
 /// Options for configuring a [`CertificateClient`].
-#[derive(Clone, SafeDebug)]
+#[derive(Clone, Default, SafeDebug)]
 pub struct CertificateClientOptions {
     /// The API version to use.
     pub api_version: String,
@@ -35,169 +23,27 @@ pub struct CertificateClientOptions {
     pub client_options: ClientOptions,
 }
 
-impl Default for CertificateClientOptions {
-    fn default() -> Self {
-        Self {
-            api_version: DEFAULT_API_VERSION.to_owned(),
-            client_options: ClientOptions::default(),
-        }
-    }
-}
-
 /// A minimal certificates client backed by azure_core.
 #[derive(Debug)]
-pub struct CertificateClient {
-    endpoint: Url,
-    api_version: String,
-    pipeline: Pipeline,
-}
+pub struct CertificateClient;
 
 impl CertificateClient {
     /// Creates a new `CertificateClient`.
     pub fn new(
-        endpoint: &str,
-        credential: Arc<dyn TokenCredential>,
-        options: Option<CertificateClientOptions>,
+        _endpoint: &str,
+        _credential: Arc<dyn TokenCredential>,
+        _options: Option<CertificateClientOptions>,
     ) -> Result<Self> {
-        let options = options.unwrap_or_default();
-        let endpoint = Url::parse(endpoint)?;
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
-            credential,
-            vec!["https://vault.azure.net/.default"],
-        ));
-        Ok(Self {
-            endpoint,
-            api_version: options.api_version,
-            pipeline: Pipeline::new(
-                option_env!("CARGO_PKG_NAME"),
-                option_env!("CARGO_PKG_VERSION"),
-                options.client_options,
-                Vec::new(),
-                vec![auth_policy],
-                None,
-            ),
-        })
+        unimplemented!()
     }
 
     /// Begins creating a certificate and returns a poller to track the operation.
     pub fn begin_create_certificate(
         &self,
-        certificate_name: &str,
-        parameters: RequestContent<CreateCertificateParameters>,
+        _certificate_name: &str,
+        _parameters: RequestContent<CreateCertificateParameters>,
         _options: Option<()>,
     ) -> Result<Poller<CertificateOperation>> {
-        let pipeline = self.pipeline.clone();
-        let api_version = self.api_version.clone();
-        let certificate_name = certificate_name.to_owned();
-        let parameters: Body = parameters.into();
-
-        let mut create_url = self.endpoint.clone();
-        create_url.append_path(&format!("/certificates/{certificate_name}/create"));
-        create_url
-            .query_pairs_mut()
-            .append_pair("api-version", &api_version);
-
-        let mut pending_url = self.endpoint.clone();
-        pending_url.append_path(&format!("/certificates/{certificate_name}/pending"));
-        pending_url
-            .query_pairs_mut()
-            .append_pair("api-version", &api_version);
-
-        Ok(Poller::new(
-            move |poller_state: PollerState, poller_options| {
-                let (mut request, next_link) = match poller_state {
-                    PollerState::More(continuation) => {
-                        let next_link = match continuation {
-                            PollerContinuation::Links { next_link, .. } => next_link,
-                            _ => unreachable!("unexpected continuation variant"),
-                        };
-                        // Preserve api-version
-                        let qp: Vec<_> = next_link
-                            .query_pairs()
-                            .filter(|(k, _)| k != "api-version")
-                            .map(|(k, v)| (k.into_owned(), v.into_owned()))
-                            .collect();
-                        let mut next_link = next_link.clone();
-                        next_link.query_pairs_mut().clear().extend_pairs(qp);
-                        next_link
-                            .query_pairs_mut()
-                            .append_pair("api-version", &api_version);
-                        let mut req = Request::new(next_link.clone(), Method::Get);
-                        req.insert_header("accept", "application/json");
-                        (req, next_link)
-                    }
-                    PollerState::Initial => {
-                        let mut req = Request::new(create_url.clone(), Method::Post);
-                        req.insert_header("accept", "application/json");
-                        req.insert_header("content-type", "application/json");
-                        req.set_body(&parameters);
-                        (req, pending_url.clone())
-                    }
-                };
-
-                let pipeline = pipeline.clone();
-                let api_version = api_version.clone();
-                let ctx = poller_options.context.clone();
-                Box::pin(async move {
-                    let rsp = pipeline.send(&ctx, &mut request, None).await?;
-                    let (status, headers, body) = rsp.deconstruct();
-                    let retry_after = get_retry_after(
-                        &headers,
-                        &[RETRY_AFTER_MS, X_MS_RETRY_AFTER_MS, RETRY_AFTER],
-                        &poller_options,
-                    );
-                    let operation: CertificateOperation = json::from_json(&body)?;
-                    let response: azure_core::http::Response<CertificateOperation> =
-                        RawResponse::from_bytes(status, headers, body).into();
-
-                    Ok(match operation.status() {
-                        PollerStatus::InProgress => PollerResult::InProgress {
-                            response,
-                            retry_after,
-                            continuation: PollerContinuation::Links {
-                                next_link,
-                                final_link: None,
-                            },
-                        },
-                        PollerStatus::Succeeded => PollerResult::Succeeded {
-                            response,
-                            target: Box::new(move || {
-                                Box::pin(async move {
-                                    let final_link: Url = operation
-                                        .target
-                                        .ok_or_else(|| {
-                                            azure_core::Error::new(
-                                                ErrorKind::Other,
-                                                "missing target",
-                                            )
-                                        })?
-                                        .parse()
-                                        .map_err(|e| azure_core::Error::new(ErrorKind::Other, e))?;
-
-                                    let qp: Vec<_> = final_link
-                                        .query_pairs()
-                                        .filter(|(k, _)| k != "api-version")
-                                        .map(|(k, v)| (k.into_owned(), v.into_owned()))
-                                        .collect();
-                                    let mut final_link = final_link.clone();
-                                    final_link.query_pairs_mut().clear().extend_pairs(qp);
-                                    final_link
-                                        .query_pairs_mut()
-                                        .append_pair("api-version", &api_version);
-
-                                    let mut req = Request::new(final_link, Method::Get);
-                                    req.insert_header("accept", "application/json");
-                                    let rsp = pipeline.send(&ctx, &mut req, None).await?;
-                                    let (status, headers, body) = rsp.deconstruct();
-                                    Ok(RawResponse::from_bytes(status, headers, body).into())
-                                })
-                            }),
-                        },
-                        _ => PollerResult::Done { response },
-                    })
-                })
-            },
-            None,
-        ))
+        unimplemented!()
     }
 }

--- a/sdk/core/azure_core_examples/src/certificates/models.rs
+++ b/sdk/core/azure_core_examples/src/certificates/models.rs
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Models for the example certificates client.
+
+use azure_core::{
+    http::{
+        poller::{PollerStatus, StatusMonitor},
+        JsonFormat, RequestContent,
+    },
+    json::to_json,
+    Result,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A certificate.
+#[derive(Clone, Default, Deserialize, Serialize, Debug)]
+pub struct Certificate {
+    /// The certificate id.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// The DER-encoded certificate bytes.
+    #[serde(
+        default,
+        deserialize_with = "base64_option::deserialize",
+        serialize_with = "base64_option::serialize",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cer: Option<Vec<u8>>,
+}
+
+mod base64_option {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(value: &Option<Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use base64::Engine as _;
+        match value {
+            Some(v) => base64::engine::general_purpose::STANDARD
+                .encode(v)
+                .serialize(serializer),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use base64::Engine as _;
+        let s: Option<String> = Option::deserialize(deserializer)?;
+        match s {
+            Some(s) => {
+                let bytes = base64::engine::general_purpose::STANDARD
+                    .decode(&s)
+                    .map_err(serde::de::Error::custom)?;
+                Ok(Some(bytes))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+/// A certificate operation returned during LROs.
+#[derive(Clone, Default, Deserialize, Serialize, Debug)]
+pub struct CertificateOperation {
+    /// The status of the operation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+
+    /// The target URL of the completed certificate.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+
+    /// The error, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<HashMap<String, String>>,
+
+    /// The certificate id.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+}
+
+impl StatusMonitor for CertificateOperation {
+    type Output = Certificate;
+    type Format = JsonFormat;
+    fn status(&self) -> PollerStatus {
+        match self.status.as_deref() {
+            Some("completed") => PollerStatus::Succeeded,
+            Some("cancelled") => PollerStatus::Canceled,
+            Some(_) if self.error.is_some() => PollerStatus::Failed,
+            _ => PollerStatus::InProgress,
+        }
+    }
+}
+
+/// Parameters for creating a certificate.
+#[derive(Clone, Default, Deserialize, Serialize, Debug)]
+pub struct CreateCertificateParameters {
+    /// The management policy for the certificate.
+    #[serde(rename = "policy", skip_serializing_if = "Option::is_none")]
+    pub certificate_policy: Option<CertificatePolicy>,
+
+    /// Application-specific metadata as key-value pairs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<HashMap<String, String>>,
+}
+
+impl TryFrom<CreateCertificateParameters> for RequestContent<CreateCertificateParameters> {
+    type Error = azure_core::Error;
+    fn try_from(value: CreateCertificateParameters) -> Result<Self> {
+        Ok(to_json(&value)?.into())
+    }
+}
+
+/// Certificate management policy.
+#[derive(Clone, Default, Deserialize, Serialize, Debug)]
+pub struct CertificatePolicy {
+    /// Properties of the X.509 component of the certificate.
+    #[serde(rename = "x509_props", skip_serializing_if = "Option::is_none")]
+    pub x509_certificate_properties: Option<X509CertificateProperties>,
+
+    /// Issuer parameters.
+    #[serde(rename = "issuer", skip_serializing_if = "Option::is_none")]
+    pub issuer_parameters: Option<IssuerParameters>,
+}
+
+/// X.509 certificate properties.
+#[derive(Clone, Default, Deserialize, Serialize, Debug)]
+pub struct X509CertificateProperties {
+    /// The subject name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
+}
+
+/// Issuer parameters.
+#[derive(Clone, Default, Deserialize, Serialize, Debug)]
+pub struct IssuerParameters {
+    /// The issuer name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}

--- a/sdk/core/azure_core_examples/src/client/mod.rs
+++ b/sdk/core/azure_core_examples/src/client/mod.rs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Example service client for use in `azure_core` examples and tests.
+
+/// A public HTTP endpoint used for transport examples and benchmarks.
+pub const HTTP_ENDPOINT: &str = "https://azuresdkforcpp.azurewebsites.net";
+
+use crate::credentials::TokenCredential;
+use azure_core::{
+    fmt::SafeDebug,
+    http::{ClientMethodOptions, ClientOptions, Pipeline, RawResponse, Request, Url},
+    Result,
+};
+use std::sync::Arc;
+
+/// Options for configuring a [`TestServiceClient`].
+#[derive(Clone, SafeDebug)]
+pub struct TestServiceClientOptions {
+    /// Options passed through to the underlying HTTP client.
+    pub client_options: ClientOptions,
+    /// The API version to use for requests.
+    pub api_version: Option<String>,
+}
+
+impl Default for TestServiceClientOptions {
+    fn default() -> Self {
+        Self {
+            client_options: ClientOptions::default(),
+            api_version: Some("2023-10-01".to_string()),
+        }
+    }
+}
+
+/// A minimal example service client backed by an [`azure_core`] [`Pipeline`].
+pub struct TestServiceClient {
+    endpoint: Url,
+    api_version: String,
+    pipeline: Pipeline,
+}
+
+/// Per-call options for [`TestServiceClient::get`].
+#[derive(Default, SafeDebug)]
+pub struct TestServiceClientGetMethodOptions<'a> {
+    /// Common per-call options.
+    pub method_options: ClientMethodOptions<'a>,
+}
+
+impl TestServiceClient {
+    /// Create a new `TestServiceClient`.
+    pub fn new(
+        endpoint: &str,
+        _credential: Arc<dyn TokenCredential>,
+        options: Option<TestServiceClientOptions>,
+    ) -> Result<Self> {
+        let options = options.unwrap_or_default();
+        let mut endpoint = Url::parse(endpoint)?;
+        if !endpoint.scheme().starts_with("http") {
+            return Err(azure_core::Error::with_message(
+                azure_core::error::ErrorKind::Other,
+                format!("{endpoint} must use http(s)"),
+            ));
+        }
+        endpoint.set_query(None);
+
+        Ok(Self {
+            endpoint,
+            api_version: options.api_version.unwrap_or_default(),
+            pipeline: Pipeline::new(
+                option_env!("CARGO_PKG_NAME"),
+                option_env!("CARGO_PKG_VERSION"),
+                options.client_options,
+                Vec::default(),
+                Vec::default(),
+                None,
+            ),
+        })
+    }
+
+    /// Returns the URL associated with this client.
+    pub fn endpoint(&self) -> &Url {
+        &self.endpoint
+    }
+
+    /// Sends a GET request to `path` relative to the configured endpoint.
+    pub async fn get(
+        &self,
+        path: &str,
+        options: Option<TestServiceClientGetMethodOptions<'_>>,
+    ) -> Result<RawResponse> {
+        let options = options.unwrap_or_default();
+        let mut url = self.endpoint.clone();
+        url.set_path(path);
+        url.query_pairs_mut()
+            .append_pair("api-version", &self.api_version);
+
+        let mut request = Request::new(url, azure_core::http::Method::Get);
+
+        let response = self
+            .pipeline
+            .send(&options.method_options.context, &mut request, None)
+            .await?;
+        if !response.status().is_success() {
+            return Err(azure_core::Error::with_message(
+                azure_core::error::ErrorKind::HttpResponse {
+                    status: response.status(),
+                    error_code: None,
+                    raw_response: None,
+                },
+                format!("Failed to GET {}: {}", request.url(), response.status()),
+            ));
+        }
+        Ok(response)
+    }
+}

--- a/sdk/core/azure_core_examples/src/identity/developer_tools_credential.rs
+++ b/sdk/core/azure_core_examples/src/identity/developer_tools_credential.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use azure_core::credentials::{AccessToken, TokenCredential, TokenRequestOptions};
+use std::{fmt, sync::Arc};
+
+/// Options for constructing a new [`DeveloperToolsCredential`].
+#[derive(Clone, Debug, Default)]
+pub struct DeveloperToolsCredentialOptions;
+
+/// Authenticates through developer tools such as the Azure CLI.
+///
+/// This is a stub for use in examples that do not need to authenticate.
+pub struct DeveloperToolsCredential;
+
+impl DeveloperToolsCredential {
+    /// Creates a new instance of `DeveloperToolsCredential`.
+    pub fn new(_options: Option<DeveloperToolsCredentialOptions>) -> azure_core::Result<Arc<Self>> {
+        Ok(Arc::new(Self))
+    }
+}
+
+impl fmt::Debug for DeveloperToolsCredential {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DeveloperToolsCredential").finish()
+    }
+}
+
+#[async_trait::async_trait]
+impl TokenCredential for DeveloperToolsCredential {
+    async fn get_token(
+        &self,
+        _scopes: &[&str],
+        _options: Option<TokenRequestOptions<'_>>,
+    ) -> azure_core::Result<AccessToken> {
+        unimplemented!("DeveloperToolsCredential is not runnable in azure_core_examples")
+    }
+}

--- a/sdk/core/azure_core_examples/src/identity/mock_credential.rs
+++ b/sdk/core/azure_core_examples/src/identity/mock_credential.rs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use azure_core::{
+    credentials::{AccessToken, Secret, TokenCredential, TokenRequestOptions},
+    time::{Duration, OffsetDateTime},
+};
+use std::sync::Arc;
+
+/// A mock [`TokenCredential`] useful for testing.
+#[derive(Clone, Debug, Default)]
+pub struct MockCredential;
+
+impl MockCredential {
+    /// Create a new `MockCredential`.
+    pub fn new() -> azure_core::Result<Arc<Self>> {
+        Ok(Arc::new(MockCredential {}))
+    }
+}
+
+#[async_trait::async_trait]
+impl TokenCredential for MockCredential {
+    async fn get_token(
+        &self,
+        scopes: &[&str],
+        _: Option<TokenRequestOptions<'_>>,
+    ) -> azure_core::Result<AccessToken> {
+        let token: Secret = format!("TEST TOKEN {}", scopes.join(" ")).into();
+        let expires_on = OffsetDateTime::now_utc().saturating_add(Duration::minutes(5));
+
+        Ok(AccessToken { token, expires_on })
+    }
+}

--- a/sdk/core/azure_core_examples/src/identity/mod.rs
+++ b/sdk/core/azure_core_examples/src/identity/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Example identity credentials backed by azure_core primitives.
+
+mod developer_tools_credential;
+mod mock_credential;
+
+pub use developer_tools_credential::{DeveloperToolsCredential, DeveloperToolsCredentialOptions};
+pub use mock_credential::MockCredential;

--- a/sdk/core/azure_core_examples/src/lib.rs
+++ b/sdk/core/azure_core_examples/src/lib.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Example client implementations for `azure_core` documentation and tests.
+//!
+//! This crate provides minimal example service clients to use in `azure_core` examples and tests,
+//! avoiding circular dependencies on production service client crates.
+
+pub mod certificates;
+pub mod client;
+pub mod identity;
+pub mod secrets;
+
+pub use azure_core::credentials;

--- a/sdk/core/azure_core_examples/src/secrets/mod.rs
+++ b/sdk/core/azure_core_examples/src/secrets/mod.rs
@@ -11,9 +11,14 @@ use crate::secrets::models::{
 };
 use azure_core::{
     credentials::TokenCredential,
+    error::{CheckSuccessOptions, ErrorKind},
     fmt::SafeDebug,
-    http::{ClientOptions, Method, Pager, Pipeline, Request, RequestContent, Response, Url},
-    Result,
+    http::{
+        pager::{PagerContinuation, PagerResult, PagerState},
+        ClientOptions, Method, Pager, Pipeline, PipelineSendOptions, RawResponse, Request,
+        RequestContent, Response, Url,
+    },
+    json, Result,
 };
 use std::sync::Arc;
 
@@ -38,9 +43,35 @@ pub trait ResourceExt {
 
 impl ResourceExt for SecretProperties {
     fn resource_id(&self) -> Result<ResourceId> {
-        unimplemented!()
+        let id = self.id.as_deref().ok_or_else(|| {
+            azure_core::Error::with_message(ErrorKind::DataConversion, "missing resource id")
+        })?;
+        let url: Url = id.parse()?;
+        let vault_url = format!("{}://{}", url.scheme(), url.authority());
+        let mut segments = url
+            .path_segments()
+            .ok_or_else(|| {
+                azure_core::Error::with_message(ErrorKind::DataConversion, "invalid url")
+            })?
+            .filter(|s| !s.is_empty());
+        // skip the collection segment (e.g. "secrets")
+        let _ = segments.next();
+        let name = segments
+            .next()
+            .ok_or_else(|| {
+                azure_core::Error::with_message(ErrorKind::DataConversion, "missing name")
+            })?
+            .to_string();
+        let version = segments.next().map(String::from);
+        Ok(ResourceId {
+            source_id: id.to_string(),
+            vault_url,
+            name,
+            version,
+        })
     }
 }
+
 /// Options for configuring a [`SecretClient`].
 #[derive(Clone, Default, SafeDebug)]
 pub struct SecretClientOptions {
@@ -49,48 +80,89 @@ pub struct SecretClientOptions {
     /// Common client options including transport and policies.
     pub client_options: ClientOptions,
 }
+
 /// A minimal secrets client backed by azure_core.
 #[derive(Debug)]
-pub struct SecretClient(Pipeline);
+pub struct SecretClient {
+    endpoint: Url,
+    pipeline: Pipeline,
+}
 
 impl SecretClient {
     /// Creates a new `SecretClient`.
     pub fn new(
-        _endpoint: &str,
+        endpoint: &str,
         _credential: Arc<dyn TokenCredential>,
         options: Option<SecretClientOptions>,
     ) -> Result<Self> {
+        let endpoint = Url::parse(endpoint)?;
         let options = options.unwrap_or_default();
-        Ok(Self(Pipeline::new(
-            option_env!("CARGO_PKG_NAME"),
-            option_env!("CARGO_PKG_VERSION"),
-            options.client_options,
-            Vec::new(),
-            Vec::new(),
-            None,
-        )))
+        Ok(Self {
+            endpoint,
+            pipeline: Pipeline::new(
+                option_env!("CARGO_PKG_NAME"),
+                option_env!("CARGO_PKG_VERSION"),
+                options.client_options,
+                Vec::new(),
+                Vec::new(),
+                None,
+            ),
+        })
     }
 
     /// Gets a secret by name.
     pub async fn get_secret(
         &self,
-        _secret_name: &str,
+        secret_name: &str,
         _options: Option<()>,
     ) -> Result<Response<Secret>> {
-        let mut request =
-            Request::new(Url::parse("https://my-vault.vault.azure.net")?, Method::Get);
-        let rsp = self.0.send(&Default::default(), &mut request, None).await?;
+        let mut url = self.endpoint.clone();
+        url.set_path(&format!("secrets/{secret_name}"));
+        let mut request = Request::new(url, Method::Get);
+        request.insert_header("accept", "application/json");
+        let rsp = self
+            .pipeline
+            .send(
+                &Default::default(),
+                &mut request,
+                Some(PipelineSendOptions {
+                    check_success: CheckSuccessOptions {
+                        success_codes: &[200],
+                    },
+                    ..Default::default()
+                }),
+            )
+            .await?;
         Ok(rsp.into())
     }
 
     /// Sets a secret.
     pub async fn set_secret(
         &self,
-        _secret_name: &str,
-        _body: RequestContent<SetSecretParameters>,
+        secret_name: &str,
+        body: RequestContent<SetSecretParameters>,
         _options: Option<()>,
     ) -> Result<Response<Secret>> {
-        unimplemented!()
+        let mut url = self.endpoint.clone();
+        url.set_path(&format!("secrets/{secret_name}"));
+        let mut request = Request::new(url, Method::Put);
+        request.insert_header("accept", "application/json");
+        request.insert_header("content-type", "application/json");
+        request.set_body(body);
+        let rsp = self
+            .pipeline
+            .send(
+                &Default::default(),
+                &mut request,
+                Some(PipelineSendOptions {
+                    check_success: CheckSuccessOptions {
+                        success_codes: &[200],
+                    },
+                    ..Default::default()
+                }),
+            )
+            .await?;
+        Ok(rsp.into())
     }
 
     /// Updates secret properties.
@@ -108,6 +180,49 @@ impl SecretClient {
         &self,
         _options: Option<SecretClientListSecretPropertiesOptions<'_>>,
     ) -> Result<Pager<ListSecretPropertiesResult>> {
-        unimplemented!()
+        let pipeline = self.pipeline.clone();
+        let mut first_url = self.endpoint.clone();
+        first_url.set_path("secrets");
+        Ok(Pager::new(
+            move |state: PagerState, pager_options| {
+                let url = match state {
+                    PagerState::More(continuation) => {
+                        continuation.try_into().expect("expected Url")
+                    }
+                    PagerState::Initial => first_url.clone(),
+                };
+                let mut request = Request::new(url, Method::Get);
+                request.insert_header("accept", "application/json");
+                let pipeline = pipeline.clone();
+                let first_url = first_url.clone();
+                Box::pin(async move {
+                    let rsp = pipeline
+                        .send(
+                            &pager_options.context,
+                            &mut request,
+                            Some(PipelineSendOptions {
+                                check_success: CheckSuccessOptions {
+                                    success_codes: &[200],
+                                },
+                                ..Default::default()
+                            }),
+                        )
+                        .await?;
+                    let (status, headers, body) = rsp.deconstruct();
+                    let res: ListSecretPropertiesResult = json::from_json(&body)?;
+                    let rsp = RawResponse::from_bytes(status, headers, body).into();
+                    Ok(match res.next_link {
+                        Some(next_link) if !next_link.is_empty() => PagerResult::More {
+                            response: rsp,
+                            continuation: PagerContinuation::Link(
+                                first_url.join(next_link.as_ref())?,
+                            ),
+                        },
+                        _ => PagerResult::Done { response: rsp },
+                    })
+                })
+            },
+            None,
+        ))
     }
 }

--- a/sdk/core/azure_core_examples/src/secrets/mod.rs
+++ b/sdk/core/azure_core_examples/src/secrets/mod.rs
@@ -11,15 +11,9 @@ use crate::secrets::models::{
 };
 use azure_core::{
     credentials::TokenCredential,
-    error::ErrorKind,
     fmt::SafeDebug,
-    http::{
-        pager::{PagerContinuation, PagerOptions, PagerResult, PagerState},
-        policies::{auth::BearerTokenAuthorizationPolicy, Policy},
-        ClientOptions, Method, Pager, Pipeline, RawResponse, Request, RequestContent, Response,
-        Url, UrlExt as _,
-    },
-    json, Result,
+    http::{ClientOptions, Method, Pager, Pipeline, Request, RequestContent, Response, Url},
+    Result,
 };
 use std::sync::Arc;
 
@@ -44,219 +38,76 @@ pub trait ResourceExt {
 
 impl ResourceExt for SecretProperties {
     fn resource_id(&self) -> Result<ResourceId> {
-        parse_resource_id(self.id.as_deref())
+        unimplemented!()
     }
 }
-
-fn parse_resource_id(id: Option<&str>) -> Result<ResourceId> {
-    let id = id.ok_or_else(|| {
-        azure_core::Error::with_message(ErrorKind::DataConversion, "missing resource id")
-    })?;
-    let url: Url = id
-        .parse()
-        .map_err(|e| azure_core::Error::new(ErrorKind::DataConversion, e))?;
-    let vault_url = format!("{}://{}", url.scheme(), url.authority());
-    let mut segments = url
-        .path_segments()
-        .ok_or_else(|| azure_core::Error::with_message(ErrorKind::DataConversion, "invalid url"))?
-        .filter(|s| !s.is_empty());
-    // skip the collection segment (e.g. "secrets")
-    segments.next().ok_or_else(|| {
-        azure_core::Error::with_message(ErrorKind::DataConversion, "missing collection")
-    })?;
-    let name = segments
-        .next()
-        .ok_or_else(|| azure_core::Error::with_message(ErrorKind::DataConversion, "missing name"))?
-        .to_owned();
-    let version = segments.next().map(|s| s.to_owned());
-    Ok(ResourceId {
-        source_id: id.to_owned(),
-        vault_url,
-        name,
-        version,
-    })
-}
-
-const DEFAULT_API_VERSION: &str = "7.5";
-
 /// Options for configuring a [`SecretClient`].
-#[derive(Clone, SafeDebug)]
+#[derive(Clone, Default, SafeDebug)]
 pub struct SecretClientOptions {
     /// The API version to use.
     pub api_version: String,
     /// Common client options including transport and policies.
     pub client_options: ClientOptions,
 }
-
-impl Default for SecretClientOptions {
-    fn default() -> Self {
-        Self {
-            api_version: DEFAULT_API_VERSION.to_owned(),
-            client_options: ClientOptions::default(),
-        }
-    }
-}
-
 /// A minimal secrets client backed by azure_core.
 #[derive(Debug)]
-pub struct SecretClient {
-    endpoint: Url,
-    api_version: String,
-    pipeline: Pipeline,
-}
+pub struct SecretClient(Pipeline);
 
 impl SecretClient {
     /// Creates a new `SecretClient`.
     pub fn new(
-        endpoint: &str,
-        credential: Arc<dyn TokenCredential>,
+        _endpoint: &str,
+        _credential: Arc<dyn TokenCredential>,
         options: Option<SecretClientOptions>,
     ) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let endpoint = Url::parse(endpoint)?;
-        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
-            credential,
-            vec!["https://vault.azure.net/.default"],
-        ));
-        Ok(Self {
-            endpoint,
-            api_version: options.api_version,
-            pipeline: Pipeline::new(
-                option_env!("CARGO_PKG_NAME"),
-                option_env!("CARGO_PKG_VERSION"),
-                options.client_options,
-                Vec::new(),
-                vec![auth_policy],
-                None,
-            ),
-        })
+        Ok(Self(Pipeline::new(
+            option_env!("CARGO_PKG_NAME"),
+            option_env!("CARGO_PKG_VERSION"),
+            options.client_options,
+            Vec::new(),
+            Vec::new(),
+            None,
+        )))
     }
 
     /// Gets a secret by name.
     pub async fn get_secret(
         &self,
-        secret_name: &str,
+        _secret_name: &str,
         _options: Option<()>,
     ) -> Result<Response<Secret>> {
-        let mut url = self.endpoint.clone();
-        url.append_path(&format!("/secrets/{secret_name}/"));
-        url.query_pairs_mut()
-            .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Get);
-        request.insert_header("accept", "application/json");
-        let rsp = self
-            .pipeline
-            .send(&Default::default(), &mut request, None)
-            .await?;
+        let mut request =
+            Request::new(Url::parse("https://my-vault.vault.azure.net")?, Method::Get);
+        let rsp = self.0.send(&Default::default(), &mut request, None).await?;
         Ok(rsp.into())
     }
 
     /// Sets a secret.
     pub async fn set_secret(
         &self,
-        secret_name: &str,
-        body: RequestContent<SetSecretParameters>,
+        _secret_name: &str,
+        _body: RequestContent<SetSecretParameters>,
         _options: Option<()>,
     ) -> Result<Response<Secret>> {
-        let mut url = self.endpoint.clone();
-        url.append_path(&format!("/secrets/{secret_name}"));
-        url.query_pairs_mut()
-            .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Put);
-        request.insert_header("accept", "application/json");
-        request.insert_header("content-type", "application/json");
-        let body: azure_core::http::Body = body.into();
-        request.set_body(&body);
-        let rsp = self
-            .pipeline
-            .send(&Default::default(), &mut request, None)
-            .await?;
-        Ok(rsp.into())
+        unimplemented!()
     }
 
     /// Updates secret properties.
     pub async fn update_secret_properties(
         &self,
-        secret_name: &str,
-        body: RequestContent<UpdateSecretPropertiesParameters>,
+        _secret_name: &str,
+        _body: RequestContent<UpdateSecretPropertiesParameters>,
         _options: Option<()>,
     ) -> Result<Response<Secret>> {
-        let mut url = self.endpoint.clone();
-        url.append_path(&format!("/secrets/{secret_name}/"));
-        url.query_pairs_mut()
-            .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Patch);
-        request.insert_header("accept", "application/json");
-        request.insert_header("content-type", "application/json");
-        let body: azure_core::http::Body = body.into();
-        request.set_body(&body);
-        let rsp = self
-            .pipeline
-            .send(&Default::default(), &mut request, None)
-            .await?;
-        Ok(rsp.into())
+        unimplemented!()
     }
 
     /// Lists secret properties (paginated).
     pub fn list_secret_properties(
         &self,
-        options: Option<SecretClientListSecretPropertiesOptions<'_>>,
+        _options: Option<SecretClientListSecretPropertiesOptions<'_>>,
     ) -> Result<Pager<ListSecretPropertiesResult>> {
-        let pager_options = options.map(|o| {
-            let method_options = o.method_options;
-            PagerOptions {
-                context: method_options.context.into_owned(),
-                ..method_options
-            }
-        });
-        let pipeline = self.pipeline.clone();
-        let api_version = self.api_version.clone();
-        let mut first_url = self.endpoint.clone();
-        first_url.append_path("/secrets");
-        first_url
-            .query_pairs_mut()
-            .append_pair("api-version", &api_version);
-
-        Ok(Pager::new(
-            move |state: PagerState, pager_options| {
-                let pipeline = pipeline.clone();
-                let api_version = api_version.clone();
-                let url = match state {
-                    PagerState::More(next_link) => {
-                        let mut next_link: Url = next_link.try_into().expect("expected Url");
-                        let qp: Vec<_> = next_link
-                            .query_pairs()
-                            .filter(|(k, _)| k != "api-version")
-                            .map(|(k, v)| (k.into_owned(), v.into_owned()))
-                            .collect();
-                        next_link.query_pairs_mut().clear().extend_pairs(qp);
-                        next_link
-                            .query_pairs_mut()
-                            .append_pair("api-version", &api_version);
-                        next_link
-                    }
-                    PagerState::Initial => first_url.clone(),
-                };
-                let mut request = Request::new(url.clone(), Method::Get);
-                request.insert_header("accept", "application/json");
-                Box::pin(async move {
-                    let rsp = pipeline
-                        .send(&pager_options.context, &mut request, None)
-                        .await?;
-                    let (status, headers, body) = rsp.deconstruct();
-                    let result: ListSecretPropertiesResult = json::from_json(&body)?;
-                    let response: Response<ListSecretPropertiesResult> =
-                        RawResponse::from_bytes(status, headers, body).into();
-                    Ok(match result.next_link {
-                        Some(ref next_link) if !next_link.is_empty() => PagerResult::More {
-                            response,
-                            continuation: PagerContinuation::Link(url.join(next_link.as_ref())?),
-                        },
-                        _ => PagerResult::Done { response },
-                    })
-                })
-            },
-            pager_options,
-        ))
+        unimplemented!()
     }
 }

--- a/sdk/core/azure_core_examples/src/secrets/mod.rs
+++ b/sdk/core/azure_core_examples/src/secrets/mod.rs
@@ -1,0 +1,262 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Example secrets client backed by azure_core primitives.
+
+pub mod models;
+
+use crate::secrets::models::{
+    ListSecretPropertiesResult, Secret, SecretClientListSecretPropertiesOptions, SecretProperties,
+    SetSecretParameters, UpdateSecretPropertiesParameters,
+};
+use azure_core::{
+    credentials::TokenCredential,
+    error::ErrorKind,
+    fmt::SafeDebug,
+    http::{
+        pager::{PagerContinuation, PagerOptions, PagerResult, PagerState},
+        policies::{auth::BearerTokenAuthorizationPolicy, Policy},
+        ClientOptions, Method, Pager, Pipeline, RawResponse, Request, RequestContent, Response,
+        Url, UrlExt as _,
+    },
+    json, Result,
+};
+use std::sync::Arc;
+
+/// Resource identifier parsed from a Key Vault URL.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResourceId {
+    /// The original URL.
+    pub source_id: String,
+    /// The vault base URL.
+    pub vault_url: String,
+    /// The resource name.
+    pub name: String,
+    /// The optional resource version.
+    pub version: Option<String>,
+}
+
+/// Extension trait to obtain a [`ResourceId`] from a model that has an `id` field.
+pub trait ResourceExt {
+    /// Returns the [`ResourceId`] parsed from the resource's id URL.
+    fn resource_id(&self) -> Result<ResourceId>;
+}
+
+impl ResourceExt for SecretProperties {
+    fn resource_id(&self) -> Result<ResourceId> {
+        parse_resource_id(self.id.as_deref())
+    }
+}
+
+fn parse_resource_id(id: Option<&str>) -> Result<ResourceId> {
+    let id = id.ok_or_else(|| {
+        azure_core::Error::with_message(ErrorKind::DataConversion, "missing resource id")
+    })?;
+    let url: Url = id
+        .parse()
+        .map_err(|e| azure_core::Error::new(ErrorKind::DataConversion, e))?;
+    let vault_url = format!("{}://{}", url.scheme(), url.authority());
+    let mut segments = url
+        .path_segments()
+        .ok_or_else(|| azure_core::Error::with_message(ErrorKind::DataConversion, "invalid url"))?
+        .filter(|s| !s.is_empty());
+    // skip the collection segment (e.g. "secrets")
+    segments.next().ok_or_else(|| {
+        azure_core::Error::with_message(ErrorKind::DataConversion, "missing collection")
+    })?;
+    let name = segments
+        .next()
+        .ok_or_else(|| azure_core::Error::with_message(ErrorKind::DataConversion, "missing name"))?
+        .to_owned();
+    let version = segments.next().map(|s| s.to_owned());
+    Ok(ResourceId {
+        source_id: id.to_owned(),
+        vault_url,
+        name,
+        version,
+    })
+}
+
+const DEFAULT_API_VERSION: &str = "7.5";
+
+/// Options for configuring a [`SecretClient`].
+#[derive(Clone, SafeDebug)]
+pub struct SecretClientOptions {
+    /// The API version to use.
+    pub api_version: String,
+    /// Common client options including transport and policies.
+    pub client_options: ClientOptions,
+}
+
+impl Default for SecretClientOptions {
+    fn default() -> Self {
+        Self {
+            api_version: DEFAULT_API_VERSION.to_owned(),
+            client_options: ClientOptions::default(),
+        }
+    }
+}
+
+/// A minimal secrets client backed by azure_core.
+#[derive(Debug)]
+pub struct SecretClient {
+    endpoint: Url,
+    api_version: String,
+    pipeline: Pipeline,
+}
+
+impl SecretClient {
+    /// Creates a new `SecretClient`.
+    pub fn new(
+        endpoint: &str,
+        credential: Arc<dyn TokenCredential>,
+        options: Option<SecretClientOptions>,
+    ) -> Result<Self> {
+        let options = options.unwrap_or_default();
+        let endpoint = Url::parse(endpoint)?;
+        let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
+            credential,
+            vec!["https://vault.azure.net/.default"],
+        ));
+        Ok(Self {
+            endpoint,
+            api_version: options.api_version,
+            pipeline: Pipeline::new(
+                option_env!("CARGO_PKG_NAME"),
+                option_env!("CARGO_PKG_VERSION"),
+                options.client_options,
+                Vec::new(),
+                vec![auth_policy],
+                None,
+            ),
+        })
+    }
+
+    /// Gets a secret by name.
+    pub async fn get_secret(
+        &self,
+        secret_name: &str,
+        _options: Option<()>,
+    ) -> Result<Response<Secret>> {
+        let mut url = self.endpoint.clone();
+        url.append_path(&format!("/secrets/{secret_name}/"));
+        url.query_pairs_mut()
+            .append_pair("api-version", &self.api_version);
+        let mut request = Request::new(url, Method::Get);
+        request.insert_header("accept", "application/json");
+        let rsp = self
+            .pipeline
+            .send(&Default::default(), &mut request, None)
+            .await?;
+        Ok(rsp.into())
+    }
+
+    /// Sets a secret.
+    pub async fn set_secret(
+        &self,
+        secret_name: &str,
+        body: RequestContent<SetSecretParameters>,
+        _options: Option<()>,
+    ) -> Result<Response<Secret>> {
+        let mut url = self.endpoint.clone();
+        url.append_path(&format!("/secrets/{secret_name}"));
+        url.query_pairs_mut()
+            .append_pair("api-version", &self.api_version);
+        let mut request = Request::new(url, Method::Put);
+        request.insert_header("accept", "application/json");
+        request.insert_header("content-type", "application/json");
+        let body: azure_core::http::Body = body.into();
+        request.set_body(&body);
+        let rsp = self
+            .pipeline
+            .send(&Default::default(), &mut request, None)
+            .await?;
+        Ok(rsp.into())
+    }
+
+    /// Updates secret properties.
+    pub async fn update_secret_properties(
+        &self,
+        secret_name: &str,
+        body: RequestContent<UpdateSecretPropertiesParameters>,
+        _options: Option<()>,
+    ) -> Result<Response<Secret>> {
+        let mut url = self.endpoint.clone();
+        url.append_path(&format!("/secrets/{secret_name}/"));
+        url.query_pairs_mut()
+            .append_pair("api-version", &self.api_version);
+        let mut request = Request::new(url, Method::Patch);
+        request.insert_header("accept", "application/json");
+        request.insert_header("content-type", "application/json");
+        let body: azure_core::http::Body = body.into();
+        request.set_body(&body);
+        let rsp = self
+            .pipeline
+            .send(&Default::default(), &mut request, None)
+            .await?;
+        Ok(rsp.into())
+    }
+
+    /// Lists secret properties (paginated).
+    pub fn list_secret_properties(
+        &self,
+        options: Option<SecretClientListSecretPropertiesOptions<'_>>,
+    ) -> Result<Pager<ListSecretPropertiesResult>> {
+        let pager_options = options.map(|o| {
+            let method_options = o.method_options;
+            PagerOptions {
+                context: method_options.context.into_owned(),
+                ..method_options
+            }
+        });
+        let pipeline = self.pipeline.clone();
+        let api_version = self.api_version.clone();
+        let mut first_url = self.endpoint.clone();
+        first_url.append_path("/secrets");
+        first_url
+            .query_pairs_mut()
+            .append_pair("api-version", &api_version);
+
+        Ok(Pager::new(
+            move |state: PagerState, pager_options| {
+                let pipeline = pipeline.clone();
+                let api_version = api_version.clone();
+                let url = match state {
+                    PagerState::More(next_link) => {
+                        let mut next_link: Url = next_link.try_into().expect("expected Url");
+                        let qp: Vec<_> = next_link
+                            .query_pairs()
+                            .filter(|(k, _)| k != "api-version")
+                            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+                            .collect();
+                        next_link.query_pairs_mut().clear().extend_pairs(qp);
+                        next_link
+                            .query_pairs_mut()
+                            .append_pair("api-version", &api_version);
+                        next_link
+                    }
+                    PagerState::Initial => first_url.clone(),
+                };
+                let mut request = Request::new(url.clone(), Method::Get);
+                request.insert_header("accept", "application/json");
+                Box::pin(async move {
+                    let rsp = pipeline
+                        .send(&pager_options.context, &mut request, None)
+                        .await?;
+                    let (status, headers, body) = rsp.deconstruct();
+                    let result: ListSecretPropertiesResult = json::from_json(&body)?;
+                    let response: Response<ListSecretPropertiesResult> =
+                        RawResponse::from_bytes(status, headers, body).into();
+                    Ok(match result.next_link {
+                        Some(ref next_link) if !next_link.is_empty() => PagerResult::More {
+                            response,
+                            continuation: PagerContinuation::Link(url.join(next_link.as_ref())?),
+                        },
+                        _ => PagerResult::Done { response },
+                    })
+                })
+            },
+            pager_options,
+        ))
+    }
+}

--- a/sdk/core/azure_core_examples/src/secrets/models.rs
+++ b/sdk/core/azure_core_examples/src/secrets/models.rs
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Models for the example secrets client.
+
+use async_trait::async_trait;
+use azure_core::{
+    http::{
+        pager::{Page, PagerOptions},
+        RequestContent,
+    },
+    json::to_json,
+    Result,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A secret value and its properties.
+#[derive(Clone, Default, Deserialize, Serialize, Debug)]
+pub struct Secret {
+    /// The secret id.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// The secret value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+}
+
+/// Properties of a secret (no value).
+#[derive(Clone, Default, Deserialize, Serialize, Debug)]
+pub struct SecretProperties {
+    /// The secret id.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+}
+
+/// A page of secret properties.
+#[derive(Clone, Default, Deserialize, Serialize, Debug)]
+pub struct ListSecretPropertiesResult {
+    /// A list of secret properties.
+    #[serde(default)]
+    pub value: Vec<SecretProperties>,
+
+    /// The URL to get the next set of secrets.
+    #[serde(rename = "nextLink", skip_serializing_if = "Option::is_none")]
+    pub next_link: Option<String>,
+}
+
+#[async_trait]
+impl Page for ListSecretPropertiesResult {
+    type Item = SecretProperties;
+    type IntoIter = <Vec<SecretProperties> as IntoIterator>::IntoIter;
+    async fn into_items(self) -> Result<Self::IntoIter> {
+        Ok(self.value.into_iter())
+    }
+}
+
+/// Parameters for setting a secret.
+#[derive(Clone, Default, Deserialize, Serialize, Debug)]
+pub struct SetSecretParameters {
+    /// The value of the secret.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+
+    /// The content type of the secret.
+    #[serde(rename = "contentType", skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+
+    /// Application-specific metadata as key-value pairs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<HashMap<String, String>>,
+}
+
+impl TryFrom<SetSecretParameters> for RequestContent<SetSecretParameters> {
+    type Error = azure_core::Error;
+    fn try_from(value: SetSecretParameters) -> Result<Self> {
+        Ok(to_json(&value)?.into())
+    }
+}
+
+/// Parameters for updating secret properties.
+#[derive(Clone, Default, Deserialize, Serialize, Debug)]
+pub struct UpdateSecretPropertiesParameters {
+    /// The content type of the secret.
+    #[serde(rename = "contentType", skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+
+    /// The secret management attributes.
+    #[serde(rename = "attributes", skip_serializing_if = "Option::is_none")]
+    pub secret_attributes: Option<serde_json::Value>,
+
+    /// Application-specific metadata as key-value pairs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<HashMap<String, String>>,
+}
+
+impl TryFrom<UpdateSecretPropertiesParameters>
+    for RequestContent<UpdateSecretPropertiesParameters>
+{
+    type Error = azure_core::Error;
+    fn try_from(value: UpdateSecretPropertiesParameters) -> Result<Self> {
+        Ok(to_json(&value)?.into())
+    }
+}
+
+/// Options for `SecretClient::list_secret_properties`.
+#[derive(Clone, Default, Debug)]
+pub struct SecretClientListSecretPropertiesOptions<'a> {
+    /// Allows customization of the method call.
+    pub method_options: PagerOptions<'a>,
+}

--- a/sdk/core/azure_core_macros/CHANGELOG.md
+++ b/sdk/core/azure_core_macros/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2026-05-11)
 
 ### Features Added

--- a/sdk/core/azure_core_macros/Cargo.toml
+++ b/sdk/core/azure_core_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_core_macros"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 description = "Procedural macros for client libraries built on azure_core."
 readme = "README.md"
 authors.workspace = true

--- a/sdk/core/azure_core_opentelemetry/CHANGELOG.md
+++ b/sdk/core/azure_core_opentelemetry/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2026-05-11)
 
 ### Features Added

--- a/sdk/core/azure_core_opentelemetry/Cargo.toml
+++ b/sdk/core/azure_core_opentelemetry/Cargo.toml
@@ -23,8 +23,8 @@ opentelemetry_sdk.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-azure_core_test = { workspace = true, features = ["tracing"] }
-azure_core_test_macros.workspace = true
+azure_core_test = { path = "../azure_core_test", features = ["tracing"] }
+azure_core_test_macros.path = "../azure_core_test_macros"
 azure_identity.workspace = true
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 tokio.workspace = true

--- a/sdk/core/azure_core_opentelemetry/Cargo.toml
+++ b/sdk/core/azure_core_opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_core_opentelemetry"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 description = "OpenTelemetry integration for the Azure SDK for Rust"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/core/azure_core_test/Cargo.toml
+++ b/sdk/core/azure_core_test/Cargo.toml
@@ -50,7 +50,7 @@ zip.workspace = true
 
 [dev-dependencies]
 # Crate used in README.md example.
-azure_security_keyvault_secrets = "1.0.0"
+azure_security_keyvault_secrets.path = "../../keyvault/azure_security_keyvault_secrets"
 clap.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "signal"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }

--- a/sdk/core/azure_core_test/Cargo.toml
+++ b/sdk/core/azure_core_test/Cargo.toml
@@ -21,7 +21,7 @@ tracing = ["tracing-subscriber"]
 [dependencies]
 async-trait.workspace = true
 azure_core = { workspace = true, features = ["test"] }
-azure_core_test_macros.workspace = true
+azure_core_test_macros.path = "../azure_core_test_macros"
 azure_identity.workspace = true
 clap.workspace = true
 dotenvy = "0.15.7"
@@ -50,7 +50,7 @@ zip.workspace = true
 
 [dev-dependencies]
 # Crate used in README.md example.
-azure_security_keyvault_secrets = { path = "../../keyvault/azure_security_keyvault_secrets" }
+azure_security_keyvault_secrets = "1.0.0"
 clap.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "signal"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }

--- a/sdk/core/azure_core_test_macros/Cargo.toml
+++ b/sdk/core/azure_core_test_macros/Cargo.toml
@@ -24,5 +24,5 @@ quote.workspace = true
 syn.workspace = true
 
 [dev-dependencies]
-azure_core_test.workspace = true
+azure_core_test.path = "../azure_core_test"
 tokio.workspace = true

--- a/sdk/core/typespec/CHANGELOG.md
+++ b/sdk/core/typespec/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2026-05-11)
 
 ### Features Added

--- a/sdk/core/typespec/Cargo.toml
+++ b/sdk/core/typespec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typespec"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/sdk/core/typespec_client_core/CHANGELOG.md
+++ b/sdk/core/typespec_client_core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2026-05-11)
 
 ### Features Added

--- a/sdk/core/typespec_client_core/Cargo.toml
+++ b/sdk/core/typespec_client_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typespec_client_core"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 authors.workspace = true
 edition.workspace = true
 description = "Client runtime for TypeSpec-generated libraries."

--- a/sdk/core/typespec_macros/CHANGELOG.md
+++ b/sdk/core/typespec_macros/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2026-05-11)
 
 ### Features Added

--- a/sdk/core/typespec_macros/Cargo.toml
+++ b/sdk/core/typespec_macros/Cargo.toml
@@ -27,7 +27,7 @@ cargo_metadata.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
-typespec_client_core = { path = "../typespec_client_core", features = [
+typespec_client_core = { workspace = true, features = [
   "http",
   "json",
   "xml",

--- a/sdk/core/typespec_macros/Cargo.toml
+++ b/sdk/core/typespec_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typespec_macros"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 authors.workspace = true
 edition.workspace = true
 description = "Procedural macros for client libraries built on typespec."

--- a/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
@@ -20,7 +20,7 @@ edition.workspace = true
 async-lock.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
-azure_core = { path = "../../core/azure_core", version = "1.1.0-beta.1", default-features = false }
+azure_core = { workspace = true, default-features = false }
 azure_core_amqp.workspace = true
 futures.workspace = true
 rand.workspace = true

--- a/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
@@ -20,7 +20,7 @@ edition.workspace = true
 async-lock.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
-azure_core = { path = "../../core/azure_core", version = "1.0.0", default-features = false }
+azure_core = { path = "../../core/azure_core", version = "1.1.0-beta.1", default-features = false }
 azure_core_amqp.workspace = true
 futures.workspace = true
 rand.workspace = true

--- a/sdk/identity/azure_identity/CHANGELOG.md
+++ b/sdk/identity/azure_identity/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2026-05-11)
 
 ### Features Added
@@ -10,17 +20,17 @@
 
 - Added `#[non_exhaustive]` to `UserAssignedId`.
 
-## 0.35.0 (2026-04-022)
-
-### Other Changes
-
-- Updated dependencies.
-
 ## 0.34.0 (2026-04-08)
 
 ### Other Changes
 
 - Upgraded dependencies
+
+## 0.35.0 (2026-04-022)
+
+### Other Changes
+
+- Updated dependencies.
 
 ## 0.33.0 (2026-03-09)
 

--- a/sdk/identity/azure_identity/CHANGELOG.md
+++ b/sdk/identity/azure_identity/CHANGELOG.md
@@ -20,17 +20,17 @@
 
 - Added `#[non_exhaustive]` to `UserAssignedId`.
 
-## 0.34.0 (2026-04-08)
-
-### Other Changes
-
-- Upgraded dependencies
-
 ## 0.35.0 (2026-04-022)
 
 ### Other Changes
 
 - Updated dependencies.
+
+## 0.34.0 (2026-04-08)
+
+### Other Changes
+
+- Upgraded dependencies
 
 ## 0.33.0 (2026-03-09)
 

--- a/sdk/identity/azure_identity/Cargo.toml
+++ b/sdk/identity/azure_identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_identity"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Azure identity helper crate"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/keyvault/azure_security_keyvault_certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure_security_keyvault_certificates/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2026-05-12)
 
 ### Features Added

--- a/sdk/keyvault/azure_security_keyvault_certificates/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_certificates/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_security_keyvault_certificates"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Azure Key Vault Certificates"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/keyvault/azure_security_keyvault_keys/CHANGELOG.md
+++ b/sdk/keyvault/azure_security_keyvault_keys/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2026-05-12)
 
 ### Features Added

--- a/sdk/keyvault/azure_security_keyvault_keys/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_security_keyvault_keys"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Azure Key Vault Keys"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/keyvault/azure_security_keyvault_secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure_security_keyvault_secrets/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2026-05-12)
 
 ### Features Added

--- a/sdk/keyvault/azure_security_keyvault_secrets/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_secrets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_security_keyvault_secrets"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Azure Key Vault Secrets"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/servicebus/azure_messaging_servicebus/Cargo.toml
+++ b/sdk/servicebus/azure_messaging_servicebus/Cargo.toml
@@ -20,7 +20,7 @@ publish = false
 async-lock.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
-azure_core = { path = "../../core/azure_core", version = "1.0.0", default-features = false }
+azure_core = { path = "../../core/azure_core", version = "1.1.0-beta.1", default-features = false }
 azure_core_amqp.workspace = true
 futures.workspace = true
 rand.workspace = true

--- a/sdk/servicebus/azure_messaging_servicebus/Cargo.toml
+++ b/sdk/servicebus/azure_messaging_servicebus/Cargo.toml
@@ -20,7 +20,7 @@ publish = false
 async-lock.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
-azure_core = { path = "../../core/azure_core", version = "1.1.0-beta.1", default-features = false }
+azure_core = { workspace = true, default-features = false }
 azure_core_amqp.workspace = true
 futures.workspace = true
 rand.workspace = true
@@ -36,7 +36,6 @@ default = ["azure_core_amqp/default"]
 azure_core_amqp = { workspace = true, features = ["test"] }
 azure_core_test = { workspace = true, features = ["tracing"] }
 azure_identity.workspace = true
-azure_messaging_servicebus = { path = "." }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }

--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2026-05-13)
 
 ### Breaking Changes

--- a/sdk/storage/azure_storage_blob/Cargo.toml
+++ b/sdk/storage/azure_storage_blob/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_storage_blob"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 description = "Microsoft Azure Blob Storage client library for Rust"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/storage/azure_storage_queue/CHANGELOG.md
+++ b/sdk/storage/azure_storage_queue/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2026-05-13)
 
 ### Breaking Changes

--- a/sdk/storage/azure_storage_queue/Cargo.toml
+++ b/sdk/storage/azure_storage_queue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_storage_queue"
-version = "1.0.0"
+version = "1.1.0-beta.1"
 description = "Microsoft Azure Queue client library for Rust"
 readme = "README.md"
 authors.workspace = true


### PR DESCRIPTION
- Increment package version after release of typespec, typespec_macros, typespec_client_core, azure_core, azure_core_macros, azure_core_amqp, azure_core_opentelemetry
- Increment package version after release of azure_identity
- Increment package version after release of azure_security_keyvault_secrets, azure_security_keyvault_certificates, azure_security_keyvault_keys
- Increment package version after release of azure_storage_blob, azure_storage_queue
- Change service crate dependencies to version-only

  Also creates a new azure_core_examples so we can break an otherwise-supported cross-target cyclic dependency that results in different versions. This effectively duplicates secret and certificate client definitions and a few other types that don't actually need to run.