### PR TITLE
fix(eventhubs): broaden AMQP recoverable connection handling

### DIFF
--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
@@ -96,44 +96,50 @@ impl Authorizer {
         path: &Url,
     ) -> azure_core_amqp::Result<AccessToken> {
         debug!("Authorizing path: {path}");
-        let mut scopes = self.authorization_scopes.lock().await;
 
-        if !scopes.contains_key(path) {
-            debug!("Creating new authorization scope for path: {path}");
-
-            debug!("Get Token.");
-            let token = self
-                .credential
-                .get_token(&[EVENTHUBS_AUTHORIZATION_SCOPE], None)
-                .await
-                .map_err(AmqpError::from)?;
-
-            debug!("Token for path {path} expires at {}", token.expires_on);
-
-            self.perform_authorization(connection, path, &token).await?;
-
-            // insert returns some if it *fails* to insert, None if it succeeded.
-            let present = scopes.insert(path.clone(), token);
-            if present.is_some() {
-                return Err(AmqpError::with_message(
-                    "Unable to add authentication token",
-                ));
-            }
-
-            debug!("Token verified.");
-            self.authorization_refresher.get_or_init(|| {
-                debug!("Starting authorization refresh task.");
-                let self_clone = self.clone();
-                let async_runtime = get_async_runtime();
-                async_runtime.spawn(Box::pin(self_clone.refresh_tokens_task()))
-            });
-        } else {
+        // Fast path: cached token under a brief lock.
+        if let Some(token) = self.authorization_scopes.lock().await.get(path).cloned() {
             debug!("Token already exists for path: {path}");
+            return Ok(token);
         }
-        Ok(scopes
-            .get(path)
-            .ok_or_else(|| AmqpError::with_message("Unable to add authentication token"))?
-            .clone())
+
+        // Slow path: fetch the credential and perform the CBS attach *without*
+        // holding the scope cache lock. Holding it across `perform_authorization`
+        // would block `clear()` (called from `recover_from_error`) for as long as
+        // the CBS attach is in flight; if that CBS attach is itself the operation
+        // that triggers recovery, the result is a self-deadlock. Matches the
+        // pattern used by `ensure_sender` / `ensure_receiver` / `get_session` in
+        // `RecoverableConnection`.
+        debug!("Creating new authorization scope for path: {path}");
+
+        debug!("Get Token.");
+        let token = self
+            .credential
+            .get_token(&[EVENTHUBS_AUTHORIZATION_SCOPE], None)
+            .await
+            .map_err(AmqpError::from)?;
+
+        debug!("Token for path {path} expires at {}", token.expires_on);
+
+        self.perform_authorization(connection, path, &token).await?;
+        debug!("Token verified.");
+
+        // Insert; if another task won the race, return its cached token and drop
+        // ours. Both CBS auths succeeded against the same link, so either
+        // credential is acceptable to the broker.
+        let stored = {
+            let mut scopes = self.authorization_scopes.lock().await;
+            scopes.entry(path.clone()).or_insert(token).clone()
+        };
+
+        self.authorization_refresher.get_or_init(|| {
+            debug!("Starting authorization refresh task.");
+            let self_clone = self.clone();
+            let async_runtime = get_async_runtime();
+            async_runtime.spawn(Box::pin(self_clone.refresh_tokens_task()))
+        });
+
+        Ok(stored)
     }
 
     /// Actually perform an authorization against the Event Hubs service.
@@ -662,5 +668,98 @@ mod tests {
         info!("Second token expiration get count: {}", final_count);
 
         Ok(())
+    }
+
+    // Regression test for the self-deadlock described in
+    // https://github.com/Azure/azure-sdk-for-rust/issues/4414.
+    //
+    // Before the fix, `authorize_path` held the `authorization_scopes` async
+    // mutex across `credential.get_token().await` and the CBS attach. If the
+    // in-flight CBS call failed and triggered `recover_from_error`, recovery
+    // would call `authorizer.clear().await`, which tries to acquire the same
+    // mutex; that call blocked forever because the task holding the mutex was
+    // suspended inside the call that needed recovery.
+    //
+    // This test reproduces the lock-during-IO shape with a credential whose
+    // `get_token` blocks until released. We spawn `authorize_path` and, once
+    // it has entered the slow path, race a `clear()` against it. With the
+    // bug, `clear()` would never return; with the fix, it returns promptly
+    // because the slow path runs lock-free.
+    #[tokio::test]
+    async fn authorize_path_does_not_block_clear() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use tokio::sync::Notify;
+
+        #[derive(Debug)]
+        struct GatedCredential {
+            entered: AtomicBool,
+            release: Notify,
+        }
+
+        #[async_trait::async_trait]
+        impl TokenCredential for GatedCredential {
+            async fn get_token(
+                &self,
+                _scopes: &[&str],
+                _options: Option<TokenRequestOptions<'_>>,
+            ) -> azure_core::Result<AccessToken> {
+                self.entered.store(true, Ordering::SeqCst);
+                self.release.notified().await;
+                Ok(AccessToken::new(
+                    azure_core::credentials::Secret::new("mock_token"),
+                    OffsetDateTime::now_utc() + Duration::seconds(60),
+                ))
+            }
+        }
+
+        let credential = Arc::new(GatedCredential {
+            entered: AtomicBool::new(false),
+            release: Notify::new(),
+        });
+
+        let url = Url::parse("amqps://example.com").unwrap();
+        let connection = RecoverableConnection::new(
+            url.clone(),
+            None,
+            None,
+            credential.clone(),
+            Default::default(),
+        );
+
+        let authorizer = Arc::new(Authorizer::new(
+            Arc::downgrade(&connection),
+            credential.clone(),
+        ));
+        authorizer.disable_authorization().unwrap();
+        connection.disable_connection().await.unwrap();
+
+        let path = Url::parse("amqps://example.com/test").unwrap();
+
+        let auth_task = {
+            let authorizer = authorizer.clone();
+            let connection = connection.clone();
+            let path = path.clone();
+            tokio::spawn(async move { authorizer.authorize_path(&connection, &path).await })
+        };
+
+        // Wait for the spawned task to enter the credential's gated `get_token`.
+        // At this point the bug would have it holding the authorization_scopes
+        // mutex; the fix has already released it.
+        while !credential.entered.load(Ordering::SeqCst) {
+            tokio::task::yield_now().await;
+        }
+
+        // `clear()` must not block on the in-flight authorization. A 2s budget
+        // is generous; the operation should complete in microseconds.
+        tokio::time::timeout(std::time::Duration::from_secs(2), authorizer.clear())
+            .await
+            .expect("authorizer.clear() blocked while authorize_path was mid-IO");
+
+        // Let the in-flight authorization complete and verify it returns.
+        credential.release.notify_one();
+        auth_task
+            .await
+            .expect("authorize_path task panicked")
+            .expect("authorize_path returned an error");
     }
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 use crate::{common::recoverable::RecoverableConnection, error::Result};
-use async_lock::Mutex as AsyncMutex;
+use async_lock::RwLock;
 use azure_core::{
     async_runtime::{get_async_runtime, SpawnedTask},
     credentials::{AccessToken, TokenCredential},
@@ -42,7 +42,7 @@ impl Default for TokenRefreshTimes {
 }
 
 pub(crate) struct Authorizer {
-    authorization_scopes: AsyncMutex<HashMap<Url, AccessToken>>,
+    authorization_scopes: RwLock<HashMap<Url, AccessToken>>,
     authorization_refresher: OnceLock<SpawnedTask>,
     /// Bias to apply to token refresh time. This determines how much time we will refresh the token before it expires.
     token_refresh_bias: SyncMutex<TokenRefreshTimes>,
@@ -63,7 +63,7 @@ impl Authorizer {
     ) -> Self {
         Self {
             authorization_refresher: OnceLock::new(),
-            authorization_scopes: AsyncMutex::new(HashMap::new()),
+            authorization_scopes: RwLock::new(HashMap::new()),
             token_refresh_bias: SyncMutex::new(TokenRefreshTimes::default()),
             credential,
             recoverable_connection,
@@ -74,7 +74,7 @@ impl Authorizer {
 
     pub(crate) async fn clear(&self) {
         debug!("Clearing authorization scopes.");
-        let mut scopes = self.authorization_scopes.lock().await;
+        let mut scopes = self.authorization_scopes.write().await;
         scopes.clear();
     }
 
@@ -98,7 +98,7 @@ impl Authorizer {
         debug!("Authorizing path: {path}");
 
         // Fast path: cached token under a brief lock.
-        if let Some(token) = self.authorization_scopes.lock().await.get(path).cloned() {
+        if let Some(token) = self.authorization_scopes.read().await.get(path).cloned() {
             debug!("Token already exists for path: {path}");
             return Ok(token);
         }
@@ -128,7 +128,7 @@ impl Authorizer {
         // ours. Both CBS auths succeeded against the same link, so either
         // credential is acceptable to the broker.
         let stored = {
-            let mut scopes = self.authorization_scopes.lock().await;
+            let mut scopes = self.authorization_scopes.write().await;
             scopes.entry(path.clone()).or_insert(token).clone()
         };
 
@@ -215,7 +215,7 @@ impl Authorizer {
         loop {
             let mut expiration_times = vec![];
             {
-                let scopes = self.authorization_scopes.lock().await;
+                let scopes = self.authorization_scopes.read().await;
                 for (path, token) in scopes.iter() {
                     debug!(
                         "Token expiration time for path {}: {}",
@@ -299,7 +299,7 @@ impl Authorizer {
             // Refresh the tokens.
             // First, collect the tokens that need refreshing while holding the lock briefly
             let tokens_to_refresh = {
-                let scopes = self.authorization_scopes.lock().await;
+                let scopes = self.authorization_scopes.read().await;
                 let mut to_refresh = Vec::new();
                 for (url, token) in scopes.iter() {
                     if token.expires_on >= now + (token_refresh_bias) {
@@ -343,7 +343,7 @@ impl Authorizer {
 
             // Finally, update the scopes map with the new tokens
             if !updated_tokens.is_empty() {
-                let mut scopes = self.authorization_scopes.lock().await;
+                let mut scopes = self.authorization_scopes.write().await;
                 for (url, token) in updated_tokens.into_iter() {
                     scopes.insert(url.clone(), token);
                 }
@@ -478,7 +478,7 @@ mod tests {
         assert!(result.is_ok());
 
         // Verify token is stored
-        let scopes = authorizer.authorization_scopes.lock().await;
+        let scopes = authorizer.authorization_scopes.read().await;
         assert!(scopes.contains_key(&path));
 
         // Verify expiration time

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -1074,9 +1074,9 @@ mod tests {
 
         // Test DetachError -> ReconnectLink. The link's detach handshake failed;
         // reattach is required to make any further use of it.
-        let err = AmqpError::from(AmqpErrorKind::DetachError(Box::new(
-            std::io::Error::other("detach error"),
-        )));
+        let err = AmqpError::from(AmqpErrorKind::DetachError(Box::new(std::io::Error::other(
+            "detach error",
+        ))));
         assert_eq!(
             RecoverableConnection::should_retry_amqp_error(&err),
             ErrorRecoveryAction::ReconnectLink

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -762,8 +762,7 @@ impl RecoverableConnection {
                     ErrorRecoveryAction::RetryAction
                 } else if matches!(
                     described_error.condition,
-                    AmqpErrorCondition::UnauthorizedAccess
-                        | AmqpErrorCondition::ConnectionForced
+                    AmqpErrorCondition::ConnectionForced
                         | AmqpErrorCondition::ConnectionFramingError
                 ) {
                     debug!(
@@ -771,6 +770,23 @@ impl RecoverableConnection {
                         described_error
                     );
                     ErrorRecoveryAction::ReconnectConnection
+                } else if matches!(
+                    described_error.condition,
+                    AmqpErrorCondition::UnauthorizedAccess
+                ) {
+                    // Fail fast on auth failures, matching the .NET and Java Event Hubs
+                    // SDKs, which both classify `amqp:unauthorized-access` as non-transient
+                    // / non-retriable. A runtime unauthorized-access almost always means a
+                    // bad or revoked credential or missing RBAC, not a momentarily expired
+                    // token; keeping tokens fresh is the CBS refresher's job (proactive
+                    // pre-expiry renewal), not something to recover by reconnecting on a 401.
+                    // Routing this to ReconnectConnection would turn a fast failure into N
+                    // full reconnect + re-auth cycles before the error finally surfaces.
+                    debug!(
+                        "AMQP described error is an auth failure; not retrying: {:?}",
+                        described_error
+                    );
+                    ErrorRecoveryAction::ReturnError
                 } else if matches!(
                     described_error.condition,
                     AmqpErrorCondition::LinkStolen | AmqpErrorCondition::LinkDetachForced
@@ -812,16 +828,46 @@ impl RecoverableConnection {
     /// `LinkStolen` so a displaced receiver surfaces the steal instead of
     /// silently re-attaching. .NET parallel: `InvalidateConsumerWhenPartitionIsStolen`.
     pub(super) fn should_retry_receive_error(amqp_error: &AmqpError) -> ErrorRecoveryAction {
-        if let AmqpErrorKind::AmqpDescribedError(described_error) = amqp_error.kind() {
-            if matches!(described_error.condition, AmqpErrorCondition::LinkStolen) {
-                debug!(
-                    "Receive operation will not retry link-stolen: {:?}",
-                    described_error
-                );
-                return ErrorRecoveryAction::ReturnError;
-            }
+        // A `LinkStolen` means the partition was claimed by another consumer; reattaching
+        // would silently resurrect a displaced receiver, so surface it instead. The
+        // condition can arrive at the top level or wrapped through `azure_core::Error` (the
+        // same wrapping `classify_azure_core_chain` unwraps), and the chain walk would
+        // otherwise reclassify a wrapped `LinkStolen` to `ReconnectLink`, defeating this
+        // guard. So check the whole source chain, not just the top-level kind.
+        if Self::is_link_stolen(amqp_error) {
+            debug!("Receive operation will not retry link-stolen: {amqp_error}");
+            return ErrorRecoveryAction::ReturnError;
         }
         Self::should_retry_amqp_error(amqp_error)
+    }
+
+    /// Returns true if `amqp_error` is, or wraps via its [`std::error::Error::source`]
+    /// chain, an [`AmqpErrorKind::AmqpDescribedError`] whose condition is `LinkStolen`.
+    /// Mirrors the bounded walk in [`Self::classify_azure_core_chain`].
+    fn is_link_stolen(amqp_error: &AmqpError) -> bool {
+        use std::error::Error as _;
+        const MAX_DEPTH: usize = 16;
+        fn is_stolen(e: &AmqpError) -> bool {
+            matches!(
+                e.kind(),
+                AmqpErrorKind::AmqpDescribedError(d)
+                    if matches!(d.condition, AmqpErrorCondition::LinkStolen)
+            )
+        }
+        if is_stolen(amqp_error) {
+            return true;
+        }
+        let mut cause: Option<&(dyn std::error::Error + 'static)> = amqp_error.source();
+        for _ in 0..MAX_DEPTH {
+            let Some(c) = cause else { break };
+            if let Some(amqp) = c.downcast_ref::<AmqpError>() {
+                if is_stolen(amqp) {
+                    return true;
+                }
+            }
+            cause = c.source();
+        }
+        false
     }
 
     /// Walks the [`std::error::Error::source`] chain looking for a wrapped [`AmqpError`]
@@ -1026,7 +1072,9 @@ mod tests {
             ErrorRecoveryAction::ReconnectConnection
         );
 
-        // Test UnauthorizedAccess -> ReconnectConnection
+        // Test UnauthorizedAccess -> ReturnError. Auth failures are non-transient
+        // (matches the .NET / Java SDKs); reconnecting on a 401 would only burn the
+        // retry budget against a bad credential before the error surfaces.
         let err = AmqpError::from(AmqpErrorKind::AmqpDescribedError(AmqpDescribedError::new(
             AmqpErrorCondition::UnauthorizedAccess,
             None,
@@ -1034,7 +1082,7 @@ mod tests {
         )));
         assert_eq!(
             RecoverableConnection::should_retry_amqp_error(&err),
-            ErrorRecoveryAction::ReconnectConnection
+            ErrorRecoveryAction::ReturnError
         );
 
         // Test EntityDisabledError -> RetryAction (matched by the first arm of the
@@ -1104,6 +1152,42 @@ mod tests {
         assert_eq!(
             RecoverableConnection::should_retry_amqp_error(&err),
             ErrorRecoveryAction::ReconnectLink
+        );
+    }
+
+    #[test]
+    fn receive_error_link_stolen_returns_error_top_level_and_wrapped() {
+        use azure_core::error::ErrorKind as AzureErrorKind;
+        use azure_core_amqp::AmqpDescribedError;
+
+        // Top-level LinkStolen must surface as ReturnError so the stolen partition is
+        // reported, not silently reattached (.NET: InvalidateConsumerWhenPartitionIsStolen).
+        let top = AmqpError::from(AmqpErrorKind::AmqpDescribedError(AmqpDescribedError::new(
+            AmqpErrorCondition::LinkStolen,
+            None,
+            Default::default(),
+        )));
+        assert_eq!(
+            RecoverableConnection::should_retry_receive_error(&top),
+            ErrorRecoveryAction::ReturnError
+        );
+
+        // LinkStolen wrapped through azure_core::Error (as the ensure_* wrappers produce)
+        // would slip past a top-level-only guard and be reclassified to ReconnectLink by
+        // the source-chain walk, resurrecting a stolen receiver. It must still ReturnError.
+        let inner = AmqpError::from(AmqpErrorKind::AmqpDescribedError(AmqpDescribedError::new(
+            AmqpErrorCondition::LinkStolen,
+            None,
+            Default::default(),
+        )));
+        let wrapped = AmqpError::from(azure_core::Error::with_error(
+            AzureErrorKind::Other,
+            inner,
+            "ensure_receiver failed",
+        ));
+        assert_eq!(
+            RecoverableConnection::should_retry_receive_error(&wrapped),
+            ErrorRecoveryAction::ReturnError
         );
     }
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -782,6 +782,16 @@ impl RecoverableConnection {
                     ErrorRecoveryAction::ReturnError
                 }
             }
+            AmqpErrorKind::AzureCore(_) => {
+                // The ensure_* callsites in the per-operation wrappers (sender, CBS,
+                // management) re-wrap inner AmqpError values through
+                // `azure_core::Error::with_error`, producing
+                // `AzureCore(azure_core::Error { source: original AmqpError })`.
+                // If we don't walk the source chain we'd classify those as
+                // ReturnError and lose the ability to recover transport-level failures
+                // that round-trip through this wrapping pattern.
+                Self::classify_azure_core_chain(amqp_error)
+            }
             _ => {
                 debug!(err=?amqp_error, "Other AMQP error: {amqp_error}");
                 ErrorRecoveryAction::ReturnError
@@ -803,6 +813,35 @@ impl RecoverableConnection {
             }
         }
         Self::should_retry_amqp_error(amqp_error)
+    }
+
+    /// Walks the [`std::error::Error::source`] chain looking for a wrapped [`AmqpError`]
+    /// whose kind is something other than [`AmqpErrorKind::AzureCore`], and classifies
+    /// that. Falls back to `ReturnError` if no recoverable inner kind is found.
+    ///
+    /// A bounded loop guards against pathological self-referential chains.
+    fn classify_azure_core_chain(amqp_error: &AmqpError) -> ErrorRecoveryAction {
+        use std::error::Error as _;
+        const MAX_DEPTH: usize = 16;
+        let mut cause: Option<&(dyn std::error::Error + 'static)> = amqp_error.source();
+        for _ in 0..MAX_DEPTH {
+            let Some(c) = cause else { break };
+            if let Some(amqp) = c.downcast_ref::<AmqpError>() {
+                if !matches!(amqp.kind(), AmqpErrorKind::AzureCore(_)) {
+                    debug!(
+                        err=?amqp_error,
+                        "Unwrapped AzureCore chain to inner AmqpError: {amqp}"
+                    );
+                    return Self::should_retry_amqp_error(amqp);
+                }
+            }
+            cause = c.source();
+        }
+        debug!(
+            err=?amqp_error,
+            "AzureCore-wrapped error with no recoverable inner kind: {amqp_error}"
+        );
+        ErrorRecoveryAction::ReturnError
     }
 }
 
@@ -1056,6 +1095,79 @@ mod tests {
         assert_eq!(
             RecoverableConnection::should_retry_amqp_error(&err),
             ErrorRecoveryAction::ReconnectLink
+        );
+    }
+
+    #[test]
+    fn azure_core_wrapped_errors_unwrap_to_inner_kind() {
+        // The per-operation wrappers in sender.rs / claims_based_security.rs /
+        // management.rs all wrap an inner AmqpError via
+        // `AmqpError::from(azure_core::Error::with_error(AzureErrorKind::Other, e, "..."))`.
+        // Before this test we'd classify the outer error as ReturnError via the
+        // catch-all, silently turning a recoverable transport failure into a
+        // non-retriable one. should_retry_amqp_error must walk the source chain
+        // and honour the inner kind's classification.
+        use azure_core::error::ErrorKind as AzureErrorKind;
+
+        // AzureCore(... ConnectionDropped ...) -> ReconnectConnection
+        let inner = AmqpError::from(AmqpErrorKind::ConnectionDropped(Box::new(
+            std::io::Error::new(std::io::ErrorKind::ConnectionAborted, "dropped"),
+        )));
+        let wrapped = AmqpError::from(azure_core::Error::with_error(
+            AzureErrorKind::Other,
+            inner,
+            "ensure_sender failed",
+        ));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&wrapped),
+            ErrorRecoveryAction::ReconnectConnection
+        );
+
+        // AzureCore(... LinkClosedByRemote ...) -> ReconnectLink
+        let inner = AmqpError::from(AmqpErrorKind::LinkClosedByRemote(Box::new(
+            std::io::Error::other("link closed"),
+        )));
+        let wrapped = AmqpError::from(azure_core::Error::with_error(
+            AzureErrorKind::Other,
+            inner,
+            "ensure_amqp_cbs failed",
+        ));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&wrapped),
+            ErrorRecoveryAction::ReconnectLink
+        );
+
+        // Nested wrapping: AzureCore(... AzureCore(... ConnectionDropped ...) ...).
+        // The recovery path can re-wrap (e.g. ensure_connection inside
+        // ensure_management_client). The chain walk must keep descending.
+        let innermost = AmqpError::from(AmqpErrorKind::ConnectionDropped(Box::new(
+            std::io::Error::new(std::io::ErrorKind::ConnectionAborted, "dropped"),
+        )));
+        let mid = AmqpError::from(azure_core::Error::with_error(
+            AzureErrorKind::Other,
+            innermost,
+            "ensure_connection failed",
+        ));
+        let outer = AmqpError::from(azure_core::Error::with_error(
+            AzureErrorKind::Other,
+            mid,
+            "create_management_client failed",
+        ));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&outer),
+            ErrorRecoveryAction::ReconnectConnection
+        );
+
+        // AzureCore wrapping something that isn't an AmqpError -> ReturnError.
+        // (No recoverable inner kind to honour; preserve the catch-all default.)
+        let wrapped = AmqpError::from(azure_core::Error::with_error(
+            AzureErrorKind::Other,
+            std::io::Error::other("non-AMQP failure"),
+            "unrelated error path",
+        ));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&wrapped),
+            ErrorRecoveryAction::ReturnError
         );
     }
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -776,7 +776,7 @@ impl RecoverableConnection {
                 ) {
                     // Fail fast on auth failures, matching the .NET and Java Event Hubs
                     // SDKs, which both classify `amqp:unauthorized-access` as non-transient
-                    // / non-retriable. A runtime unauthorized-access almost always means a
+                    // / non-retryable. A runtime unauthorized-access almost always means a
                     // bad or revoked credential or missing RBAC, not a momentarily expired
                     // token; keeping tokens fresh is the CBS refresher's job (proactive
                     // pre-expiry renewal), not something to recover by reconnecting on a 401.

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -697,7 +697,10 @@ impl RecoverableConnection {
     ///
     /// Connection-level transport failures (dropped, framing, idle timeout) require a
     /// full reconnect. Link/session-level failures only require reattach. Described
-    /// errors are bucketed by their `AmqpErrorCondition`. Anything not recognised falls
+    /// errors are bucketed by their `AmqpErrorCondition`. `TransportImplementationError`
+    /// is intentionally left to fall through to `ReturnError`: it covers errors local
+    /// to the AMQP backend with no defined recovery semantics, and blind retries risk
+    /// hammering a deterministic bug. Anything else not recognised likewise falls
     /// through to `ReturnError`.
     pub(super) fn should_retry_amqp_error(amqp_error: &AmqpError) -> ErrorRecoveryAction {
         match amqp_error.kind() {
@@ -734,7 +737,11 @@ impl RecoverableConnection {
             AmqpErrorKind::LinkClosedByRemote(_)
             | AmqpErrorKind::LinkDetachedByRemote(_)
             | AmqpErrorKind::LinkStateError(_)
-            | AmqpErrorKind::DetachError(_) => {
+            | AmqpErrorKind::DetachError(_)
+            | AmqpErrorKind::TransferLimitExceeded(_) => {
+                // TransferLimitExceeded means more transfers were sent than the
+                // link's credit allowed. Reattaching resets link credit; a full
+                // session/connection reconnect is unnecessary.
                 debug!("Link state error: {}", amqp_error);
                 ErrorRecoveryAction::ReconnectLink
             }
@@ -748,6 +755,8 @@ impl RecoverableConnection {
                         | AmqpErrorCondition::EntityUpdated
                         | AmqpErrorCondition::EntityDisabledError
                         | AmqpErrorCondition::TimeoutError
+                        | AmqpErrorCondition::InternalError
+                        | AmqpErrorCondition::OperationCancelled
                 ) {
                     debug!("AMQP described error can be retried: {:?}", described_error);
                     ErrorRecoveryAction::RetryAction
@@ -1168,6 +1177,50 @@ mod tests {
         assert_eq!(
             RecoverableConnection::should_retry_amqp_error(&wrapped),
             ErrorRecoveryAction::ReturnError
+        );
+    }
+
+    #[test]
+    fn transfer_limit_exceeded_reattaches_link() {
+        // amqp:link:transfer-limit-exceeded: peer sent more transfers than the
+        // link's credit allowed. Reattaching resets link credit; ReturnError
+        // would have surfaced a recoverable condition to the caller.
+        let err = AmqpError::from(AmqpErrorKind::TransferLimitExceeded(Box::new(
+            std::io::Error::other("transfer limit exceeded"),
+        )));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&err),
+            ErrorRecoveryAction::ReconnectLink
+        );
+    }
+
+    #[test]
+    fn internal_error_and_operation_cancelled_are_retried() {
+        use azure_core_amqp::AmqpDescribedError;
+
+        // amqp:internal-error is conventionally transient (consistent with the
+        // .NET / Java Service Bus + Event Hubs SDKs). The link and connection
+        // are unaffected.
+        let err = AmqpError::from(AmqpErrorKind::AmqpDescribedError(AmqpDescribedError::new(
+            AmqpErrorCondition::InternalError,
+            None,
+            Default::default(),
+        )));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&err),
+            ErrorRecoveryAction::RetryAction
+        );
+
+        // com.microsoft:operation-cancelled: service-side cancel of a single
+        // operation. The link is alive, the op can be retried.
+        let err = AmqpError::from(AmqpErrorKind::AmqpDescribedError(AmqpDescribedError::new(
+            AmqpErrorCondition::OperationCancelled,
+            None,
+            Default::default(),
+        )));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&err),
+            ErrorRecoveryAction::RetryAction
         );
     }
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -116,6 +116,57 @@ async fn or_init_cell<T>(
         .clone()
 }
 
+/// Describes which per-connection caches an [`ErrorRecoveryAction`] must invalidate.
+///
+/// Splitting "which caches" from "actually clearing them" lets the cache-clearing happen
+/// inside async lock acquisitions while the policy stays a pure value that's easy to
+/// unit-test for regressions (e.g. forgetting to drop the management client when the
+/// entire connection is being reset).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RecoveryPlan {
+    drop_connection: bool,
+    clear_authorizer: bool,
+    clear_sessions: bool,
+    clear_senders: bool,
+    clear_receivers: bool,
+    drop_mgmt_client: bool,
+}
+
+impl RecoveryPlan {
+    /// Returns the recovery plan for an action, or `None` if the action does not
+    /// require any cache invalidation (i.e. `RetryAction` / `ReturnError`, which
+    /// should never reach `recover_from_error`).
+    fn for_action(action: &ErrorRecoveryAction) -> Option<Self> {
+        match action {
+            ErrorRecoveryAction::ReconnectConnection => Some(Self {
+                drop_connection: true,
+                clear_authorizer: true,
+                clear_sessions: true,
+                clear_senders: true,
+                clear_receivers: true,
+                drop_mgmt_client: false,
+            }),
+            ErrorRecoveryAction::ReconnectSession => Some(Self {
+                drop_connection: false,
+                clear_authorizer: false,
+                clear_sessions: true,
+                clear_senders: true,
+                clear_receivers: true,
+                drop_mgmt_client: false,
+            }),
+            ErrorRecoveryAction::ReconnectLink => Some(Self {
+                drop_connection: false,
+                clear_authorizer: false,
+                clear_sessions: true,
+                clear_senders: true,
+                clear_receivers: true,
+                drop_mgmt_client: true,
+            }),
+            ErrorRecoveryAction::RetryAction | ErrorRecoveryAction::ReturnError => None,
+        }
+    }
+}
+
 impl RecoverableConnection {
     pub fn new(
         url: Url,
@@ -597,7 +648,6 @@ impl RecoverableConnection {
         connection: Weak<RecoverableConnection>,
         reason: ErrorRecoveryAction,
     ) -> azure_core_amqp::error::Result<()> {
-        // If the connection is None, we cannot recover.
         let Some(connection) = connection.upgrade() else {
             warn!(
                 "Connection is None, cannot recover from error: {:?}",
@@ -606,42 +656,39 @@ impl RecoverableConnection {
             return Err(AmqpError::with_message("Missing Connection"));
         };
 
-        // Log the error and attempt to recover.
         warn!(err=?reason, "Recovering from error: {:?}", reason);
-        // Upgrade the weak reference to a strong reference.
-        match reason {
-            ErrorRecoveryAction::ReconnectConnection => {
-                debug!("Recovering from connection error: {:?}", reason);
-                connection.connections.lock().await.take();
-                connection.authorizer.clear().await;
-                connection.session_instances.write().await.clear();
-                connection.sender_instances.write().await.clear();
-                connection.receiver_instances.write().await.clear();
-            }
-            ErrorRecoveryAction::ReconnectSession => {
-                debug!("Recovering from session error: {:?}", reason);
-                // Recreate the session and sender/receiver as needed.
-                connection.session_instances.write().await.clear();
-                connection.sender_instances.write().await.clear();
-                connection.receiver_instances.write().await.clear();
-            }
-            ErrorRecoveryAction::ReconnectLink => {
-                debug!("Recovering from link error: {:?}", reason);
-                // Recreate the session and sender/receiver as needed.
-                connection.session_instances.write().await.clear();
-                connection.sender_instances.write().await.clear();
-                connection.receiver_instances.write().await.clear();
-                connection.mgmt_client.lock().await.take();
-            }
-            _ => {
-                warn!("Recover action {reason:?} should already have been handled.");
-                return Err(AmqpError::with_message(format!(
-                    "Unknown error recovery action: {reason:?}"
-                )));
-            }
-        }
 
+        let Some(plan) = RecoveryPlan::for_action(&reason) else {
+            warn!("Recover action {reason:?} should already have been handled.");
+            return Err(AmqpError::with_message(format!(
+                "Unknown error recovery action: {reason:?}"
+            )));
+        };
+
+        debug!("Applying recovery plan {plan:?} for {reason:?}");
+        connection.apply_recovery_plan(plan).await;
         Ok(())
+    }
+
+    async fn apply_recovery_plan(&self, plan: RecoveryPlan) {
+        if plan.drop_connection {
+            self.connections.lock().await.take();
+        }
+        if plan.clear_authorizer {
+            self.authorizer.clear().await;
+        }
+        if plan.clear_sessions {
+            self.session_instances.write().await.clear();
+        }
+        if plan.clear_senders {
+            self.sender_instances.write().await.clear();
+        }
+        if plan.clear_receivers {
+            self.receiver_instances.write().await.clear();
+        }
+        if plan.drop_mgmt_client {
+            self.mgmt_client.lock().await.take();
+        }
     }
 
     pub(super) fn should_retry_amqp_error(amqp_error: &AmqpError) -> ErrorRecoveryAction {
@@ -705,15 +752,6 @@ impl RecoverableConnection {
                         described_error
                     );
                     ErrorRecoveryAction::ReconnectConnection
-                } else if matches!(
-                    described_error.condition,
-                    AmqpErrorCondition::EntityDisabledError
-                ) {
-                    debug!(
-                        "AMQP described error triggers a disconnect: {:?}",
-                        described_error
-                    );
-                    ErrorRecoveryAction::RetryAction
                 } else {
                     debug!(
                         "AMQP described error cannot be retried: {:?}",
@@ -928,5 +966,48 @@ mod tests {
             RecoverableConnection::should_retry_amqp_error(&err),
             ErrorRecoveryAction::ReconnectConnection
         );
+
+        // Test EntityDisabledError -> RetryAction (matched by the first arm of the
+        // described-error branch; a removed-but-unreachable elif previously also
+        // listed it).
+        let err = AmqpError::from(AmqpErrorKind::AmqpDescribedError(AmqpDescribedError::new(
+            AmqpErrorCondition::EntityDisabledError,
+            None,
+            Default::default(),
+        )));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&err),
+            ErrorRecoveryAction::RetryAction
+        );
+    }
+
+    #[test]
+    fn recovery_plan_reconnect_link_drops_mgmt_client_but_keeps_connection() {
+        let plan = RecoveryPlan::for_action(&ErrorRecoveryAction::ReconnectLink)
+            .expect("ReconnectLink has a recovery plan");
+        assert!(!plan.drop_connection);
+        assert!(!plan.clear_authorizer);
+        assert!(plan.clear_sessions);
+        assert!(plan.clear_senders);
+        assert!(plan.clear_receivers);
+        assert!(plan.drop_mgmt_client);
+    }
+
+    #[test]
+    fn recovery_plan_reconnect_session_keeps_mgmt_client_and_connection() {
+        let plan = RecoveryPlan::for_action(&ErrorRecoveryAction::ReconnectSession)
+            .expect("ReconnectSession has a recovery plan");
+        assert!(!plan.drop_connection);
+        assert!(!plan.clear_authorizer);
+        assert!(plan.clear_sessions);
+        assert!(plan.clear_senders);
+        assert!(plan.clear_receivers);
+        assert!(!plan.drop_mgmt_client);
+    }
+
+    #[test]
+    fn recovery_plan_none_for_non_reconnect_actions() {
+        assert!(RecoveryPlan::for_action(&ErrorRecoveryAction::RetryAction).is_none());
+        assert!(RecoveryPlan::for_action(&ErrorRecoveryAction::ReturnError).is_none());
     }
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -713,7 +713,9 @@ impl RecoverableConnection {
             }
             AmqpErrorKind::ConnectionClosedByRemote(_)
             | AmqpErrorKind::ConnectionDetachedByRemote(_)
-            | AmqpErrorKind::ConnectionDropped(_) => {
+            | AmqpErrorKind::ConnectionDropped(_)
+            | AmqpErrorKind::FramingError(_)
+            | AmqpErrorKind::IdleTimeoutElapsed(_) => {
                 debug!("Connection dropped error: {}", amqp_error);
                 ErrorRecoveryAction::ReconnectConnection
             }
@@ -723,7 +725,8 @@ impl RecoverableConnection {
             }
             AmqpErrorKind::LinkClosedByRemote(_)
             | AmqpErrorKind::LinkDetachedByRemote(_)
-            | AmqpErrorKind::LinkStateError(_) => {
+            | AmqpErrorKind::LinkStateError(_)
+            | AmqpErrorKind::DetachError(_) => {
                 debug!("Link state error: {}", amqp_error);
                 ErrorRecoveryAction::ReconnectLink
             }
@@ -733,7 +736,6 @@ impl RecoverableConnection {
                 if matches!(
                     described_error.condition,
                     AmqpErrorCondition::ResourceLimitExceeded
-                        | AmqpErrorCondition::LinkStolen
                         | AmqpErrorCondition::ServerBusyError
                         | AmqpErrorCondition::EntityUpdated
                         | AmqpErrorCondition::EntityDisabledError
@@ -752,6 +754,18 @@ impl RecoverableConnection {
                         described_error
                     );
                     ErrorRecoveryAction::ReconnectConnection
+                } else if matches!(
+                    described_error.condition,
+                    AmqpErrorCondition::LinkStolen | AmqpErrorCondition::LinkDetachForced
+                ) {
+                    // The link is gone; retrying the same operation against it will keep
+                    // failing. Reattach. (LinkStolen was previously classified as a retry,
+                    // which guaranteed N spins through the backoff before bailing.)
+                    debug!(
+                        "AMQP described error requires link reattach: {:?}",
+                        described_error
+                    );
+                    ErrorRecoveryAction::ReconnectLink
                 } else {
                     debug!(
                         "AMQP described error cannot be retried: {:?}",
@@ -978,6 +992,62 @@ mod tests {
         assert_eq!(
             RecoverableConnection::should_retry_amqp_error(&err),
             ErrorRecoveryAction::RetryAction
+        );
+
+        // Test IdleTimeoutElapsed -> ReconnectConnection. Idle-timeout means the peer
+        // hasn't sent a frame inside the negotiated heartbeat window, so the transport
+        // is effectively dead.
+        let err = AmqpError::from(AmqpErrorKind::IdleTimeoutElapsed(Box::new(
+            std::io::Error::new(std::io::ErrorKind::TimedOut, "idle timeout"),
+        )));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&err),
+            ErrorRecoveryAction::ReconnectConnection
+        );
+
+        // Test FramingError -> ReconnectConnection. The wire protocol is corrupted;
+        // there is no recovery short of a fresh connection.
+        let err = AmqpError::from(AmqpErrorKind::FramingError(Box::new(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "framing error",
+        ))));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&err),
+            ErrorRecoveryAction::ReconnectConnection
+        );
+
+        // Test DetachError -> ReconnectLink. The link's detach handshake failed;
+        // reattach is required to make any further use of it.
+        let err = AmqpError::from(AmqpErrorKind::DetachError(Box::new(
+            std::io::Error::other("detach error"),
+        )));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&err),
+            ErrorRecoveryAction::ReconnectLink
+        );
+
+        // Test LinkStolen -> ReconnectLink. Behavior change: previously classified as
+        // RetryAction, which burned the entire backoff against a link that is gone.
+        let err = AmqpError::from(AmqpErrorKind::AmqpDescribedError(AmqpDescribedError::new(
+            AmqpErrorCondition::LinkStolen,
+            None,
+            Default::default(),
+        )));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&err),
+            ErrorRecoveryAction::ReconnectLink
+        );
+
+        // Test LinkDetachForced -> ReconnectLink. The peer force-detached the link;
+        // reattach is required.
+        let err = AmqpError::from(AmqpErrorKind::AmqpDescribedError(AmqpDescribedError::new(
+            AmqpErrorCondition::LinkDetachForced,
+            None,
+            Default::default(),
+        )));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&err),
+            ErrorRecoveryAction::ReconnectLink
         );
     }
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -679,6 +679,13 @@ impl RecoverableConnection {
         if plan.clear_authorizer {
             self.authorizer.clear().await;
         }
+        // Clearing a cache drops its per-path `OnceCell` entries, so the next
+        // `ensure_*` for a path re-inits a fresh cell against the new connection.
+        // A task already mid-`get_or_try_init` (or holding a value it just read)
+        // keeps using the old cell until it next re-enters `ensure_*`, so there's
+        // a brief window where stale, pre-recovery links can still be handed out.
+        // Closing that window (invalidating in-flight work immediately via a
+        // recovery generation counter) is tracked in #4454.
         if plan.clear_sessions {
             self.session_instances.write().await.clear();
         }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -144,7 +144,7 @@ impl RecoveryPlan {
                 clear_sessions: true,
                 clear_senders: true,
                 clear_receivers: true,
-                drop_mgmt_client: false,
+                drop_mgmt_client: true,
             }),
             ErrorRecoveryAction::ReconnectSession => Some(Self {
                 drop_connection: false,
@@ -979,6 +979,21 @@ mod tests {
             RecoverableConnection::should_retry_amqp_error(&err),
             ErrorRecoveryAction::RetryAction
         );
+    }
+
+    #[test]
+    fn recovery_plan_reconnect_connection_clears_everything() {
+        let plan = RecoveryPlan::for_action(&ErrorRecoveryAction::ReconnectConnection)
+            .expect("ReconnectConnection has a recovery plan");
+        // Regression guard: a full reconnect must drop the management client too,
+        // otherwise it would be left holding a session attached to the just-dropped
+        // connection and the next management call would fail and re-trigger recovery.
+        assert!(plan.drop_mgmt_client);
+        assert!(plan.drop_connection);
+        assert!(plan.clear_authorizer);
+        assert!(plan.clear_sessions);
+        assert!(plan.clear_senders);
+        assert!(plan.clear_receivers);
     }
 
     #[test]

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -665,7 +665,8 @@ impl RecoverableConnection {
                 }
             }
             AmqpErrorKind::ConnectionClosedByRemote(_)
-            | AmqpErrorKind::ConnectionDetachedByRemote(_) => {
+            | AmqpErrorKind::ConnectionDetachedByRemote(_)
+            | AmqpErrorKind::ConnectionDropped(_) => {
                 debug!("Connection dropped error: {}", amqp_error);
                 ErrorRecoveryAction::ReconnectConnection
             }
@@ -685,13 +686,33 @@ impl RecoverableConnection {
                 if matches!(
                     described_error.condition,
                     AmqpErrorCondition::ResourceLimitExceeded
-                        | AmqpErrorCondition::ConnectionFramingError
                         | AmqpErrorCondition::LinkStolen
                         | AmqpErrorCondition::ServerBusyError
                         | AmqpErrorCondition::EntityUpdated
                         | AmqpErrorCondition::EntityDisabledError
+                        | AmqpErrorCondition::TimeoutError
                 ) {
                     debug!("AMQP described error can be retried: {:?}", described_error);
+                    ErrorRecoveryAction::RetryAction
+                } else if matches!(
+                    described_error.condition,
+                    AmqpErrorCondition::UnauthorizedAccess
+                        | AmqpErrorCondition::ConnectionForced
+                        | AmqpErrorCondition::ConnectionFramingError
+                ) {
+                    debug!(
+                        "AMQP described error requires reconnect: {:?}",
+                        described_error
+                    );
+                    ErrorRecoveryAction::ReconnectConnection
+                } else if matches!(
+                    described_error.condition,
+                    AmqpErrorCondition::EntityDisabledError
+                ) {
+                    debug!(
+                        "AMQP described error triggers a disconnect: {:?}",
+                        described_error
+                    );
                     ErrorRecoveryAction::RetryAction
                 } else {
                     debug!(
@@ -860,5 +881,52 @@ mod tests {
         );
 
         assert_eq!(connection_manager.custom_endpoint, Some(custom_endpoint));
+    }
+
+    #[test]
+    fn test_should_retry_amqp_error() {
+        use azure_core_amqp::AmqpDescribedError;
+
+        // Test ConnectionDropped -> ReconnectConnection
+        let err = AmqpError::from(AmqpErrorKind::ConnectionDropped(Box::new(
+            std::io::Error::new(std::io::ErrorKind::ConnectionAborted, "dropped"),
+        )));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&err),
+            ErrorRecoveryAction::ReconnectConnection
+        );
+
+        // Test TimeoutError -> RetryAction
+        let err = AmqpError::from(AmqpErrorKind::AmqpDescribedError(AmqpDescribedError::new(
+            AmqpErrorCondition::TimeoutError,
+            None,
+            Default::default(),
+        )));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&err),
+            ErrorRecoveryAction::RetryAction
+        );
+
+        // Test ConnectionForced -> ReconnectConnection
+        let err = AmqpError::from(AmqpErrorKind::AmqpDescribedError(AmqpDescribedError::new(
+            AmqpErrorCondition::ConnectionForced,
+            None,
+            Default::default(),
+        )));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&err),
+            ErrorRecoveryAction::ReconnectConnection
+        );
+
+        // Test UnauthorizedAccess -> ReconnectConnection
+        let err = AmqpError::from(AmqpErrorKind::AmqpDescribedError(AmqpDescribedError::new(
+            AmqpErrorCondition::UnauthorizedAccess,
+            None,
+            Default::default(),
+        )));
+        assert_eq!(
+            RecoverableConnection::should_retry_amqp_error(&err),
+            ErrorRecoveryAction::ReconnectConnection
+        );
     }
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -670,6 +670,8 @@ impl RecoverableConnection {
         Ok(())
     }
 
+    /// Side-effecting half of `recover_from_error`: takes the locks and clears
+    /// whichever caches the [`RecoveryPlan`] flagged.
     async fn apply_recovery_plan(&self, plan: RecoveryPlan) {
         if plan.drop_connection {
             self.connections.lock().await.take();
@@ -691,6 +693,12 @@ impl RecoverableConnection {
         }
     }
 
+    /// Classifies an [`AmqpError`] into the recovery action the retry loop should take.
+    ///
+    /// Connection-level transport failures (dropped, framing, idle timeout) require a
+    /// full reconnect. Link/session-level failures only require reattach. Described
+    /// errors are bucketed by their `AmqpErrorCondition`. Anything not recognised falls
+    /// through to `ReturnError`.
     pub(super) fn should_retry_amqp_error(amqp_error: &AmqpError) -> ErrorRecoveryAction {
         match amqp_error.kind() {
             AmqpErrorKind::ManagementStatusCode(code, _) => {

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -700,7 +700,7 @@ impl RecoverableConnection {
     /// errors are bucketed by their `AmqpErrorCondition`. `TransportImplementationError`
     /// is intentionally left to fall through to `ReturnError`: it covers errors local
     /// to the AMQP backend with no defined recovery semantics, and blind retries risk
-    /// hammering a deterministic bug. Anything else not recognised likewise falls
+    /// hammering a deterministic bug. Anything else not recognized likewise falls
     /// through to `ReturnError`.
     pub(super) fn should_retry_amqp_error(amqp_error: &AmqpError) -> ErrorRecoveryAction {
         match amqp_error.kind() {
@@ -1114,8 +1114,8 @@ mod tests {
         // `AmqpError::from(azure_core::Error::with_error(AzureErrorKind::Other, e, "..."))`.
         // Before this test we'd classify the outer error as ReturnError via the
         // catch-all, silently turning a recoverable transport failure into a
-        // non-retriable one. should_retry_amqp_error must walk the source chain
-        // and honour the inner kind's classification.
+        // non-retryable one. should_retry_amqp_error must walk the source chain
+        // and honor the inner kind's classification.
         use azure_core::error::ErrorKind as AzureErrorKind;
 
         // AzureCore(... ConnectionDropped ...) -> ReconnectConnection
@@ -1168,7 +1168,7 @@ mod tests {
         );
 
         // AzureCore wrapping something that isn't an AmqpError -> ReturnError.
-        // (No recoverable inner kind to honour; preserve the catch-all default.)
+        // (No recoverable inner kind to honor; preserve the catch-all default.)
         let wrapped = AmqpError::from(azure_core::Error::with_error(
             AzureErrorKind::Other,
             std::io::Error::other("non-AMQP failure"),


### PR DESCRIPTION
## Summary

Improves AMQP connection recovery in `azure_messaging_eventhubs` for scenarios described in #4227 and #4414. Adds previously-missing error classifications, fixes a stale management-client reference after a full reconnect, unwraps errors that arrive double-wrapped through `azure_core::Error`, and resolves a self-deadlock between in-flight CBS authorization and recovery's `authorizer.clear()`. Rebased onto #4517, which reworked the per-partition caches into per-path `OnceCell` + `RwLock`; this PR adapts the recovery path to that design and gives the authorizer's token cache the same `RwLock` treatment.

## What changed

### Error classification (`should_retry_amqp_error`)

- Broadened transport-level failures: `FramingError` and `IdleTimeoutElapsed` now trigger `ReconnectConnection`.
- `DetachError` now triggers `ReconnectLink`.
- `TransferLimitExceeded` now triggers `ReconnectLink` (reattaching resets link credit).
- Described errors `ConnectionForced` and `ConnectionFramingError` now trigger `ReconnectConnection` (`ConnectionFramingError` was previously `RetryAction`, which spun the backoff against a connection that was already gone).
- Described errors `LinkStolen` (previously `RetryAction`) and `LinkDetachForced` (previously `ReturnError`) now reattach. Retrying against a link that's gone burned the full backoff budget before bailing.
- Described errors `InternalError`, `OperationCancelled`, and `TimeoutError` now retry. Transient by Azure SDK convention; the link and connection are unaffected.
- Described error `UnauthorizedAccess` is deliberately `ReturnError` (fail fast). Both the .NET and Java Event Hubs SDKs classify `amqp:unauthorized-access` as non-transient; a runtime 401 almost always means a bad/revoked credential or missing RBAC, not an expired token (token freshness is the CBS refresher's job). Reconnecting on it would only burn the retry budget before surfacing the error.
- `AmqpErrorKind::AzureCore(_)` now walks the `std::error::Error::source()` chain (bounded depth 16) and reclassifies by the inner `AmqpError` kind. Previously these fell to `ReturnError`, which masked recoverable transport failures that round-trip through the `ensure_*` wrappers in `sender.rs` / `claims_based_security.rs` / `management.rs`.
- `should_retry_receive_error` walks that same source chain for `LinkStolen`, not just the top-level kind, so a steal wrapped through `azure_core::Error` still surfaces as `ReturnError` instead of being reclassified to `ReconnectLink` by the chain walk and silently resurrecting a displaced receiver. (.NET parallel: `InvalidateConsumerWhenPartitionIsStolen`.)
- `TransportImplementationError` is intentionally left as `ReturnError`. The variant covers errors local to the AMQP backend with no defined recovery semantics; blind retries risk hammering a deterministic bug.

### Management client lifecycle

- `mgmt_client` is now dropped on `ReconnectConnection`. Previously the management client survived a full reconnect with a session attached to the just-dropped connection; the next management call would fail and trigger another recovery.

### Cache locking (now upstream's, via #4517)

- The per-partition cache lock-during-IO problem this PR originally fixed was resolved upstream in #4517, which reworked `sender_instances` / `session_instances` / `receiver_instances` into `RwLock<HashMap<Url, Arc<OnceCell<...>>>>` so each path attaches inside its own `OnceCell` without holding the map lock. After rebasing onto it, this PR's own equivalent commit was dropped as redundant; the `OnceCell` approach is strictly better, since it also avoids the wasted-attach race the manual version had (a losing racer's `OnceCell` never runs its init at all).
- `apply_recovery_plan` was adapted to the new API: cache invalidation now takes the `RwLock` write lock (`.write().await.clear()`) instead of the old async mutex.
- A comment on `apply_recovery_plan` documents the remaining stale-cell window: clearing a cache drops its per-path `OnceCell`s, but a task already mid-init keeps the old cell until it next re-enters `ensure_*`, so a stale pre-recovery link can briefly be handed out. Closing that window (a recovery generation counter) is tracked in #4454.

### Authorizer lock contention

- `Authorizer::authorize_path` no longer holds the `authorization_scopes` lock across `credential.get_token()` and the CBS attach. Fast path takes a brief lock for a cache lookup; slow path mints and presents the token lock-free; then re-acquires briefly to insert race-tolerantly via `entry().or_insert(...)`.
- Fixes the self-deadlock described in #4414: an in-flight CBS authorization whose error triggers `ReconnectConnection` would call `recover_from_error` -> `authorizer.clear().await`, which blocks forever on the same lock held by the suspended caller.
- The `authorization_scopes` cache was converted from an async mutex to `RwLock`, matching the per-partition caches from #4517. The fast-path token lookup and the refresh task's expiry scans now take a shared read lock, so concurrent `authorize_path` lookups no longer serialize; inserts, `clear()`, and the refresh update take the write lock. It can't use the per-path `OnceCell` pattern the connection caches use, because the refresh task rewrites token entries in place and `OnceCell` is write-once.
- Tradeoff: a stale token can briefly land in the cache if recovery's `clear()` races against a slow-path insert. Self-heals through the retry loop. Tracked with the equivalent per-partition race in #4454.

### Refactor and docs

- Extracted `RecoveryPlan` POD from `recover_from_error` so cache-invalidation decisions are testable as plain values without an AMQP fixture.
- Doc comments added on `should_retry_amqp_error` and `apply_recovery_plan` describing the recovery policy.

## Still open

- Stale-token / stale-resource race after recovery, tracked in #4454.
- Live recovery test against an actual Event Hubs namespace, covering the fault-injection scenarios in #4227.

## Test plan

- [x] `cargo test -p azure_messaging_eventhubs --lib` (85 passing locally, including new tests for `RecoveryPlan`, `AzureCore` source-chain unwrapping, `TransferLimitExceeded`, `InternalError`, `OperationCancelled`, `UnauthorizedAccess` fail-fast, the wrapped-`LinkStolen` receive guard, and `authorize_path_does_not_block_clear`)
- [x] `cargo clippy -p azure_messaging_eventhubs --all-targets --all-features` clean
- [x] `cargo fmt -p azure_messaging_eventhubs --check` clean
- [x] CI green (all checks pass on Azure Pipelines build 6420698)
- [ ] Live recovery test against an actual Event Hubs namespace

---

Builds on @milas's #4213. That PR is still open, so its commit (`3dbc82796`) rides along as the base of this branch and shows up in this diff; the other commits here are my additions on top. Review #4213 first; once it merges, that commit drops out of this PR.
