### PR TITLE
[Perf] Add support for results-file to perf tests

### DIFF
--- a/sdk/core/azure_core_test/src/perf/config_tests.rs
+++ b/sdk/core/azure_core_test/src/perf/config_tests.rs
@@ -120,6 +120,7 @@ fn test_perf_runner_new_with_empty_tests() {
     assert_eq!(runner.options.test_results_filename, "./results.json");
     assert!(!runner.options.no_cleanup);
     assert!(!runner.options.latency);
+    assert!(runner.options.results_file.is_empty());
 }
 
 #[test]
@@ -261,6 +262,24 @@ fn test_perf_runner_with_command_line_test_results_file() {
 }
 
 #[test]
+fn test_perf_runner_with_command_line_results_file() {
+    let tests = vec![create_basic_test_metadata()];
+    let args = vec!["perf-tests", "--results-file", "/tmp/latency-results.json"];
+
+    let result = PerfRunner::with_command_line(env!("CARGO_MANIFEST_DIR"), file!(), tests, args);
+    assert!(
+        result.is_ok(),
+        "PerfRunner::with_command_line should succeed with --results-file"
+    );
+
+    let runner = result.unwrap();
+    assert_eq!(
+        runner.options.results_file,
+        "/tmp/latency-results.json"
+    );
+}
+
+#[test]
 fn test_perf_runner_with_command_line_no_cleanup() {
     let tests = vec![create_basic_test_metadata()];
     let args = vec!["perf-tests", "--no-cleanup"];
@@ -306,6 +325,7 @@ fn test_perf_runner_with_command_line_all_options() {
     assert_eq!(runner.options.warmup, Duration::seconds(15));
     assert_eq!(runner.options.test_results_filename, "/custom/results.json");
     assert!(runner.options.no_cleanup);
+    assert!(runner.options.results_file.is_empty());
 }
 
 #[test]

--- a/sdk/core/azure_core_test/src/perf/config_tests.rs
+++ b/sdk/core/azure_core_test/src/perf/config_tests.rs
@@ -273,10 +273,7 @@ fn test_perf_runner_with_command_line_results_file() {
     );
 
     let runner = result.unwrap();
-    assert_eq!(
-        runner.options.results_file,
-        "/tmp/latency-results.json"
-    );
+    assert_eq!(runner.options.results_file, "/tmp/latency-results.json");
 }
 
 #[test]

