### PR TITLE
remove unused dev-dependency on cargo_metadata in typespec_macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,39 +954,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3330,10 +3297,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "serde"
@@ -4152,7 +4115,6 @@ dependencies = [
 name = "typespec_macros"
 version = "1.1.0-beta.1"
 dependencies = [
- "cargo_metadata",
  "proc-macro2",
  "quote",
  "rustc_version",

--- a/sdk/core/typespec_macros/Cargo.toml
+++ b/sdk/core/typespec_macros/Cargo.toml
@@ -23,7 +23,6 @@ rustc_version.workspace = true
 syn.workspace = true
 
 [dev-dependencies]
-cargo_metadata.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
This dependency appears to have been unused (CI will confirm) and updating it to `0.3.3` ends up bumping up our MSRV to 1.91. However, it's unused, so we can just remove it.