### PR TITLE
cosmos: decode database RID from container RID

### DIFF
--- a/sdk/cosmos/.github/instructions/cosmos.changelog.instructions.md
+++ b/sdk/cosmos/.github/instructions/cosmos.changelog.instructions.md
@@ -7,17 +7,11 @@ applyTo: "sdk/cosmos/**/CHANGELOG.md"
 
 - Never modify already released sections (anything not marked "Unreleased"). Only add entries under the current "(Unreleased)" version.
 
-- Before modifying CHANGELOG.md:
-    - Check if the current branch already has an associated PR with a changelog entry
-    - If a changelog entry for the current PR already exists, DO NOT add additional entries
-    - All changes within a single PR should be summarized in ONE changelog entry
-    - The PR author is responsible for updating the existing entry if needed, not the AI agent
-
 - If the PR title starts with `[Internal]`, do not change any `CHANGELOG.md` files.
 
-- Add one entry per PR under an existing category header (for example: "Features Added", "Breaking Changes", "Bugs Fixed", "Other Changes").
+- Add entries under an existing category header (for example: "Features Added", "Breaking Changes", "Bugs Fixed", "Other Changes"). A single PR may produce multiple entries when it spans multiple categories or distinct customer-visible changes.
 	- Do not create new category headers.
-	- Put the entry under the most appropriate existing category.
+	- Put each entry under the most appropriate existing category.
 
 - Entry format:
 	- Prefer the existing style used in the file.

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -6,9 +6,13 @@
 
 ### Breaking Changes
 