--- a/sdk/core/azure_core_test/src/perf/mod.rs
+++ b/sdk/core/azure_core_test/src/perf/mod.rs
@@ -410,7 +410,8 @@ impl PerfRunner {
                 )
                 .await?;
             if self.options.latency {
-                Self::print_latencies("Latency Distribution", &mut latencies);
+                latencies.sort();
+                Self::print_latencies("Latency Distribution", &latencies);
 
                 // Still useful to print the latencies above even if we're not writing them to a file.
                 if !self.options.results_file.is_empty() {
@@ -574,11 +575,11 @@ impl PerfRunner {
         Ok((operations_per_second, all_latencies))
     }
 
-    fn print_latencies(header: &str, latencies: &mut [tokio::time::Duration]) {
+    /// Print latency percentiles to the console. Requires the latencies to be pre-sorted.
+    fn print_latencies(header: &str, latencies: &[tokio::time::Duration]) {
         if latencies.is_empty() {
             return;
         }
-        latencies.sort();
         println!("=== {} ===", header);
         let percentiles = [0.5, 0.75, 0.9, 0.99, 0.999, 0.9999, 0.99999, 1.0];
         for percentile in percentiles {

--- a/sdk/core/azure_core_test/src/perf/mod.rs
+++ b/sdk/core/azure_core_test/src/perf/mod.rs
@@ -130,6 +130,15 @@ struct PerfTestOutputs {
     pub average_memory_use: Option<f64>,
 }
 
+/// Per-operation latency result matching the PerfAutomation JSON format.
+#[derive(Serialize)]
+struct OperationResult {
+    #[serde(rename = "Time")]
+    time: f64,
+    #[serde(rename = "Size")]
+    size: i64,
+}
+
 #[derive(Debug, Clone)]
 struct PerfRunnerOptions {
     no_cleanup: bool,
@@ -140,13 +149,14 @@ struct PerfRunnerOptions {
     disable_progress: bool,
     latency: bool,
     test_results_filename: String,
+    results_file: String,
 }
 
 impl Display for PerfRunnerOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "PerfRunnerOptions {{ no_cleanup: {}, iterations: {}, parallel: {}, duration: {}, warmup: {}, disable_progress: {}, latency: {}, test_results_filename: '{}' }}",
+            "PerfRunnerOptions {{ no_cleanup: {}, iterations: {}, parallel: {}, duration: {}, warmup: {}, disable_progress: {}, latency: {}, test_results_filename: '{}', results_file: '{}' }}",
             self.no_cleanup,
             self.iterations,
             self.parallel,
@@ -154,7 +164,8 @@ impl Display for PerfRunnerOptions {
             self.warmup,
             self.disable_progress,
             self.latency,
-            self.test_results_filename
+            self.test_results_filename,
+            self.results_file
         )
     }
 }
@@ -183,6 +194,10 @@ impl From<&ArgMatches> for PerfRunnerOptions {
                 .get_one::<String>("test-results")
                 .expect("defaulted by clap")
                 .to_string(),
+            results_file: matches
+                .get_one::<String>("results-file")
+                .cloned()
+                .unwrap_or_default(),
         }
     }
 }
@@ -395,7 +410,33 @@ impl PerfRunner {
                 )
                 .await?;
             if self.options.latency {
-                Self::print_latencies("Latency Distribution", latencies);
+                Self::print_latencies("Latency Distribution", latencies.clone());
+
+                if !self.options.results_file.is_empty() {
+                    // Detect size from the selected test's subcommand args, defaulting to -1.
+                    let size: i64 = self
+                        .try_get_test_arg::<usize>("size")
+                        .ok()
+                        .flatten()
+                        .map(|s| s as i64)
+                        .unwrap_or(-1);
+
+                    let results: Vec<OperationResult> = latencies
+                        .iter()
+                        .map(|l| OperationResult {
+                            time: l.as_secs_f64() * 1000.0,
+                            size,
+                        })
+                        .collect();
+
+                    let json = serde_json::to_string_pretty(&results).with_context(
+                        ErrorKind::DataConversion,
+                        "Failed to serialize latency results to JSON.",
+                    )?;
+
+                    std::fs::write(&self.options.results_file, json)
+                        .with_context(ErrorKind::Io, "Failed to write latency results to file.")?;
+                }
             }
             if !self.options.no_cleanup {
                 println!("========== Starting test cleanup ==========");
@@ -618,6 +659,11 @@ impl PerfRunner {
             .required(false).global(true))
             .arg(clap::arg!(-l --latency "Track and print per-operation latency statistics")
             .required(false).global(true))
+            .arg(
+                clap::arg!(--"results-file" <FILE> "File path to store per-operation latency results (requires --latency)")
+                    .required(false)
+                    .global(true),
+            )
         ;
         for test in tests {
             let mut subcommand = clap::Command::new(test.name).about(test.description);

--- a/sdk/core/azure_core_test/src/perf/mod.rs
+++ b/sdk/core/azure_core_test/src/perf/mod.rs
@@ -401,7 +401,7 @@ impl PerfRunner {
                 self.options.duration
             );
 
-            let (operations_per_second, latencies) = self
+            let (operations_per_second, mut latencies) = self
                 .run_test_for(
                     &test_instances,
                     &test_contexts,
@@ -410,8 +410,9 @@ impl PerfRunner {
                 )
                 .await?;
             if self.options.latency {
-                Self::print_latencies("Latency Distribution", latencies.clone());
+                Self::print_latencies("Latency Distribution", &mut latencies);
 
+                // Still useful to print the latencies above even if we're not writing them to a file.
                 if !self.options.results_file.is_empty() {
                     // Detect size from the selected test's subcommand args, defaulting to -1.
                     let size: i64 = self
@@ -573,7 +574,7 @@ impl PerfRunner {
         Ok((operations_per_second, all_latencies))
     }
 
-    fn print_latencies(header: &str, mut latencies: Vec<tokio::time::Duration>) {
+    fn print_latencies(header: &str, latencies: &mut [tokio::time::Duration]) {
         if latencies.is_empty() {
             return;
         }

--- a/sdk/storage/azure_storage_blob/perf-tests.yml
+++ b/sdk/storage/azure_storage_blob/perf-tests.yml
@@ -35,11 +35,11 @@ Tests:
       - --size 10485760 --parallel 32
       - --size 1073741824 --parallel 1 --warmup 60 --duration 60
       - --size 1073741824 --parallel 8 --warmup 60 --duration 60
-      - --size 1073741824 --parallel 64 --warmup 30 --duration 60 --count 1 -l stream
-      - --size 1073741824 --parallel 64 --warmup 30 --duration 60 --count 1 -l core
-      - --size 1073741824 --parallel 64 --warmup 30 --duration 60 --count 1 -l simple
-      - --size 1073741824 --parallel 64 --warmup 30 --duration 60 --count 1 -l into
-      - --size 1073741824 --parallel 64 --warmup 30 --duration 60 --count 1 -l vec_bytes
+      - --size 1073741824 --parallel 64 --warmup 30 --duration 60 --count 1 --collect stream
+      - --size 1073741824 --parallel 64 --warmup 30 --duration 60 --count 1 --collect core
+      - --size 1073741824 --parallel 64 --warmup 30 --duration 60 --count 1 --collect simple
+      - --size 1073741824 --parallel 64 --warmup 30 --duration 60 --count 1 --collect into
+      - --size 1073741824 --parallel 64 --warmup 30 --duration 60 --count 1 --collect vec_bytes
 
   - Test: upload
     Class: upload_blob

--- a/sdk/storage/azure_storage_blob/perf/download_blob_test.rs
+++ b/sdk/storage/azure_storage_blob/perf/download_blob_test.rs
@@ -88,7 +88,7 @@ impl DownloadBlobTest {
                     name: "collect",
                     display_message: "Collect the blob contents instead of streaming them",
                     mandatory: false,
-                    short_activator: Some('l'),
+                    short_activator: None,
                     long_activator: "collect",
                     expected_args_len: 1,
                     option_type: PerfTestOptionKind::String,


### PR DESCRIPTION
This changes adds support for the `--results-file` argument that can come from `PerfAutomation`. If this argument is set, the per-operation latency results are to be written to the specified file in the specific JSON format that the `PerfAutomation` tool looks for.

Tested locally and with `PerfAutomation` specifying `--advanced-stats` pointing at local repo.