### PR TITLE
Cosmos: update global sample after change

### DIFF
--- a/samples/cosmos_read_item_native_tls/src/main.rs
+++ b/samples/cosmos_read_item_native_tls/src/main.rs
@@ -29,9 +29,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let container_client = db_client.container_client(&args.container).await?;
 
     let response = container_client
-        .read_item::<serde_json::Value>(&args.partition_key, &args.item_id, None)
+        .read_item(&args.partition_key, &args.item_id, None)
         .await?;
-    let item = response.into_model()?;
+    let item: serde_json::Value = response.into_model()?;
     println!("{}", serde_json::to_string_pretty(&item)?);
 
     Ok(())


### PR DESCRIPTION
The Cosmos sample in `./samples` was broken by #4401 . I believe the check for that only happens in `main` which is why that was missed. This should resolve that issue, and our merge to main should ensure we don't break it again (by running the check)