### PR TITLE
Hand off @ronniegeraghty CODEOWNERS to new owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,10 +19,10 @@
 
 # Catch all for loose files in the root, which are mostly global configuration and
 # should not be changed without team discussion.
-/*                       @heaths @xirzec @RickWinter @ronniegeraghty @LarryOsterman
+/*                       @heaths @xirzec @RickWinter @LarryOsterman
 
 # Catch all for non-code project files and unowned files | folders
-/**                      @heaths @xirzec @RickWinter @ronniegeraghty @LarryOsterman
+/**                      @heaths @xirzec @RickWinter @LarryOsterman
 
 # Allow service owners to approve crate version updates, which impact Cargo.lock
 /Cargo.lock
@@ -32,13 +32,13 @@
 ##################
 
 # GitHub integration and bot rules
-/.github/                @heaths @xirzec @RickWinter @ronniegeraghty @LarryOsterman
+/.github/                @heaths @xirzec @RickWinter @LarryOsterman
 
 ###########
 # SDK
 ###########
 # Catch all
-/sdk/                    @heaths @xirzec @RickWinter @ronniegeraghty @LarryOsterman
+/sdk/                    @heaths @xirzec @RickWinter @LarryOsterman
 
 # AzureSDKOwners: @heaths
 # ServiceLabel: %Azure.Core
@@ -93,7 +93,7 @@
 /eng/                    @danieljurek @weshaggard @heaths @xirzec @RickWinter
 /eng/common/             @Azure/azure-sdk-eng
 /.github/workflows/      @Azure/azure-sdk-eng
-/.github/CODEOWNERS      @xirzec @RickWinter @ronniegeraghty @Azure/azure-sdk-eng
+/.github/CODEOWNERS      @xirzec @RickWinter @Azure/azure-sdk-eng
 /.config/1espt/          @benbp @weshaggard
 /sdk/canary/             @danieljurek
 


### PR DESCRIPTION
## Summary

Removing `@ronniegeraghty` from `.github/CODEOWNERS` as Ronnie transitions from the Azure SDK / Tools portfolio into a different role.

## What changed

See the diff. For lines where removing Ronnie would leave fewer than one human owner, a replacement was added per discussion with Ronnie. All other lines simply drop his alias.

## Reviewers

Tagging the existing co-owners on the affected lines for review.

## Related

- Workitem: Azure/projects/424 - "Review CODEOWNERS entries in SDK repos, transfer to right new owner"
- Full handoff plan: internal doc `projects/sdk-team-brain-dump/codeowners-handoff/README.md` in `ronniegeraghty/ronnies-agent-team`

---
*Opened as part of the Azure SDK handoff. Marking as draft until Ronnie reviews; flip to ready-for-review once approved internally.*