+- Removed `CosmosDriver::resolve_container_by_rid` and the supporting `CosmosOperation::read_container_by_rid` factory and `ContainerCache::get_or_fetch_by_rid`. These RID-keyed entry points had no callers; container resolution now goes exclusively through `resolve_container` / `resolve_container_by_name`. ([#4506](https://github.com/Azure/azure-sdk-for-rust/pull/4506))
+
 ### Bugs Fixed
 
 ### Other Changes
+
+- `CosmosDriver::resolve_container_by_name` no longer issues an extra `read_database` round-trip to discover the database RID. The database RID is now extracted in-process from the encoded byte layout of the container RID returned by the container read. ([#4506](https://github.com/Azure/azure-sdk-for-rust/pull/4506))
 
 ## 0.3.0 (2026-05-29)
 

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/container_cache.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/container_cache.rs
@@ -105,28 +105,6 @@ impl ContainerCache {
         self.get_or_fetch_impl(&self.by_name, key, fetch_fn).await
     }
 
-    /// Looks up a container by RID, fetching if not cached.
-    ///
-    /// On a cache miss, calls `fetch_fn` to resolve the container from the
-    /// service. The resolved reference is then cross-populated into the
-    /// by-name cache. Concurrent requests for the same RID share one fetch.
-    pub(crate) async fn get_or_fetch_by_rid<F, Fut>(
-        &self,
-        account_endpoint: &str,
-        container_rid: &str,
-        fetch_fn: F,
-    ) -> crate::error::Result<Arc<ContainerReference>>
-    where
-        F: FnOnce() -> Fut,
-        Fut: std::future::Future<Output = crate::error::Result<ContainerReference>>,
-    {
-        let key = ContainerRidKey {
-            account_endpoint: account_endpoint.to_owned(),
-            container_rid: container_rid.to_owned(),
-        };
-        self.get_or_fetch_impl(&self.by_rid, key, fetch_fn).await
-    }
-
     /// Returns a cached container looked up by name, or `None` if not cached.
     #[allow(dead_code)] // Used in tests; will be called from production code once lookup-by-name is wired up.
     pub(crate) async fn get_by_name(
@@ -337,39 +315,6 @@ mod tests {
 
         assert_eq!(resolved.name(), "mycoll");
         assert_eq!(counter.load(Ordering::SeqCst), 1);
-    }
-
-    // --- get_or_fetch_by_rid ---
-
-    #[tokio::test]
-    async fn fetch_by_rid_caches_and_cross_populates_name() {
-        let cache = ContainerCache::new();
-        let counter = Arc::new(AtomicUsize::new(0));
-
-        let container = test_container("mydb", "mycoll");
-        let container_rid = container.rid().to_owned();
-        let container_clone = container.clone();
-        let counter_clone = counter.clone();
-
-        let resolved = cache
-            .get_or_fetch_by_rid(ACCOUNT_ENDPOINT, &container_rid, || async move {
-                counter_clone.fetch_add(1, Ordering::SeqCst);
-                Ok(container_clone)
-            })
-            .await
-            .unwrap();
-
-        assert_eq!(resolved.name(), "mycoll");
-        assert_eq!(counter.load(Ordering::SeqCst), 1);
-
-        // Should be cross-populated and retrievable by name
-        let by_name = cache.get_by_name(ACCOUNT_ENDPOINT, "mydb", "mycoll").await;
-        assert!(by_name.is_some());
-        assert_eq!(by_name.unwrap().rid(), container_rid);
-
-        // Should also be retrievable by RID
-        let by_rid = cache.get_by_rid(ACCOUNT_ENDPOINT, &container_rid).await;
-        assert!(by_rid.is_some());
     }
 
     // --- put ---

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
@@ -25,7 +25,7 @@ use crate::{
     models::{
         effective_partition_key::EffectivePartitionKey, AccountEndpoint, AccountReference,
         ContainerProperties, ContainerReference, ContinuationToken, CosmosOperation,
-        DatabaseProperties, DatabaseReference, PartitionKey, ResolvedToken, ResourceType,
+        DatabaseReference, PartitionKey, ResolvedToken, ResourceType,
     },
     options::{
         ConnectionPoolOptions, DriverOptions, OperationOptions, OperationOptionsView,
@@ -714,39 +714,6 @@ impl CosmosDriver {
         let db_ref = DatabaseReference::from_name(self.account().clone(), db_name.to_owned());
         let options = OperationOptions::default();
 
-        let db_result = self
-            .execute_singleton_operation(
-                CosmosOperation::read_database(db_ref.clone()),
-                options.clone(),
-            )
-            .await?;
-        let db_headers = db_result.headers().clone();
-        let db_diagnostics = db_result.diagnostics();
-        let db_props: DatabaseProperties = db_result.into_body().into_single().map_err(|e| {
-            crate::error::CosmosError::builder()
-                .with_status(crate::error::CosmosStatus::SERIALIZATION_RESPONSE_BODY_INVALID)
-                .with_message("failed to deserialize database response")
-                .with_response_parts(crate::models::CosmosResponsePayload::new(
-                    crate::models::ResponseBody::NoPayload,
-                    db_headers.clone(),
-                ))
-                .with_diagnostics(db_diagnostics.clone())
-                .with_source(e)
-                .build()
-        })?;
-        let db_rid = db_props.system_properties.rid.ok_or_else(|| {
-            crate::error::CosmosError::builder()
-                .with_status(crate::error::CosmosStatus::SERIALIZATION_RESPONSE_BODY_INVALID)
-                .with_message("database response missing _rid")
-                .with_response_parts(crate::models::CosmosResponsePayload::new(
-                    crate::models::ResponseBody::NoPayload,
-                    db_headers,
-                ))
-                .with_diagnostics(db_diagnostics)
-                .with_source(std::io::Error::other("missing _rid"))
-                .build()
-        })?;
-
         let container_result = self
             .execute_singleton_operation(
                 CosmosOperation::read_container_by_name(db_ref, container_name.to_owned()),
@@ -778,92 +745,39 @@ impl CosmosDriver {
                     .with_message("container response missing _rid")
                     .with_response_parts(crate::models::CosmosResponsePayload::new(
                         crate::models::ResponseBody::NoPayload,
-                        container_headers,
+                        container_headers.clone(),
                     ))
-                    .with_diagnostics(container_diagnostics)
+                    .with_diagnostics(container_diagnostics.clone())
                     .with_source(std::io::Error::other("missing _rid"))
                     .build()
             })?;
 
-        Ok(ContainerReference::new(
-            self.account().clone(),
-            db_props.id.into_owned(),
-            db_rid,
-            container_props.id.clone().into_owned(),
-            container_rid,
-            &container_props,
-        ))
-    }
-
-    async fn fetch_container_by_rid(
-        &self,
-        db_rid: &str,
-        container_rid: &str,
-    ) -> crate::error::Result<ContainerReference> {
-        let db_ref = DatabaseReference::from_rid(self.account().clone(), db_rid.to_owned());
-        let options = OperationOptions::default();
-
-        let db_result = self
-            .execute_singleton_operation(
-                CosmosOperation::read_database(db_ref.clone()),
-                options.clone(),
-            )
-            .await?;
-        let db_headers = db_result.headers().clone();
-        let db_diagnostics = db_result.diagnostics();
-        let db_props: DatabaseProperties = db_result.into_body().into_single().map_err(|e| {
-            crate::error::CosmosError::builder()
-                .with_status(crate::error::CosmosStatus::SERIALIZATION_RESPONSE_BODY_INVALID)
-                .with_message(format!(
-                    "failed to deserialize database response (db_rid='{db_rid}'): {e}"
-                ))
-                .with_response_parts(crate::models::CosmosResponsePayload::new(
-                    crate::models::ResponseBody::NoPayload,
-                    db_headers,
-                ))
-                .with_diagnostics(db_diagnostics)
-                .with_source(e)
-                .build()
-        })?;
-        let resolved_db_rid = db_props
-            .system_properties
-            .rid
-            .clone()
-            .unwrap_or_else(|| db_rid.to_owned());
-
-        let container_result = self
-            .execute_singleton_operation(
-                CosmosOperation::read_container_by_rid(db_ref, container_rid.to_owned()),
-                options,
-            )
-            .await?;
-        let container_headers = container_result.headers().clone();
-        let container_diagnostics = container_result.diagnostics();
-        let container_props: ContainerProperties = container_result
-            .into_body()
-            .into_single()
-            .map_err(|e| {
-                crate::error::CosmosError::builder().with_status(crate::error::CosmosStatus::SERIALIZATION_RESPONSE_BODY_INVALID)
+        // Derive the database RID from the container RID's encoded byte
+        // layout. This avoids an extra `read_database` round-trip — the
+        // first 4 decoded bytes of the container RID are the parent database RID.
+        let db_rid = crate::models::resource_id::ResourceId::new(container_rid.clone())
+            .database_rid()
+            .ok_or_else(|| {
+                crate::error::CosmosError::builder()
+                    .with_status(crate::error::CosmosStatus::SERIALIZATION_RESPONSE_BODY_INVALID)
                     .with_message(format!(
-                        "failed to deserialize container response (db_rid='{db_rid}', container_rid='{container_rid}'): {e}"
+                        "failed to extract database RID from container RID '{container_rid}'"
                     ))
-                    .with_response_parts(crate::models::CosmosResponsePayload::new(crate::models::ResponseBody::NoPayload, container_headers))
+                    .with_response_parts(crate::models::CosmosResponsePayload::new(
+                        crate::models::ResponseBody::NoPayload,
+                        container_headers,
+                    ))
                     .with_diagnostics(container_diagnostics)
-                    .with_source(e)
+                    .with_source(std::io::Error::other("invalid container _rid"))
                     .build()
             })?;
-        let resolved_container_rid = container_props
-            .system_properties
-            .rid
-            .clone()
-            .unwrap_or_else(|| container_rid.to_owned());
 
         Ok(ContainerReference::new(
             self.account().clone(),
-            db_props.id.into_owned(),
-            resolved_db_rid,
+            db_name.to_owned(),
+            db_rid.as_str().to_owned(),
             container_props.id.clone().into_owned(),
-            resolved_container_rid,
+            container_rid,
             &container_props,
         ))
     }
@@ -1645,38 +1559,6 @@ impl CosmosDriver {
                         crate::error::CosmosErrorBuilder::from_error(err)
                             .with_context(format!(
                                 "resolve container by name (db='{db_name_owned}', container='{container_name_owned}')"
-                            ))
-                            .build()
-                    })
-            })
-            .await?;
-
-        Ok(resolved.as_ref().clone())
-    }
-
-    /// Resolves a container by database RID and container RID.
-    ///
-    /// Attempts to resolve from `ContainerCache` first. On cache miss, fetches
-    /// metadata from the service and populates the cache.
-    pub async fn resolve_container_by_rid(
-        &self,
-        db_rid: &str,
-        container_rid: &str,
-    ) -> crate::error::Result<ContainerReference> {
-        let endpoint = self.account().endpoint().as_str().to_owned();
-        let db_rid_owned = db_rid.to_owned();
-        let container_rid_owned = container_rid.to_owned();
-
-        let resolved = self
-            .runtime
-            .container_cache()
-            .get_or_fetch_by_rid(&endpoint, container_rid, || async move {
-                self.fetch_container_by_rid(&db_rid_owned, &container_rid_owned)
-                    .await
-                    .map_err(|err| {
-                        crate::error::CosmosErrorBuilder::from_error(err)
-                            .with_context(format!(
-                                "resolve container by rid (db_rid='{db_rid_owned}', container_rid='{container_rid_owned}')"
                             ))
                             .build()
                     })

--- a/sdk/cosmos/azure_data_cosmos_driver/src/models/cosmos_operation.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/models/cosmos_operation.rs
@@ -444,17 +444,6 @@ impl CosmosOperation {
         Self::new(OperationType::Read, resource_ref, None)
     }
 
-    /// Reads a container's properties by database RID and container RID.
-    pub fn read_container_by_rid(
-        database: DatabaseReference,
-        container_rid: impl Into<std::borrow::Cow<'static, str>>,
-    ) -> Self {
-        let resource_ref: CosmosResourceReference = CosmosResourceReference::from(database)
-            .with_resource_type(ResourceType::DocumentCollection)
-            .with_rid(container_rid.into());
-        Self::new(OperationType::Read, resource_ref, None)
-    }
-
     // ===== Data Plane Factory Methods =====
 
     /// Creates a new item (document) in a container.

--- a/sdk/cosmos/azure_data_cosmos_driver/src/models/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/models/mod.rs
@@ -88,6 +88,7 @@ use std::borrow::Cow;
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)] // Reserved wire-format model for read-database/query-databases responses.
 pub(crate) struct DatabaseProperties {
     /// Unique identifier for the database within the account.
     pub id: Cow<'static, str>,

--- a/sdk/cosmos/azure_data_cosmos_driver/src/models/resource_id.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/models/resource_id.rs
@@ -6,7 +6,68 @@
 //! This module provides newtypes for resource names and RIDs (resource identifiers),
 //! as well as internal ID enums that enforce either all-names or all-RIDs addressing.
 
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use std::borrow::Cow;
+
+// =============================================================================
+// RID Parsing (byte-level helpers)
+// =============================================================================
+//
+// Cosmos DB RIDs are base64-encoded byte sequences whose layout encodes the
+// resource hierarchy:
+//   [0..4)   database
+//   [4..8)   container (collection)
+//   [8..16)  document/sub-resource
+//
+// These helpers decode/encode the wire format. Cosmos uses standard Base64
+// with `-` substituted for `/`. They are intentionally inline-only — callers
+// extract whatever component they need and discard the rest.
+
+/// Errors that can occur when parsing a Cosmos DB RID.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum RidParseError {
+    /// The RID string is empty.
+    Empty,
+    /// The RID string length is not a multiple of 4 (invalid Base64 padding).
+    InvalidLength,
+    /// The RID string contains invalid Base64 characters.
+    InvalidBase64,
+}
+
+impl std::fmt::Display for RidParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "RID string is empty"),
+            Self::InvalidLength => write!(f, "RID has invalid byte length"),
+            Self::InvalidBase64 => write!(f, "RID contains invalid Base64"),
+        }
+    }
+}
+
+impl std::error::Error for RidParseError {}
+
+/// Decodes a Cosmos DB RID string into its raw bytes.
+///
+/// RIDs use standard Base64 with `-` substituted for `/`.
+pub(crate) fn decode_rid(rid: &str) -> Result<Vec<u8>, RidParseError> {
+    if rid.is_empty() {
+        return Err(RidParseError::Empty);
+    }
+    if !rid.len().is_multiple_of(4) {
+        return Err(RidParseError::InvalidLength);
+    }
+    let b64 = rid.replace('-', "/");
+    STANDARD
+        .decode(&b64)
+        .map_err(|_| RidParseError::InvalidBase64)
+}
+
+/// Encodes raw bytes into a Cosmos DB RID string.
+///
+/// Uses standard Base64 with `/` replaced by `-`.
+pub(crate) fn encode_rid(bytes: &[u8]) -> String {
+    STANDARD.encode(bytes).replace('/', "-")
+}
 
 /// A resource name (user-provided identifier).
 ///
@@ -68,6 +129,22 @@ impl ResourceId {
     /// Returns the RID as a string slice.
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    /// Extracts the database RID embedded at the start of this RID.
+    ///
+    /// Cosmos DB RIDs encode the resource hierarchy in their bytes; the first
+    /// 4 decoded bytes always identify the parent database. This accessor
+    /// performs the parse inline (decode → take first 4 bytes → re-encode) and
+    /// discards everything else; nothing is cached.
+    ///
+    /// Returns `None` if `self` is empty or otherwise not a valid Cosmos RID.
+    pub(crate) fn database_rid(&self) -> Option<ResourceId> {
+        let bytes = decode_rid(self.as_str()).ok()?;
+        if bytes.len() < 4 {
+            return None;
+        }
+        Some(ResourceId::new(encode_rid(&bytes[0..4])))
     }
 }
 
@@ -159,7 +236,6 @@ impl ResourceIdentifier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use base64::{engine::general_purpose::STANDARD, Engine as _};
 
     // =========================================================================
     // ParsedResourceId (test-only)
@@ -237,54 +313,8 @@ mod tests {
     }
 
     // =========================================================================
-    // RID Parsing Utilities (test-only)
+    // Test helpers exercising the promoted byte-level utilities
     // =========================================================================
-
-    /// Errors that can occur when parsing a Cosmos DB RID.
-    #[derive(Clone, Debug, PartialEq, Eq)]
-    enum RidParseError {
-        /// The RID string is empty.
-        Empty,
-        /// The RID string length is not a multiple of 4 (invalid Base64 padding).
-        InvalidLength,
-        /// The RID string contains invalid Base64 characters.
-        InvalidBase64,
-    }
-
-    impl std::fmt::Display for RidParseError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            match self {
-                Self::Empty => write!(f, "RID string is empty"),
-                Self::InvalidLength => write!(f, "RID has invalid byte length"),
-                Self::InvalidBase64 => write!(f, "RID contains invalid Base64"),
-            }
-        }
-    }
-
-    impl std::error::Error for RidParseError {}
-
-    /// Decodes a Cosmos DB RID string into its raw bytes.
-    ///
-    /// RIDs use standard Base64 with `-` substituted for `/`.
-    fn decode_rid(rid: &str) -> Result<Vec<u8>, RidParseError> {
-        if rid.is_empty() {
-            return Err(RidParseError::Empty);
-        }
-        if !rid.len().is_multiple_of(4) {
-            return Err(RidParseError::InvalidLength);
-        }
-        let b64 = rid.replace('-', "/");
-        STANDARD
-            .decode(&b64)
-            .map_err(|_| RidParseError::InvalidBase64)
-    }
-
-    /// Encodes raw bytes into a Cosmos DB RID string.
-    ///
-    /// Uses standard Base64 with `/` replaced by `-`.
-    fn encode_rid(bytes: &[u8]) -> String {
-        STANDARD.encode(bytes).replace('/', "-")
-    }
 
     /// Extracts the database RID string from a container (collection) RID string.
     fn extract_database_rid_from_container_rid(
@@ -405,6 +435,38 @@ mod tests {
         assert_eq!(parsed.database_rid().map(|r| r.as_str()), Some("db123"));
         assert_eq!(parsed.container_rid().map(|r| r.as_str()), Some("coll456"));
         assert_eq!(parsed.document_rid().map(|r| r.as_str()), Some("doc789"));
+    }
+
+    #[test]
+    fn resource_id_database_rid_extracts_first_4_bytes() {
+        // Container RID = 8 bytes; first 4 are database, second 4 are container.
+        let mut bytes = [0u8; 8];
+        bytes[0..4].copy_from_slice(&[0x0A, 0x0B, 0x0C, 0x0D]);
+        bytes[4..8].copy_from_slice(&[0x80, 0x01, 0x02, 0x03]);
+        let container_rid = ResourceId::new(encode_rid(&bytes));
+
+        let db_rid = container_rid.database_rid().expect("should parse");
+        assert_eq!(db_rid.as_str(), encode_rid(&[0x0A, 0x0B, 0x0C, 0x0D]));
+    }
+
+    #[test]
+    fn resource_id_database_rid_works_on_database_rid_itself() {
+        // A 4-byte (database-only) RID should still yield a valid db RID equal to itself.
+        let bytes: [u8; 4] = [0x01, 0x02, 0x03, 0x04];
+        let db_rid = ResourceId::new(encode_rid(&bytes));
+
+        let extracted = db_rid.database_rid().expect("should parse");
+        assert_eq!(extracted.as_str(), db_rid.as_str());
+    }
+
+    #[test]
+    fn resource_id_database_rid_returns_none_for_invalid_rid() {
+        // Empty
+        assert!(ResourceId::new("").database_rid().is_none());
+        // Bad base64 (length not multiple of 4)
+        assert!(ResourceId::new("abc").database_rid().is_none());
+        // Garbage characters
+        assert!(ResourceId::new("!!!!").database_rid().is_none());
     }
 
     // ===== RID parsing tests =====


### PR DESCRIPTION
In order to resolve a container by name, we were previously issuing TWO requests:

1. A `read_database` request to fetch the Database RID
2. A `read_container` request to fetch the Container information

We _do_ cache the `ContainerReference` created in this process, but it still creates a major unnecessary spike in `read_database` requests when creating several `ContainerClient`s for containers in the same database.

Rather than adding caching here, we actually don't need to fetch the DB RID. We can derive it from the Container RID (we do this in other SDKs). This PR adds code to do that and then removes the `read_database` operation from the resolve code path.

However, this does put us in a bad spot for the `resolve_container_by_rid` API. Since a `ContainerReference` needs to hold both the name and RID for each layer of the hierarchy, resolving by RID would require fetching DB metadata to get the name. When we fetch by name and need the RID, we can grab the container metadata and derive everything from that, but we couldn't do that if we had to get the name from the RID. Fortunately, we don't even use that code path, so I just removed it for now :). If we need to be able to resolve a container by RID **and** get the DB name, then we can introduce some caching here.