### PR TITLE
[Storage] Add transfer options to perf tests

### DIFF
--- a/sdk/storage/azure_storage_blob/perf/download_blob_test.rs
+++ b/sdk/storage/azure_storage_blob/perf/download_blob_test.rs
@@ -8,12 +8,11 @@ use std::{
 
 use azure_core::{error::ErrorKind, http::Url, Bytes};
 use azure_core_test::{
-    perf::{
-        CreatePerfTestReturn, PerfRunner, PerfTest, PerfTestMetadata, PerfTestOption,
-        PerfTestOptionKind,
-    },
+    perf::{CreatePerfTestReturn, PerfRunner, PerfTest, PerfTestMetadata},
     TestContext,
 };
+
+use super::options;
 use azure_storage_blob::{BlobClient, BlobContainerClient};
 use azure_storage_blob_test::get_test_credential;
 use bytes::BytesMut;
@@ -75,45 +74,10 @@ impl DownloadBlobTest {
             name: "download_blob",
             description: "Download blobs from a container",
             options: vec![
-                PerfTestOption {
-                    name: "count",
-                    display_message: "The number of blobs to download",
-                    mandatory: false,
-                    short_activator: Some('c'),
-                    long_activator: "count",
-                    expected_args_len: 1,
-                    option_type: PerfTestOptionKind::Uint32,
-                    ..Default::default()
-                },
-                PerfTestOption {
-                    name: "collect",
-                    display_message: "Collect the blob contents instead of streaming them",
-                    mandatory: false,
-                    short_activator: None,
-                    long_activator: "collect",
-                    expected_args_len: 1,
-                    option_type: PerfTestOptionKind::String,
-                    ..Default::default()
-                },
-                PerfTestOption {
-                    name: "size",
-                    display_message: "The size of each blob in bytes",
-                    mandatory: true,
-                    short_activator: Some('s'),
-                    long_activator: "size",
-                    expected_args_len: 1,
-                    option_type: PerfTestOptionKind::Usize,
-                    ..Default::default()
-                },
-                PerfTestOption {
-                    name: "endpoint",
-                    display_message: "The endpoint of the blob storage",
-                    mandatory: false,
-                    short_activator: Some('e'),
-                    long_activator: "endpoint",
-                    expected_args_len: 1,
-                    ..Default::default()
-                },
+                options::count(),
+                options::collect(),
+                options::size(),
+                options::endpoint(),
             ],
             create_test: Self::create_download_blob_test,
         }

--- a/sdk/storage/azure_storage_blob/perf/download_blob_test.rs
+++ b/sdk/storage/azure_storage_blob/perf/download_blob_test.rs
@@ -3,6 +3,7 @@
 
 use std::{
     hint::black_box,
+    num::NonZero,
     sync::{Arc, OnceLock},
 };
 
@@ -13,7 +14,7 @@ use azure_core_test::{
 };
 
 use super::options;
-use azure_storage_blob::{BlobClient, BlobContainerClient};
+use azure_storage_blob::{models::BlobClientDownloadOptions, BlobClient, BlobContainerClient};
 use azure_storage_blob_test::get_test_credential;
 use bytes::BytesMut;
 use futures::{FutureExt, StreamExt, TryStreamExt};
@@ -30,6 +31,8 @@ pub struct DownloadBlobTest {
     count: u32,
     size: usize,
     collect: CollectOptions,
+    concurrency: Option<NonZero<usize>>,
+    partition_size: Option<NonZero<usize>>,
     endpoint: Option<String>,
     client: OnceLock<BlobContainerClient>,
 }
@@ -62,6 +65,12 @@ impl DownloadBlobTest {
                     .try_get_test_arg("size")?
                     .expect("size argument is mandatory"),
                 collect: collect_options,
+                concurrency: runner
+                    .try_get_test_arg::<usize>("concurrency")?
+                    .and_then(NonZero::new),
+                partition_size: runner
+                    .try_get_test_arg::<usize>("partition-size")?
+                    .and_then(NonZero::new),
                 endpoint,
                 client: OnceLock::new(),
             }) as Box<dyn PerfTest>)
