### PR TITLE
Cosmos: fix samples and remove Headers::with_capacity

### DIFF
--- a/eng/scripts/Test-Semver.ps1
+++ b/eng/scripts/Test-Semver.ps1
@@ -18,7 +18,7 @@ function Get-OutputPackages($workspacePackages) {
   $packages = @()
   switch ($PsCmdlet.ParameterSetName) {
     'Named' {
-      Write-Verbose 'Getting named packages form workspace'
+      Write-Verbose 'Getting named packages from workspace'
       $packages = $workspacePackages.Where({ $_.name -in $PackageNames })
     }
 
@@ -88,3 +88,6 @@ if ($finalExitCode) {
   LogError "SemVer checks failed"
   exit $finalExitCode
 }
+
+# Explicitly return 0, to clear LASTEXITCODE in case there were any failures that were ignored due to the above conditions
+exit 0

--- a/samples/cosmos_read_item_native_tls/Cargo.toml
+++ b/samples/cosmos_read_item_native_tls/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/azure/azure-sdk-for-rust"
 publish = false
 
 [dependencies]
-azure_core = { version = "0.35.0", default-features = false, features = [
+azure_core = { version = "1.0.0", default-features = false, features = [
   "reqwest",
   "tokio",
 ] }
@@ -17,7 +17,7 @@ azure_data_cosmos = { path = "../../sdk/cosmos/azure_data_cosmos", default-featu
   "reqwest",
   "native_tls",
 ] }
-azure_identity = { version = "0.35.0", default-features = false, features = [
+azure_identity = { version = "1.0.0", default-features = false, features = [
   "tokio",
 ] }
 clap = { version = "4.6.0", features = ["derive", "env"] }

--- a/sdk/core/typespec/src/http/headers.rs
+++ b/sdk/core/typespec/src/http/headers.rs
@@ -134,11 +134,6 @@ impl Headers {
         Self::default()
     }
 
-    /// Create a new headers collection with at least the specified capacity.
-    pub fn with_capacity(n: usize) -> Self {
-        Self(std::collections::HashMap::with_capacity(n))
-    }
-
     /// Gets the headers represented by `H`, or return an error if the header is not found.
     pub fn get<H: FromHeaders>(&self) -> crate::Result<H> {
         match H::from_headers(self) {


### PR DESCRIPTION
This fixes some small issues in the `release/azure_data_cosmos-previews` branch that will cause conflicts in the merge to `main`.

1. We added `Headers::with_capacity` to the `typespec` crate. We ended up not using it, thus never ported it down to `main`. Since we never used it, it's safe to just remove it.

2. The Cosmos sample in `samples/` should reference `azure_core`/`azure_identity` 1.0.0

3. There was a bug in `Test-Semver.ps1`. It never clears `$LASTEXITCODE` if `cargo semver-checks` failed BUT we ignored the failure because it was a known scenario. Since Azure DevOps runs it using the pwsh step, that caused it to fail the entire step. Now, `Test-Semver.ps1` has an explicit `exit 0` if no actionable errors occurred, which clears `LASTEXITCODE` properly.