### PR TITLE
Gate cargo-audit and cargo-docs-rs on CI only

### DIFF
--- a/eng/cgmanifest.json
+++ b/eng/cgmanifest.json
@@ -12,6 +12,13 @@
     {
       "component": {
         "type": "cargo",
+        "cargo": { "name": "cargo-docs-rs", "version": "1.0.3" }
+      },
+      "developmentDependency": true
+    },
+    {
+      "component": {
+        "type": "cargo",
         "cargo": { "name": "cargo-semver-checks", "version": "0.45.0" }
       },
       "developmentDependency": true

--- a/eng/pipelines/templates/jobs/analyze.yml
+++ b/eng/pipelines/templates/jobs/analyze.yml
@@ -42,6 +42,7 @@ jobs:
         -PackageInfoDirectory '$(Build.ArtifactStagingDirectory)/PackageInfo'
         -Toolchain 'nightly'
         -SkipPackageAnalysis:('$(NoPackagesChanged)' -eq 'true')
+        -Audit:('$(Build.Reason)' -ne 'PullRequest')
         -Deny
 
   - template: /eng/common/pipelines/templates/steps/check-spelling.yml

--- a/eng/scripts/Analyze-Code.ps1
+++ b/eng/scripts/Analyze-Code.ps1
@@ -29,18 +29,24 @@ Analyzing code with
     RUST_LOG: '${env:RUST_LOG}'
 "@
 
+if ($Audit) {
+  $cargoAuditVersionParams = Get-VersionParamsFromCgManifest cargo-audit
+  Invoke-LoggedCommand "cargo install cargo-audit --locked $($cargoAuditVersionParams -join ' ')" -GroupOutput
+}
+
 if ($Deny) {
   $cargoDenyVersionParams = Get-VersionParamsFromCgManifest cargo-deny
   Invoke-LoggedCommand "cargo install cargo-deny --locked $($cargoDenyVersionParams -join ' ')" -GroupOutput
 }
+
+$taploCliVersionParams = Get-VersionParamsFromCgManifest taplo-cli
+Invoke-LoggedCommand "cargo install taplo-cli --locked $($taploCliVersionParams -join ' ')" -GroupOutput
 
 $packageArgs = if ($PackageName) {
   '--package ' + ($PackageName -join ' --package ')
 }
 
 if ($Audit) {
-  $cargoAuditVersionParams = Get-VersionParamsFromCgManifest cargo-audit
-  Invoke-LoggedCommand "cargo install cargo-audit --locked $($cargoAuditVersionParams -join ' ')" -GroupOutput
   Invoke-LoggedCommand "cargo audit" -GroupOutput
 }
 
@@ -48,8 +54,6 @@ Invoke-LoggedCommand "cargo check --manifest-path sdk/core/azure_core/Cargo.toml
 
 Invoke-LoggedCommand "cargo fmt $packageArgs -- --check" -GroupOutput
 
-$taploCliVersionParams = Get-VersionParamsFromCgManifest taplo-cli
-Invoke-LoggedCommand "cargo install taplo-cli --locked $($taploCliVersionParams -join ' ')" -GroupOutput
 Invoke-LoggedCommand "taplo format --check"
 
 Invoke-LoggedCommand "cargo clippy $packageArgs --all-features --all-targets --keep-going --no-deps" -GroupOutput
@@ -78,6 +82,7 @@ if (!$SkipPackageAnalysis) {
     return
   }
 
+  # Ideally would want to install this with the others, but not replicate the conditions in which the tool is run.
   if ($Toolchain -eq 'nightly') {
     $cargoDocsRsVersionParams = Get-VersionParamsFromCgManifest cargo-docs-rs
     Invoke-LoggedCommand "cargo install cargo-docs-rs --locked $($cargoDocsRsVersionParams -join ' ')" -GroupOutput

--- a/eng/scripts/Analyze-Code.ps1
+++ b/eng/scripts/Analyze-Code.ps1
@@ -11,6 +11,7 @@ param(
   [string[]]$PackageName,
 
   [string]$Toolchain = 'stable',
+  [switch]$Audit,
   [switch]$Deny,
   [switch]$SkipPackageAnalysis
 )
@@ -37,9 +38,11 @@ $packageArgs = if ($PackageName) {
   '--package ' + ($PackageName -join ' --package ')
 }
 
-$cargoAuditVersionParams = Get-VersionParamsFromCgManifest cargo-audit
-Invoke-LoggedCommand "cargo install cargo-audit --locked $($cargoAuditVersionParams -join ' ')" -GroupOutput
-Invoke-LoggedCommand "cargo audit" -GroupOutput
+if ($Audit) {
+  $cargoAuditVersionParams = Get-VersionParamsFromCgManifest cargo-audit
+  Invoke-LoggedCommand "cargo install cargo-audit --locked $($cargoAuditVersionParams -join ' ')" -GroupOutput
+  Invoke-LoggedCommand "cargo audit" -GroupOutput
+}
 
 Invoke-LoggedCommand "cargo check --manifest-path sdk/core/azure_core/Cargo.toml $packageArgs --all-features --all-targets --keep-going" -GroupOutput
 
@@ -76,7 +79,8 @@ if (!$SkipPackageAnalysis) {
   }
 
   if ($Toolchain -eq 'nightly') {
-    Invoke-LoggedCommand "cargo install --locked cargo-docs-rs" -GroupOutput
+    $cargoDocsRsVersionParams = Get-VersionParamsFromCgManifest cargo-docs-rs
+    Invoke-LoggedCommand "cargo install cargo-docs-rs --locked $($cargoDocsRsVersionParams -join ' ')" -GroupOutput
   }
 
   class Package {


### PR DESCRIPTION
- Add `-Audit` switch to `Analyze-Code.ps1` to gate `cargo-audit`
  install and run; pass it only on non-PR builds via `analyze.yml`
- Pin `cargo-docs-rs` version via `Get-VersionParamsFromCgManifest`
  and register it in `eng/cgmanifest.json` (v1.0.3)

Resolves #4259

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
