### PR TITLE
fix(cosmos): correct PK-range targeting and continuation fan-out on split

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
@@ -39,3 +39,38 @@ pub struct MockItem {
     /// The global merge order of the item, which will be used by the mock query pipeline to sort items.
     pub merge_order: usize,
 }
+
+/// Error type returned by tests when they cannot conclusively determine pass or fail status, such as when a split doesn't complete within the expected time.
+#[derive(PartialEq, Eq)]
+pub enum InconclusiveError {
+    /// The test was inconclusive because a partition split did not complete within the expected time.
+    SplitNotCompleted,
+}
+
+// The Debug format is used when a test returns an error, so we need to include some context in the logs to make it clear.
+impl std::fmt::Debug for InconclusiveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InconclusiveError::SplitNotCompleted => {
+                write!(f, "InconclusiveError::SplitNotCompleted")
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for InconclusiveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InconclusiveError::SplitNotCompleted => write!(
+                f,
+                "inconclusive: partition split did not complete within the expected time"
+            )?,
+        }
+        write!(
+            f,
+            " (an inconclusive result does NOT indicate a failure, only that this test couldn't complete because of backend delays or intermittent issues; this failure does NOT need to block PR merges)"
+        )
+    }
+}
+
+impl std::error::Error for InconclusiveError {}

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
@@ -477,7 +477,6 @@ impl TestClient {
                     let test_result = Box::pin(test(&run)).await;
 
                     if let Err(e) = &test_result {
-                        println!("Error running test: {}", e);
                         // Check if the error is a 429
                         let is_429 = e.to_string().contains("TooManyRequests")
                             || e.to_string().contains("Too Many Requests");
@@ -502,7 +501,18 @@ impl TestClient {
             run.cleanup().await?;
 
             match result {
-                Ok(test_result) => test_result,
+                Ok(test_result) => {
+                    if let Err(e) = &test_result {
+                        if e.downcast_ref::<super::InconclusiveError>().is_some() {
+                            // Make it clear to the reader that the failure is an inconclusive one
+                            eprintln!(concat!("This test returned an inconclusive result. ",
+                                "This does NOT indicate a failure, but rather that the test was unable to complete successfully ",
+                                "due to an external factor (e.g. a split not completing in time). ",
+                                "Inconclusive results do not need to block PRs unless the PR is specifically touching code related to this test."));
+                        }
+                    }
+                    test_result
+                }
                 Err(_) => Err(format!("Test timed out after {} seconds", timeout.as_secs()).into()),
             }
         } else if test_mode == CosmosTestMode::Required {

--- a/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_query_split.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_query_split.rs
@@ -1,0 +1,264 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#![cfg(feature = "key_auth")]
+
+use crate::split_tests::framework::InconclusiveError;
+
+use super::framework;
+
+use std::error::Error;
+use std::num::NonZeroU32;
+use std::time::{Duration, Instant};
+
+use azure_data_cosmos::{
+    models::{ContainerProperties, ThroughputProperties},
+    options::{MaxItemCountHint, QueryOptions},
+    query::FeedScope,
+    ContinuationToken, CreateContainerOptions, ReadFeedRangesOptions,
+};
+use framework::{MockItem, TestClient, TestOptions};
+use futures::{StreamExt, TryStreamExt};
+
+const PAGE_SIZE: u32 = 5;
+const PARTITION_KEY_COUNT: usize = 5;
+const ITEMS_PER_PARTITION_KEY: usize = 5;
+
+// We wait 10 minutes for the split to occur. If it doesn't, we "fail" the test,
+// but with a clear message indicating that it only failed because the split didn't happen in time, rather than panicking on some other assumption later in the test.
+// Splits _often_ complete in time, but when they don't, we don't necessarily want to block any given PR.
+const SPLIT_POLL_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+const SPLIT_POLL_INTERVAL: Duration = Duration::from_secs(15);
+
+#[tokio::test]
+#[cfg_attr(
+    not(test_category = "split"),
+    ignore = "requires test_category 'split'"
+)]
+pub async fn query_continuation_survives_partition_split() -> Result<(), Box<dyn Error>> {
+    TestClient::run_with_unique_db(
+        async |run_context, db_client| {
+            // Create a container with a single physical partition by
+            // pinning throughput to 1000 RU/s.
+            let properties =
+                ContainerProperties::new("QuerySplitContainer", "/partitionKey".into());
+            let throughput = ThroughputProperties::manual(1000);
+            let container_client = run_context
+                .create_container(
+                    db_client,
+                    properties,
+                    Some(CreateContainerOptions::default().with_throughput(throughput)),
+                )
+                .await?;
+
+            println!("Container created with 1000 RU/s throughput to ensure single physical partition, inserting docs");
+
+            // Seed enough items across multiple PK values that a
+            // split can actually redistribute documents and that a page size
+            // of PAGE_SIZE yields at least 3 pages.
+            let mut expected_ids: Vec<String> = Vec::new();
+            for p in 0..PARTITION_KEY_COUNT {
+                let partition_key = format!("partition{p}");
+                for i in 0..ITEMS_PER_PARTITION_KEY {
+                    let item = MockItem {
+                        id: format!("{p}-{i}"),
+                        partition_key: partition_key.clone(),
+                        merge_order: p * ITEMS_PER_PARTITION_KEY + i,
+                    };
+                    expected_ids.push(item.id.clone());
+                    container_client
+                        .create_item(item.partition_key.clone(), &item.id.clone(), item, None)
+                        .await?;
+                }
+            }
+            assert!(
+                expected_ids.len() >= (PAGE_SIZE as usize) * 3,
+                "need at least 3 pages worth of items, have {}",
+                expected_ids.len()
+            );
+
+            println!("Documents inserted, starting query with pagination to capture continuation token");
+
+            // Confirm single physical partition.
+            let ranges_before = container_client.read_feed_ranges(None).await?;
+            assert!(
+                ranges_before.len() == 1,
+                "expected single physical partition before split, got {}",
+                ranges_before.len()
+            );
+
+            // Fetch a single page and capture a continuation token.
+            let mut collected: Vec<String> = Vec::new();
+            let saved_token = {
+                let initial_options = QueryOptions::default().with_max_item_count(
+                    MaxItemCountHint::Limit(NonZeroU32::new(PAGE_SIZE).unwrap()),
+                );
+                let mut pages = container_client
+                    .query_items::<MockItem>(
+                        "SELECT * FROM c",
+                        FeedScope::full_container(),
+                        Some(initial_options),
+                    )
+                    .await?
+                    .into_pages();
+
+                // There's a small chance we get empty pages from the backend, so loop until we get at least _something_ back.
+                // That way we know we've got a continuation token representing actual progress through the item stream.
+                while collected.len() == 0 {
+                    let first_page = pages
+                        .next()
+                        .await
+                        .expect("query should yield at least one page before split")?;
+                    for item in first_page.into_items() {
+                        collected.push(item.id);
+                    }
+                }
+
+                // Round-trip through string form to mirror real usage (e.g.
+                // persisting the token across processes).
+                let token = pages.to_continuation_token()?;
+                let serialized = token.as_str().to_owned();
+
+                // Assert that we've just got the first five items:
+                let expected_first_page: Vec<String> = expected_ids
+                    .iter()
+                    .take(collected.len())
+                    .cloned()
+                    .collect();
+                assert_eq!(
+                    collected, expected_first_page,
+                    "first page should contain the first {} items in id sort order",
+                    PAGE_SIZE
+                );
+                ContinuationToken::from_string(serialized)
+            };
+
+            println!("Captured continuation token after fetching first page, now updating throughput to trigger split");
+
+            // Force a split by raising throughput to 13000 RU/s
+            // (>10k forces at least 2 physical partitions).
+            let split_start = Instant::now();
+            let new_throughput = ThroughputProperties::manual(13000);
+            let mut poller = container_client
+                .begin_replace_throughput(new_throughput, None)
+                .await?;
+            println!("Throughput update initiated, polling for completion...");
+            let mut last_throughput = None;
+            let mut poll_count = 0;
+            while let Some(status) = poller.try_next().await? {
+                if split_start.elapsed() >= SPLIT_POLL_TIMEOUT {
+                    return Err(InconclusiveError::SplitNotCompleted.into());
+                }
+
+                assert!(status.status().is_success());
+                last_throughput = Some(status.into_model()?);
+                if poll_count % 15 == 0 {
+                    println!(
+                        "Throughput update in progress... polled {} times, last observed throughput: {} RU/s",
+                        poll_count,
+                        last_throughput.as_ref().and_then(|t| t.throughput()).unwrap_or(0)
+                    );
+                }
+                poll_count += 1;
+            }
+            let final_throughput = last_throughput
+                .expect("throughput poller should have yielded at least one response");
+            assert_eq!(Some(13000), final_throughput.throughput());
+            println!("Throughput update completed, new throughput: {} RU/s", final_throughput.throughput().unwrap_or(0));
+
+            // Poll read_feed_ranges until we observe >= 2 physical
+            // partitions or the timeout elapses.
+            let mut iterations = 0;
+            let observed_ranges = loop {
+                let ranges = container_client
+                    .read_feed_ranges(Some(ReadFeedRangesOptions::default().with_force_refresh(true)))
+                    .await?;
+                if ranges.len() >= 2 {
+                    break ranges;
+                }
+                if split_start.elapsed() >= SPLIT_POLL_TIMEOUT {
+                    return Err(InconclusiveError::SplitNotCompleted.into());
+                }
+
+                // Every minute, print a message to indicate we're still waiting and the test isn't hanging
+                if iterations % 4 == 0 {
+                    println!(
+                        "Waiting for split to complete... elapsed: {:?}, last observed physical partition count: {}",
+                        split_start.elapsed(),
+                        ranges.len()
+                    );
+                }
+                tokio::time::sleep(SPLIT_POLL_INTERVAL).await;
+                iterations += 1;
+            };
+            println!(
+                "Split observed after {:?}; physical partition count: {}",
+                split_start.elapsed(),
+                observed_ranges.len()
+            );
+
+            // Resume pagination using the saved continuation token.
+            // Round-trip the token between every page so we keep exercising
+            // the suspend/resume path now that the topology has changed.
+            let mut continuation = Some(saved_token);
+            loop {
+                let mut resume_options = QueryOptions::default().with_max_item_count(
+                    MaxItemCountHint::Limit(NonZeroU32::new(PAGE_SIZE).unwrap()),
+                );
+                if let Some(token) = continuation.take() {
+                    resume_options = resume_options.with_continuation_token(token);
+                }
+
+                let mut pages = container_client
+                    .query_items::<MockItem>(
+                        "SELECT * FROM c",
+                        FeedScope::full_container(),
+                        Some(resume_options),
+                    )
+                    .await?
+                    .into_pages();
+
+                let Some(page) = pages.next().await else {
+                    break;
+                };
+                let page = page?;
+                for item in page.into_items() {
+                    collected.push(item.id);
+                }
+
+                let token = pages.to_continuation_token()?;
+                let serialized = token.as_str().to_owned();
+                drop(pages);
+                continuation = Some(ContinuationToken::from_string(serialized));
+            }
+
+            // The query is a plain `SELECT *` with no `ORDER BY`, so Cosmos
+            // makes no guarantees about the relative order in which items are
+            // returned across physical partitions, and that order is expected
+            // to shift mid-stream when a split fans the request out across the
+            // new EPK ranges. What the SDK *does* guarantee, and what this
+            // assertion is here to verify, is that every seeded item is
+            // returned exactly once: no losses and no duplicates across the
+            // split boundary. Sort both sides before comparing so an ordering
+            // change cannot mask (or be mistaken for) a correctness failure.
+            let mut collected_sorted = collected.clone();
+            collected_sorted.sort();
+            let mut expected_sorted = expected_ids.clone();
+            expected_sorted.sort();
+            assert_eq!(
+                collected.len(),
+                expected_ids.len(),
+                "collected {} items but expected {} (duplicates or losses across split)",
+                collected.len(),
+                expected_ids.len()
+            );
+            assert_eq!(
+                collected_sorted, expected_sorted,
+                "items collected across split should match the seeded ground truth (order-independent)"
+            );
+
+            Ok(())
+        },
+        Some(TestOptions::new().with_timeout(Duration::from_secs(40 * 60))),
+    )
+    .await
+}

--- a/sdk/cosmos/azure_data_cosmos/tests/split_tests/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/split_tests/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+mod cosmos_query_split;
 mod cosmos_split_offers;
 
 #[path = "../framework/mod.rs"]

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
@@ -71,7 +71,7 @@ fn request_target_overrides(
             ..
         } => OperationOverrides {
             partition_key_range_id: Some(partition_key_range_id),
-            feed_range: Some(range),
+            feed_range: range,
             continuation,
             ..Default::default()
         },
@@ -1452,7 +1452,7 @@ impl CosmosDriver {
             operation,
             overrides,
             &effective_options,
-            options.custom_headers(),
+            options.custom_headers.as_ref(),
             self.location_state_store.as_ref(),
             &transport,
             &endpoint,
@@ -2557,16 +2557,41 @@ mod tests {
         )
         .unwrap();
         let overrides = request_target_overrides(
-            RequestTarget::EffectivePartitionKeyRange {
-                range: range.clone(),
-                partition_key_range_id: "merged".to_string(),
-            },
+            RequestTarget::effective_partition_key_range(
+                range.clone(),
+                "merged".to_string(),
+                crate::models::FeedRange::new(
+                    EffectivePartitionKey::from("00"),
+                    EffectivePartitionKey::from("40"),
+                )
+                .unwrap(),
+            ),
             Some("ct".to_string()),
         );
 
         assert_eq!(overrides.partition_key_range_id.as_deref(), Some("merged"));
         assert_eq!(overrides.continuation.as_deref(), Some("ct"));
         assert_eq!(overrides.feed_range, Some(range));
+    }
+
+    #[test]
+    fn effective_partition_key_range_override_omits_exact_feed_range() {
+        let range = crate::models::FeedRange::new(
+            EffectivePartitionKey::from("10"),
+            EffectivePartitionKey::from("20"),
+        )
+        .unwrap();
+        let overrides = request_target_overrides(
+            RequestTarget::effective_partition_key_range(
+                range.clone(),
+                "pkrange".to_string(),
+                range,
+            ),
+            None,
+        );
+
+        assert_eq!(overrides.partition_key_range_id.as_deref(), Some("pkrange"));
+        assert_eq!(overrides.feed_range, None);
     }
 
     #[tokio::test]

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/dataflow/mocks.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/dataflow/mocks.rs
@@ -215,14 +215,12 @@ pub(crate) fn logical_partition_target() -> RequestTarget {
 
 /// Creates a `RequestTarget` for an EPK range ("" to "80", partition key range ID "0").
 pub(crate) fn epk_range_target() -> RequestTarget {
-    RequestTarget::EffectivePartitionKeyRange {
-        range: FeedRange::new(
-            EffectivePartitionKey::min(),
-            EffectivePartitionKey::from("80"),
-        )
-        .unwrap(),
-        partition_key_range_id: "0".to_string(),
-    }
+    let range = FeedRange::new(
+        EffectivePartitionKey::min(),
+        EffectivePartitionKey::from("80"),
+    )
+    .unwrap();
+    RequestTarget::effective_partition_key_range(range.clone(), "0".to_string(), range)
 }
 
 /// Creates a test response with the given body.

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/dataflow/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/dataflow/mod.rs
@@ -51,7 +51,7 @@ pub(crate) use drained::DrainedLeaf;
 pub(crate) use node::{PageResult, PipelineNode};
 pub use pipeline::OperationPlan;
 pub(crate) use pipeline::Pipeline;
-pub(crate) use request::{Request, RequestTarget};
+pub(crate) use request::{intersect_feed_ranges, Request, RequestTarget};
 pub(crate) use snapshot::PipelineNodeState;
 pub(crate) use topology::CachedTopologyProvider;
 

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/dataflow/planner.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/dataflow/planner.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 use super::{
+    intersect_feed_ranges,
     query_plan::{QueryInfo, QueryPlan},
     DrainedLeaf, PartitionRoutingRefresh, Pipeline, PipelineNode, PipelineNodeState, Request,
     RequestTarget, SequentialDrain, TopologyProvider,
@@ -211,13 +212,15 @@ pub(crate) async fn build_sequential_drain(
                     && resolved_range.range.min_inclusive() <= &cursor.current_min_epk
                     && &cursor.current_max_epk < resolved_range.range.max_exclusive()
                 {
-                    let resumed_target = RequestTarget::EffectivePartitionKeyRange {
-                        range: FeedRange::new(
-                            cursor.current_min_epk.clone(),
-                            cursor.current_max_epk.clone(),
-                        )?,
-                        partition_key_range_id: resolved_range.partition_key_range_id.clone(),
-                    };
+                    let resumed_range = FeedRange::new(
+                        cursor.current_min_epk.clone(),
+                        cursor.current_max_epk.clone(),
+                    )?;
+                    let resumed_target = RequestTarget::effective_partition_key_range(
+                        resumed_range,
+                        resolved_range.partition_key_range_id.clone(),
+                        resolved_range.range.clone(),
+                    );
                     let resumed_continuation = cursor.server_continuation.take();
                     request_nodes.push(Box::new(Request::new(
                         Arc::clone(operation),
@@ -225,13 +228,15 @@ pub(crate) async fn build_sequential_drain(
                         resumed_continuation,
                     )));
 
-                    let tail_target = RequestTarget::EffectivePartitionKeyRange {
-                        range: FeedRange::new(
-                            cursor.current_max_epk.clone(),
-                            resolved_range.range.max_exclusive().clone(),
-                        )?,
-                        partition_key_range_id: resolved_range.partition_key_range_id,
-                    };
+                    let tail_range = FeedRange::new(
+                        cursor.current_max_epk.clone(),
+                        resolved_range.range.max_exclusive().clone(),
+                    )?;
+                    let tail_target = RequestTarget::effective_partition_key_range(
+                        tail_range,
+                        resolved_range.partition_key_range_id,
+                        resolved_range.range,
+                    );
                     request_nodes.push(Box::new(Request::new(
                         Arc::clone(operation),
                         tail_target,
@@ -241,13 +246,18 @@ pub(crate) async fn build_sequential_drain(
                 }
             }
 
-            // Carry the server continuation onto the first surviving leaf,
-            // then clear it so subsequent leaves start fresh.
+            // Carry the server continuation to every leaf node, because
+            // we don't know which ones have been drained. The service does, and will
+            // just return empty pages for those if needed.
             let initial_continuation = resume.as_mut().and_then(|c| c.server_continuation.take());
-            let target = RequestTarget::EffectivePartitionKeyRange {
-                range: resolved_range.range,
-                partition_key_range_id: resolved_range.partition_key_range_id,
-            };
+            let range = intersect_feed_ranges(&resolved_range.range, &feed_range).expect(
+                "topology provider must return ranges that overlap the query plan EPK range",
+            );
+            let target = RequestTarget::effective_partition_key_range(
+                range,
+                resolved_range.partition_key_range_id,
+                resolved_range.range,
+            );
             request_nodes.push(Box::new(Request::new(
                 Arc::clone(operation),
                 target,
@@ -480,7 +490,22 @@ mod tests {
 
     /// Asserts that the pipeline is a `SequentialDrain` containing `Request` nodes
     /// targeting the given EPK ranges (in order).
+    type ExpectedDrainRequestWithPartition<'a> = (&'a str, &'a str, &'a str, &'a str, &'a str);
+    type ExpectedDrainRequestWithContinuation<'a> =
+        (&'a str, &'a str, &'a str, &'a str, &'a str, Option<&'a str>);
+
     fn assert_drain_requests(pipeline: Pipeline, expected: &[(&str, &str, &str)]) {
+        let expected = expected
+            .iter()
+            .map(|&(min, max, pk_range_id)| (min, max, pk_range_id, min, max))
+            .collect::<Vec<_>>();
+        assert_drain_requests_with_partitions(pipeline, &expected);
+    }
+
+    fn assert_drain_requests_with_partitions(
+        pipeline: Pipeline,
+        expected: &[ExpectedDrainRequestWithPartition<'_>],
+    ) {
         let drain = pipeline
             .into_root()
             .downcast::<SequentialDrain>()
@@ -493,30 +518,35 @@ mod tests {
             expected.len(),
             children.len(),
         );
-        for (child, &(min, max, pk_range_id)) in children.into_iter().zip(expected) {
+        for (child, &(min, max, pk_range_id, partition_min, partition_max)) in
+            children.into_iter().zip(expected)
+        {
             let request = child
                 .downcast::<Request>()
                 .expect("expected Request child node");
             assert_eq!(
                 *request.target(),
-                RequestTarget::EffectivePartitionKeyRange {
-                    range: FeedRange::new(
+                RequestTarget::effective_partition_key_range(
+                    FeedRange::new(
                         EffectivePartitionKey::from(min),
                         EffectivePartitionKey::from(max),
                     )
                     .unwrap(),
-                    partition_key_range_id: pk_range_id.to_string(),
-                },
+                    pk_range_id.to_string(),
+                    FeedRange::new(
+                        EffectivePartitionKey::from(partition_min),
+                        EffectivePartitionKey::from(partition_max),
+                    )
+                    .unwrap(),
+                ),
                 "mismatch for pk range {pk_range_id}"
             );
         }
     }
 
-    /// Asserts that each `Request` child targets the given range and has the
-    /// expected server continuation snapshot state.
-    fn assert_drain_requests_with_continuation(
+    fn assert_drain_requests_with_partitions_and_continuation(
         pipeline: Pipeline,
-        expected: &[(&str, &str, &str, Option<&str>)],
+        expected: &[ExpectedDrainRequestWithContinuation<'_>],
     ) {
         let drain = pipeline
             .into_root()
@@ -531,20 +561,27 @@ mod tests {
             children.len(),
         );
 
-        for (child, &(min, max, pk_range_id, continuation)) in children.into_iter().zip(expected) {
+        for (child, &(min, max, pk_range_id, partition_min, partition_max, continuation)) in
+            children.into_iter().zip(expected)
+        {
             let request = child
                 .downcast::<Request>()
                 .expect("expected Request child node");
             assert_eq!(
                 *request.target(),
-                RequestTarget::EffectivePartitionKeyRange {
-                    range: FeedRange::new(
+                RequestTarget::effective_partition_key_range(
+                    FeedRange::new(
                         EffectivePartitionKey::from(min),
                         EffectivePartitionKey::from(max),
                     )
                     .unwrap(),
-                    partition_key_range_id: pk_range_id.to_string(),
-                },
+                    pk_range_id.to_string(),
+                    FeedRange::new(
+                        EffectivePartitionKey::from(partition_min),
+                        EffectivePartitionKey::from(partition_max),
+                    )
+                    .unwrap(),
+                ),
                 "mismatch for pk range {pk_range_id}"
             );
 
@@ -665,7 +702,6 @@ mod tests {
     #[tokio::test]
     async fn topology_partition_wider_than_query_range() {
         // The topology partition [, FF) is wider than query range [20, 80).
-        // The resolved range matches the topology, not the query range.
         let plan = plan_with_ranges(vec![qr("20", "80")]);
         let op = cross_partition_query_operation();
         let mut topology = MockTopologyProvider::new(vec![Ok(vec![rr("", "FF", "pkrange-wide")])]);
@@ -673,7 +709,7 @@ mod tests {
         let pipeline = build_sequential_drain(&plan, &mut topology, &Arc::new(op), None)
             .await
             .unwrap();
-        assert_drain_requests(pipeline, &[("", "FF", "pkrange-wide")]);
+        assert_drain_requests_with_partitions(pipeline, &[("20", "80", "pkrange-wide", "", "FF")]);
     }
 
     #[tokio::test]
@@ -1001,11 +1037,11 @@ mod tests {
             .await
             .unwrap();
 
-        assert_drain_requests_with_continuation(
+        assert_drain_requests_with_partitions_and_continuation(
             pipeline,
             &[
-                ("55", "AA", "pk-merged", Some("server-token-xyz")),
-                ("AA", "FF", "pk-merged", None),
+                ("55", "AA", "pk-merged", "", "FF", Some("server-token-xyz")),
+                ("AA", "FF", "pk-merged", "", "FF", None),
             ],
         );
     }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/dataflow/request.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/dataflow/request.rs
@@ -27,30 +27,49 @@ pub(crate) enum RequestTarget {
     /// An EPK slice that must be queried inside a broader physical partition key range
     /// (assuming the cached topology remains valid).
     EffectivePartitionKeyRange {
-        /// EPK range scoped by this request.
-        range: FeedRange,
+        /// EPK range scoped by this request, when narrower than `partition_key_range`.
+        range: Option<FeedRange>,
         /// Partition key range ID containing `range`.
         partition_key_range_id: String,
+        /// EPK range owned by the physical partition key range ID.
+        partition_key_range: FeedRange,
     },
 }
 
 impl RequestTarget {
-    /// Returns the EPK slice owned by this request target, if any.
-    fn owned_range(&self) -> Option<&FeedRange> {
-        match self {
-            RequestTarget::EffectivePartitionKeyRange { range, .. } => Some(range),
-            _ => None,
+    /// Creates a target for an effective partition key range inside a physical partition.
+    pub(crate) fn effective_partition_key_range(
+        range: FeedRange,
+        partition_key_range_id: String,
+        partition_key_range: FeedRange,
+    ) -> Self {
+        let range = if range == partition_key_range {
+            None
+        } else {
+            Some(range)
+        };
+
+        Self::EffectivePartitionKeyRange {
+            range,
+            partition_key_range_id,
+            partition_key_range,
         }
     }
 
-    /// Returns `true` if this target's EPK range starts at the same point as `parent_range`.
-    fn covers_start_of(&self, parent_range: &FeedRange) -> bool {
-        self.owned_range()
-            .is_some_and(|range| range.min_inclusive() == parent_range.min_inclusive())
+    /// Returns the EPK slice owned by this request target, if any.
+    fn owned_range(&self) -> Option<&FeedRange> {
+        match self {
+            RequestTarget::EffectivePartitionKeyRange {
+                range,
+                partition_key_range,
+                ..
+            } => Some(range.as_ref().unwrap_or(partition_key_range)),
+            _ => None,
+        }
     }
 }
 
-fn intersect_feed_ranges(left: &FeedRange, right: &FeedRange) -> Option<FeedRange> {
+pub(crate) fn intersect_feed_ranges(left: &FeedRange, right: &FeedRange) -> Option<FeedRange> {
     let min = if left.min_inclusive() >= right.min_inclusive() {
         left.min_inclusive().clone()
     } else {
@@ -253,8 +272,12 @@ impl Request {
                         self.handle_response(response)
                     })
             }
-            RequestTarget::EffectivePartitionKeyRange { range, .. } => {
-                let range = range.clone();
+            RequestTarget::EffectivePartitionKeyRange { .. } => {
+                let range = self
+                    .target
+                    .owned_range()
+                    .expect("effective partition key range target must have an owned range")
+                    .clone();
                 self.split_for_topology_change(context, &range).await
             }
         }
@@ -271,6 +294,11 @@ impl Request {
             .resolve_ranges(range, PartitionRoutingRefresh::ForceRefresh)
             .await?;
 
+        let continuation = match &self.state {
+            RequestState::Continuing { continuation } => Some(continuation.clone()),
+            _ => None,
+        };
+
         let replacement_nodes: Vec<Box<dyn PipelineNode>> = resolved
             .into_iter()
             .map(|resolved_range| {
@@ -282,24 +310,17 @@ impl Request {
                     "topology provider must return ranges that overlap the request's owned EPK range",
                 );
 
-                let target = RequestTarget::EffectivePartitionKeyRange {
-                    range: owned_range,
+                let target = RequestTarget::effective_partition_key_range(
+                    owned_range,
                     partition_key_range_id,
-                };
+                    resolved_range,
+                );
 
-                // Carry over the server continuation to the first replacement that
-                // covers the same starting EPK. For a split, only the left-most child
-                // inherits the continuation since it resumes where this node left off.
-                let continuation = match (target.covers_start_of(range), &self.state) {
-                    (
-                        true,
-                        RequestState::Continuing {
-                            continuation: latest_server_continuation,
-                        },
-                    ) => Some(latest_server_continuation.clone()),
-                    _ => None,
-                };
-                Box::new(Request::new(self.operation.clone(), target, continuation))
+                Box::new(Request::new(
+                    self.operation.clone(),
+                    target,
+                    continuation.clone(),
+                ))
                     as Box<dyn PipelineNode>
             })
             .collect();
@@ -441,7 +462,7 @@ mod tests {
         continuation: Option<&str>,
     ) -> RequestSpec {
         request_spec(
-            effective_partition_key_range_target(min, max, partition_key_range_id),
+            effective_partition_key_range_target(min, max, partition_key_range_id, min, max),
             continuation,
         )
     }
@@ -450,10 +471,18 @@ mod tests {
         min: &str,
         max: &str,
         partition_key_range_id: &str,
+        partition_min: &str,
+        partition_max: &str,
         continuation: Option<&str>,
     ) -> RequestSpec {
         request_spec(
-            effective_partition_key_range_target(min, max, partition_key_range_id),
+            effective_partition_key_range_target(
+                min,
+                max,
+                partition_key_range_id,
+                partition_min,
+                partition_max,
+            ),
             continuation,
         )
     }
@@ -525,15 +554,22 @@ mod tests {
         min: &str,
         max: &str,
         partition_key_range_id: &str,
+        partition_min: &str,
+        partition_max: &str,
     ) -> RequestTarget {
-        RequestTarget::EffectivePartitionKeyRange {
-            range: FeedRange::new(
+        RequestTarget::effective_partition_key_range(
+            FeedRange::new(
                 EffectivePartitionKey::from(min),
                 EffectivePartitionKey::from(max),
             )
             .unwrap(),
-            partition_key_range_id: partition_key_range_id.to_string(),
-        }
+            partition_key_range_id.to_string(),
+            FeedRange::new(
+                EffectivePartitionKey::from(partition_min),
+                EffectivePartitionKey::from(partition_max),
+            )
+            .unwrap(),
+        )
     }
 
     #[tokio::test]
@@ -653,7 +689,7 @@ mod tests {
             ]],
             vec![
                 partition_key_request("", "40", "1", Some("server-token")),
-                partition_key_request("40", "80", "2", None),
+                partition_key_request("40", "80", "2", Some("server-token")),
             ],
         )
         .await;
@@ -668,8 +704,8 @@ mod tests {
             ],
             vec![vec![physical_partition("", "80", "merged")]],
             vec![
-                effective_partition_key_request("", "40", "merged", Some("merge-token")),
-                effective_partition_key_request("40", "80", "merged", None),
+                effective_partition_key_request("", "40", "merged", "", "80", Some("merge-token")),
+                effective_partition_key_request("40", "80", "merged", "", "80", None),
             ],
         )
         .await;
@@ -700,8 +736,8 @@ mod tests {
     async fn topology_rewrite_can_return_from_merged_epk_slices_to_exact_pk_ranges() {
         assert_topology_rewrite(
             vec![
-                effective_partition_key_request("", "40", "merged", Some("ct")),
-                effective_partition_key_request("40", "80", "merged", None),
+                effective_partition_key_request("", "40", "merged", "", "80", Some("ct")),
+                effective_partition_key_request("40", "80", "merged", "", "80", None),
             ],
             vec![vec![
                 physical_partition("", "40", "left"),
@@ -737,10 +773,10 @@ mod tests {
             ],
             vec![
                 partition_key_request("00", "10", "split-a", Some("ct")),
-                effective_partition_key_request("10", "20", "split-b", None),
-                effective_partition_key_request("20", "30", "split-b", None),
-                effective_partition_key_request("30", "40", "split-c", None),
-                effective_partition_key_request("40", "50", "split-c", None),
+                effective_partition_key_request("10", "20", "split-b", "10", "30", Some("ct")),
+                effective_partition_key_request("20", "30", "split-b", "10", "30", None),
+                effective_partition_key_request("30", "40", "split-c", "30", "50", None),
+                effective_partition_key_request("40", "50", "split-c", "30", "50", None),
                 partition_key_request("50", "80", "split-d", None),
             ],
         )

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/operation_pipeline.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/operation_pipeline.rs
@@ -14,13 +14,15 @@ use azure_core::http::headers::{AsHeaders, HeaderName, HeaderValue};
 
 use crate::{
     diagnostics::{DiagnosticsContextBuilder, ExecutionContext, PipelineType, TransportSecurity},
-    driver::routing::{
-        can_circuit_breaker_trigger_failover, is_eligible_for_ppaf, is_eligible_for_ppcb,
-        partition_endpoint_state::HealthStatus, partition_key_range_id::PartitionKeyRangeId,
-        remove_probe_succeeded_entry, session_manager::SessionManager, AccountEndpointState,
-        CosmosEndpoint, LocationEffect, LocationSnapshot, LocationStateStore,
+    driver::{
+        routing::{
+            can_circuit_breaker_trigger_failover, is_eligible_for_ppaf, is_eligible_for_ppcb,
+            partition_endpoint_state::HealthStatus, partition_key_range_id::PartitionKeyRangeId,
+            remove_probe_succeeded_entry, session_manager::SessionManager, AccountEndpointState,
+            CosmosEndpoint, LocationEffect, LocationSnapshot, LocationStateStore,
+        },
+        transport::CosmosTransport,
     },
-    driver::transport::CosmosTransport,
     models::{
         cosmos_headers::QUERY_CONTENT_TYPE, request_header_names, AccountEndpoint, ActivityId,
         CosmosOperation, CosmosResponse, Credential, DefaultConsistencyLevel,
@@ -89,6 +91,10 @@ impl OperationOverrides {
                     HeaderValue::from(feed_range.max_exclusive().as_str().to_owned()),
                 );
             }
+            headers.insert(
+                HeaderName::from_static(request_header_names::READ_FEED_KEY_TYPE),
+                HeaderValue::from_static("EffectivePartitionKey"),
+            );
         }
 
         if let Some(pk_range_id) = &self.partition_key_range_id {
@@ -1255,8 +1261,9 @@ mod tests {
         },
         models::{
             request_header_names, AccountReference, ActivityId, ContainerProperties,
-            ContainerReference, CosmosOperation, DatabaseReference, FeedRange, ItemReference,
-            PartitionKey, PartitionKeyDefinition, SystemProperties, ThroughputControlGroupName,
+            ContainerReference, CosmosOperation, DatabaseReference, EffectivePartitionKey,
+            FeedRange, ItemReference, PartitionKey, PartitionKeyDefinition, SystemProperties,
+            ThroughputControlGroupName,
         },
         options::{PriorityLevel, ThroughputControlGroupSnapshot},
     };
@@ -1299,6 +1306,80 @@ mod tests {
             endpoint,
             transport_mode: TransportMode::Gateway,
         }
+    }
+
+    #[test]
+    fn apply_headers_pk_range_only_omits_read_key_type() {
+        let overrides = OperationOverrides {
+            partition_key_range_id: Some("0".to_string()),
+            ..Default::default()
+        };
+        let mut headers = azure_core::http::headers::Headers::new();
+        overrides
+            .apply_headers(&mut headers)
+            .expect("apply_headers should succeed");
+
+        assert_eq!(
+            headers
+                .get_optional_str(&HeaderName::from_static(
+                    request_header_names::PARTITION_KEY_RANGE_ID
+                ))
+                .map(|s| s.to_string()),
+            Some("0".to_string())
+        );
+        assert!(
+            headers
+                .get_optional_str(&HeaderName::from_static(
+                    request_header_names::READ_FEED_KEY_TYPE
+                ))
+                .is_none(),
+            "whole-PK-range targets must not emit x-ms-read-key-type"
+        );
+        assert!(headers
+            .get_optional_str(&HeaderName::from_static(request_header_names::START_EPK))
+            .is_none());
+        assert!(headers
+            .get_optional_str(&HeaderName::from_static(request_header_names::END_EPK))
+            .is_none());
+    }
+
+    #[test]
+    fn apply_headers_feed_range_emits_read_key_type_and_epk_bounds() {
+        let feed_range = FeedRange::new(
+            EffectivePartitionKey::from("10"),
+            EffectivePartitionKey::from("20"),
+        )
+        .unwrap();
+        let overrides = OperationOverrides {
+            partition_key_range_id: Some("pkrange".to_string()),
+            feed_range: Some(feed_range),
+            ..Default::default()
+        };
+        let mut headers = azure_core::http::headers::Headers::new();
+        overrides
+            .apply_headers(&mut headers)
+            .expect("apply_headers should succeed");
+
+        assert_eq!(
+            headers
+                .get_optional_str(&HeaderName::from_static(
+                    request_header_names::READ_FEED_KEY_TYPE
+                ))
+                .map(|s| s.to_string()),
+            Some("EffectivePartitionKey".to_string())
+        );
+        assert_eq!(
+            headers
+                .get_optional_str(&HeaderName::from_static(request_header_names::START_EPK))
+                .map(|s| s.to_string()),
+            Some("10".to_string())
+        );
+        assert_eq!(
+            headers
+                .get_optional_str(&HeaderName::from_static(request_header_names::END_EPK))
+                .map(|s| s.to_string()),
+            Some("20".to_string())
+        );
     }
 
     #[test]

--- a/sdk/cosmos/azure_data_cosmos_driver/src/models/cosmos_headers.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/models/cosmos_headers.rs
@@ -59,6 +59,7 @@ pub(crate) mod request_header_names {
     pub const THROUGHPUT_BUCKET: &str = "x-ms-cosmos-throughput-bucket";
     pub const START_EPK: &str = "x-ms-start-epk";
     pub const END_EPK: &str = "x-ms-end-epk";
+    pub const READ_FEED_KEY_TYPE: &str = "x-ms-read-key-type";
     #[allow(dead_code)] // Reserved for future direct partition-key header writes.
     pub const PARTITION_KEY: &str = "x-ms-documentdb-partitionkey";
     pub const PARTITION_KEY_RANGE_ID: &str = "x-ms-documentdb-partitionkeyrangeid";

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/operation_options.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/operation_options.rs
@@ -174,20 +174,7 @@ pub struct OperationOptions {
 
     // Additional headers beyond those natively supported by the driver.
     // May be removed in the future as we analyze exactly what options are needed.
-    custom_headers: Option<HashMap<HeaderName, HeaderValue>>,
-}
-
-impl OperationOptions {
-    /// Sets additional headers to include in the request.
-    pub fn with_custom_headers(mut self, headers: HashMap<HeaderName, HeaderValue>) -> Self {
-        self.custom_headers = Some(headers);
-        self
-    }
-
-    /// Gets the custom headers.
-    pub fn custom_headers(&self) -> Option<&HashMap<HeaderName, HeaderValue>> {
-        self.custom_headers.as_ref()
-    }
+    pub custom_headers: Option<HashMap<HeaderName, HeaderValue>>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This fixes an issue discovered while testing composite continuation tokens in cross-partition SELECT/WHERE queries. Essentially, we need avoid emitting the `x-ms-start-epk` and `x-ms-end-epk` headers IF our target range exactly matches the bounds of the partition key range we're specifying. If we include those headers, we get a 400 from the backend (no sub-status code). This _may_ be a bug on the backend, but for now we can fix it by just removing those headers. That also aligns the Rust SDK behaviour with other SDKs which omit those headers in the same circumstance.

This also fixes an issue where we were only providing the server continuation token to the left-mode node in the event of a split. Now we provide it to all new nodes.

Finally, there is a new live test in the "split" category that forces a split. I'm still running a local test to find the right timeout value, right now it's at 40mins, which is a bit ridiculous, but in practice it completes much sooner. I'll update the timeout once I've identified approximately how long it takes.