### PR TITLE
feat(eventhubs)!: surface stolen partitions via ConsumerDisconnected

### DIFF
--- a/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Breaking Changes
 
-- The `amqp:link:stolen` AMQP condition is no longer auto-retried on the receive path. Operations on a stolen receiver link now return `EventHubsError::ConsumerDisconnected`. Previously the recoverable-connection retry list silently re-attached link-stolen receivers, which on `EventProcessor` masked partition steals on the displaced instance and could cause duplicate processing.
+- On the receive path, the `amqp:link:stolen` AMQP condition is no longer auto-retried. A receiver displaced by a higher-or-equal-epoch attacher now surfaces the error (translated to `EventHubsError::ConsumerDisconnected` by `EventReceiver::stream_events`) instead of silently re-attaching. Sender, CBS, and management operations retain the historical retry-on-stolen behavior.
 
 ### Bugs Fixed
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
@@ -4,12 +4,17 @@
 
 ### Features Added
 
-- `EventProcessorBuilder::with_owner_level` enables epoch-based exclusive partition receivers. When set, the broker disconnects any existing receiver on the same partition when a new receiver opens with the same or higher epoch, preventing duplicate processing across consumer instances. Note that `0` is a valid (exclusive) epoch.
-- `PartitionClient::is_revoked` lets a consumer detect that the load balancer has transferred a partition to another instance and stop processing. Revocation is currently poll-based; a consumer should check `is_revoked()` between calls to `stream_events().next().await`.
+- The `EventProcessor` now opens every partition receiver with AMQP epoch (owner level) `0` and surfaces broker-initiated displacement as the new `EventHubsError::ConsumerDisconnected` error kind. When a second `EventProcessor` instance claims a partition this instance is currently holding, the broker disconnects this instance's receiver and the consumer's `stream_events()` resolves with `ConsumerDisconnected`. This matches the behavior of `EventProcessorClient` in the .NET and Java Azure SDKs. Consumers should pattern-match on `ErrorKind::ConsumerDisconnected` to detect a stolen partition and re-acquire a client via `next_partition_client()`.
+- Added `EventHubsError::ConsumerDisconnected(Option<AmqpDescribedError>)` error variant.
 
 ### Breaking Changes
 
+- The `amqp:link:stolen` AMQP condition is no longer auto-retried on the receive path. Operations on a stolen receiver link now return `EventHubsError::ConsumerDisconnected`. Previously the recoverable-connection retry list silently re-attached link-stolen receivers, which on `EventProcessor` masked partition steals on the displaced instance and could cause duplicate processing.
+
 ### Bugs Fixed
