### PR TITLE
perf(eventhubs): reduce producer and consumer lock contention across threads

### DIFF
--- a/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Other Changes
 
-- Improved multithreaded throughput when a single `ProducerClient` is shared across threads. The per-path sender and session caches no longer serialize on a single connection-wide lock, so sends to different partitions can be set up concurrently and the link attach no longer blocks unrelated sends.
+- Reduced lock contention when a single `ProducerClient` or `ConsumerClient` is shared across threads. The per-path sender, session, and receiver caches no longer serialize on a connection-wide lock: each partition's link attach runs without holding the shared lock, so the partitions on a shared client set up and recover concurrently instead of one at a time, and steady-state sends no longer queue behind an unrelated partition's attach.
 
 ## 0.14.0 (Unreleased)
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### Other Changes
 
+- Improved multithreaded throughput when a single `ProducerClient` is shared across threads. The per-path sender and session caches no longer serialize on a single connection-wide lock, so sends to different partitions can be set up concurrently and the link attach no longer blocks unrelated sends.
+
 ## 0.14.0 (Unreleased)
 
 ### Features Added

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -340,14 +340,28 @@ impl RecoverableConnection {
 
     pub(crate) async fn close_receiver(self: &Arc<Self>, source_url: &Url) -> Result<()> {
         // Drop the map's write lock as soon as the cell is removed so the detach
-        // (network I/O) doesn't hold it. Peel the cell to its inner receiver; if
-        // the cell was never initialized this is `None` and there is nothing to
-        // detach.
-        let cell = self.receiver_instances.write().await.remove(source_url);
-        let Some(receiver) = cell
-            .and_then(|cell| Arc::try_unwrap(cell).ok())
-            .and_then(OnceCell::into_inner)
-        else {
+        // (network I/O) doesn't hold it.
+        let Some(cell) = self.receiver_instances.write().await.remove(source_url) else {
+            // No entry for this path; nothing to detach.
+            return Ok(());
+        };
+        let receiver = match Arc::try_unwrap(cell) {
+            Ok(cell) => cell.into_inner(),
+            Err(_) => {
+                // A concurrent `ensure_receiver` is mid-attach and still holds a
+                // clone of the cell. The map entry is already removed and
+                // `EventReceiver::closed` stops the stream from reattaching, so
+                // the in-flight receiver is dropped once its operation completes;
+                // we just can't detach it by value here.
+                trace!(
+                    source = %source_url,
+                    "close_receiver skipped detach; attach in flight"
+                );
+                return Ok(());
+            }
+        };
+        let Some(receiver) = receiver else {
+            // Cell was removed before any attach completed; nothing to detach.
             return Ok(());
         };
         let strong_count = Arc::strong_count(&receiver);

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -76,14 +76,14 @@ pub(crate) struct RecoverableConnection {
     application_id: Option<String>,
     custom_endpoint: Option<Url>,
     mgmt_client: AsyncMutex<Option<Arc<AmqpManagement>>>,
-    receiver_instances: AsyncMutex<HashMap<Url, Arc<AmqpReceiver>>>,
-    // The sender and session caches are keyed by path. Each entry is an
-    // independently-initialized `OnceCell`, so concurrent sends to *different*
-    // partitions never serialize on a shared lock, and the expensive attach
-    // (authorize + session begin + link attach) happens without holding the
-    // map-wide lock. See issue #2243.
+    // The sender, session, and receiver caches are keyed by path. Each entry is
+    // an independently-initialized `OnceCell`, so concurrent operations on
+    // *different* partitions never serialize on a shared lock, and the expensive
+    // attach (authorize + session begin + link attach) happens without holding
+    // the map-wide lock. See issues #2243 and #4563.
     sender_instances: RwLock<HashMap<Url, Arc<OnceCell<Arc<AmqpSender>>>>>,
     session_instances: RwLock<HashMap<Url, Arc<OnceCell<Arc<AmqpSession>>>>>,
+    receiver_instances: RwLock<HashMap<Url, Arc<OnceCell<Arc<AmqpReceiver>>>>>,
     pub(super) authorizer: Arc<Authorizer>,
     connections: AsyncMutex<Option<Arc<AmqpConnection>>>,
     connection_name: String,
@@ -120,7 +120,7 @@ impl RecoverableConnection {
                 connections: AsyncMutex::new(None),
                 session_instances: RwLock::new(HashMap::new()),
                 sender_instances: RwLock::new(HashMap::new()),
-                receiver_instances: AsyncMutex::new(HashMap::new()),
+                receiver_instances: RwLock::new(HashMap::new()),
                 mgmt_client: AsyncMutex::new(None),
                 authorizer,
                 #[cfg(test)]
@@ -209,9 +209,16 @@ impl RecoverableConnection {
             }
         }
 
-        let mut receiver_instances = self.receiver_instances.lock().await;
-        for (source_url, receiver) in receiver_instances.drain() {
+        let mut receiver_instances = self.receiver_instances.write().await;
+        for (source_url, cell) in receiver_instances.drain() {
             trace!("Detaching receiver for source URL {}.", source_url);
+            let Some(receiver) = Arc::try_unwrap(cell).ok().and_then(OnceCell::into_inner) else {
+                trace!(
+                    "Failed to detach receiver for source URL {}, references exist.",
+                    source_url
+                );
+                continue;
+            };
             if let Ok(receiver) = Arc::try_unwrap(receiver) {
                 trace!("Detaching receiver for source URL {}.", source_url);
                 receiver.detach().await?;
@@ -332,24 +339,31 @@ impl RecoverableConnection {
     }
 
     pub(crate) async fn close_receiver(self: &Arc<Self>, source_url: &Url) -> Result<()> {
-        let mut receiver_instances = self.receiver_instances.lock().await;
-        if let Some(receiver) = receiver_instances.remove(source_url) {
-            let strong_count = Arc::strong_count(&receiver);
-            let r = Arc::try_unwrap(receiver);
-            if let Ok(receiver) = r {
-                trace!("Detaching receiver: {:?}", source_url);
-                receiver.detach().await?;
-            } else {
-                // In-flight `receive_delivery` holds a clone of the Arc.
-                // Map entry is already removed; `EventReceiver::closed`
-                // (set before this call by `request_close`) stops the
-                // stream from reattaching on its next poll.
-                warn!(
-                    source = %source_url,
-                    strong_count,
-                    "close_receiver could not detach by-value"
-                );
-            }
+        // Drop the map's write lock as soon as the cell is removed so the detach
+        // (network I/O) doesn't hold it. Peel the cell to its inner receiver; if
+        // the cell was never initialized this is `None` and there is nothing to
+        // detach.
+        let cell = self.receiver_instances.write().await.remove(source_url);
+        let Some(receiver) = cell
+            .and_then(|cell| Arc::try_unwrap(cell).ok())
+            .and_then(OnceCell::into_inner)
+        else {
+            return Ok(());
+        };
+        let strong_count = Arc::strong_count(&receiver);
+        if let Ok(receiver) = Arc::try_unwrap(receiver) {
+            trace!("Detaching receiver: {:?}", source_url);
+            receiver.detach().await?;
+        } else {
+            // In-flight `receive_delivery` holds a clone of the Arc.
+            // Map entry is already removed; `EventReceiver::closed`
+            // (set before this call by `request_close`) stops the
+            // stream from reattaching on its next poll.
+            warn!(
+                source = %source_url,
+                strong_count,
+                "close_receiver could not detach by-value"
+            );
         }
         Ok(())
     }
@@ -476,30 +490,49 @@ impl RecoverableConnection {
         message_source: &AmqpSource,
         receiver_options: &AmqpReceiverOptions,
     ) -> azure_core_amqp::Result<Arc<AmqpReceiver>> {
-        let mut receiver_instances = self.receiver_instances.lock().await;
-        if !receiver_instances.contains_key(source_url) {
-            self.ensure_connection().await?;
-            self.authorizer.authorize_path(self, source_url).await?;
+        // Resolve the per-path cell while holding the map lock only briefly, then
+        // attach (ensure connection + authorize + session begin + link attach)
+        // without holding it, so receivers for other partitions can be created
+        // concurrently and steady-state receives never serialize on a shared
+        // lock. See issues #2243 and #4563.
+        let cell = self.receiver_cell(source_url).await;
+        let receiver = cell
+            .get_or_try_init(|| async {
+                self.ensure_connection().await?;
+                self.authorizer.authorize_path(self, source_url).await?;
 
-            let session = self.get_session(source_url).await?;
+                let session = self.get_session(source_url).await?;
 
-            debug!("Create receiver on partition {source_url}.");
-            let receiver = AmqpReceiver::new();
-            receiver
-                .attach(
-                    &session,
-                    message_source.clone(),
-                    Some(receiver_options.clone()),
-                )
-                .await?;
+                debug!("Create receiver on partition {source_url}.");
+                let receiver = AmqpReceiver::new();
+                receiver
+                    .attach(
+                        &session,
+                        message_source.clone(),
+                        Some(receiver_options.clone()),
+                    )
+                    .await?;
+                Ok::<_, AmqpError>(Arc::new(receiver))
+            })
+            .await?;
 
-            receiver_instances.insert(source_url.clone(), Arc::new(receiver));
+        Ok(receiver.clone())
+    }
+
+    /// Returns the `OnceCell` that owns the receiver for `source_url`, inserting
+    /// an uninitialized one if absent. The read path is taken first so
+    /// steady-state lookups share a read lock; only first-time inserts take the
+    /// write lock.
+    async fn receiver_cell(&self, source_url: &Url) -> Arc<OnceCell<Arc<AmqpReceiver>>> {
+        if let Some(cell) = self.receiver_instances.read().await.get(source_url) {
+            return cell.clone();
         }
-
-        Ok(receiver_instances
-            .get(source_url)
-            .ok_or_else(|| AmqpError::with_message("Missing message receiver"))?
-            .clone())
+        self.receiver_instances
+            .write()
+            .await
+            .entry(source_url.clone())
+            .or_insert_with(|| Arc::new(OnceCell::new()))
+            .clone()
     }
 
     pub(super) async fn ensure_sender(
@@ -577,21 +610,21 @@ impl RecoverableConnection {
                 connection.authorizer.clear().await;
                 connection.session_instances.write().await.clear();
                 connection.sender_instances.write().await.clear();
-                connection.receiver_instances.lock().await.clear();
+                connection.receiver_instances.write().await.clear();
             }
             ErrorRecoveryAction::ReconnectSession => {
                 debug!("Recovering from session error: {:?}", reason);
                 // Recreate the session and sender/receiver as needed.
                 connection.session_instances.write().await.clear();
                 connection.sender_instances.write().await.clear();
-                connection.receiver_instances.lock().await.clear();
+                connection.receiver_instances.write().await.clear();
             }
             ErrorRecoveryAction::ReconnectLink => {
                 debug!("Recovering from link error: {:?}", reason);
                 // Recreate the session and sender/receiver as needed.
                 connection.session_instances.write().await.clear();
                 connection.sender_instances.write().await.clear();
-                connection.receiver_instances.lock().await.clear();
+                connection.receiver_instances.write().await.clear();
                 connection.mgmt_client.lock().await.take();
             }
             _ => {
@@ -757,12 +790,13 @@ mod tests {
         assert!(!connection_manager.connections.lock_blocking().is_some());
     }
 
-    // The per-path sender/session caches must hand out one shared `OnceCell` per
-    // path (so concurrent first-sends to a partition attach exactly once) and
-    // distinct cells for distinct paths (so sends to different partitions never
-    // share a cell and can initialize concurrently). See issue #2243.
+    // The per-path sender/session/receiver caches must hand out one shared
+    // `OnceCell` per path (so concurrent first-operations on a partition attach
+    // exactly once) and distinct cells for distinct paths (so operations on
+    // different partitions never share a cell and can initialize concurrently).
+    // See issues #2243 and #4563.
     #[tokio::test]
-    async fn sender_and_session_cells_are_keyed_by_path() {
+    async fn sender_session_and_receiver_cells_are_keyed_by_path() {
         let url = Url::parse("amqps://example.com").unwrap();
         let connection = RecoverableConnection::new(
             url,
@@ -775,7 +809,7 @@ mod tests {
         let path_a = Url::parse("amqps://example.com/eh/Partitions/0").unwrap();
         let path_b = Url::parse("amqps://example.com/eh/Partitions/1").unwrap();
 
-        // Same path resolves to the same cell, both for senders and sessions.
+        // Same path resolves to the same cell for senders, sessions, and receivers.
         assert!(Arc::ptr_eq(
             &connection.sender_cell(&path_a).await,
             &connection.sender_cell(&path_a).await
@@ -784,16 +818,25 @@ mod tests {
             &connection.session_cell(&path_a).await,
             &connection.session_cell(&path_a).await
         ));
+        assert!(Arc::ptr_eq(
+            &connection.receiver_cell(&path_a).await,
+            &connection.receiver_cell(&path_a).await
+        ));
 
         // Different paths resolve to different cells.
         assert!(!Arc::ptr_eq(
             &connection.sender_cell(&path_a).await,
             &connection.sender_cell(&path_b).await
         ));
+        assert!(!Arc::ptr_eq(
+            &connection.receiver_cell(&path_a).await,
+            &connection.receiver_cell(&path_b).await
+        ));
 
         // Cells are uninitialized until an attach succeeds.
         assert!(connection.sender_cell(&path_a).await.get().is_none());
         assert!(connection.session_cell(&path_a).await.get().is_none());
+        assert!(connection.receiver_cell(&path_a).await.get().is_none());
     }
 
     // The RecoverableConnection supports using a custom endpoint for connecting to Event Hubs proxies.

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -18,11 +18,8 @@ use crate::{
     producer::DEFAULT_EVENTHUBS_APPLICATION,
     RetryOptions,
 };
-use async_lock::Mutex as AsyncMutex;
-use azure_core::{
-    credentials::TokenCredential, error::ErrorKind as AzureErrorKind, http::Url, time::Duration,
-    Uuid,
-};
+use async_lock::{Mutex as AsyncMutex, OnceCell, RwLock};
+use azure_core::{credentials::TokenCredential, http::Url, time::Duration, Uuid};
 use azure_core_amqp::{
     error::{AmqpErrorCondition, AmqpErrorKind},
     AmqpClaimsBasedSecurity, AmqpConnection, AmqpConnectionApis, AmqpConnectionOptions, AmqpError,
@@ -80,8 +77,13 @@ pub(crate) struct RecoverableConnection {
     custom_endpoint: Option<Url>,
     mgmt_client: AsyncMutex<Option<Arc<AmqpManagement>>>,
     receiver_instances: AsyncMutex<HashMap<Url, Arc<AmqpReceiver>>>,
-    sender_instances: AsyncMutex<HashMap<Url, Arc<AmqpSender>>>,
-    session_instances: AsyncMutex<HashMap<Url, Arc<AmqpSession>>>,
+    // The sender and session caches are keyed by path. Each entry is an
+    // independently-initialized `OnceCell`, so concurrent sends to *different*
+    // partitions never serialize on a shared lock, and the expensive attach
+    // (authorize + session begin + link attach) happens without holding the
+    // map-wide lock. See issue #2243.
+    sender_instances: RwLock<HashMap<Url, Arc<OnceCell<Arc<AmqpSender>>>>>,
+    session_instances: RwLock<HashMap<Url, Arc<OnceCell<Arc<AmqpSession>>>>>,
     pub(super) authorizer: Arc<Authorizer>,
     connections: AsyncMutex<Option<Arc<AmqpConnection>>>,
     connection_name: String,
@@ -116,8 +118,8 @@ impl RecoverableConnection {
                 custom_endpoint,
                 retry_options,
                 connections: AsyncMutex::new(None),
-                session_instances: AsyncMutex::new(HashMap::new()),
-                sender_instances: AsyncMutex::new(HashMap::new()),
+                session_instances: RwLock::new(HashMap::new()),
+                sender_instances: RwLock::new(HashMap::new()),
                 receiver_instances: AsyncMutex::new(HashMap::new()),
                 mgmt_client: AsyncMutex::new(None),
                 authorizer,
@@ -186,9 +188,16 @@ impl RecoverableConnection {
             }
         }
 
-        let mut sender_instances = self.sender_instances.lock().await;
-        for (path, sender) in sender_instances.drain() {
+        let mut sender_instances = self.sender_instances.write().await;
+        for (path, cell) in sender_instances.drain() {
             trace!("Detaching sender for path {}.", path);
+            let Some(sender) = Arc::try_unwrap(cell).ok().and_then(OnceCell::into_inner) else {
+                trace!(
+                    "Failed to detach sender for path {}, references exist.",
+                    path
+                );
+                continue;
+            };
             if let Ok(sender) = Arc::try_unwrap(sender) {
                 trace!("Detaching sender for path {}.", path);
                 sender.detach().await?;
@@ -214,9 +223,16 @@ impl RecoverableConnection {
             }
         }
 
-        let mut session_instances = self.session_instances.lock().await;
-        for (session_id, session) in session_instances.drain() {
+        let mut session_instances = self.session_instances.write().await;
+        for (session_id, cell) in session_instances.drain() {
             trace!("Detaching session for ID {}.", session_id);
+            let Some(session) = Arc::try_unwrap(cell).ok().and_then(OnceCell::into_inner) else {
+                trace!(
+                    "Failed to detach session for ID {}, references exist.",
+                    session_id
+                );
+                continue;
+            };
             if let Ok(session) = Arc::try_unwrap(session) {
                 session.end().await?;
             } else {
@@ -342,35 +358,46 @@ impl RecoverableConnection {
         self: &Arc<Self>,
         source_url: &Url,
     ) -> azure_core_amqp::Result<Arc<AmqpSession>> {
-        let mut session_instances = self.session_instances.lock().await;
-        if !session_instances.contains_key(source_url) {
-            debug!("Creating session for partition: {:?}", source_url);
-            let connection = self.ensure_connection().await?;
+        // Resolve the per-path cell while holding the map lock only briefly, then
+        // initialize (which may begin a new AMQP session) without holding it, so
+        // that sessions for other partitions can be created concurrently.
+        let cell = self.session_cell(source_url).await;
+        let session = cell
+            .get_or_try_init(|| async {
+                debug!("Creating session for partition: {:?}", source_url);
+                let connection = self.ensure_connection().await?;
 
-            let session = AmqpSession::new();
-            session
-                .begin(
-                    connection.as_ref(),
-                    Some(AmqpSessionOptions {
-                        incoming_window: Some(u32::MAX),
-                        outgoing_window: Some(u32::MAX),
-                        ..Default::default()
-                    }),
-                )
-                .await?;
-            session_instances.insert(source_url.clone(), Arc::new(session));
-        }
-        let rv = session_instances
-            .get(source_url)
-            .ok_or_else(|| {
-                AmqpError::from(azure_core::Error::with_message(
-                    AzureErrorKind::Other,
-                    "Could not find session",
-                ))
-            })?
-            .clone();
+                let session = AmqpSession::new();
+                session
+                    .begin(
+                        connection.as_ref(),
+                        Some(AmqpSessionOptions {
+                            incoming_window: Some(u32::MAX),
+                            outgoing_window: Some(u32::MAX),
+                            ..Default::default()
+                        }),
+                    )
+                    .await?;
+                Ok::<_, AmqpError>(Arc::new(session))
+            })
+            .await?;
         debug!("Cloning session for partition {:?}", source_url);
-        Ok(rv)
+        Ok(session.clone())
+    }
+
+    /// Returns the `OnceCell` that owns the session for `source_url`, inserting an
+    /// uninitialized one if absent. The read path is taken first so steady-state
+    /// lookups share a read lock; only first-time inserts take the write lock.
+    async fn session_cell(&self, source_url: &Url) -> Arc<OnceCell<Arc<AmqpSession>>> {
+        if let Some(cell) = self.session_instances.read().await.get(source_url) {
+            return cell.clone();
+        }
+        self.session_instances
+            .write()
+            .await
+            .entry(source_url.clone())
+            .or_insert_with(|| Arc::new(OnceCell::new()))
+            .clone()
     }
 
     async fn create_connection(&self) -> azure_core_amqp::Result<Arc<AmqpConnection>> {
@@ -479,39 +506,52 @@ impl RecoverableConnection {
         self: &Arc<Self>,
         path: &Url,
     ) -> azure_core_amqp::Result<Arc<AmqpSender>> {
-        let mut sender_instances = self.sender_instances.lock().await;
-        if !sender_instances.contains_key(path) {
-            // Ensure that we are authorized to access the senders path.
-            self.authorizer.authorize_path(self, path).await?;
+        // Resolve the per-path cell while holding the map lock only briefly, then
+        // attach (authorize + session begin + link attach) without holding it, so
+        // that senders for other partitions can be created concurrently and
+        // steady-state sends never serialize on a shared lock. See issue #2243.
+        let cell = self.sender_cell(path).await;
+        let sender = cell
+            .get_or_try_init(|| async {
+                // Ensure that we are authorized to access the senders path.
+                self.authorizer.authorize_path(self, path).await?;
 
-            // Retrieve a session for the sender from the session cache.
-            let session = self.get_session(path).await?;
-            let sender = AmqpSender::new();
-            sender
-                .attach(
-                    &session,
-                    format!(
-                        "{}-rust-sender",
-                        self.application_id
-                            .as_ref()
-                            .unwrap_or(&DEFAULT_EVENTHUBS_APPLICATION.to_string())
-                    ),
-                    path.to_string(),
-                    None,
-                )
-                .await?;
-            sender_instances.insert(path.clone(), Arc::new(sender));
+                // Retrieve a session for the sender from the session cache.
+                let session = self.get_session(path).await?;
+                let sender = AmqpSender::new();
+                sender
+                    .attach(
+                        &session,
+                        format!(
+                            "{}-rust-sender",
+                            self.application_id
+                                .as_ref()
+                                .unwrap_or(&DEFAULT_EVENTHUBS_APPLICATION.to_string())
+                        ),
+                        path.to_string(),
+                        None,
+                    )
+                    .await?;
+                Ok::<_, AmqpError>(Arc::new(sender))
+            })
+            .await?;
+
+        Ok(sender.clone())
+    }
+
+    /// Returns the `OnceCell` that owns the sender for `path`, inserting an
+    /// uninitialized one if absent. The read path is taken first so steady-state
+    /// lookups share a read lock; only first-time inserts take the write lock.
+    async fn sender_cell(&self, path: &Url) -> Arc<OnceCell<Arc<AmqpSender>>> {
+        if let Some(cell) = self.sender_instances.read().await.get(path) {
+            return cell.clone();
         }
-
-        Ok(sender_instances
-            .get(path)
-            .ok_or_else(|| {
-                AmqpError::from(azure_core::Error::with_message(
-                    AzureErrorKind::Other,
-                    "Missing message sender",
-                ))
-            })?
-            .clone())
+        self.sender_instances
+            .write()
+            .await
+            .entry(path.clone())
+            .or_insert_with(|| Arc::new(OnceCell::new()))
+            .clone()
     }
 
     pub(super) async fn recover_from_error(
@@ -535,22 +575,22 @@ impl RecoverableConnection {
                 debug!("Recovering from connection error: {:?}", reason);
                 connection.connections.lock().await.take();
                 connection.authorizer.clear().await;
-                connection.session_instances.lock().await.clear();
-                connection.sender_instances.lock().await.clear();
+                connection.session_instances.write().await.clear();
+                connection.sender_instances.write().await.clear();
                 connection.receiver_instances.lock().await.clear();
             }
             ErrorRecoveryAction::ReconnectSession => {
                 debug!("Recovering from session error: {:?}", reason);
                 // Recreate the session and sender/receiver as needed.
-                connection.session_instances.lock().await.clear();
-                connection.sender_instances.lock().await.clear();
+                connection.session_instances.write().await.clear();
+                connection.sender_instances.write().await.clear();
                 connection.receiver_instances.lock().await.clear();
             }
             ErrorRecoveryAction::ReconnectLink => {
                 debug!("Recovering from link error: {:?}", reason);
                 // Recreate the session and sender/receiver as needed.
-                connection.session_instances.lock().await.clear();
-                connection.sender_instances.lock().await.clear();
+                connection.session_instances.write().await.clear();
+                connection.sender_instances.write().await.clear();
                 connection.receiver_instances.lock().await.clear();
                 connection.mgmt_client.lock().await.take();
             }
@@ -715,6 +755,45 @@ mod tests {
         ));
 
         assert!(!connection_manager.connections.lock_blocking().is_some());
+    }
+
+    // The per-path sender/session caches must hand out one shared `OnceCell` per
+    // path (so concurrent first-sends to a partition attach exactly once) and
+    // distinct cells for distinct paths (so sends to different partitions never
+    // share a cell and can initialize concurrently). See issue #2243.
+    #[tokio::test]
+    async fn sender_and_session_cells_are_keyed_by_path() {
+        let url = Url::parse("amqps://example.com").unwrap();
+        let connection = RecoverableConnection::new(
+            url,
+            None,
+            None,
+            Arc::new(MockCredential),
+            Default::default(),
+        );
+
+        let path_a = Url::parse("amqps://example.com/eh/Partitions/0").unwrap();
+        let path_b = Url::parse("amqps://example.com/eh/Partitions/1").unwrap();
+
+        // Same path resolves to the same cell, both for senders and sessions.
+        assert!(Arc::ptr_eq(
+            &connection.sender_cell(&path_a).await,
+            &connection.sender_cell(&path_a).await
+        ));
+        assert!(Arc::ptr_eq(
+            &connection.session_cell(&path_a).await,
+            &connection.session_cell(&path_a).await
+        ));
+
+        // Different paths resolve to different cells.
+        assert!(!Arc::ptr_eq(
+            &connection.sender_cell(&path_a).await,
+            &connection.sender_cell(&path_b).await
+        ));
+
+        // Cells are uninitialized until an attach succeeds.
+        assert!(connection.sender_cell(&path_a).await.get().is_none());
+        assert!(connection.session_cell(&path_a).await.get().is_none());
     }
 
     // The RecoverableConnection supports using a custom endpoint for connecting to Event Hubs proxies.

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -96,6 +96,26 @@ pub(crate) struct RecoverableConnection {
 unsafe impl Send for RecoverableConnection {}
 unsafe impl Sync for RecoverableConnection {}
 
+/// Returns the per-path `OnceCell` for `key`, inserting an uninitialized one if
+/// absent. The read path is taken first so steady-state lookups share a read
+/// lock; only the first insert for a key takes the write lock. The attach then
+/// runs inside the returned `OnceCell`, so the map lock is never held across it
+/// and different paths set up concurrently. Shared by the sender, session, and
+/// receiver caches so all three keep identical concurrency semantics.
+async fn or_init_cell<T>(
+    map: &RwLock<HashMap<Url, Arc<OnceCell<Arc<T>>>>>,
+    key: &Url,
+) -> Arc<OnceCell<Arc<T>>> {
+    if let Some(cell) = map.read().await.get(key) {
+        return cell.clone();
+    }
+    map.write()
+        .await
+        .entry(key.clone())
+        .or_insert_with(|| Arc::new(OnceCell::new()))
+        .clone()
+}
+
 impl RecoverableConnection {
     pub fn new(
         url: Url,
@@ -414,18 +434,9 @@ impl RecoverableConnection {
     }
 
     /// Returns the `OnceCell` that owns the session for `source_url`, inserting an
-    /// uninitialized one if absent. The read path is taken first so steady-state
-    /// lookups share a read lock; only first-time inserts take the write lock.
+    /// uninitialized one if absent. See [`or_init_cell`] for the locking strategy.
     async fn session_cell(&self, source_url: &Url) -> Arc<OnceCell<Arc<AmqpSession>>> {
-        if let Some(cell) = self.session_instances.read().await.get(source_url) {
-            return cell.clone();
-        }
-        self.session_instances
-            .write()
-            .await
-            .entry(source_url.clone())
-            .or_insert_with(|| Arc::new(OnceCell::new()))
-            .clone()
+        or_init_cell(&self.session_instances, source_url).await
     }
 
     async fn create_connection(&self) -> azure_core_amqp::Result<Arc<AmqpConnection>> {
@@ -534,19 +545,9 @@ impl RecoverableConnection {
     }
 
     /// Returns the `OnceCell` that owns the receiver for `source_url`, inserting
-    /// an uninitialized one if absent. The read path is taken first so
-    /// steady-state lookups share a read lock; only first-time inserts take the
-    /// write lock.
+    /// an uninitialized one if absent. See [`or_init_cell`] for the locking strategy.
     async fn receiver_cell(&self, source_url: &Url) -> Arc<OnceCell<Arc<AmqpReceiver>>> {
-        if let Some(cell) = self.receiver_instances.read().await.get(source_url) {
-            return cell.clone();
-        }
-        self.receiver_instances
-            .write()
-            .await
-            .entry(source_url.clone())
-            .or_insert_with(|| Arc::new(OnceCell::new()))
-            .clone()
+        or_init_cell(&self.receiver_instances, source_url).await
     }
 
     pub(super) async fn ensure_sender(
@@ -587,18 +588,9 @@ impl RecoverableConnection {
     }
 
     /// Returns the `OnceCell` that owns the sender for `path`, inserting an
-    /// uninitialized one if absent. The read path is taken first so steady-state
-    /// lookups share a read lock; only first-time inserts take the write lock.
+    /// uninitialized one if absent. See [`or_init_cell`] for the locking strategy.
     async fn sender_cell(&self, path: &Url) -> Arc<OnceCell<Arc<AmqpSender>>> {
-        if let Some(cell) = self.sender_instances.read().await.get(path) {
-            return cell.clone();
-        }
-        self.sender_instances
-            .write()
-            .await
-            .entry(path.clone())
-            .or_insert_with(|| Arc::new(OnceCell::new()))
-            .clone()
+        or_init_cell(&self.sender_instances, path).await
     }
 
     pub(super) async fn recover_from_error(

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -1039,14 +1039,17 @@ pub(crate) mod tests {
                             ..Default::default()
                         }))
                         .await
-                        .unwrap();
+                        .expect("feed: create_batch");
                     batch
                         .try_add_event_data(
                             EventData::builder().with_body(b"heartbeat").build(),
                             None,
                         )
-                        .unwrap();
-                    producer.send_batch(batch, None).await.unwrap();
+                        .expect("feed: add heartbeat event");
+                    producer
+                        .send_batch(batch, None)
+                        .await
+                        .expect("feed: send_batch");
                     sleep(Duration::milliseconds(250)).await;
                 }
             }
@@ -1088,8 +1091,23 @@ pub(crate) mod tests {
         )
         .await?;
 
+        // Stop the feed and observe its cancellation. A clean cancel is
+        // expected; a panic in the feed (e.g. one of its `expect`s firing) is
+        // re-raised here instead of being silently swallowed, which would
+        // otherwise surface only as the receive loop starving for deliveries.
         feed.abort();
+        match feed.await {
+            Ok(()) => {}
+            Err(err) if err.is_cancelled() => {}
+            Err(err) => std::panic::resume_unwind(err.into_panic()),
+        }
 
+        // Close both clients explicitly so neither leaks its AMQP connection
+        // across live tests. The feed task has finished by now, so its producer
+        // clone is gone and the unwrap holds the sole reference.
+        if let Ok(producer) = Arc::try_unwrap(producer) {
+            producer.close().await?;
+        }
         if let Ok(consumer) = Arc::try_unwrap(consumer) {
             consumer.close().await?;
         }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -709,11 +709,13 @@ pub mod builders {
 #[cfg(test)]
 pub(crate) mod tests {
     use crate::{
-        common::tests::force_errors, ConsumerClient, Result, StartLocation, StartPosition,
+        common::tests::force_errors, models::EventData, ConsumerClient, EventDataBatchOptions,
+        ProducerClient, Result, StartLocation, StartPosition,
     };
-    use azure_core::time::Duration;
-    use azure_core_amqp::error::AmqpErrorKind;
+    use azure_core::{sleep::sleep, time::Duration};
+    use azure_core_amqp::{error::AmqpErrorKind, AmqpError};
     use azure_core_test::{recorded, TestContext};
+    use futures::stream::StreamExt;
     use std::{
         sync::Arc,
         time::{SystemTime, UNIX_EPOCH},
@@ -994,5 +996,133 @@ pub(crate) mod tests {
         .await?;
 
         Ok(())
+    }
+
+    // --- Receiver-side recovery tests (issue #4563) ------------------------
+    //
+    // These mirror the producer's `force_errors_send_batch_*` tests but drive
+    // the consumer receive path, which re-resolves the per-path receiver cache
+    // on every `receive_delivery`. A background producer feeds the partition so
+    // the receive loop keeps pulling deliveries; without traffic the loop would
+    // block in `receive_delivery` and never re-enter the recovery path the
+    // receiver-cache change touches. After the forced error the receiver
+    // re-attaches transparently and deliveries resume.
+
+    const RECEIVE_TEST_PARTITION: &str = "0";
+
+    async fn run_receive_recovery(
+        ctx: &TestContext,
+        test_name: &str,
+        make_error: fn() -> AmqpError,
+    ) -> Result<()> {
+        let recording = ctx.recording();
+        let host = recording.var("EVENTHUBS_HOST", None);
+        let eventhub = recording.var("EVENTHUB_NAME", None);
+        let credential = recording.credential();
+
+        // Feed the partition continuously from an independent producer
+        // connection so the consumer always has deliveries to pull. The forced
+        // error is injected only on the consumer, so this producer stays stable.
+        let producer = Arc::new(
+            ProducerClient::builder()
+                .with_application_id(format!("{test_name}-feed"))
+                .open(host.as_str(), eventhub.as_str(), credential.clone())
+                .await?,
+        );
+        let feed = tokio::spawn({
+            let producer = producer.clone();
+            async move {
+                loop {
+                    let batch = producer
+                        .create_batch(Some(EventDataBatchOptions {
+                            partition_id: Some(RECEIVE_TEST_PARTITION.to_string()),
+                            ..Default::default()
+                        }))
+                        .await
+                        .unwrap();
+                    batch
+                        .try_add_event_data(
+                            EventData::builder().with_body(b"heartbeat").build(),
+                            None,
+                        )
+                        .unwrap();
+                    producer.send_batch(batch, None).await.unwrap();
+                    sleep(Duration::milliseconds(250)).await;
+                }
+            }
+        });
+
+        let consumer = Arc::new(
+            ConsumerClient::builder()
+                .with_application_id(test_name.to_string())
+                .open(host.as_str(), eventhub, credential.clone())
+                .await?,
+        );
+
+        force_errors(
+            consumer.clone(),
+            |consumer: Arc<ConsumerClient>| {
+                let consumer = consumer.clone();
+                async move {
+                    // Default start position is "latest", so we receive the
+                    // heartbeat events the feed produces from now on.
+                    let receiver = consumer
+                        .open_receiver_on_partition(RECEIVE_TEST_PARTITION.to_string(), None)
+                        .await
+                        .unwrap();
+                    let mut stream = std::pin::pin!(receiver.stream_events());
+                    while let Some(event) = stream.next().await {
+                        // Recovery is transparent: after the forced error the
+                        // receiver re-attaches and deliveries resume, so the
+                        // stream keeps yielding Ok.
+                        event.unwrap();
+                    }
+                }
+            },
+            move |consumer: Arc<ConsumerClient>| {
+                info!("Forcing error on consumer receiver");
+                consumer.force_error(make_error()).unwrap();
+            },
+            Duration::seconds(10), // Seconds until forcing the error.
+            Duration::seconds(30), // Seconds until test timeout.
+        )
+        .await?;
+
+        feed.abort();
+
+        if let Ok(consumer) = Arc::try_unwrap(consumer) {
+            consumer.close().await?;
+        }
+        Ok(())
+    }
+
+    #[recorded::test(live)]
+    async fn force_errors_receive_link(ctx: TestContext) -> Result<()> {
+        run_receive_recovery(&ctx, "force_errors_receive_link", || {
+            AmqpError::from(AmqpErrorKind::LinkClosedByRemote(Box::new(
+                azure_core::error::Error::new(azure_core::error::ErrorKind::Other, "Forced error"),
+            )))
+        })
+        .await
+    }
+
+    #[recorded::test(live)]
+    async fn force_errors_receive_session(ctx: TestContext) -> Result<()> {
+        run_receive_recovery(&ctx, "force_errors_receive_session", || {
+            AmqpError::from(AmqpErrorKind::SessionClosedByRemote(Box::new(
+                azure_core::error::Error::new(azure_core::error::ErrorKind::Other, "Forced error"),
+            )))
+        })
+        .await
+    }
+
+    #[recorded::test(live)]
+    async fn force_errors_receive_connection(ctx: TestContext) -> Result<()> {
+        run_receive_recovery(&ctx, "force_errors_receive_connection", || {
+            AmqpError::from(AmqpErrorKind::ConnectionClosedByRemote(Box::new(
+                azure_core::error::Error::new(azure_core::error::ErrorKind::Other, "Forced error"),
+            )))
+        })
+        .await
     }
 }


### PR DESCRIPTION
Addresses #2243 and #4563. Sharing one client across threads serializes its AMQP link setup. The contention lives in `RecoverableConnection`, which kept its sender, session, and receiver caches each behind a connection-wide async mutex: every send or receive took that lock just to find its cached link, operations on different partitions queued on it, and the first operation on a partition held it across the whole attach (authorize, session begin, link attach) while everything else waited.

This swaps each cache for a `RwLock<HashMap<Url, Arc<OnceCell<Arc<T>>>>>` keyed by path. Steady-state lookups share a read lock, the first insert for a path takes the write lock, and the attach runs inside the per-path `OnceCell`, so the map lock is held only long enough to find the cell and different partitions set up concurrently. `OnceCell` still guarantees one attach per path under concurrent first-callers. Recovery is unchanged: `recover_from_error` clears the maps and the next operation re-attaches. The public API is unchanged.

For the producer this removes serialization from the hot send path (`get_sender` runs on every send). For the consumer the win is narrower and concentrated in startup and recovery: `ensure_receiver` runs on every `receive_delivery`, so a single `ConsumerClient` backing many partitions (the `EventProcessor` case) re-attached them one at a time on startup and recovery; now they attach concurrently. The steady-state per-receive cost was already a sub-microsecond lock, so the gain there is modest. `mgmt_client` stays an `AsyncMutex`: it is a single value, not a keyed map, so there is no per-key parallelism to gain.

Tests: a unit test pins the per-path cell keying for all three caches, and new `force_errors_receive_{link,session,connection}` live tests exercise receiver recovery, with a background producer feeding the partition so the receive loop keeps re-entering `ensure_receiver`, mirroring the producer's `force_errors_send_batch_*`.

Build, clippy, and unit tests are green. The live `force_errors_*` tests (the existing producer ones and the new receiver ones) require a real namespace with Entra auth and are skipped otherwise; they have not been run as part of this change.

