### PR TITLE
Use published azure_core_test, macros crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
  "async-trait",
  "azure_core_examples",
  "azure_core_macros 1.0.0",
- "azure_core_test",
+ "azure_core_test 0.2.0",
  "bytes",
  "criterion",
  "futures",
@@ -428,8 +428,8 @@ name = "azure_core_opentelemetry"
 version = "1.1.0-beta.1"
 dependencies = [
  "azure_core 1.0.0",
- "azure_core_test",
- "azure_core_test_macros",
+ "azure_core_test 0.1.0",
+ "azure_core_test_macros 0.1.0",
  "azure_identity 1.0.0",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -440,13 +440,40 @@ dependencies = [
 
 [[package]]
 name = "azure_core_test"
-version = "0.2.0"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2804e3700e030700e4c9c00c2e37d86c4092323ad81f21f1a43a44fc06f0afe"
 dependencies = [
  "async-trait",
  "azure_core 1.0.0",
- "azure_core_test_macros",
+ "azure_core_test_macros 0.1.0",
  "azure_identity 1.0.0",
- "azure_security_keyvault_secrets 1.0.0",
+ "clap",
+ "dotenvy",
+ "flate2",
+ "futures",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tar",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "zip",
+]
+
+[[package]]
+name = "azure_core_test"
+version = "0.2.0"
+dependencies = [
+ "async-trait",
+ "azure_core 1.1.0-beta.1",
+ "azure_core_examples",
+ "azure_core_test_macros 0.2.0",
+ "azure_identity 1.1.0-beta.1",
  "clap",
  "dotenvy",
  "flate2",
@@ -467,9 +494,20 @@ dependencies = [
 
 [[package]]
 name = "azure_core_test_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "878a0b374ba6a37254f01886984b8d9c828f32011e606518930c19535849301f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "azure_core_test_macros"
 version = "0.2.0"
 dependencies = [
- "azure_core_test",
+ "azure_core_test 0.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -483,7 +521,7 @@ dependencies = [
  "async-lock",
  "async-trait",
  "azure_core 1.0.0",
- "azure_core_test",
+ "azure_core_test 0.1.0",
  "azure_data_cosmos_driver",
  "azure_identity 1.0.0",
  "base64 0.22.1",
@@ -613,9 +651,9 @@ version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core 1.0.0",
- "azure_core_test",
- "azure_security_keyvault_secrets 1.1.0-beta.1",
+ "azure_core 1.1.0-beta.1",
+ "azure_core_examples",
+ "azure_core_test 0.2.0",
  "clap",
  "futures",
  "include-file",
@@ -641,7 +679,7 @@ dependencies = [
  "async-trait",
  "azure_core 1.0.0",
  "azure_core_amqp 1.0.0",
- "azure_core_test",
+ "azure_core_test 0.1.0",
  "azure_identity 1.0.0",
  "azure_messaging_eventhubs",
  "criterion",
@@ -662,7 +700,7 @@ dependencies = [
  "async-trait",
  "azure_core 1.0.0",
  "azure_core_opentelemetry 1.0.0",
- "azure_core_test",
+ "azure_core_test 0.1.0",
  "azure_identity 1.0.0",
  "azure_messaging_eventhubs",
  "azure_storage_blob 1.0.0",
@@ -688,7 +726,7 @@ dependencies = [
  "async-trait",
  "azure_core 1.0.0",
  "azure_core_amqp 1.0.0",
- "azure_core_test",
+ "azure_core_test 0.1.0",
  "azure_identity 1.0.0",
  "futures",
  "rand 0.10.1",
@@ -708,7 +746,7 @@ dependencies = [
  "async-lock",
  "async-trait",
  "azure_core 1.0.0",
- "azure_core_test",
+ "azure_core_test 0.1.0",
  "azure_identity 1.0.0",
  "azure_security_keyvault_keys",
  "azure_security_keyvault_test",
@@ -730,7 +768,7 @@ dependencies = [
  "async-lock",
  "async-trait",
  "azure_core 1.0.0",
- "azure_core_test",
+ "azure_core_test 0.1.0",
  "azure_identity 1.0.0",
  "azure_security_keyvault_test",
  "criterion",
@@ -748,29 +786,12 @@ dependencies = [
 
 [[package]]
 name = "azure_security_keyvault_secrets"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b370d75ebb8807cc1ccfc6fe647b1e61e13052cba2e800b95f0cf0bd27d9a"
-dependencies = [
- "async-lock",
- "async-trait",
- "azure_core 1.0.0",
- "futures",
- "rustc_version",
- "serde",
- "serde_json",
- "time",
- "tokio",
-]
-
-[[package]]
-name = "azure_security_keyvault_secrets"
 version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
  "azure_core 1.0.0",
- "azure_core_test",
+ "azure_core_test 0.1.0",
  "azure_identity 1.0.0",
  "azure_security_keyvault_test",
  "futures",
@@ -818,7 +839,7 @@ dependencies = [
  "async-trait",
  "azure_core 1.0.0",
  "azure_core_opentelemetry 1.0.0",
- "azure_core_test",
+ "azure_core_test 0.1.0",
  "azure_identity 1.0.0",
  "azure_storage_blob_test",
  "bytes",
@@ -845,7 +866,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "azure_core 1.0.0",
- "azure_core_test",
+ "azure_core_test 0.1.0",
  "azure_identity 1.0.0",
  "azure_storage_blob 1.1.0-beta.1",
  "bytes",
@@ -860,7 +881,7 @@ dependencies = [
  "async-trait",
  "azure_core 1.0.0",
  "azure_core_opentelemetry 1.0.0",
- "azure_core_test",
+ "azure_core_test 0.1.0",
  "azure_identity 1.0.0",
  "clap",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,13 +69,11 @@ version = "1.0.0"
 
 [workspace.dependencies.azure_core_test]
 # azure_core_test should only ever be in dev-dependencies herein
-path = "sdk/core/azure_core_test"
-version = "0.2.0"
+version = "0.1.0"
 
 [workspace.dependencies.azure_core_test_macros]
 # azure_core_test_macros should only ever be in dev-dependencies herein
-path = "sdk/core/azure_core_test_macros"
-version = "0.2.0"
+version = "0.1.0"
 
 [workspace.dependencies.azure_identity]
 # azure_identity should only ever be in dev-dependencies herein

--- a/sdk/core/azure_core_opentelemetry/Cargo.toml
+++ b/sdk/core/azure_core_opentelemetry/Cargo.toml
@@ -23,8 +23,8 @@ opentelemetry_sdk.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-azure_core_test = { path = "../azure_core_test", features = ["tracing"] }
-azure_core_test_macros.path = "../azure_core_test_macros"
+azure_core_test = { workspace = true, features = ["tracing"] }
+azure_core_test_macros.workspace = true
 azure_identity.workspace = true
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 tokio.workspace = true

--- a/sdk/core/azure_core_test/Cargo.toml
+++ b/sdk/core/azure_core_test/Cargo.toml
@@ -19,9 +19,9 @@ tracing = ["tracing-subscriber"]
 
 [dependencies]
 async-trait.workspace = true
-azure_core = { path = "../azure_core", features = ["test"] }
-azure_core_test_macros.path = "../azure_core_test_macros"
-azure_identity.path = "../../identity/azure_identity"
+azure_core = { path = "../azure_core", version = "1.1.0-beta.1", default-features = false, features = ["test"] }
+azure_core_test_macros = { path = "../azure_core_test_macros", version = "0.2.0" }
+azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
 clap.workspace = true
 dotenvy = "0.15.7"
 flate2.workspace = true

--- a/sdk/core/azure_core_test/Cargo.toml
+++ b/sdk/core/azure_core_test/Cargo.toml
@@ -19,9 +19,9 @@ tracing = ["tracing-subscriber"]
 
 [dependencies]
 async-trait.workspace = true
-azure_core = { workspace = true, features = ["test"] }
-azure_core_test_macros.workspace = true
-azure_identity.workspace = true
+azure_core = { path = "../azure_core", features = ["test"] }
+azure_core_test_macros.path = "../azure_core_test_macros"
+azure_identity.path = "../../identity/azure_identity"
 clap.workspace = true
 dotenvy = "0.15.7"
 flate2.workspace = true
@@ -48,7 +48,7 @@ url.workspace = true
 zip.workspace = true
 
 [dev-dependencies]
-azure_security_keyvault_secrets.version = "1.0.0"
+azure_core_examples.path = "../azure_core_examples"
 clap.workspace = true
 include-file.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "signal"] }

--- a/sdk/core/azure_core_test/src/http/clients.rs
+++ b/sdk/core/azure_core_test/src/http/clients.rs
@@ -14,6 +14,7 @@ use std::fmt;
 /// # Examples
 ///
 /// ```
+/// # use azure_core_examples::secrets as azure_security_keyvault_secrets;
 /// use azure_core::{
 ///     http::{headers::Headers, AsyncRawResponse, ClientOptions, StatusCode, Transport},
 ///     Bytes,

--- a/sdk/core/azure_core_test/tests/readme.rs
+++ b/sdk/core/azure_core_test/tests/readme.rs
@@ -3,6 +3,8 @@
 #![allow(dead_code)]
 #![allow(unknown_lints)]
 #![allow(unnameable_test_items)]
+
+use azure_core_examples::secrets as azure_security_keyvault_secrets;
 use include_file::include_markdown;
 
 #[ignore = "only compile doc examples"]

--- a/sdk/identity/azure_identity/Cargo.toml
+++ b/sdk/identity/azure_identity/Cargo.toml
@@ -15,7 +15,7 @@ edition.workspace = true
 [dependencies]
 async-lock.workspace = true
 async-trait.workspace = true
-azure_core.path = "../../core/azure_core"
+azure_core = { path = "../../core/azure_core", version = "1.1.0-beta.1", default-features = false }
 futures.workspace = true
 openssl = { workspace = true, optional = true }
 pin-project.workspace = true

--- a/sdk/identity/azure_identity/Cargo.toml
+++ b/sdk/identity/azure_identity/Cargo.toml
@@ -15,7 +15,7 @@ edition.workspace = true
 [dependencies]
 async-lock.workspace = true
 async-trait.workspace = true
-azure_core.workspace = true
+azure_core.path = "../../core/azure_core"
 futures.workspace = true
 openssl = { workspace = true, optional = true }
 pin-project.workspace = true
@@ -27,8 +27,8 @@ tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-azure_core_test.workspace = true
-azure_security_keyvault_secrets = { path = "../../keyvault/azure_security_keyvault_secrets" }
+azure_core_test.path = "../../core/azure_core_test"
+azure_core_examples.path = "../../core/azure_core_examples"
 clap.workspace = true
 include-file.workspace = true
 serde_json.workspace = true

--- a/sdk/identity/azure_identity/README.md
+++ b/sdk/identity/azure_identity/README.md
@@ -56,7 +56,7 @@ let client = SecretClient::new("https://TODO.vault.azure.net/", credential.clone
 
 This example demonstrates how to authenticate an Entra application with an access token from a managed identity. See [Configure an application to trust a managed identity](https://learn.microsoft.com/entra/workload-id/workload-identity-federation-config-app-trust-managed-identity) for more information about this scenario. This example shows a Key Vault client, however the same approach can work with any Azure SDK client that uses a `TokenCredential`.
 
-```rust no_run
+```rust ignore client-assertion
 use azure_core::credentials::TokenCredential;
 use azure_core::http::ClientMethodOptions;
 use azure_identity::{ClientAssertion, ClientAssertionCredential, ManagedIdentityCredential};

--- a/sdk/identity/azure_identity/tests/readme.rs
+++ b/sdk/identity/azure_identity/tests/readme.rs
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 
 #![allow(dead_code)]
+use azure_core_examples::secrets as azure_security_keyvault_secrets;
 use include_file::include_markdown;
 
 #[ignore = "only compile doc examples"]
 #[tokio::test]
 async fn dev() -> Result<(), Box<dyn std::error::Error>> {
-    include_markdown!("README.md", "dev");
+    include_markdown!("README.md", "dev", scope);
+    include_markdown!("README.md", "client-assertion", scope);
 
     Ok(())
 }


### PR DESCRIPTION
Resolves #4526 by publishing the `azure_core_test` and `azure_core_test_macros` crates so we can use the same bifurcated versioning scheme as other crates.
Most crates will use a workspace dependency using a `version` that exists in crates.io. Crates requiring changes to `azure_core` or crates lower in the stack can use a `path`.

This also removes a dependency on `azure_core` from `azure_core_test_macros`. It was merely a convenience to use `TestMode` but we only need to duplicate partial functionality.
