### PR TITLE
[Storage] Fortify flaky live tests for `find_blobs_by_tags` API

### DIFF
--- a/sdk/storage/azure_storage_blob/assets.json
+++ b/sdk/storage/azure_storage_blob/assets.json
@@ -1,6 +1,6 @@
 {
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
-  "Tag": "rust/azure_storage_blob_a6b159d0dc",
+  "Tag": "rust/azure_storage_blob_ff706259b1",
   "TagPrefix": "rust/azure_storage_blob"
 }

--- a/sdk/storage/azure_storage_blob/assets.json
+++ b/sdk/storage/azure_storage_blob/assets.json
@@ -1,6 +1,6 @@
 {
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
-  "Tag": "rust/azure_storage_blob_ff706259b1",
+  "Tag": "rust/azure_storage_blob_2f17520363",
   "TagPrefix": "rust/azure_storage_blob"
 }

--- a/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
@@ -440,7 +440,7 @@ async fn test_find_blobs_by_tags(ctx: TestContext) -> Result<(), Box<dyn Error>>
         .await?;
     }
 
-    // Sleeping to allow for tag indexing.
+    // Find "hello world" blob by its tag {"foo": "bar"}.
     // In live mode, poll until tags are indexed (up to 60s total timeout).
     // In record mode, use a fixed 15s sleep.
     if ctx.recording().test_mode() == TestMode::Live {
@@ -465,22 +465,22 @@ async fn test_find_blobs_by_tags(ctx: TestContext) -> Result<(), Box<dyn Error>>
             );
             time::sleep(Duration::from_secs(5)).await;
         }
-    } else if ctx.recording().test_mode() == TestMode::Record {
-        time::sleep(Duration::from_secs(15)).await;
+    } else {
+        if ctx.recording().test_mode() == TestMode::Record {
+            time::sleep(Duration::from_secs(15)).await;
+        }
+        let mut pager = container_client
+            .find_blobs_by_tags("\"foo\"='bar'", None)?
+            .into_pages();
+        let filter_blob_segment = pager.try_next().await?.unwrap().into_model()?;
+        let blobs = &filter_blob_segment.blob_items;
+        assert!(
+            blobs
+                .iter()
+                .any(|blob| blob.name.as_ref().unwrap() == &blob1_name),
+            "Failed to find \"{blob1_name}\" in filtered blob results."
+        );
     }
-
-    // Find "hello world" blob by its tag {"foo": "bar"}
-    let mut pager = container_client
-        .find_blobs_by_tags("\"foo\"='bar'", None)?
-        .into_pages();
-    let filter_blob_segment = pager.try_next().await?.unwrap().into_model()?;
-    let blobs = &filter_blob_segment.blob_items;
-    assert!(
-        blobs
-            .iter()
-            .any(|blob| blob.name.as_ref().unwrap() == &blob1_name),
-        "Failed to find \"{blob1_name}\" in filtered blob results."
-    );
 
     // Find "ferris the crab" blob by its tag {"fizz": "buzz"}
     let mut pager = container_client

--- a/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
@@ -5,7 +5,7 @@ use azure_core::{
     http::{RequestContent, StatusCode},
     time::{parse_rfc3339, to_rfc3339, OffsetDateTime},
 };