+
+- Increased `DEFAULT_PARTITION_EXPIRATION_DURATION` from 10 seconds to 60 seconds. The previous default was shorter than `DEFAULT_UPDATE_INTERVAL` (30 seconds), so ownership records expired between load-balancing cycles. The load balancer perpetually saw `current=0` for every consumer and continuously re-claimed partitions, causing widespread duplicate event processing. `EventProcessorBuilder::build` now rejects configurations where `partition_expiration_duration <= update_interval`. ([#3851](https://github.com/Azure/azure-sdk-for-rust/issues/3851))
+- The `EventProcessor`'s load-balancer reconciliation now closes the underlying AMQP receiver for any partition that has been reassigned to another consumer, so the consumer's `stream_events()` resolves and the loop can terminate. Previously a stolen partition's client could continue to attempt receives until the broker tore down the link.
 
 ### Other Changes
 
@@ -20,9 +25,6 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-
-- Increased `DEFAULT_PARTITION_EXPIRATION_DURATION` from 10 seconds to 60 seconds. The previous default was shorter than `DEFAULT_UPDATE_INTERVAL` (30 seconds), so ownership records expired between load-balancing cycles. The load balancer perpetually saw `current=0` for every consumer and continuously re-claimed partitions, causing widespread duplicate event processing. `EventProcessorBuilder::build` now rejects configurations where `partition_expiration_duration <= update_interval`. ([#3851](https://github.com/Azure/azure-sdk-for-rust/issues/3851))
-- The event processor now revokes a `PartitionClient` for any partition that has been reassigned to another consumer during a load-balancing cycle. Previously, a stolen partition's client would continue to read events indefinitely.
 
 ### Other Changes
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+- `EventProcessorBuilder::with_owner_level` enables epoch-based exclusive partition receivers. When set, the broker disconnects any existing receiver on the same partition when a new receiver opens with the same or higher epoch, preventing duplicate processing across consumer instances. Note that `0` is a valid (exclusive) epoch.
+- `PartitionClient::is_revoked` lets a consumer detect that the load balancer has transferred a partition to another instance and stop processing. Revocation is currently poll-based; a consumer should check `is_revoked()` between calls to `stream_events().next().await`.
+
 ### Breaking Changes
 
 ### Bugs Fixed
@@ -17,6 +20,9 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+
+- Increased `DEFAULT_PARTITION_EXPIRATION_DURATION` from 10 seconds to 60 seconds. The previous default was shorter than `DEFAULT_UPDATE_INTERVAL` (30 seconds), so ownership records expired between load-balancing cycles. The load balancer perpetually saw `current=0` for every consumer and continuously re-claimed partitions, causing widespread duplicate event processing. `EventProcessorBuilder::build` now rejects configurations where `partition_expiration_duration <= update_interval`. ([#3851](https://github.com/Azure/azure-sdk-for-rust/issues/3851))
+- The event processor now revokes a `PartitionClient` for any partition that has been reassigned to another consumer during a load-balancing cycle. Previously, a stolen partition's client would continue to read events indefinitely.
 
 ### Other Changes
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_processor_client.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_processor_client.rs
@@ -71,6 +71,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let checkpoint_store = Arc::new(InMemoryCheckpointStore::new());
     let processor = EventProcessor::builder()
+        // Setting owner_level enables epoch-based partition ownership.
+        // The Event Hub broker will disconnect any existing receiver on
+        // the same partition when a new receiver with the same or higher
+        // owner level connects, preventing duplicate event processing
+        // across multiple consumer instances.
+        .with_owner_level(0)
         .build(consumer, checkpoint_store)
         .await?;
     let background_processor = BackgroundProcessor::new(processor.clone());
@@ -90,6 +96,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut event_stream = partition_client.stream_events();
     let mut event_count = 0;
     while let Some(event) = event_stream.next().await {
+        // Check if the partition was reassigned to another consumer
+        // during rebalancing. When revoked, stop processing so the
+        // partition client can be re-acquired.
+        if partition_client.is_revoked() {
+            println!("Partition was reassigned, stopping.");
+            break;
+        }
         println!("Received message {event_count}");
         event_count += 1;
         if event_count > 10 {

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_processor_client.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_processor_client.rs
@@ -72,11 +72,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Opened consumer client");
 
     let checkpoint_store = Arc::new(InMemoryCheckpointStore::new());
-    // The processor opens each partition receiver with epoch (owner level)
-    // 0 internally, matching the .NET and Java `EventProcessorClient`. The
-    // broker disconnects any existing receiver on the same partition when
-    // another consumer instance attaches, which terminates the displaced
-    // consumer's `stream_events()` with `ErrorKind::ConsumerDisconnected`.
+    // Receivers open with epoch 0; another instance attaching displaces
+    // this one and `stream_events()` resolves with `ConsumerDisconnected`.
     let processor = EventProcessor::builder()
         .build(consumer, checkpoint_store)
         .await?;
@@ -94,33 +91,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         partition_client.get_partition_id()
     );
 
-    let mut event_stream = partition_client.stream_events();
-    let mut event_count = 0;
-    while let Some(event) = event_stream.next().await {
+    let mut event_stream = partition_client.stream_events().take(10).enumerate();
+    while let Some((idx, event)) = event_stream.next().await {
         match event {
             Ok(event) => {
-                println!("Received message {event_count}");
-                event_count += 1;
-                if event_count > 10 {
-                    println!("Received 10 events, stopping the processor.");
-                    break;
-                }
-                // Process the received event
-                println!("Received event: {:?}", event);
-                println!("Partition key: {:?}", event.partition_key());
-                println!("Event offset: {:?}", event.offset());
-                println!("Event sequence number: {:?}", event.sequence_number());
+                println!("Received event #{idx}: {event:?}");
+                println!("  partition key:   {:?}", event.partition_key());
+                println!("  offset:          {:?}", event.offset());
+                println!("  sequence number: {:?}", event.sequence_number());
             }
             Err(err) if matches!(err.kind, ErrorKind::ConsumerDisconnected(_)) => {
-                // The broker disconnected this receiver because another
-                // consumer instance opened a receiver on the same partition.
-                // The load balancer will hand us a fresh partition client
-                // via `next_partition_client` on the next dispatch cycle.
+                // Partition reassigned; re-acquire via `next_partition_client`.
                 println!("Partition was reassigned to another consumer, stopping.");
                 break;
             }
             Err(err) => {
-                eprintln!("Error receiving event: {:?}", err);
+                eprintln!("Error receiving event: {err:?}");
                 break;
             }
         }

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_processor_client.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_processor_client.rs
@@ -8,7 +8,9 @@
 //! processed.
 
 use azure_identity::DeveloperToolsCredential;
-use azure_messaging_eventhubs::{ConsumerClient, EventProcessor, InMemoryCheckpointStore};
+use azure_messaging_eventhubs::{
+    error::ErrorKind, ConsumerClient, EventProcessor, InMemoryCheckpointStore,
+};
 use futures::StreamExt;
 use std::sync::Arc;
 use tokio::sync::Mutex as AsyncMutex;
@@ -70,13 +72,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Opened consumer client");
 
     let checkpoint_store = Arc::new(InMemoryCheckpointStore::new());
+    // The processor opens each partition receiver with epoch (owner level)
+    // 0 internally, matching the .NET and Java `EventProcessorClient`. The
+    // broker disconnects any existing receiver on the same partition when
+    // another consumer instance attaches, which terminates the displaced
+    // consumer's `stream_events()` with `ErrorKind::ConsumerDisconnected`.
     let processor = EventProcessor::builder()
-        // Setting owner_level enables epoch-based partition ownership.
-        // The Event Hub broker will disconnect any existing receiver on
-        // the same partition when a new receiver with the same or higher
-        // owner level connects, preventing duplicate event processing
-        // across multiple consumer instances.
-        .with_owner_level(0)
         .build(consumer, checkpoint_store)
         .await?;
     let background_processor = BackgroundProcessor::new(processor.clone());
@@ -96,30 +97,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut event_stream = partition_client.stream_events();
     let mut event_count = 0;
     while let Some(event) = event_stream.next().await {
-        // Check if the partition was reassigned to another consumer
-        // during rebalancing. When revoked, stop processing so the
-        // partition client can be re-acquired.
-        if partition_client.is_revoked() {
-            println!("Partition was reassigned, stopping.");
-            break;
-        }
-        println!("Received message {event_count}");
-        event_count += 1;
-        if event_count > 10 {
-            println!("Received 10 events, stopping the processor.");
-            break;
-        }
         match event {
             Ok(event) => {
-                println!("Received event: {:?}", event);
+                println!("Received message {event_count}");
+                event_count += 1;
+                if event_count > 10 {
+                    println!("Received 10 events, stopping the processor.");
+                    break;
+                }
                 // Process the received event
+                println!("Received event: {:?}", event);
                 println!("Partition key: {:?}", event.partition_key());
                 println!("Event offset: {:?}", event.offset());
                 println!("Event sequence number: {:?}", event.sequence_number());
             }
+            Err(err) if matches!(err.kind, ErrorKind::ConsumerDisconnected(_)) => {
+                // The broker disconnected this receiver because another
+                // consumer instance opened a receiver on the same partition.
+                // The load balancer will hand us a fresh partition client
+                // via `next_partition_client` on the next dispatch cycle.
+                println!("Partition was reassigned to another consumer, stopping.");
+                break;
+            }
             Err(err) => {
-                // Handle the error
                 eprintln!("Error receiving event: {:?}", err);
+                break;
             }
         }
     }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -318,12 +318,21 @@ impl RecoverableConnection {
     pub(crate) async fn close_receiver(self: &Arc<Self>, source_url: &Url) -> Result<()> {
         let mut receiver_instances = self.receiver_instances.lock().await;
         if let Some(receiver) = receiver_instances.remove(source_url) {
+            let strong_count = Arc::strong_count(&receiver);
             let r = Arc::try_unwrap(receiver);
             if let Ok(receiver) = r {
                 trace!("Detaching receiver: {:?}", source_url);
                 receiver.detach().await?;
             } else {
-                warn!("Failed to detach receiver: {:?}", source_url);
+                // In-flight `receive_delivery` holds a clone of the Arc.
+                // Map entry is already removed; `EventReceiver::closed`
+                // (set before this call by `request_close`) stops the
+                // stream from reattaching on its next poll.
+                warn!(
+                    source = %source_url,
+                    strong_count,
+                    "close_receiver could not detach by-value"
+                );
             }
         }
         Ok(())
@@ -594,19 +603,11 @@ impl RecoverableConnection {
             AmqpErrorKind::SendRejected => ErrorRecoveryAction::ReturnError,
             AmqpErrorKind::AmqpDescribedError(described_error) => {
                 debug!("AMQP described error: {:?}", described_error);
-                // `LinkStolen` (amqp:link:stolen) is deliberately NOT in the
-                // retry set. When the Event Hubs broker disconnects a receiver
-                // because another receiver attached with a higher-or-equal
-                // epoch (owner level), retrying would silently re-attach the
-                // displaced receiver and either be displaced again
-                // immediately, or race the new owner and cause duplicate
-                // processing. The displaced caller needs to see the error and
-                // stop. The .NET SDK takes the same stance via
-                // `InvalidateConsumerWhenPartitionIsStolen = true`.
                 if matches!(
                     described_error.condition,
                     AmqpErrorCondition::ResourceLimitExceeded
                         | AmqpErrorCondition::ConnectionFramingError
+                        | AmqpErrorCondition::LinkStolen
                         | AmqpErrorCondition::ServerBusyError
                         | AmqpErrorCondition::EntityUpdated
                         | AmqpErrorCondition::EntityDisabledError
@@ -626,6 +627,22 @@ impl RecoverableConnection {
                 ErrorRecoveryAction::ReturnError
             }
         }
+    }
+
+    /// Like `should_retry_amqp_error` but returns `ReturnError` on
+    /// `LinkStolen` so a displaced receiver surfaces the steal instead of
+    /// silently re-attaching. .NET parallel: `InvalidateConsumerWhenPartitionIsStolen`.
+    pub(super) fn should_retry_receive_error(amqp_error: &AmqpError) -> ErrorRecoveryAction {
+        if let AmqpErrorKind::AmqpDescribedError(described_error) = amqp_error.kind() {
+            if matches!(described_error.condition, AmqpErrorCondition::LinkStolen) {
+                debug!(
+                    "Receive operation will not retry link-stolen: {:?}",
+                    described_error
+                );
+                return ErrorRecoveryAction::ReturnError;
+            }
+        }
+        Self::should_retry_amqp_error(amqp_error)
     }
 }
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -594,25 +594,24 @@ impl RecoverableConnection {
             AmqpErrorKind::SendRejected => ErrorRecoveryAction::ReturnError,
             AmqpErrorKind::AmqpDescribedError(described_error) => {
                 debug!("AMQP described error: {:?}", described_error);
+                // `LinkStolen` (amqp:link:stolen) is deliberately NOT in the
+                // retry set. When the Event Hubs broker disconnects a receiver
+                // because another receiver attached with a higher-or-equal
+                // epoch (owner level), retrying would silently re-attach the
+                // displaced receiver and either be displaced again
+                // immediately, or race the new owner and cause duplicate
+                // processing. The displaced caller needs to see the error and
+                // stop. The .NET SDK takes the same stance via
+                // `InvalidateConsumerWhenPartitionIsStolen = true`.
                 if matches!(
                     described_error.condition,
                     AmqpErrorCondition::ResourceLimitExceeded
                         | AmqpErrorCondition::ConnectionFramingError
-                        | AmqpErrorCondition::LinkStolen
                         | AmqpErrorCondition::ServerBusyError
                         | AmqpErrorCondition::EntityUpdated
                         | AmqpErrorCondition::EntityDisabledError
                 ) {
                     debug!("AMQP described error can be retried: {:?}", described_error);
-                    ErrorRecoveryAction::RetryAction
-                } else if matches!(
-                    described_error.condition,
-                    AmqpErrorCondition::EntityDisabledError
-                ) {
-                    debug!(
-                        "AMQP described error triggers a disconnect: {:?}",
-                        described_error
-                    );
                     ErrorRecoveryAction::RetryAction
                 } else {
                     debug!(

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/receiver.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/receiver.rs
@@ -38,7 +38,7 @@ impl RecoverableReceiver {
     }
 
     fn should_retry_receive_operation(e: &AmqpError) -> ErrorRecoveryAction {
-        RecoverableConnection::should_retry_amqp_error(e)
+        RecoverableConnection::should_retry_receive_error(e)
     }
 }
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/event_receiver.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/event_receiver.rs
@@ -1,15 +1,36 @@
 // Copyright (c) Microsoft Corporation. All Rights reserved
 // Licensed under the MIT license.
 
-use crate::{common::recoverable::RecoverableConnection, error::Result, models::ReceivedEventData};
+use crate::{
+    common::recoverable::RecoverableConnection,
+    error::{ErrorKind, EventHubsError, Result},
+    models::ReceivedEventData,
+};
 use async_stream::try_stream;
 use azure_core::{http::Url, time::Duration};
 use azure_core_amqp::{
-    AmqpDeliveryApis as _, AmqpReceiverApis as _, AmqpReceiverOptions, AmqpSource,
+    error::{AmqpErrorCondition, AmqpErrorKind},
+    AmqpDeliveryApis as _, AmqpError, AmqpReceiverApis as _, AmqpReceiverOptions, AmqpSource,
 };
 use futures::Stream;
 use std::sync::Arc;
 use tracing::trace;
+
+/// Translates AMQP errors raised on the receive path into `EventHubsError`,
+/// recognizing the `amqp:link:stolen` condition (broker-initiated displacement
+/// when another receiver attaches with a higher-or-equal epoch) and surfacing
+/// it as the typed `ConsumerDisconnected` variant. The retry layer (see
+/// `should_retry_amqp_error` in `common/recoverable/connection.rs`) deliberately
+/// returns this error rather than silently re-attaching, so this mapping is the
+/// signal a stolen-partition consumer observes.
+fn translate_receive_error(error: AmqpError) -> EventHubsError {
+    if let AmqpErrorKind::AmqpDescribedError(described) = error.kind() {
+        if matches!(described.condition, AmqpErrorCondition::LinkStolen) {
+            return EventHubsError::from(ErrorKind::ConsumerDisconnected(Some(described.clone())));
+        }
+    }
+    EventHubsError::from(error)
+}
 
 /// A message receiver that can be used to receive messages from an Event Hub.
 ///
@@ -119,6 +140,12 @@ impl EventReceiver {
     ///
     pub fn stream_events(&self) -> impl Stream<Item = Result<ReceivedEventData>> + '_ {
         // Use async_stream to create a stream that yields messages from the receiver.
+        // AMQP errors are translated through `translate_receive_error` so the
+        // broker-initiated link-stolen condition surfaces as the typed
+        // `EventHubsError::ConsumerDisconnected` rather than an opaque
+        // `AmqpError`. Consumers pattern-matching on
+        // `ErrorKind::ConsumerDisconnected` can break out of their receive
+        // loop and re-acquire a partition client.
         Box::pin(try_stream! {
             loop {
                 let receiver = self.connection.get_receiver(&self.source_url,
@@ -127,7 +154,7 @@ impl EventReceiver {
                     self.timeout
                 ).await?;
 
-                let delivery = receiver.receive_delivery().await?;
+                let delivery = receiver.receive_delivery().await.map_err(translate_receive_error)?;
 
 
                  // Now that we have a delivery, we can process it.
@@ -141,6 +168,19 @@ impl EventReceiver {
 
     /// Closes the event receiver, detaching from the remote.
     pub async fn close(self) -> Result<()> {
+        self.connection.close_receiver(&self.source_url).await
+    }
+
+    /// Closes the underlying AMQP receiver link without consuming the
+    /// `EventReceiver` value.
+    ///
+    /// This is the cooperative-shutdown counterpart to `close(self)` for
+    /// callers that hold the receiver by shared reference (for example, the
+    /// `EventProcessor`'s partition-revocation path, which must close a
+    /// receiver while user code still holds an `Arc<PartitionClient>` over
+    /// it). The next `stream_events()` poll on this receiver will resolve
+    /// with an error so the consumer's loop can terminate.
+    pub(crate) async fn request_close(&self) -> Result<()> {
         self.connection.close_receiver(&self.source_url).await
     }
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/event_receiver.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/event_receiver.rs
@@ -13,16 +13,15 @@ use azure_core_amqp::{
     AmqpDeliveryApis as _, AmqpError, AmqpReceiverApis as _, AmqpReceiverOptions, AmqpSource,
 };
 use futures::Stream;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use tracing::trace;
 
-/// Translates AMQP errors raised on the receive path into `EventHubsError`,
-/// recognizing the `amqp:link:stolen` condition (broker-initiated displacement
-/// when another receiver attaches with a higher-or-equal epoch) and surfacing
-/// it as the typed `ConsumerDisconnected` variant. The retry layer (see
-/// `should_retry_amqp_error` in `common/recoverable/connection.rs`) deliberately
-/// returns this error rather than silently re-attaching, so this mapping is the
-/// signal a stolen-partition consumer observes.
+/// Maps `amqp:link:stolen` (broker-initiated epoch displacement) on the
+/// receive path to the typed `ConsumerDisconnected` variant. Other errors
+/// pass through unchanged.
 fn translate_receive_error(error: AmqpError) -> EventHubsError {
     if let AmqpErrorKind::AmqpDescribedError(described) = error.kind() {
         if matches!(described.condition, AmqpErrorCondition::LinkStolen) {
@@ -78,6 +77,10 @@ pub struct EventReceiver {
     source_url: Url,
     partition_id: String,
     timeout: Option<Duration>,
+    // Set by `request_close()` to terminate `stream_events()` even if
+    // `close_receiver` could not detach by-value because an in-flight
+    // receive holds a strong Arc on the AMQP receiver.
+    closed: AtomicBool,
 }
 
 impl EventReceiver {
@@ -96,6 +99,7 @@ impl EventReceiver {
             message_source,
             partition_id,
             timeout,
+            closed: AtomicBool::new(false),
         }
     }
 
@@ -139,15 +143,14 @@ impl EventReceiver {
     /// ```
     ///
     pub fn stream_events(&self) -> impl Stream<Item = Result<ReceivedEventData>> + '_ {
-        // Use async_stream to create a stream that yields messages from the receiver.
-        // AMQP errors are translated through `translate_receive_error` so the
-        // broker-initiated link-stolen condition surfaces as the typed
-        // `EventHubsError::ConsumerDisconnected` rather than an opaque
-        // `AmqpError`. Consumers pattern-matching on
-        // `ErrorKind::ConsumerDisconnected` can break out of their receive
-        // loop and re-acquire a partition client.
         Box::pin(try_stream! {
             loop {
+                // Stop here if `request_close` has been called; otherwise
+                // `get_receiver` below would reattach a new link.
+                if self.closed.load(Ordering::Acquire) {
+                    Err(EventHubsError::from(ErrorKind::ConsumerDisconnected(None)))?;
+                }
+
                 let receiver = self.connection.get_receiver(&self.source_url,
                     self.message_source.clone(),
                     self.receiver_options.clone(),
@@ -156,12 +159,11 @@ impl EventReceiver {
 
                 let delivery = receiver.receive_delivery().await.map_err(translate_receive_error)?;
 
-
-                 // Now that we have a delivery, we can process it.
-                 let message = delivery.into_message();
-                 let message = ReceivedEventData::from(message);
-                 trace!("Received message: {:?}", message);
-                 yield message;
+                // Now that we have a delivery, we can process it.
+                let message = delivery.into_message();
+                let message = ReceivedEventData::from(message);
+                trace!("Received message: {:?}", message);
+                yield message;
             }
         })
     }
@@ -171,16 +173,13 @@ impl EventReceiver {
         self.connection.close_receiver(&self.source_url).await
     }
 
-    /// Closes the underlying AMQP receiver link without consuming the
-    /// `EventReceiver` value.
-    ///
-    /// This is the cooperative-shutdown counterpart to `close(self)` for
-    /// callers that hold the receiver by shared reference (for example, the
-    /// `EventProcessor`'s partition-revocation path, which must close a
-    /// receiver while user code still holds an `Arc<PartitionClient>` over
-    /// it). The next `stream_events()` poll on this receiver will resolve
-    /// with an error so the consumer's loop can terminate.
+    /// Closes the AMQP receiver without consuming the `EventReceiver`.
+    /// Used by `EventProcessor` to revoke a partition while the consumer
+    /// still holds an `Arc<PartitionClient>`. Sets the close flag before
+    /// the detach so the next `stream_events()` poll resolves with
+    /// `ConsumerDisconnected` regardless of detach outcome.
     pub(crate) async fn request_close(&self) -> Result<()> {
+        self.closed.store(true, Ordering::Release);
         self.connection.close_receiver(&self.source_url).await
     }
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/error.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/error.rs
@@ -27,6 +27,16 @@ pub enum ErrorKind {
     /// This is used to wrap an AMQP error in an Even Hubs error.
     ///
     AmqpError(AmqpError),
+
+    /// The receiver was disconnected by the broker because another receiver
+    /// connected with the same or higher epoch (owner level). This is the
+    /// signal that the partition was taken over by another consumer
+    /// instance. Mirrors `EventHubsException.FailureReason.ConsumerDisconnected`
+    /// in the .NET SDK.
+    ///
+    /// Carries the underlying AMQP described error (with condition
+    /// `amqp:link:stolen`) when one is available.
+    ConsumerDisconnected(Option<AmqpDescribedError>),
 }
 
 /// Represents an error that can occur in the Event Hubs module.
@@ -62,6 +72,9 @@ impl std::fmt::Display for EventHubsError {
             ErrorKind::SendRejected(e) => write!(f, "Send rejected: {:?}", e),
             ErrorKind::InvalidManagementResponse => f.write_str("Invalid management response"),
             ErrorKind::AmqpError(source) => write!(f, "AMQP Error: {:?}", source),
+            ErrorKind::ConsumerDisconnected(e) => {
+                write!(f, "Consumer disconnected by broker (partition stolen): {:?}", e)
+            }
         }
     }
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/error.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/error.rs
@@ -28,14 +28,11 @@ pub enum ErrorKind {
     ///
     AmqpError(AmqpError),
 
-    /// The receiver was disconnected by the broker because another receiver
-    /// connected with the same or higher epoch (owner level). This is the
-    /// signal that the partition was taken over by another consumer
-    /// instance. Mirrors `EventHubsException.FailureReason.ConsumerDisconnected`
-    /// in the .NET SDK.
-    ///
-    /// Carries the underlying AMQP described error (with condition
-    /// `amqp:link:stolen`) when one is available.
+    /// Receiver was disconnected by the broker because another receiver
+    /// attached with the same or higher epoch (owner level). The inner
+    /// `AmqpDescribedError` is for logging; match on the variant:
+    /// `matches!(err.kind, ErrorKind::ConsumerDisconnected(_))`.
+    /// Mirrors `EventHubsException.FailureReason.ConsumerDisconnected` (.NET).
     ConsumerDisconnected(Option<AmqpDescribedError>),
 }
 
@@ -73,7 +70,11 @@ impl std::fmt::Display for EventHubsError {
             ErrorKind::InvalidManagementResponse => f.write_str("Invalid management response"),
             ErrorKind::AmqpError(source) => write!(f, "AMQP Error: {:?}", source),
             ErrorKind::ConsumerDisconnected(e) => {
-                write!(f, "Consumer disconnected by broker (partition stolen): {:?}", e)
+                write!(
+                    f,
+                    "Consumer disconnected by broker (partition stolen): {:?}",
+                    e
+                )
             }
         }
     }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/partition_client.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/partition_client.rs
@@ -12,9 +12,12 @@ use azure_core_amqp::{message::AmqpAnnotationKey, AmqpValue};
 use futures::Stream;
 use std::{
     pin::Pin,
-    sync::{Arc, OnceLock, Weak},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, OnceLock, Weak,
+    },
 };
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 /// Represents a client for interacting with a specific partition in Event Hubs.
 ///
@@ -26,6 +29,7 @@ pub struct PartitionClient {
     client_details: ConsumerClientDetails,
     event_receiver: OnceLock<EventReceiver>,
     consumers: Weak<ProcessorConsumersMap>,
+    revoked: Arc<AtomicBool>,
 }
 
 // It's safe to use the PartitionClient from multiple threads simultaneously.
@@ -45,6 +49,7 @@ impl PartitionClient {
             client_details,
             event_receiver: OnceLock::new(),
             consumers,
+            revoked: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -54,6 +59,25 @@ impl PartitionClient {
     /// A reference to the partition ID as a String slice.
     pub fn get_partition_id(&self) -> &str {
         &self.partition_id
+    }
+
+    /// Marks this partition client as revoked.
+    ///
+    /// When a partition is reassigned to another consumer by the load balancer,
+    /// the event processor calls this method to signal that this client should
+    /// stop processing events. Callers should check [`is_revoked`](Self::is_revoked)
+    /// between event receives and stop when it returns `true`.
+    pub fn revoke(&self) {
+        info!("Revoking partition client for partition {}", self.partition_id);
+        self.revoked.store(true, Ordering::Relaxed);
+    }
+
+    /// Returns `true` if this partition client has been revoked.
+    ///
+    /// A revoked partition client indicates that the partition has been
+    /// reassigned to another consumer and this client should stop processing.
+    pub fn is_revoked(&self) -> bool {
+        self.revoked.load(Ordering::Relaxed)
     }
 
     /// Receives events from the partition.

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/partition_client.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/partition_client.rs
@@ -12,24 +12,29 @@ use azure_core_amqp::{message::AmqpAnnotationKey, AmqpValue};
 use futures::Stream;
 use std::{
     pin::Pin,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc, OnceLock, Weak,
-    },
+    sync::{Arc, OnceLock, Weak},
 };
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, trace, warn};
 
 /// Represents a client for interacting with a specific partition in Event Hubs.
 ///
 /// The `PartitionClient` provides methods for receiving events, updating checkpoints,
 /// and managing the lifecycle of the client for a specific partition.
+///
+/// When the load balancer transfers this partition to another consumer
+/// instance (or the broker itself disconnects the receiver because another
+/// consumer opened a higher-or-equal-epoch receiver on the same partition),
+/// `stream_events()` resolves with an error and the loop terminates. There
+/// is no separate poll flag; the stream's termination is the only signal.
+/// Consumers should re-acquire a partition client via
+/// [`EventProcessor::next_partition_client`](crate::EventProcessor::next_partition_client)
+/// after stream termination.
 pub struct PartitionClient {
     partition_id: String,
     checkpoint_store: Arc<dyn CheckpointStore + Send + Sync>,
     client_details: ConsumerClientDetails,
     event_receiver: OnceLock<EventReceiver>,
     consumers: Weak<ProcessorConsumersMap>,
-    revoked: AtomicBool,
 }
 
 // It's safe to use the PartitionClient from multiple threads simultaneously.
@@ -49,7 +54,6 @@ impl PartitionClient {
             client_details,
             event_receiver: OnceLock::new(),
             consumers,
-            revoked: AtomicBool::new(false),
         }
     }
 
@@ -61,31 +65,23 @@ impl PartitionClient {
         &self.partition_id
     }
 
-    /// Marks this partition client as revoked.
+    /// Closes the underlying AMQP receiver without consuming this
+    /// `PartitionClient`, so that any in-flight `stream_events()` call on
+    /// this client resolves and the consumer's loop can exit.
     ///
-    /// Only the SDK calls this; user code observing revocation should poll
-    /// [`is_revoked`](Self::is_revoked). Allowing arbitrary callers to revoke
-    /// would desynchronize the processor's internal consumers map.
-    pub(crate) fn revoke(&self) {
-        info!("Revoking partition client for partition {}", self.partition_id);
-        // Release pairs with Acquire in `is_revoked` so any state mutated
-        // before `revoke()` is visible to a reader that observes `true`.
-        self.revoked.store(true, Ordering::Release);
-    }
-
-    /// Returns `true` if this partition client has been revoked.
-    ///
-    /// A revoked partition client indicates that the load balancer has
-    /// transferred this partition to another consumer instance. The consumer
-    /// loop should check this between calls to `stream_events().next().await`
-    /// and stop processing when it returns `true`.
-    ///
-    /// Note: revocation is poll-based today. A consumer awaiting events on a
-    /// low-traffic partition will not observe revocation until the next event
-    /// arrives or the AMQP receiver fails. A future change is expected to make
-    /// `stream_events()` itself terminate on revocation; see PR description.
-    pub fn is_revoked(&self) -> bool {
-        self.revoked.load(Ordering::Acquire)
+    /// Called by the `EventProcessor`'s load-balancer reconciliation when
+    /// this partition has been transferred to another instance, as a
+    /// backstop for the broker-initiated disconnect path. Idempotent if the
+    /// receiver was not yet set or has already been closed.
+    pub(crate) async fn request_close_receiver(&self) {
+        if let Some(receiver) = self.event_receiver.get() {
+            if let Err(e) = receiver.request_close().await {
+                warn!(
+                    "Failed to close event receiver during revocation for partition {}: {:?}",
+                    self.partition_id, e
+                );
+            }
+        }
     }
 
     /// Receives events from the partition.

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/partition_client.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/partition_client.rs
@@ -21,14 +21,10 @@ use tracing::{debug, trace, warn};
 /// The `PartitionClient` provides methods for receiving events, updating checkpoints,
 /// and managing the lifecycle of the client for a specific partition.
 ///
-/// When the load balancer transfers this partition to another consumer
-/// instance (or the broker itself disconnects the receiver because another
-/// consumer opened a higher-or-equal-epoch receiver on the same partition),
-/// `stream_events()` resolves with an error and the loop terminates. There
-/// is no separate poll flag; the stream's termination is the only signal.
-/// Consumers should re-acquire a partition client via
-/// [`EventProcessor::next_partition_client`](crate::EventProcessor::next_partition_client)
-/// after stream termination.
+/// Stream termination is the only revocation signal: when the partition is
+/// reassigned (or the broker disconnects the receiver via epoch), `stream_events()`
+/// resolves with `EventHubsError::ConsumerDisconnected`. Re-acquire via
+/// [`EventProcessor::next_partition_client`](crate::EventProcessor::next_partition_client).
 pub struct PartitionClient {
     partition_id: String,
     checkpoint_store: Arc<dyn CheckpointStore + Send + Sync>,
@@ -65,14 +61,9 @@ impl PartitionClient {
         &self.partition_id
     }
 
-    /// Closes the underlying AMQP receiver without consuming this
-    /// `PartitionClient`, so that any in-flight `stream_events()` call on
-    /// this client resolves and the consumer's loop can exit.
-    ///
-    /// Called by the `EventProcessor`'s load-balancer reconciliation when
-    /// this partition has been transferred to another instance, as a
-    /// backstop for the broker-initiated disconnect path. Idempotent if the
-    /// receiver was not yet set or has already been closed.
+    /// Closes the AMQP receiver so any in-flight `stream_events()` resolves.
+    /// Called by load-balancer reconciliation as a backstop for the
+    /// broker-initiated disconnect path. Idempotent.
     pub(crate) async fn request_close_receiver(&self) {
         if let Some(receiver) = self.event_receiver.get() {
             if let Err(e) = receiver.request_close().await {

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/partition_client.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/partition_client.rs
@@ -29,7 +29,7 @@ pub struct PartitionClient {
     client_details: ConsumerClientDetails,
     event_receiver: OnceLock<EventReceiver>,
     consumers: Weak<ProcessorConsumersMap>,
-    revoked: Arc<AtomicBool>,
+    revoked: AtomicBool,
 }
 
 // It's safe to use the PartitionClient from multiple threads simultaneously.
@@ -49,7 +49,7 @@ impl PartitionClient {
             client_details,
             event_receiver: OnceLock::new(),
             consumers,
-            revoked: Arc::new(AtomicBool::new(false)),
+            revoked: AtomicBool::new(false),
         }
     }
 
@@ -63,21 +63,29 @@ impl PartitionClient {
 
     /// Marks this partition client as revoked.
     ///
-    /// When a partition is reassigned to another consumer by the load balancer,
-    /// the event processor calls this method to signal that this client should
-    /// stop processing events. Callers should check [`is_revoked`](Self::is_revoked)
-    /// between event receives and stop when it returns `true`.
-    pub fn revoke(&self) {
+    /// Only the SDK calls this; user code observing revocation should poll
+    /// [`is_revoked`](Self::is_revoked). Allowing arbitrary callers to revoke
+    /// would desynchronize the processor's internal consumers map.
+    pub(crate) fn revoke(&self) {
         info!("Revoking partition client for partition {}", self.partition_id);
-        self.revoked.store(true, Ordering::Relaxed);
+        // Release pairs with Acquire in `is_revoked` so any state mutated
+        // before `revoke()` is visible to a reader that observes `true`.
+        self.revoked.store(true, Ordering::Release);
     }
 
     /// Returns `true` if this partition client has been revoked.
     ///
-    /// A revoked partition client indicates that the partition has been
-    /// reassigned to another consumer and this client should stop processing.
+    /// A revoked partition client indicates that the load balancer has
+    /// transferred this partition to another consumer instance. The consumer
+    /// loop should check this between calls to `stream_events().next().await`
+    /// and stop processing when it returns `true`.
+    ///
+    /// Note: revocation is poll-based today. A consumer awaiting events on a
+    /// low-traffic partition will not observe revocation until the next event
+    /// arrives or the AMQP receiver fails. A future change is expected to make
+    /// `stream_events()` itself terminate on revocation; see PR description.
     pub fn is_revoked(&self) -> bool {
-        self.revoked.load(Ordering::Relaxed)
+        self.revoked.load(Ordering::Acquire)
     }
 
     /// Receives events from the partition.

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/processor.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/processor.rs
@@ -50,6 +50,7 @@ pub struct EventProcessor {
     next_partition_client_sender: Sender<Arc<PartitionClient>>,
     client_details: ConsumerClientDetails,
     prefetch: u32,
+    owner_level: Option<i64>,
     update_interval: Duration,
     start_positions: StartPositions,
     is_running: std::sync::Mutex<bool>,
@@ -62,6 +63,7 @@ struct EventProcessorOptions {
     update_interval: Duration,
     start_positions: StartPositions,
     prefetch: u32,
+    owner_level: Option<i64>,
     partition_ids: Vec<String>,
 }
 
@@ -123,6 +125,38 @@ impl ProcessorConsumersMap {
         info!("Consumers for partition now: {:?}", consumers.keys());
         Ok(())
     }
+
+    /// Returns the set of partition IDs that have active partition clients.
+    fn get_active_partition_ids(&self) -> Result<Vec<String>> {
+        let consumers = self
+            .consumers
+            .lock()
+            .map_err(|_| EventHubsError::with_message("Could not lock consumers mutex."))?;
+        Ok(consumers.keys().cloned().collect())
+    }
+
+    /// Revokes and removes partition clients for partitions that are no longer
+    /// owned by this processor instance.
+    ///
+    /// This is called during dispatch when the load balancer indicates that
+    /// a partition has been reassigned to another consumer. The partition client
+    /// is marked as revoked (so the consumer can detect it via `is_revoked()`)
+    /// and removed from the consumers map (so a new client can be created if the
+    /// partition is later reassigned back).
+    fn revoke_partition_clients(&self, partition_ids: &[String]) -> Result<()> {
+        let mut consumers = self
+            .consumers
+            .lock()
+            .map_err(|_| EventHubsError::with_message("Could not lock consumers mutex."))?;
+        for partition_id in partition_ids {
+            if let Some(weak) = consumers.remove(partition_id) {
+                if let Some(client) = weak.upgrade() {
+                    client.revoke();
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 //pub(crate) type ConsumersType = std::sync::Mutex<HashMap<String, Arc<PartitionClient>>>;
@@ -163,6 +197,7 @@ impl EventProcessor {
             ))),
             client_details,
             prefetch: options.prefetch,
+            owner_level: options.owner_level,
             update_interval: options.update_interval,
             start_positions: options.start_positions,
             next_partition_client_sender: sender,
@@ -293,6 +328,25 @@ impl EventProcessor {
             e
         })?;
 
+        // Detect partitions that were stolen by another consumer.
+        // Compare the set of partitions we currently own (from load_balance)
+        // against active partition clients. Revoke any clients for partitions
+        // we no longer own so they stop processing.
+        let owned_ids: std::collections::HashSet<&str> =
+            ownerships.iter().map(|o| o.partition_id.as_str()).collect();
+        let active_ids = consumers.get_active_partition_ids()?;
+        let stolen: Vec<String> = active_ids
+            .into_iter()
+            .filter(|id| !owned_ids.contains(id.as_str()))
+            .collect();
+        if !stolen.is_empty() {
+            info!(
+                "Partitions no longer owned, revoking: {}",
+                stolen.join(", ")
+            );
+            consumers.revoke_partition_clients(&stolen)?;
+        }
+
         let checkpoints = self.get_checkpoint_map().await;
         let checkpoints = checkpoints.map_err(|e| {
             error!("Error in getting checkpoint map: {:?}", e);
@@ -366,6 +420,7 @@ impl EventProcessor {
                 Some(OpenReceiverOptions {
                     start_position: Some(start_position),
                     prefetch: Some(self.prefetch),
+                    owner_level: self.owner_level,
                     ..Default::default()
                 }),
             )
@@ -527,7 +582,7 @@ pub mod builders {
 
     const DEFAULT_PREFETCH: u32 = 300;
     const DEFAULT_UPDATE_INTERVAL: Duration = Duration::seconds(30);
-    const DEFAULT_PARTITION_EXPIRATION_DURATION: Duration = Duration::seconds(10);
+    const DEFAULT_PARTITION_EXPIRATION_DURATION: Duration = Duration::seconds(60);
 
     /// Builder for creating an `EventProcessor`.
     /// This builder allows you to configure various options for the event processor,
@@ -560,12 +615,13 @@ pub mod builders {
     /// ```
     #[derive(Default)]
     pub struct EventProcessorBuilder {
-        update_interval: Option<Duration>,
-        start_positions: Option<StartPositions>,
-        max_partition_count: Option<usize>,
-        prefetch: Option<u32>,
-        load_balancing_strategy: Option<super::ProcessorStrategy>,
-        partition_expiration_duration: Option<Duration>,
+        pub(crate) update_interval: Option<Duration>,
+        pub(crate) start_positions: Option<StartPositions>,
+        pub(crate) max_partition_count: Option<usize>,
+        pub(crate) prefetch: Option<u32>,
+        pub(crate) owner_level: Option<i64>,
+        pub(crate) load_balancing_strategy: Option<super::ProcessorStrategy>,
+        pub(crate) partition_expiration_duration: Option<Duration>,
     }
     impl EventProcessorBuilder {
         pub(super) fn new() -> Self {
@@ -611,6 +667,17 @@ pub mod builders {
             self
         }
 
+        /// Sets the owner level (epoch) for partition receivers.
+        ///
+        /// When set, the Event Hub broker enforces exclusive access: a new
+        /// receiver with the same or higher owner level will disconnect any
+        /// existing receiver on the same partition. This prevents duplicate
+        /// processing when partitions are rebalanced across consumers.
+        pub fn with_owner_level(mut self, owner_level: i64) -> Self {
+            self.owner_level = Some(owner_level);
+            self
+        }
+
         /// Sets the partition expiration duration for the event processor.
         pub fn with_partition_expiration_duration(
             mut self,
@@ -627,6 +694,19 @@ pub mod builders {
             consumer_client: ConsumerClient,
             checkpoint_store: Arc<dyn CheckpointStore + Send + Sync>,
         ) -> Result<Arc<EventProcessor>> {
+            let update_interval = self.update_interval.unwrap_or(DEFAULT_UPDATE_INTERVAL);
+            let partition_expiration_duration = self
+                .partition_expiration_duration
+                .unwrap_or(DEFAULT_PARTITION_EXPIRATION_DURATION);
+
+            if partition_expiration_duration <= update_interval {
+                return Err(crate::EventHubsError::with_message(format!(
+                    "partition_expiration_duration ({partition_expiration_duration:?}) \
+                     must be greater than update_interval ({update_interval:?})"
+                ))
+                .into());
+            }
+
             // Retrieve the set of partitions from the consumer client
             // and limit the number of partitions to the specified max_partition_count.
             let mut eh_properties = consumer_client.get_eventhub_properties().await?;
@@ -641,15 +721,49 @@ pub mod builders {
                     strategy: self
                         .load_balancing_strategy
                         .unwrap_or(super::ProcessorStrategy::Greedy),
-                    partition_expiration_duration: self
-                        .partition_expiration_duration
-                        .unwrap_or(DEFAULT_PARTITION_EXPIRATION_DURATION),
-                    update_interval: self.update_interval.unwrap_or(DEFAULT_UPDATE_INTERVAL),
+                    partition_expiration_duration,
+                    update_interval,
                     start_positions: self.start_positions.unwrap_or_default(),
                     prefetch: self.prefetch.unwrap_or(DEFAULT_PREFETCH),
+                    owner_level: self.owner_level,
                     partition_ids: eh_properties.partition_ids,
                 },
             )
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::builders::EventProcessorBuilder;
+    use azure_core::time::Duration;
+
+    #[test]
+    fn builder_stores_owner_level() {
+        let builder = EventProcessorBuilder::default().with_owner_level(5);
+        assert_eq!(builder.owner_level, Some(5));
+    }
+
+    #[test]
+    fn builder_owner_level_defaults_to_none() {
+        let builder = EventProcessorBuilder::default();
+        assert_eq!(builder.owner_level, None);
+    }
+
+    #[test]
+    fn builder_stores_update_interval() {
+        let builder =
+            EventProcessorBuilder::default().with_update_interval(Duration::seconds(10));
+        assert_eq!(builder.update_interval, Some(Duration::seconds(10)));
+    }
+
+    #[test]
+    fn builder_stores_partition_expiration_duration() {
+        let builder = EventProcessorBuilder::default()
+            .with_partition_expiration_duration(Duration::seconds(120));
+        assert_eq!(
+            builder.partition_expiration_duration,
+            Some(Duration::seconds(120))
+        );
     }
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/processor.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/processor.rs
@@ -615,14 +615,36 @@ pub mod builders {
     /// ```
     #[derive(Default)]
     pub struct EventProcessorBuilder {
-        pub(crate) update_interval: Option<Duration>,
-        pub(crate) start_positions: Option<StartPositions>,
-        pub(crate) max_partition_count: Option<usize>,
-        pub(crate) prefetch: Option<u32>,
-        pub(crate) owner_level: Option<i64>,
-        pub(crate) load_balancing_strategy: Option<super::ProcessorStrategy>,
-        pub(crate) partition_expiration_duration: Option<Duration>,
+        update_interval: Option<Duration>,
+        start_positions: Option<StartPositions>,
+        max_partition_count: Option<usize>,
+        prefetch: Option<u32>,
+        owner_level: Option<i64>,
+        load_balancing_strategy: Option<super::ProcessorStrategy>,
+        partition_expiration_duration: Option<Duration>,
     }
+    /// Returns an error if `partition_expiration_duration` is not strictly
+    /// greater than `update_interval`. When expiration is shorter than the
+    /// load-balancing cycle, every consumer's ownership record expires before
+    /// the next cycle observes it, so the load balancer perpetually re-claims
+    /// every partition. This is extracted from `build()` to make the rule
+    /// directly unit-testable without needing a live `ConsumerClient`.
+    pub(crate) fn validate_expiration_vs_update_interval(
+        partition_expiration_duration: Duration,
+        update_interval: Duration,
+    ) -> Result<()> {
+        if partition_expiration_duration <= update_interval {
+            return Err(crate::EventHubsError::with_message(format!(
+                "partition_expiration_duration ({partition_expiration_duration:?}) must be \
+                 greater than update_interval ({update_interval:?}); otherwise ownership \
+                 records expire between load-balancing cycles and the processor will \
+                 perpetually re-claim partitions, causing duplicate processing. A ratio of \
+                 at least 2x is recommended."
+            )));
+        }
+        Ok(())
+    }
+
     impl EventProcessorBuilder {
         pub(super) fn new() -> Self {
             EventProcessorBuilder {
@@ -673,6 +695,17 @@ pub mod builders {
         /// receiver with the same or higher owner level will disconnect any
         /// existing receiver on the same partition. This prevents duplicate
         /// processing when partitions are rebalanced across consumers.
+        ///
+        /// Note: `0` is a valid owner level. Per the AMQP epoch semantics
+        /// implemented by Event Hubs, a new receiver opened with epoch `0`
+        /// displaces a prior receiver that was using epoch `0`. Calling this
+        /// with any non-negative value enables exclusive (epoch) receivers;
+        /// if it is left unset (the default), receivers are non-epoch and
+        /// will coexist on the same partition.
+        ///
+        /// The .NET and Java `EventProcessorClient` always use owner level
+        /// `0` internally; passing `0` here makes the Rust processor behave
+        /// the same way.
         pub fn with_owner_level(mut self, owner_level: i64) -> Self {
             self.owner_level = Some(owner_level);
             self
@@ -699,13 +732,10 @@ pub mod builders {
                 .partition_expiration_duration
                 .unwrap_or(DEFAULT_PARTITION_EXPIRATION_DURATION);
 
-            if partition_expiration_duration <= update_interval {
-                return Err(crate::EventHubsError::with_message(format!(
-                    "partition_expiration_duration ({partition_expiration_duration:?}) \
-                     must be greater than update_interval ({update_interval:?})"
-                ))
-                .into());
-            }
+            validate_expiration_vs_update_interval(
+                partition_expiration_duration,
+                update_interval,
+            )?;
 
             // Retrieve the set of partitions from the consumer client
             // and limit the number of partitions to the specified max_partition_count.
@@ -735,35 +765,45 @@ pub mod builders {
 
 #[cfg(test)]
 mod tests {
-    use super::builders::EventProcessorBuilder;
+    use super::builders::validate_expiration_vs_update_interval;
     use azure_core::time::Duration;
 
+    /// The validation must reject the historical default (expiration=10s,
+    /// update_interval=30s). This combination is the root cause of issue
+    /// #3851: the ownership record expires 20s before the next load-balancing
+    /// cycle observes it, so every consumer reports `current=0` and
+    /// re-claims every partition every cycle.
     #[test]
-    fn builder_stores_owner_level() {
-        let builder = EventProcessorBuilder::default().with_owner_level(5);
-        assert_eq!(builder.owner_level, Some(5));
-    }
-
-    #[test]
-    fn builder_owner_level_defaults_to_none() {
-        let builder = EventProcessorBuilder::default();
-        assert_eq!(builder.owner_level, None);
-    }
-
-    #[test]
-    fn builder_stores_update_interval() {
-        let builder =
-            EventProcessorBuilder::default().with_update_interval(Duration::seconds(10));
-        assert_eq!(builder.update_interval, Some(Duration::seconds(10)));
-    }
-
-    #[test]
-    fn builder_stores_partition_expiration_duration() {
-        let builder = EventProcessorBuilder::default()
-            .with_partition_expiration_duration(Duration::seconds(120));
-        assert_eq!(
-            builder.partition_expiration_duration,
-            Some(Duration::seconds(120))
+    fn historical_default_combination_is_rejected() {
+        let result = validate_expiration_vs_update_interval(
+            Duration::seconds(10),
+            Duration::seconds(30),
         );
+        assert!(result.is_err(), "10s expiration with 30s interval must be rejected");
+    }
+
+    /// The new default (expiration=60s, update_interval=30s) must be accepted.
+    #[test]
+    fn new_default_combination_is_accepted() {
+        validate_expiration_vs_update_interval(Duration::seconds(60), Duration::seconds(30))
+            .expect("60s expiration with 30s interval must be valid");
+    }
+
+    /// Equal values are rejected: if the record expires exactly at the
+    /// instant the next cycle reads it, the read is racing the expiry.
+    #[test]
+    fn equal_values_are_rejected() {
+        let result = validate_expiration_vs_update_interval(
+            Duration::seconds(30),
+            Duration::seconds(30),
+        );
+        assert!(result.is_err(), "equal expiration and interval must be rejected");
+    }
+
+    /// Custom configurations with adequate headroom are accepted.
+    #[test]
+    fn larger_expiration_is_accepted() {
+        validate_expiration_vs_update_interval(Duration::seconds(120), Duration::seconds(60))
+            .expect("2x ratio should be accepted");
     }
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/processor.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/processor.rs
@@ -28,18 +28,10 @@ use std::{
 };
 use tracing::{debug, error, info};
 
-// The owner-level (AMQP epoch) used for every partition receiver opened by
-// `EventProcessor`. Matches the `EventProcessorClient` in the .NET
-// (`Azure.Messaging.EventHubs.Primitives.EventProcessor<TPartition>`) and
-// Java (`com.azure.messaging.eventhubs.implementation.PartitionPumpManager`)
-// SDKs, both of which hardcode `ownerLevel = 0` for processor receivers.
-// `0` is itself a valid exclusive epoch: a new receiver-at-0 displaces a
-// prior receiver-at-0 on the same partition+consumer-group, which is the
-// mechanism the processor relies on for clean steal detection.
-//
-// This is not user-configurable on `EventProcessor`. Callers who want to
-// pick a different epoch should open receivers directly via
-// `ConsumerClient::open_receiver_on_partition` with `OpenReceiverOptions`.
+// AMQP epoch (owner level) used for every partition receiver opened by
+// `EventProcessor`. Matches `EventProcessorClient` in the .NET and Java
+// SDKs. `0` is itself an exclusive epoch (a new receiver-at-0 displaces a
+// prior receiver-at-0), which is how the processor detects steals.
 const PROCESSOR_OWNER_LEVEL: i64 = 0;
 
 /// Represents the event processor responsible for processing events
@@ -52,6 +44,13 @@ const PROCESSOR_OWNER_LEVEL: i64 = 0;
 ///
 /// The event processor uses a load balancer to distribute the load
 /// across partitions and a checkpoint store to manage checkpoints.
+///
+/// Each per-partition receiver opens with AMQP epoch `0`, matching the .NET
+/// and Java `EventProcessorClient`. When another `EventProcessor` attaches
+/// to the same partition, the broker disconnects this receiver and
+/// `stream_events()` resolves with `EventHubsError::ConsumerDisconnected`.
+/// To use a different epoch, open receivers directly via
+/// `ConsumerClient::open_receiver_on_partition`.
 ///
 /// For more information on Event Processors and scenarios in which you would
 /// use an Event Processor, see the [Event Processor documentation](https://learn.microsoft.com/azure/event-hubs/event-processor-balance-partition-load).
@@ -147,21 +146,12 @@ impl ProcessorConsumersMap {
         Ok(consumers.keys().cloned().collect())
     }
 
-    /// Revokes partition clients for partitions that are no longer owned by
-    /// this processor instance.
-    ///
-    /// Called during dispatch when the load balancer indicates that a
-    /// partition has been reassigned to another consumer. The client is
-    /// removed from the consumers map (so a fresh client can be created if
-    /// the partition is later reassigned back), and the underlying event
-    /// receiver is closed so that any in-flight `stream_events()` call on
-    /// the consumer side resolves and the loop terminates. This is a
-    /// backstop: the broker's epoch-based disconnect path is the primary
-    /// signal when another instance takes over the partition.
+    /// Removes partitions reassigned away from this processor and closes
+    /// their receivers so consumer streams terminate. Backstop for the
+    /// broker's epoch-based disconnect.
     async fn revoke_partition_clients(&self, partition_ids: &[String]) -> Result<()> {
-        // Collect the strong references under the sync lock, then release
-        // the lock before awaiting any close calls. A SyncMutex guard must
-        // not be held across `.await`.
+        // Collect under the sync lock, then release before awaiting:
+        // SyncMutex guards cannot be held across `.await`.
         let to_close: Vec<Arc<PartitionClient>> = {
             let mut consumers = self
                 .consumers
@@ -347,10 +337,7 @@ impl EventProcessor {
             e
         })?;
 
-        // Detect partitions that were stolen by another consumer.
-        // Compare the set of partitions we currently own (from load_balance)
-        // against active partition clients. Revoke any clients for partitions
-        // we no longer own so they stop processing.
+        // Revoke clients for any partitions no longer in the ownership set.
         let owned_ids: std::collections::HashSet<&str> =
             ownerships.iter().map(|o| o.partition_id.as_str()).collect();
         let active_ids = consumers.get_active_partition_ids()?;
@@ -444,13 +431,30 @@ impl EventProcessor {
                 }),
             )
             .await;
-        if let Err(e) = receiver {
-            error!("Error opening receiver for partition client: {:?}", e);
+        // Roll back the consumers-map entry on failure; otherwise the
+        // partition is stuck (the map's `contains_key` check would
+        // short-circuit every retry) until steal-revocation or restart.
+        let receiver = match receiver {
+            Ok(r) => r,
+            Err(e) => {
+                error!("Error opening receiver for partition client: {:?}", e);
+                if let Some(strong_consumers) = consumers.upgrade() {
+                    let _ = strong_consumers.remove_partition_client(&partition_id);
+                }
+                return Err(e);
+            }
+        };
+        info!("Receiver opened for partition client: {:?}", &partition_id);
+        if let Err(e) = partition_client.set_event_receiver(receiver) {
+            error!(
+                "Error setting event receiver for partition {}: {:?}",
+                partition_id, e
+            );
+            if let Some(strong_consumers) = consumers.upgrade() {
+                let _ = strong_consumers.remove_partition_client(&partition_id);
+            }
             return Err(e);
         }
-        info!("Receiver opened for partition client: {:?}", &partition_id);
-        let receiver = receiver.unwrap();
-        partition_client.set_event_receiver(receiver)?;
 
         info!("Adding partition client to queue.");
 
@@ -728,10 +732,7 @@ pub mod builders {
                 .partition_expiration_duration
                 .unwrap_or(DEFAULT_PARTITION_EXPIRATION_DURATION);
 
-            validate_expiration_vs_update_interval(
-                partition_expiration_duration,
-                update_interval,
-            )?;
+            validate_expiration_vs_update_interval(partition_expiration_duration, update_interval)?;
 
             // Retrieve the set of partitions from the consumer client
             // and limit the number of partitions to the specified max_partition_count.
@@ -770,11 +771,12 @@ mod tests {
     /// re-claims every partition every cycle.
     #[test]
     fn historical_default_combination_is_rejected() {
-        let result = validate_expiration_vs_update_interval(
-            Duration::seconds(10),
-            Duration::seconds(30),
+        let result =
+            validate_expiration_vs_update_interval(Duration::seconds(10), Duration::seconds(30));
+        assert!(
+            result.is_err(),
+            "10s expiration with 30s interval must be rejected"
         );
-        assert!(result.is_err(), "10s expiration with 30s interval must be rejected");
     }
 
     /// The new default (expiration=60s, update_interval=30s) must be accepted.
@@ -788,11 +790,12 @@ mod tests {
     /// instant the next cycle reads it, the read is racing the expiry.
     #[test]
     fn equal_values_are_rejected() {
-        let result = validate_expiration_vs_update_interval(
-            Duration::seconds(30),
-            Duration::seconds(30),
+        let result =
+            validate_expiration_vs_update_interval(Duration::seconds(30), Duration::seconds(30));
+        assert!(
+            result.is_err(),
+            "equal expiration and interval must be rejected"
         );
-        assert!(result.is_err(), "equal expiration and interval must be rejected");
     }
 
     /// Custom configurations with adequate headroom are accepted.

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/processor.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/processor.rs
@@ -28,6 +28,20 @@ use std::{
 };
 use tracing::{debug, error, info};
 
+// The owner-level (AMQP epoch) used for every partition receiver opened by
+// `EventProcessor`. Matches the `EventProcessorClient` in the .NET
+// (`Azure.Messaging.EventHubs.Primitives.EventProcessor<TPartition>`) and
+// Java (`com.azure.messaging.eventhubs.implementation.PartitionPumpManager`)
+// SDKs, both of which hardcode `ownerLevel = 0` for processor receivers.
+// `0` is itself a valid exclusive epoch: a new receiver-at-0 displaces a
+// prior receiver-at-0 on the same partition+consumer-group, which is the
+// mechanism the processor relies on for clean steal detection.
+//
+// This is not user-configurable on `EventProcessor`. Callers who want to
+// pick a different epoch should open receivers directly via
+// `ConsumerClient::open_receiver_on_partition` with `OpenReceiverOptions`.
+const PROCESSOR_OWNER_LEVEL: i64 = 0;
+
 /// Represents the event processor responsible for processing events
 /// from Event Hub partitions.
 ///
@@ -50,7 +64,6 @@ pub struct EventProcessor {
     next_partition_client_sender: Sender<Arc<PartitionClient>>,
     client_details: ConsumerClientDetails,
     prefetch: u32,
-    owner_level: Option<i64>,
     update_interval: Duration,
     start_positions: StartPositions,
     is_running: std::sync::Mutex<bool>,
@@ -63,7 +76,6 @@ struct EventProcessorOptions {
     update_interval: Duration,
     start_positions: StartPositions,
     prefetch: u32,
-    owner_level: Option<i64>,
     partition_ids: Vec<String>,
 }
 
@@ -135,25 +147,33 @@ impl ProcessorConsumersMap {
         Ok(consumers.keys().cloned().collect())
     }
 
-    /// Revokes and removes partition clients for partitions that are no longer
-    /// owned by this processor instance.
+    /// Revokes partition clients for partitions that are no longer owned by
+    /// this processor instance.
     ///
-    /// This is called during dispatch when the load balancer indicates that
-    /// a partition has been reassigned to another consumer. The partition client
-    /// is marked as revoked (so the consumer can detect it via `is_revoked()`)
-    /// and removed from the consumers map (so a new client can be created if the
-    /// partition is later reassigned back).
-    fn revoke_partition_clients(&self, partition_ids: &[String]) -> Result<()> {
-        let mut consumers = self
-            .consumers
-            .lock()
-            .map_err(|_| EventHubsError::with_message("Could not lock consumers mutex."))?;
-        for partition_id in partition_ids {
-            if let Some(weak) = consumers.remove(partition_id) {
-                if let Some(client) = weak.upgrade() {
-                    client.revoke();
-                }
-            }
+    /// Called during dispatch when the load balancer indicates that a
+    /// partition has been reassigned to another consumer. The client is
+    /// removed from the consumers map (so a fresh client can be created if
+    /// the partition is later reassigned back), and the underlying event
+    /// receiver is closed so that any in-flight `stream_events()` call on
+    /// the consumer side resolves and the loop terminates. This is a
+    /// backstop: the broker's epoch-based disconnect path is the primary
+    /// signal when another instance takes over the partition.
+    async fn revoke_partition_clients(&self, partition_ids: &[String]) -> Result<()> {
+        // Collect the strong references under the sync lock, then release
+        // the lock before awaiting any close calls. A SyncMutex guard must
+        // not be held across `.await`.
+        let to_close: Vec<Arc<PartitionClient>> = {
+            let mut consumers = self
+                .consumers
+                .lock()
+                .map_err(|_| EventHubsError::with_message("Could not lock consumers mutex."))?;
+            partition_ids
+                .iter()
+                .filter_map(|id| consumers.remove(id).and_then(|w| w.upgrade()))
+                .collect()
+        };
+        for client in to_close {
+            client.request_close_receiver().await;
         }
         Ok(())
     }
@@ -197,7 +217,6 @@ impl EventProcessor {
             ))),
             client_details,
             prefetch: options.prefetch,
-            owner_level: options.owner_level,
             update_interval: options.update_interval,
             start_positions: options.start_positions,
             next_partition_client_sender: sender,
@@ -344,7 +363,7 @@ impl EventProcessor {
                 "Partitions no longer owned, revoking: {}",
                 stolen.join(", ")
             );
-            consumers.revoke_partition_clients(&stolen)?;
+            consumers.revoke_partition_clients(&stolen).await?;
         }
 
         let checkpoints = self.get_checkpoint_map().await;
@@ -420,7 +439,7 @@ impl EventProcessor {
                 Some(OpenReceiverOptions {
                     start_position: Some(start_position),
                     prefetch: Some(self.prefetch),
-                    owner_level: self.owner_level,
+                    owner_level: Some(PROCESSOR_OWNER_LEVEL),
                     ..Default::default()
                 }),
             )
@@ -619,7 +638,6 @@ pub mod builders {
         start_positions: Option<StartPositions>,
         max_partition_count: Option<usize>,
         prefetch: Option<u32>,
-        owner_level: Option<i64>,
         load_balancing_strategy: Option<super::ProcessorStrategy>,
         partition_expiration_duration: Option<Duration>,
     }
@@ -689,28 +707,6 @@ pub mod builders {
             self
         }
 
-        /// Sets the owner level (epoch) for partition receivers.
-        ///
-        /// When set, the Event Hub broker enforces exclusive access: a new
-        /// receiver with the same or higher owner level will disconnect any
-        /// existing receiver on the same partition. This prevents duplicate
-        /// processing when partitions are rebalanced across consumers.
-        ///
-        /// Note: `0` is a valid owner level. Per the AMQP epoch semantics
-        /// implemented by Event Hubs, a new receiver opened with epoch `0`
-        /// displaces a prior receiver that was using epoch `0`. Calling this
-        /// with any non-negative value enables exclusive (epoch) receivers;
-        /// if it is left unset (the default), receivers are non-epoch and
-        /// will coexist on the same partition.
-        ///
-        /// The .NET and Java `EventProcessorClient` always use owner level
-        /// `0` internally; passing `0` here makes the Rust processor behave
-        /// the same way.
-        pub fn with_owner_level(mut self, owner_level: i64) -> Self {
-            self.owner_level = Some(owner_level);
-            self
-        }
-
         /// Sets the partition expiration duration for the event processor.
         pub fn with_partition_expiration_duration(
             mut self,
@@ -755,7 +751,6 @@ pub mod builders {
                     update_interval,
                     start_positions: self.start_positions.unwrap_or_default(),
                     prefetch: self.prefetch.unwrap_or(DEFAULT_PREFETCH),
-                    owner_level: self.owner_level,
                     partition_ids: eh_properties.partition_ids,
                 },
             )

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs
@@ -99,16 +99,28 @@ async fn create_producer_client(ctx: &TestContext) -> Result<ProducerClient> {
     Ok(p)
 }
 
+fn processor_builder(
+    strategy: ProcessorStrategy,
+    update_interval: Duration,
+    expiration: Duration,
+) -> azure_messaging_eventhubs::builders::EventProcessorBuilder {
+    EventProcessor::builder()
+        .with_load_balancing_strategy(strategy)
+        .with_update_interval(update_interval)
+        .with_partition_expiration_duration(expiration)
+        .with_prefetch(300)
+}
+
 async fn create_processor(
     consumer_client: ConsumerClient,
     update_interval: Duration,
     start_positions: Option<StartPositions>,
 ) -> Result<Arc<EventProcessor>> {
-    let mut builder = EventProcessor::builder()
-        .with_load_balancing_strategy(ProcessorStrategy::Balanced)
-        .with_update_interval(update_interval)
-        .with_partition_expiration_duration(Duration::seconds(120))
-        .with_prefetch(300);
+    let mut builder = processor_builder(
+        ProcessorStrategy::Balanced,
+        update_interval,
+        Duration::seconds(120),
+    );
     if let Some(start_positions) = start_positions {
         builder = builder.with_start_positions(start_positions);
     }
@@ -116,6 +128,30 @@ async fn create_processor(
         .build(consumer_client, Arc::new(InMemoryCheckpointStore::new()))
         .await?;
     Ok(p)
+}
+
+/// Drains `next_partition_client()` until it has been idle for `idle_timeout`.
+/// Used when a test needs every partition the processor will claim, not just
+/// the first.
+async fn drain_partition_clients(
+    processor: &EventProcessor,
+    idle_timeout: std::time::Duration,
+) -> Vec<Arc<azure_messaging_eventhubs::processor::PartitionClient>> {
+    let mut clients = Vec::new();
+    loop {
+        match tokio::time::timeout(idle_timeout, processor.next_partition_client()).await {
+            Ok(Ok(client)) => {
+                info!("Claimed partition {}", client.get_partition_id());
+                clients.push(client);
+            }
+            Ok(Err(e)) => {
+                warn!("next_partition_client returned error during drain: {:?}", e);
+                break;
+            }
+            Err(_) => break,
+        }
+    }
+    clients
 }
 
 async fn start_processor_running(
@@ -391,16 +427,21 @@ async fn receive_events_from_processor(ctx: TestContext) -> Result<()> {
 }
 
 /// When a second `EventProcessor` instance starts against the same Event Hub
-/// and consumer group, the broker disconnects the displaced partition
-/// receiver because both instances open with `owner_level = Some(0)`. The
-/// displaced instance must observe this as `ErrorKind::ConsumerDisconnected`
-/// on its `stream_events()` rather than silently re-attaching.
+/// and consumer group, the broker disconnects at least one of the first
+/// instance's partition receivers because both attach with
+/// `owner_level = Some(0)`. The displaced instance must observe this as
+/// `ErrorKind::ConsumerDisconnected` on `stream_events()` rather than
+/// silently re-attaching.
 ///
 /// This is the end-to-end guard against the auto-recovery regression: the
-/// crate's `should_retry_amqp_error` deliberately excludes
-/// `AmqpErrorCondition::LinkStolen` so the steal bubbles up; if either that
-/// retry exclusion or the `event_receiver` error translation is broken, this
-/// test fails.
+/// receive-path retry decider in `should_retry_receive_error` excludes
+/// `AmqpErrorCondition::LinkStolen` and `event_receiver::translate_receive_error`
+/// translates it to the typed variant. If either is broken, this test
+/// fails.
+///
+/// The test watches every partition client A claims (not just the first),
+/// because B will only steal a fair share of partitions and that share is
+/// not deterministic.
 #[recorded::test(live)]
 async fn second_processor_displaces_first_with_consumer_disconnected(
     ctx: TestContext,
@@ -409,69 +450,85 @@ async fn second_processor_displaces_first_with_consumer_disconnected(
     // validation rule on the builder requires expiration > interval.
     const UPDATE_INTERVAL: Duration = Duration::seconds(5);
     const EXPIRATION: Duration = Duration::seconds(30);
-    // Give the broker + load balancer up to this long to displace the
-    // first processor's receiver and propagate the AMQP detach.
+    // Give the broker + load balancer up to this long to displace at least
+    // one of the first processor's receivers and propagate the AMQP detach.
     const STEAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
+    // How long to collect A's initial claims before starting B. With a 5s
+    // interval, two cycles is enough for A to grab whatever it is going to
+    // grab under a Greedy strategy.
+    const COLLECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
-    // First processor starts, receives a partition, begins streaming.
     let consumer_a = create_consumer_client(&ctx).await?;
-    let processor_a = EventProcessor::builder()
-        .with_load_balancing_strategy(ProcessorStrategy::Greedy)
-        .with_update_interval(UPDATE_INTERVAL)
-        .with_partition_expiration_duration(EXPIRATION)
-        .with_prefetch(300)
+    let processor_a = processor_builder(ProcessorStrategy::Greedy, UPDATE_INTERVAL, EXPIRATION)
         .build(consumer_a, Arc::new(InMemoryCheckpointStore::new()))
         .await?;
     let running_a = start_processor_running(&processor_a).await;
 
-    info!("Waiting for the first processor's partition client.");
-    let partition_client_a = processor_a
-        .next_partition_client()
-        .await
-        .expect("first processor should hand out a partition client");
-    let partition_id = partition_client_a.get_partition_id().to_string();
-    info!("First processor claimed partition {}", partition_id);
+    info!("Collecting all partition clients claimed by processor A.");
+    let partition_clients_a = drain_partition_clients(&processor_a, COLLECT_TIMEOUT).await;
+    assert!(
+        !partition_clients_a.is_empty(),
+        "processor A did not claim any partitions within the collect window"
+    );
+    info!(
+        "Processor A holds {} partition clients before B starts.",
+        partition_clients_a.len()
+    );
 
-    // Start the second processor against the same hub + consumer group; it
-    // will open epoch-0 receivers on the same partitions and the broker
-    // will disconnect processor A's receiver on at least one of them.
+    // Start the second processor against the same hub + consumer group;
+    // it will open epoch-0 receivers and the broker will disconnect at
+    // least one of A's receivers within the load-balancing window.
     let consumer_b = create_consumer_client(&ctx).await?;
-    let processor_b = EventProcessor::builder()
-        .with_load_balancing_strategy(ProcessorStrategy::Greedy)
-        .with_update_interval(UPDATE_INTERVAL)
-        .with_partition_expiration_duration(EXPIRATION)
-        .with_prefetch(300)
+    let processor_b = processor_builder(ProcessorStrategy::Greedy, UPDATE_INTERVAL, EXPIRATION)
         .build(consumer_b, Arc::new(InMemoryCheckpointStore::new()))
         .await?;
     let running_b = start_processor_running(&processor_b).await;
-    info!("Second processor started; waiting for steal.");
+    info!("Second processor started; watching every partition A holds for a steal.");
 
-    // Drive processor A's stream until it terminates. The expected
-    // resolution is an error whose kind is `ConsumerDisconnected`. We
-    // tolerate other errors only as a fallback for transport blips; the
-    // test fails if the stream silently ends with no error (which would
-    // be the bug this PR fixes).
-    let mut stream = partition_client_a.stream_events();
-    let observed = tokio::time::timeout(STEAL_TIMEOUT, async {
+    // Merge every partition's stream into one and watch for the first
+    // error. `select_all` does not require `Send`, which matters because
+    // `PartitionClient::stream_events` returns a non-`Send` boxed stream.
+    use futures::stream::select_all;
+    let tagged_streams = partition_clients_a.iter().map(|client| {
+        let partition_id = client.get_partition_id().to_string();
+        client
+            .stream_events()
+            .map(move |result| (partition_id.clone(), result))
+            .boxed_local()
+    });
+    let mut merged = select_all(tagged_streams);
+
+    let race = async {
         loop {
-            match stream.next().await {
-                Some(Ok(_event)) => continue,
-                Some(Err(err)) => break Some(err),
-                None => break None,
+            match merged.next().await {
+                Some((_partition_id, Ok(_event))) => continue,
+                Some((partition_id, Err(err))) => return (partition_id, Some(err)),
+                // All streams ended without an error: the bug we guard against.
+                None => return (String::new(), None),
             }
         }
-    })
-    .await;
+    };
+    let observed = tokio::time::timeout(STEAL_TIMEOUT, race).await;
 
-    // Stop both processors before asserting so we don't leak background tasks
-    // on a panic.
+    // Stop both before asserting so a panic does not leak background tasks.
     running_a.abort();
     running_b.abort();
     let _ = running_a.await;
     let _ = running_b.await;
 
-    let stream_result = observed.expect("stream did not terminate within steal timeout");
-    let err = stream_result.expect("stream ended without an error; expected ConsumerDisconnected");
+    let (partition_id, maybe_err) = observed.unwrap_or_else(|_| {
+        panic!(
+            "no partition client streamed an error within {:?}; expected ConsumerDisconnected on at least one of {} partitions",
+            STEAL_TIMEOUT,
+            partition_clients_a.len(),
+        )
+    });
+    let err = maybe_err.unwrap_or_else(|| {
+        panic!(
+            "partition {} stream ended without an error; expected ConsumerDisconnected",
+            partition_id
+        )
+    });
     assert!(
         matches!(err.kind, ErrorKind::ConsumerDisconnected(_)),
         "expected ConsumerDisconnected on displaced partition {}, got {:?}",

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs
@@ -5,8 +5,8 @@ use azure_core::time::Duration;
 use azure_core_test::{recorded, TestContext};
 use azure_messaging_eventhubs::models::StartPositions;
 use azure_messaging_eventhubs::{
-    ConsumerClient, EventProcessor, InMemoryCheckpointStore, ProcessorStrategy, ProducerClient,
-    Result, SendEventOptions, StartLocation, StartPosition,
+    error::ErrorKind, ConsumerClient, EventProcessor, InMemoryCheckpointStore, ProcessorStrategy,
+    ProducerClient, Result, SendEventOptions, StartLocation, StartPosition,
 };
 use futures::StreamExt;
 use std::collections::HashMap;
@@ -386,6 +386,98 @@ async fn receive_events_from_processor(ctx: TestContext) -> Result<()> {
     } else {
         info!("Processor still has references, not closing.");
     }
+
+    Ok(())
+}
+
+/// When a second `EventProcessor` instance starts against the same Event Hub
+/// and consumer group, the broker disconnects the displaced partition
+/// receiver because both instances open with `owner_level = Some(0)`. The
+/// displaced instance must observe this as `ErrorKind::ConsumerDisconnected`
+/// on its `stream_events()` rather than silently re-attaching.
+///
+/// This is the end-to-end guard against the auto-recovery regression: the
+/// crate's `should_retry_amqp_error` deliberately excludes
+/// `AmqpErrorCondition::LinkStolen` so the steal bubbles up; if either that
+/// retry exclusion or the `event_receiver` error translation is broken, this
+/// test fails.
+#[recorded::test(live)]
+async fn second_processor_displaces_first_with_consumer_disconnected(
+    ctx: TestContext,
+) -> Result<()> {
+    // Use a short update interval so load balancing converges quickly; the
+    // validation rule on the builder requires expiration > interval.
+    const UPDATE_INTERVAL: Duration = Duration::seconds(5);
+    const EXPIRATION: Duration = Duration::seconds(30);
+    // Give the broker + load balancer up to this long to displace the
+    // first processor's receiver and propagate the AMQP detach.
+    const STEAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
+
+    // First processor starts, receives a partition, begins streaming.
+    let consumer_a = create_consumer_client(&ctx).await?;
+    let processor_a = EventProcessor::builder()
+        .with_load_balancing_strategy(ProcessorStrategy::Greedy)
+        .with_update_interval(UPDATE_INTERVAL)
+        .with_partition_expiration_duration(EXPIRATION)
+        .with_prefetch(300)
+        .build(consumer_a, Arc::new(InMemoryCheckpointStore::new()))
+        .await?;
+    let running_a = start_processor_running(&processor_a).await;
+
+    info!("Waiting for the first processor's partition client.");
+    let partition_client_a = processor_a
+        .next_partition_client()
+        .await
+        .expect("first processor should hand out a partition client");
+    let partition_id = partition_client_a.get_partition_id().to_string();
+    info!("First processor claimed partition {}", partition_id);
+
+    // Start the second processor against the same hub + consumer group; it
+    // will open epoch-0 receivers on the same partitions and the broker
+    // will disconnect processor A's receiver on at least one of them.
+    let consumer_b = create_consumer_client(&ctx).await?;
+    let processor_b = EventProcessor::builder()
+        .with_load_balancing_strategy(ProcessorStrategy::Greedy)
+        .with_update_interval(UPDATE_INTERVAL)
+        .with_partition_expiration_duration(EXPIRATION)
+        .with_prefetch(300)
+        .build(consumer_b, Arc::new(InMemoryCheckpointStore::new()))
+        .await?;
+    let running_b = start_processor_running(&processor_b).await;
+    info!("Second processor started; waiting for steal.");
+
+    // Drive processor A's stream until it terminates. The expected
+    // resolution is an error whose kind is `ConsumerDisconnected`. We
+    // tolerate other errors only as a fallback for transport blips; the
+    // test fails if the stream silently ends with no error (which would
+    // be the bug this PR fixes).
+    let mut stream = partition_client_a.stream_events();
+    let observed = tokio::time::timeout(STEAL_TIMEOUT, async {
+        loop {
+            match stream.next().await {
+                Some(Ok(_event)) => continue,
+                Some(Err(err)) => break Some(err),
+                None => break None,
+            }
+        }
+    })
+    .await;
+
+    // Stop both processors before asserting so we don't leak background tasks
+    // on a panic.
+    running_a.abort();
+    running_b.abort();
+    let _ = running_a.await;
+    let _ = running_b.await;
+
+    let stream_result = observed.expect("stream did not terminate within steal timeout");
+    let err = stream_result.expect("stream ended without an error; expected ConsumerDisconnected");
+    assert!(
+        matches!(err.kind, ErrorKind::ConsumerDisconnected(_)),
+        "expected ConsumerDisconnected on displaced partition {}, got {:?}",
+        partition_id,
+        err.kind,
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Running multiple `EventProcessor` instances against the same hub + consumer group was broken in two ways. The default partition-ownership expiration (10s) was shorter than the load-balancer update interval (30s), so every consumer perpetually saw `current=0` and re-claimed every partition every cycle (#3851). And when the load balancer did transfer a partition between instances, the displaced receiver kept its AMQP link via the recoverable-connection retry-on-`amqp:link:stolen` path; both consumers silently continued reading events.

This PR adopts the .NET/Java `EventProcessorClient` model: every partition receiver opens with AMQP epoch (owner level) `0` so the broker enforces exclusive ownership, broker-initiated displacement surfaces as a typed error on the consumer stream, and the load balancer actively closes receivers it has reassigned. The expiration default moves to 60s, and a build-time guard prevents the #3851 misconfiguration from recurring.

## Behavior

- `EventProcessor` opens every partition receiver with owner level (AMQP epoch) `0` unconditionally. Matches `EventProcessorClient` in the .NET (`Azure.Messaging.EventHubs.Primitives.EventProcessor<TPartition>`) and Java (`com.azure.messaging.eventhubs.implementation.PartitionPumpManager`) SDKs, both of which hardcode the value.
- `AmqpErrorCondition::LinkStolen` is removed from the receive-path retry set (`should_retry_receive_error`). Sender, CBS, and management paths retain the historical retry-on-stolen behavior. The displaced receiver returns the error immediately rather than silently re-attaching.
- New `EventHubsError::ConsumerDisconnected(Option<AmqpDescribedError>)` variant. `EventReceiver::stream_events` translates the underlying `LinkStolen` AMQP error to this variant so consumers can pattern-match without unwrapping `AmqpError`. Mirrors `EventHubsException.FailureReason.ConsumerDisconnected` in .NET.
- Load-balancer reconciliation in `EventProcessor::dispatch` now closes the underlying AMQP receiver for any partition that has been reassigned, so the consumer's `stream_events()` resolves and the per-partition loop terminates.
- `DEFAULT_PARTITION_EXPIRATION_DURATION` 10s -> 60s.
- `EventProcessorBuilder::build` rejects configurations where `partition_expiration_duration <= update_interval`.

## Verification

Local on aarch64-darwin:

- `cargo check -p azure_messaging_eventhubs --all-features` -- clean
- `cargo clippy -p azure_messaging_eventhubs --all-features --all-targets --no-deps -- -D warnings` -- clean
- `cargo test -p azure_messaging_eventhubs --lib` -- 74 passed, 10 ignored (existing live), 0 failed

## Test plan

- [x] All unit tests pass locally
- [x] Clippy passes with `-D warnings` on all targets
- [x] Azure DevOps `rust - pullrequest (Build Analyze)` passes
- [x] Azure DevOps `rust - pullrequest` full build passes on stable / nightly / msrv x ubuntu / macos / windows
- [ ] (Manual) `second_processor_displaces_first_with_consumer_disconnected` run against a live Event Hub with two `EventProcessor` instances. Asserts the displaced one resolves `stream_events()` with `ErrorKind::ConsumerDisconnected` within 90s. Requires live creds.

## Cross-SDK references

- .NET `EventProcessor<TPartition>` (epoch=0, `InvalidateConsumerWhenPartitionIsStolen`): https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
- Java `PartitionPumpManager` (`setOwnerLevel(0L)`): https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/eventhubs/azure-messaging-eventhubs/src/main/java/com/azure/messaging/eventhubs/implementation/PartitionPumpManager.java
- Event Hubs epoch semantics (Microsoft Q&A confirming `0` is a valid exclusive epoch): https://learn.microsoft.com/en-us/answers/questions/2261749/new-receiver-with-higher-epoch-of-0-is-created-hen

Closes #3851.

---

This work started from @hjarraya's #3883, which introduced the initial epoch plumbing, the 60s expiration default, and the partition-revocation idea. Co-authorship is preserved on the relevant commits.