@@ -77,15 +86,25 @@ impl DownloadBlobTest {
                 options::count(),
                 options::collect(),
                 options::size(),
+                options::concurrency(),
+                options::partition_size(),
                 options::endpoint(),
             ],
             create_test: Self::create_download_blob_test,
         }
     }
 
+    fn download_options(&self) -> BlobClientDownloadOptions<'_> {
+        BlobClientDownloadOptions {
+            parallel: self.concurrency,
+            partition_size: self.partition_size,
+            ..Default::default()
+        }
+    }
+
     /// This method represents the most basic way to download a blob, where we simply stream the contents and do nothing with them. This is useful for testing the performance of streaming downloads without any additional overhead.
     async fn collect_stream(&self, blob_client: BlobClient) -> azure_core::Result<()> {
-        let response = blob_client.download(None).await?;
+        let response = blob_client.download(Some(self.download_options())).await?;
 
         let mut body = response.body;
 
@@ -98,7 +117,7 @@ impl DownloadBlobTest {
 
     /// This method collects the entire blob into memory in 512K chunks using the `collect_into` method on the body
     async fn collect_into(&self, blob_client: BlobClient) -> azure_core::Result<()> {
-        let response = blob_client.download(None).await?;
+        let response = blob_client.download(Some(self.download_options())).await?;
 
         let mut buffer = vec![0u8; self.size];
         response.body.collect_into(&mut buffer).await?;
@@ -111,7 +130,7 @@ impl DownloadBlobTest {
     /// This is useful for testing the performance of collecting the entire blob into memory, which
     /// may be a common scenario for smaller blobs.
     async fn collect_blob(&self, blob_client: BlobClient) -> azure_core::Result<Bytes> {
-        let response = blob_client.download(None).await?;
+        let response = blob_client.download(Some(self.download_options())).await?;
 
         let body = response.body.collect().await?;
         Ok(black_box(body))
@@ -120,7 +139,7 @@ impl DownloadBlobTest {
     /// This method collects the entire blob into memory using a simple loop and extending a `Vec<u8>`.
     /// This is the original blob collect method.
     async fn collect_blob_simple(&self, blob_client: BlobClient) -> azure_core::Result<Bytes> {
-        let response = blob_client.download(None).await?;
+        let response = blob_client.download(Some(self.download_options())).await?;
 
         let mut body = response.body;
 
@@ -134,7 +153,7 @@ impl DownloadBlobTest {
 
     /// This method collects the entire blob into memory using a `BytesMut` buffer.
     async fn collect_blob_vec_bytes(&self, blob_client: BlobClient) -> azure_core::Result<Bytes> {
-        let response = blob_client.download(None).await?;
+        let response = blob_client.download(Some(self.download_options())).await?;
 
         let mut body = response.body;
         let mut bytes = Vec::<Bytes>::new();

--- a/sdk/storage/azure_storage_blob/perf/list_blob_test.rs
+++ b/sdk/storage/azure_storage_blob/perf/list_blob_test.rs
@@ -5,12 +5,11 @@ use std::sync::{Arc, OnceLock};
 
 use azure_core::{error::ErrorKind, http::Url, Bytes};
 use azure_core_test::{
-    perf::{
-        CreatePerfTestReturn, PerfRunner, PerfTest, PerfTestMetadata, PerfTestOption,
-        PerfTestOptionKind,
-    },
+    perf::{CreatePerfTestReturn, PerfRunner, PerfTest, PerfTestMetadata},
     TestContext,
 };
+
+use super::options;
 use azure_storage_blob::BlobContainerClient;
 use azure_storage_blob_test::get_test_credential;
 use futures::{FutureExt, TryStreamExt};
@@ -41,27 +40,7 @@ impl ListBlobTest {
         PerfTestMetadata {
             name: "list_blob",
             description: "List blobs in a container",
-            options: vec![
-                PerfTestOption {
-                    name: "count",
-                    display_message: "The number of blobs to list",
-                    mandatory: true,
-                    short_activator: Some('c'),
-                    long_activator: "count",
-                    expected_args_len: 1,
-                    option_type: PerfTestOptionKind::Uint32,
-                    ..Default::default()
-                },
-                PerfTestOption {
-                    name: "endpoint",
-                    display_message: "The endpoint of the blob storage",
-                    mandatory: false,
-                    short_activator: Some('e'),
-                    long_activator: "endpoint",
-                    expected_args_len: 1,
-                    ..Default::default()
-                },
-            ],
+            options: vec![options::count(), options::endpoint()],
             create_test: Self::create_list_blob_test,
         }
     }

--- a/sdk/storage/azure_storage_blob/perf/options.rs
+++ b/sdk/storage/azure_storage_blob/perf/options.rs
@@ -53,3 +53,27 @@ pub fn collect() -> PerfTestOption {
         ..Default::default()
     }
 }
+
+pub fn concurrency() -> PerfTestOption {
+    PerfTestOption {
+        name: "concurrency",
+        display_message: "Number of concurrent network transfers",
+        mandatory: false,
+        long_activator: "concurrency",
+        expected_args_len: 1,
+        option_type: PerfTestOptionKind::Usize,
+        ..Default::default()
+    }
+}
+
+pub fn partition_size() -> PerfTestOption {
+    PerfTestOption {
+        name: "partition-size",
+        display_message: "Size in bytes to partition data into for each transfer",
+        mandatory: false,
+        long_activator: "partition-size",
+        expected_args_len: 1,
+        option_type: PerfTestOptionKind::Usize,
+        ..Default::default()
+    }
+}

--- a/sdk/storage/azure_storage_blob/perf/options.rs
+++ b/sdk/storage/azure_storage_blob/perf/options.rs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use azure_core_test::perf::{PerfTestOption, PerfTestOptionKind};
+
+pub fn endpoint() -> PerfTestOption {
+    PerfTestOption {
+        name: "endpoint",
+        display_message: "The endpoint of the blob storage",
+        mandatory: false,
+        short_activator: Some('e'),
+        long_activator: "endpoint",
+        expected_args_len: 1,
+        ..Default::default()
+    }
+}
+
+pub fn size() -> PerfTestOption {
+    PerfTestOption {
+        name: "size",
+        display_message: "The size of each blob in bytes",
+        mandatory: true,
+        short_activator: Some('s'),
+        long_activator: "size",
+        expected_args_len: 1,
+        option_type: PerfTestOptionKind::Usize,
+        ..Default::default()
+    }
+}
+
+pub fn count() -> PerfTestOption {
+    PerfTestOption {
+        name: "count",
+        display_message: "The number of blobs",
+        mandatory: false,
+        short_activator: Some('c'),
+        long_activator: "count",
+        expected_args_len: 1,
+        option_type: PerfTestOptionKind::Uint32,
+        ..Default::default()
+    }
+}
+
+pub fn collect() -> PerfTestOption {
+    PerfTestOption {
+        name: "collect",
+        display_message: "Collect the blob contents instead of streaming them",
+        mandatory: false,
+        short_activator: None,
+        long_activator: "collect",
+        expected_args_len: 1,
+        option_type: PerfTestOptionKind::String,
+        ..Default::default()
+    }
+}

--- a/sdk/storage/azure_storage_blob/perf/perf_tests.rs
+++ b/sdk/storage/azure_storage_blob/perf/perf_tests.rs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 mod download_blob_test;
-/// list_blob performance test.
 mod list_blob_test;
+mod options;
 mod upload_blob_test;
 
 use azure_core_test::perf::PerfRunner;

--- a/sdk/storage/azure_storage_blob/perf/upload_blob_test.rs
+++ b/sdk/storage/azure_storage_blob/perf/upload_blob_test.rs
@@ -5,12 +5,11 @@ use std::sync::{Arc, OnceLock};
 
 use azure_core::{http::Url, Bytes};
 use azure_core_test::{
-    perf::{
-        CreatePerfTestReturn, PerfRunner, PerfTest, PerfTestMetadata, PerfTestOption,
-        PerfTestOptionKind,
-    },
+    perf::{CreatePerfTestReturn, PerfRunner, PerfTest, PerfTestMetadata},
     TestContext,
 };
+
+use super::options;
 use azure_storage_blob::BlobContainerClient;
 use azure_storage_blob_test::get_test_credential;
 use futures::FutureExt;
@@ -41,27 +40,7 @@ impl UploadBlobTest {
         PerfTestMetadata {
             name: "upload_blob",
             description: "Upload blobs to a container",
-            options: vec![
-                PerfTestOption {
-                    name: "endpoint",
-                    display_message: "The endpoint of the blob storage",
-                    mandatory: false,
-                    short_activator: Some('e'),
-                    long_activator: "endpoint",
-                    expected_args_len: 1,
-                    ..Default::default()
-                },
-                PerfTestOption {
-                    name: "size",
-                    display_message: "The size of each blob in bytes",
-                    mandatory: true,
-                    short_activator: Some('s'),
-                    long_activator: "size",
-                    expected_args_len: 1,
-                    option_type: PerfTestOptionKind::Usize,
-                    ..Default::default()
-                },
-            ],
+            options: vec![options::size(), options::endpoint()],
             create_test: Self::create_upload_blob_test,
         }
     }

--- a/sdk/storage/azure_storage_blob/perf/upload_blob_test.rs
+++ b/sdk/storage/azure_storage_blob/perf/upload_blob_test.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use std::sync::{Arc, OnceLock};
+use std::{
+    num::NonZero,
+    sync::{Arc, OnceLock},
+};
 
 use azure_core::{http::Url, Bytes};
 use azure_core_test::{
@@ -10,12 +13,14 @@ use azure_core_test::{
 };
 
 use super::options;
-use azure_storage_blob::BlobContainerClient;
+use azure_storage_blob::{models::BlobClientUploadOptions, BlobContainerClient};
 use azure_storage_blob_test::get_test_credential;
 use futures::FutureExt;
 
 pub struct UploadBlobTest {
     size: usize,
+    concurrency: Option<NonZero<usize>>,
+    partition_size: Option<NonZero<u64>>,
     upload_buffer: OnceLock<Bytes>,
     endpoint: Option<String>,
     client: OnceLock<BlobContainerClient>,
@@ -30,6 +35,12 @@ impl UploadBlobTest {
                 size: runner
                     .try_get_test_arg("size")?
                     .expect("'size' parameter is required."),
+                concurrency: runner
+                    .try_get_test_arg::<usize>("concurrency")?
+                    .and_then(NonZero::new),
+                partition_size: runner
+                    .try_get_test_arg::<usize>("partition-size")?
+                    .and_then(|v| NonZero::new(v as u64)),
                 upload_buffer: OnceLock::new(),
             }) as Box<dyn PerfTest>)
         }
@@ -40,7 +51,12 @@ impl UploadBlobTest {
         PerfTestMetadata {
             name: "upload_blob",
             description: "Upload blobs to a container",
-            options: vec![options::size(), options::endpoint()],
+            options: vec![
+                options::size(),
+                options::concurrency(),
+                options::partition_size(),
+                options::endpoint(),
+            ],
             create_test: Self::create_upload_blob_test,
         }
     }
@@ -82,7 +98,12 @@ impl PerfTest for UploadBlobTest {
     async fn run(&self, _context: Arc<TestContext>) -> azure_core::Result<()> {
         let blob_client = self.client.get().unwrap().blob_client("perf-blob");
         let data_bytes = self.upload_buffer.get().unwrap().clone();
-        blob_client.upload(data_bytes.into(), None).await?;
+        let options = BlobClientUploadOptions {
+            parallel: self.concurrency,
+            partition_size: self.partition_size,
+            ..Default::default()
+        };
+        blob_client.upload(data_bytes.into(), Some(options)).await?;
 
         Ok(())
     }


### PR DESCRIPTION
This change adds support for `--concurrency` and `--partition_size` to the upload and download perf tests. Also refactors the options a bit for reusability.