-use azure_core_test::{recorded, Matcher, TestContext, TestMode, VarOptions};
+use azure_core_test::{recorded, Matcher, TestContext, VarOptions};
 use azure_storage_blob::format_filter_expression;
 use azure_storage_blob::models::{
     AccessPolicy, AccountKind, BlobContainerClientAcquireLeaseResultHeaders,
@@ -19,7 +19,7 @@ use azure_storage_blob::models::{
 use azure_storage_blob::StorageError;
 use azure_storage_blob_test::{
     create_test_blob, get_blob_name, get_blob_service_client, get_container_client,
-    get_container_name, StorageAccount,
+    get_container_name, poll_until, StorageAccount,
 };
 use futures::{StreamExt, TryStreamExt};
 use std::{collections::HashMap, error::Error, time::Duration};
@@ -408,23 +408,11 @@ async fn test_find_blobs_by_tags(ctx: TestContext) -> Result<(), Box<dyn Error>>
 
     // Create Test Blobs with Distinct Tags
     let blob1_name = get_blob_name(ctx.recording());
+    let blob1_tags = HashMap::from([("fizz".to_string(), "buzz".to_string())]);
     create_test_blob(
         &container_client.blob_client(&blob1_name.clone()),
-        Some(RequestContent::from("hello world".as_bytes().into())),
-        Some(
-            BlockBlobClientUploadOptions::default().with_tags(HashMap::from([
-                ("foo".to_string(), "bar".to_string()),
-                ("alice".to_string(), "bob".to_string()),
-            ])),
-        ),
-    )
-    .await?;
-    let blob2_name = get_blob_name(ctx.recording());
-    let blob2_tags = HashMap::from([("fizz".to_string(), "buzz".to_string())]);
-    create_test_blob(
-        &container_client.blob_client(&blob2_name.clone()),
         Some(RequestContent::from("ferris the crab".as_bytes().into())),
-        Some(BlockBlobClientUploadOptions::default().with_tags(blob2_tags.clone())),
+        Some(BlockBlobClientUploadOptions::default().with_tags(blob1_tags.clone())),
     )
     .await?;
 
@@ -440,59 +428,73 @@ async fn test_find_blobs_by_tags(ctx: TestContext) -> Result<(), Box<dyn Error>>
         .await?;
     }
 
+    let blob2_name = get_blob_name(ctx.recording());
+    create_test_blob(
+        &container_client.blob_client(&blob2_name.clone()),
+        Some(RequestContent::from("hello world".as_bytes().into())),
+        Some(
+            BlockBlobClientUploadOptions::default().with_tags(HashMap::from([
+                ("foo".to_string(), "bar".to_string()),
+                ("alice".to_string(), "bob".to_string()),
+            ])),
+        ),
+    )
+    .await?;
+
     // Find "hello world" blob by its tag {"foo": "bar"}.
     // In live mode, poll until tags are indexed (up to 60s total timeout).
     // In record mode, use a fixed 15s sleep.
-    if ctx.recording().test_mode() == TestMode::Live {
-        let deadline = time::Instant::now() + Duration::from_secs(60);
-        loop {
-            let mut pager = container_client
-                .find_blobs_by_tags("\"foo\"='bar'", None)?
-                .into_pages();
-            if let Some(resp) = pager.try_next().await? {
-                let segment = resp.into_model()?;
-                if segment
-                    .blob_items
-                    .iter()
-                    .any(|b| b.name.as_ref().unwrap() == &blob1_name)
-                {
-                    break;
-                }
-            }
-            assert!(
-                time::Instant::now() < deadline,
-                "Timed out after 60s waiting for blob tag indexing"
-            );
-            time::sleep(Duration::from_secs(5)).await;
-        }
-    } else {
-        if ctx.recording().test_mode() == TestMode::Record {
-            time::sleep(Duration::from_secs(15)).await;
-        }
+    poll_until(ctx.recording(), || async {
         let mut pager = container_client
             .find_blobs_by_tags("\"foo\"='bar'", None)?
             .into_pages();
-        let filter_blob_segment = pager.try_next().await?.unwrap().into_model()?;
+        if let Some(resp) = pager.try_next().await? {
+            let segment = resp.into_model()?;
+            if segment
+                .blob_items
+                .iter()
+                .any(|b| b.name.as_deref() == Some(blob2_name.as_str()))
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    })
+    .await?;
+    // Final assertion (covers record/playback where poll_until doesn't check the condition)
+    {
+        let mut pager = container_client
+            .find_blobs_by_tags("\"foo\"='bar'", None)?
+            .into_pages();
+        let filter_blob_segment = pager
+            .try_next()
+            .await?
+            .expect("expected at least one page from find_blobs_by_tags")
+            .into_model()?;
         let blobs = &filter_blob_segment.blob_items;
         assert!(
             blobs
                 .iter()
-                .any(|blob| blob.name.as_ref().unwrap() == &blob1_name),
-            "Failed to find \"{blob1_name}\" in filtered blob results."
+                .any(|blob| blob.name.as_deref() == Some(blob2_name.as_str())),
+            "Failed to find \"{blob2_name}\" in filtered blob results."
         );
     }
 
     // Find "ferris the crab" blob by its tag {"fizz": "buzz"}
     let mut pager = container_client
-        .find_blobs_by_tags(&format_filter_expression(&blob2_tags)?, None)?
+        .find_blobs_by_tags(&format_filter_expression(&blob1_tags)?, None)?
         .into_pages();
-    let filter_blob_segment = pager.try_next().await?.unwrap().into_model()?;
+    let filter_blob_segment = pager
+        .try_next()
+        .await?
+        .expect("expected at least one page from find_blobs_by_tags")
+        .into_model()?;
     let blobs = &filter_blob_segment.blob_items;
     assert!(
         blobs
             .iter()
-            .any(|blob| blob.name.as_ref().unwrap() == &blob2_name),
-        "Failed to find \"{blob2_name}\" in filtered blob results."
+            .any(|blob| blob.name.as_deref() == Some(blob1_name.as_str())),
+        "Failed to find \"{blob1_name}\" in filtered blob results."
     );
 
     // Max Results Scenario
@@ -503,7 +505,11 @@ async fn test_find_blobs_by_tags(ctx: TestContext) -> Result<(), Box<dyn Error>>
     let mut pager = container_client
         .find_blobs_by_tags("\"env\"='test'", Some(options))?
         .into_pages();
-    let page = pager.try_next().await?.unwrap().into_model()?;
+    let page = pager
+        .try_next()
+        .await?
+        .expect("expected at least one page from find_blobs_by_tags")
+        .into_model()?;
     let blobs = &page.blob_items;
     assert!(
         blobs.len() <= 2,

--- a/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
@@ -440,10 +440,32 @@ async fn test_find_blobs_by_tags(ctx: TestContext) -> Result<(), Box<dyn Error>>
         .await?;
     }
 
-    // Sleep in live mode to allow tags to be indexed on the service
-    if ctx.recording().test_mode() == TestMode::Live
-        || ctx.recording().test_mode() == TestMode::Record
-    {
+    // Sleeping to allow for tag indexing.
+    // In live mode, poll until tags are indexed (up to 60s total timeout).
+    // In record mode, use a fixed 15s sleep.
+    if ctx.recording().test_mode() == TestMode::Live {
+        let deadline = time::Instant::now() + Duration::from_secs(60);
+        loop {
+            let mut pager = container_client
+                .find_blobs_by_tags("\"foo\"='bar'", None)?
+                .into_pages();
+            if let Some(resp) = pager.try_next().await? {
+                let segment = resp.into_model()?;
+                if segment
+                    .blob_items
+                    .iter()
+                    .any(|b| b.name.as_ref().unwrap() == &blob1_name)
+                {
+                    break;
+                }
+            }
+            assert!(
+                time::Instant::now() < deadline,
+                "Timed out after 60s waiting for blob tag indexing"
+            );
+            time::sleep(Duration::from_secs(5)).await;
+        }
+    } else if ctx.recording().test_mode() == TestMode::Record {
         time::sleep(Duration::from_secs(15)).await;
     }
 

--- a/sdk/storage/azure_storage_blob/tests/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_service_client.rs
@@ -216,7 +216,7 @@ async fn test_find_blobs_by_tags_service(ctx: TestContext) -> Result<(), Box<dyn
     )
     .await?;
 
-    // Sleeping to allow for tag indexing.
+    // Find "hello world" blob by its tag {"foo": "bar"}.
     // In live mode, poll until tags are indexed (up to 60s total timeout).
     // In record mode, use a fixed 15s sleep.
     if ctx.recording().test_mode() == TestMode::Live {
@@ -238,21 +238,21 @@ async fn test_find_blobs_by_tags_service(ctx: TestContext) -> Result<(), Box<dyn
             );
             time::sleep(Duration::from_secs(5)).await;
         }
-    } else if ctx.recording().test_mode() == TestMode::Record {
-        time::sleep(Duration::from_secs(15)).await;
+    } else {
+        if ctx.recording().test_mode() == TestMode::Record {
+            time::sleep(Duration::from_secs(15)).await;
+        }
+        let blobs: Vec<_> = service_client
+            .find_blobs_by_tags("\"foo\"='bar'", None)?
+            .try_collect()
+            .await?;
+        assert!(
+            blobs
+                .iter()
+                .any(|blob| blob.name.as_ref().unwrap() == &blob1_name),
+            "Failed to find \"{blob1_name}\" in filtered blob results."
+        );
     }
-
-    // Find "hello world" blob by its tag {"foo": "bar"}
-    let blobs: Vec<_> = service_client
-        .find_blobs_by_tags("\"foo\"='bar'", None)?
-        .try_collect()
-        .await?;
-    assert!(
-        blobs
-            .iter()
-            .any(|blob| blob.name.as_ref().unwrap() == &blob1_name),
-        "Failed to find \"{blob1_name}\" in filtered blob results."
-    );
 
     // Find "ferris the crab" blob by its tag {"fizz": "buzz"}
     let blobs: Vec<_> = service_client

--- a/sdk/storage/azure_storage_blob/tests/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_service_client.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use azure_core::http::{ClientOptions, RequestContent, Url, XmlFormat};
-use azure_core_test::{recorded, TestContext, TestMode};
+use azure_core_test::{recorded, TestContext};
 use azure_storage_blob::models::{
     AccountKind, BlobServiceClientGetAccountInfoResultHeaders,
     BlobServiceClientGetPropertiesOptions, BlobServiceClientListContainersOptions,
@@ -12,11 +12,10 @@ use azure_storage_blob::models::{
 use azure_storage_blob::{format_filter_expression, BlobServiceClient, BlobServiceClientOptions};
 use azure_storage_blob_test::{
     create_test_blob, get_blob_name, get_blob_service_client, get_container_client,
-    get_container_name, recorded_test_setup, StorageAccount,
+    get_container_name, poll_until, recorded_test_setup, StorageAccount,
 };
 use futures::{StreamExt, TryStreamExt};
-use std::{collections::HashMap, error::Error, time::Duration};
-use tokio::time;
+use std::{collections::HashMap, error::Error};
 
 #[recorded::test]
 async fn test_get_service_properties(ctx: TestContext) -> Result<(), Box<dyn Error>> {
@@ -190,16 +189,6 @@ async fn test_find_blobs_by_tags_service(ctx: TestContext) -> Result<(), Box<dyn
     let blob1_name = get_blob_name(recording);
     create_test_blob(
         &container_client_1.blob_client(&blob1_name.clone()),
-        Some(RequestContent::from("hello world".as_bytes().into())),
-        Some(
-            BlockBlobClientUploadOptions::default()
-                .with_tags(HashMap::from([("foo".to_string(), "bar".to_string())])),
-        ),
-    )
-    .await?;
-    let blob2_name = get_blob_name(recording);
-    create_test_blob(
-        &container_client_1.blob_client(&blob2_name.clone()),
         Some(RequestContent::from("ferris the crab".as_bytes().into())),
         Some(
             BlockBlobClientUploadOptions::default()
@@ -207,41 +196,39 @@ async fn test_find_blobs_by_tags_service(ctx: TestContext) -> Result<(), Box<dyn
         ),
     )
     .await?;
+    let blob2_name = get_blob_name(recording);
+    let blob2_tags = HashMap::from([("tagged".to_string(), "true".to_string())]);
+    create_test_blob(
+        &container_client_1.blob_client(&blob2_name.clone()),
+        Some(RequestContent::from("six seven".as_bytes().into())),
+        Some(BlockBlobClientUploadOptions::default().with_tags(blob2_tags.clone())),
+    )
+    .await?;
     let blob3_name = get_blob_name(recording);
-    let blob3_tags = HashMap::from([("tagged".to_string(), "true".to_string())]);
     create_test_blob(
         &container_client_1.blob_client(&blob3_name.clone()),
-        Some(RequestContent::from("six seven".as_bytes().into())),
-        Some(BlockBlobClientUploadOptions::default().with_tags(blob3_tags.clone())),
+        Some(RequestContent::from("hello world".as_bytes().into())),
+        Some(
+            BlockBlobClientUploadOptions::default()
+                .with_tags(HashMap::from([("foo".to_string(), "bar".to_string())])),
+        ),
     )
     .await?;
 
     // Find "hello world" blob by its tag {"foo": "bar"}.
     // In live mode, poll until tags are indexed (up to 60s total timeout).
     // In record mode, use a fixed 15s sleep.
-    if ctx.recording().test_mode() == TestMode::Live {
-        let deadline = time::Instant::now() + Duration::from_secs(60);
-        loop {
-            let blobs: Vec<_> = service_client
-                .find_blobs_by_tags("\"foo\"='bar'", None)?
-                .try_collect()
-                .await?;
-            if blobs
-                .iter()
-                .any(|blob| blob.name.as_ref().unwrap() == &blob1_name)
-            {
-                break;
-            }
-            assert!(
-                time::Instant::now() < deadline,
-                "Timed out after 60s waiting for blob tag indexing"
-            );
-            time::sleep(Duration::from_secs(5)).await;
-        }
-    } else {
-        if ctx.recording().test_mode() == TestMode::Record {
-            time::sleep(Duration::from_secs(15)).await;
-        }
+    poll_until(ctx.recording(), || async {
+        let blobs: Vec<_> = service_client
+            .find_blobs_by_tags("\"foo\"='bar'", None)?
+            .try_collect()
+            .await?;
+        Ok(blobs
+            .iter()
+            .any(|blob| blob.name.as_deref() == Some(blob3_name.as_str())))
+    })
+    .await?;
+    {
         let blobs: Vec<_> = service_client
             .find_blobs_by_tags("\"foo\"='bar'", None)?
             .try_collect()
@@ -249,8 +236,8 @@ async fn test_find_blobs_by_tags_service(ctx: TestContext) -> Result<(), Box<dyn
         assert!(
             blobs
                 .iter()
-                .any(|blob| blob.name.as_ref().unwrap() == &blob1_name),
-            "Failed to find \"{blob1_name}\" in filtered blob results."
+                .any(|blob| blob.name.as_deref() == Some(blob3_name.as_str())),
+            "Failed to find \"{blob3_name}\" in filtered blob results."
         );
     }
 
@@ -262,20 +249,20 @@ async fn test_find_blobs_by_tags_service(ctx: TestContext) -> Result<(), Box<dyn
     assert!(
         blobs
             .iter()
-            .any(|blob| blob.name.as_ref().unwrap() == &blob2_name),
-        "Failed to find \"{blob2_name}\" in filtered blob results."
+            .any(|blob| blob.name.as_deref() == Some(blob1_name.as_str())),
+        "Failed to find \"{blob1_name}\" in filtered blob results."
     );
 
     // Find "six seven" blob by its tag {"tagged": "true"}
     let blobs: Vec<_> = service_client
-        .find_blobs_by_tags(&format_filter_expression(&blob3_tags)?, None)?
+        .find_blobs_by_tags(&format_filter_expression(&blob2_tags)?, None)?
         .try_collect()
         .await?;
     assert!(
         blobs
             .iter()
-            .any(|blob| blob.name.as_ref().unwrap() == &blob3_name),
-        "Failed to find \"{blob3_name}\" in filtered blob results."
+            .any(|blob| blob.name.as_deref() == Some(blob2_name.as_str())),
+        "Failed to find \"{blob2_name}\" in filtered blob results."
     );
 
     container_client_1.delete(None).await?;

--- a/sdk/storage/azure_storage_blob/tests/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_service_client.rs
@@ -216,10 +216,29 @@ async fn test_find_blobs_by_tags_service(ctx: TestContext) -> Result<(), Box<dyn
     )
     .await?;
 
-    // Sleep in live and record modes to allow tags to be indexed on the service
-    if ctx.recording().test_mode() == TestMode::Live
-        || ctx.recording().test_mode() == TestMode::Record
-    {
+    // Sleeping to allow for tag indexing.
+    // In live mode, poll until tags are indexed (up to 60s total timeout).
+    // In record mode, use a fixed 15s sleep.
+    if ctx.recording().test_mode() == TestMode::Live {
+        let deadline = time::Instant::now() + Duration::from_secs(60);
+        loop {
+            let blobs: Vec<_> = service_client
+                .find_blobs_by_tags("\"foo\"='bar'", None)?
+                .try_collect()
+                .await?;
+            if blobs
+                .iter()
+                .any(|blob| blob.name.as_ref().unwrap() == &blob1_name)
+            {
+                break;
+            }
+            assert!(
+                time::Instant::now() < deadline,
+                "Timed out after 60s waiting for blob tag indexing"
+            );
+            time::sleep(Duration::from_secs(5)).await;
+        }
+    } else if ctx.recording().test_mode() == TestMode::Record {
         time::sleep(Duration::from_secs(15)).await;
     }
 

--- a/sdk/storage/azure_storage_blob_test/src/lib.rs
+++ b/sdk/storage/azure_storage_blob_test/src/lib.rs
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 
 use std::{
+    future::Future,
     slice,
     sync::{
         atomic::{AtomicUsize, Ordering},
         mpsc::Sender,
         Arc,
     },
+    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -539,5 +541,42 @@ impl Policy for FailFirstPolicy {
             ));
         }
         next[0].send(ctx, request, &next[1..]).await
+    }
+}
+
+/// Polls an async condition until it returns `true`, with behavior adapted to the test mode.
+///
+/// - **Live**: polls every 5 seconds up to 60 seconds total, panicking on timeout.
+/// - **Record**: sleeps 15 seconds, then returns (caller asserts after).
+/// - **Playback**: returns immediately.
+///
+/// # Arguments
+///
+/// * `recording` - The current test recording context.
+/// * `check` - An async closure that returns `Ok(true)` when the condition is met.
+pub async fn poll_until<F, Fut>(recording: &Recording, mut check: F) -> Result<()>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<bool>>,
+{
+    match recording.test_mode() {
+        TestMode::Live => {
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+            loop {
+                if check().await? {
+                    return Ok(());
+                }
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "Timed out after 60s waiting for eventual consistency"
+                );
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        }
+        TestMode::Record => {
+            tokio::time::sleep(Duration::from_secs(15)).await;
+            Ok(())
+        }
+        TestMode::Playback => Ok(()),
     }
 }


### PR DESCRIPTION
Swaps to a 60s global timeout with 5s polling in live test mode. This should help to alleviate the lives test failures:
>thread 'test_find_blobs_by_tags' (126381) panicked at sdk/storage/azure_storage_blob/tests/blob_container_client.rs:456:5:
Failed to find "blob9e5euvk9" in filtered blob results.

In most cases we will not hit 60s, but previously we had a 15s wait and then a single poll, and that was working in most cases other than macOS occasionally. 