### PR TITLE
[Storage] Add managed identity support to Blob perf tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,6 +818,7 @@ dependencies = [
  "async-trait",
  "azure_core 1.0.0",
  "azure_core_test",
+ "azure_identity 1.0.0",
  "azure_storage_blob 1.1.0-beta.1",
  "bytes",
  "futures",

--- a/sdk/storage/azure_storage_blob/perf/download_blob_test.rs
+++ b/sdk/storage/azure_storage_blob/perf/download_blob_test.rs
@@ -15,6 +15,7 @@ use azure_core_test::{
     TestContext,
 };
 use azure_storage_blob::{BlobClient, BlobContainerClient};
+use azure_storage_blob_test::get_test_credential;
 use bytes::BytesMut;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 
@@ -196,7 +197,7 @@ impl PerfTest for DownloadBlobTest {
         // Setup code before running the test
 
         let recording = context.recording();
-        let credential = recording.credential();
+        let credential = get_test_credential(recording);
         let container_name = format!("perf-container-{}", azure_core::Uuid::new_v4());
         let endpoint = match &self.endpoint {
             Some(e) => e.clone(),

--- a/sdk/storage/azure_storage_blob/perf/list_blob_test.rs
+++ b/sdk/storage/azure_storage_blob/perf/list_blob_test.rs
@@ -12,6 +12,7 @@ use azure_core_test::{
     TestContext,
 };
 use azure_storage_blob::BlobContainerClient;
+use azure_storage_blob_test::get_test_credential;
 use futures::{FutureExt, TryStreamExt};
 
 pub struct ListBlobTest {
@@ -72,7 +73,7 @@ impl PerfTest for ListBlobTest {
         // Setup code before running the test
 
         let recording = context.recording();
-        let credential = recording.credential();
+        let credential = get_test_credential(recording);
         let container_name = format!("perf-container-{}", azure_core::Uuid::new_v4());
         let endpoint = match &self.endpoint {
             Some(e) => e.clone(),

--- a/sdk/storage/azure_storage_blob/perf/upload_blob_test.rs
+++ b/sdk/storage/azure_storage_blob/perf/upload_blob_test.rs
@@ -12,6 +12,7 @@ use azure_core_test::{
     TestContext,
 };
 use azure_storage_blob::BlobContainerClient;
+use azure_storage_blob_test::get_test_credential;
 use futures::FutureExt;
 
 pub struct UploadBlobTest {
@@ -72,7 +73,7 @@ impl PerfTest for UploadBlobTest {
         // Setup code before running the test
 
         let recording = context.recording();
-        let credential = recording.credential();
+        let credential = get_test_credential(recording);
         let container_name = format!("perf-container-{}", azure_core::Uuid::new_v4());
         let endpoint = match &self.endpoint {
             Some(e) => e.clone(),

--- a/sdk/storage/azure_storage_blob_test/Cargo.toml
+++ b/sdk/storage/azure_storage_blob_test/Cargo.toml
@@ -17,6 +17,7 @@ publish = false
 async-trait.workspace = true
 azure_core = { workspace = true, features = ["xml"] }
 azure_core_test.workspace = true
+azure_identity.workspace = true
 azure_storage_blob.path = "../azure_storage_blob"
 bytes.workspace = true
 futures.workspace = true

--- a/sdk/storage/azure_storage_blob_test/src/lib.rs
+++ b/sdk/storage/azure_storage_blob_test/src/lib.rs
@@ -21,7 +21,7 @@ use azure_core::{
     },
     Bytes, Result,
 };
-use azure_core_test::Recording;
+use azure_core_test::{Recording, TestMode};
 use azure_identity::ManagedIdentityCredential;
 use azure_storage_blob::{
     models::{
@@ -128,12 +128,20 @@ pub fn recorded_test_setup(
 
 /// Returns a credential suitable for storage operations.
 ///
-/// If the environment variable `AZURE_STORAGE_USE_MANAGED_IDENTITY` is set to `"true"`,
-/// returns a [`ManagedIdentityCredential`]. Otherwise, falls back to the recording's
+/// In playback mode, returns the recording's mock credential immediately.
+/// Otherwise, if the environment variable `AZURE_STORAGE_USE_MANAGED_IDENTITY` is set to
+/// `"true"`, returns a [`ManagedIdentityCredential`]. Falls back to the recording's
 /// test credential via [`Recording::credential`].
+///
+/// # Arguments
+///
+/// * `recording` - A reference to a Recording instance.
 pub fn get_test_credential(recording: &Recording) -> Arc<dyn TokenCredential> {
-    let use_managed_identity = recording
-        .var_opt("AZURE_STORAGE_USE_MANAGED_IDENTITY", None)
+    if recording.test_mode() == TestMode::Playback {
+        return recording.credential();
+    }
+
+    let use_managed_identity = std::env::var("AZURE_STORAGE_USE_MANAGED_IDENTITY")
         .map(|v| v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
 

--- a/sdk/storage/azure_storage_blob_test/src/lib.rs
+++ b/sdk/storage/azure_storage_blob_test/src/lib.rs
@@ -12,6 +12,7 @@ use std::{
 
 use async_trait::async_trait;
 use azure_core::{
+    credentials::TokenCredential,
     error::ErrorKind,
     http::{
         policies::{Policy, PolicyResult},
@@ -21,6 +22,7 @@ use azure_core::{
     Bytes, Result,
 };
 use azure_core_test::Recording;
+use azure_identity::ManagedIdentityCredential;
 use azure_storage_blob::{
     models::{
         BlockBlobClientUploadOptions, BlockBlobClientUploadResult, BlockLookupList,
@@ -122,6 +124,24 @@ pub fn recorded_test_setup(
         "https://{}.blob.core.windows.net/",
         recording.var(account_name_var, None).as_str()
     )
+}
+
+/// Returns a credential suitable for storage operations.
+///
+/// If the environment variable `AZURE_STORAGE_USE_MANAGED_IDENTITY` is set to `"true"`,
+/// returns a [`ManagedIdentityCredential`]. Otherwise, falls back to the recording's
+/// test credential via [`Recording::credential`].
+pub fn get_test_credential(recording: &Recording) -> Arc<dyn TokenCredential> {
+    let use_managed_identity = recording
+        .var_opt("AZURE_STORAGE_USE_MANAGED_IDENTITY", None)
+        .map(|v| v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    if use_managed_identity {
+        ManagedIdentityCredential::new(None).expect("failed to create ManagedIdentityCredential")
+    } else {
+        recording.credential()
+    }
 }
 
 /// Takes in a Recording instance and returns a randomized blob name with prefix "blob" of length 16.


### PR DESCRIPTION
Allows Blob perf tests to use a `ManagedIdentityCredential` based on the `AZURE_STORAGE_USE_MANAGED_IDENTITY` environment variable. This mirrors how it is done for other languages (.NET and Python) and works with our current automation.