### PR TITLE
Add workspace-level lints for macro packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,3 +172,10 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs)'] }
 
 [workspace.lints.rustdoc]
 bare_urls = "allow"
+
+[workspace.metadata.cargo-semver-checks.lints]
+# Public model structs should stay constructible when fields are added.
+# Encourage downstream code to use `..Default::default()` and
+# `#[allow(clippy::needless_update)]` on that initializer when needed, so new optional
+# fields do not force call sites to spell out every field.
+constructible_struct_adds_field = "allow"

--- a/doc/checks.md
+++ b/doc/checks.md
@@ -97,6 +97,11 @@ Documentation: [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-
 
 Runs in [Test-Semver.ps1](https://github.com/Azure/azure-sdk-for-rust/blob/main/eng/scripts/Test-Semver.ps1)
 
+Workspace-level `cargo-semver-checks` configuration ignores `constructible_struct_adds_field`.
+For public model structs, prefer examples and downstream code that initialize values with
+`..Default::default()` even when all current fields are assigned, so newly added optional
+fields do not break existing initializers.
+
 ```bash
 cargo install cargo-semver-checks
 cargo semver-checks

--- a/sdk/core/azure_core_macros/Cargo.toml
+++ b/sdk/core/azure_core_macros/Cargo.toml
@@ -25,3 +25,6 @@ tracing.workspace = true
 [dev-dependencies]
 tokio.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+
+[lints]
+workspace = true

--- a/sdk/core/azure_core_test_macros/Cargo.toml
+++ b/sdk/core/azure_core_test_macros/Cargo.toml
@@ -24,3 +24,6 @@ syn.workspace = true
 [dev-dependencies]
 azure_core_test.path = "../azure_core_test"
 tokio.workspace = true
+
+[lints]
+workspace = true

--- a/sdk/core/typespec_macros/Cargo.toml
+++ b/sdk/core/typespec_macros/Cargo.toml
@@ -34,3 +34,6 @@ typespec_client_core = { workspace = true, features = [
 
 [package.metadata.docs.rs]
 features = []
+
+[lints]
+workspace = true

--- a/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/Cargo.toml
@@ -42,3 +42,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 
 [features]
 default = ["azure_core/default"]
+
+[lints]
+workspace = true


### PR DESCRIPTION
Introduce workspace-level lint configurations across multiple Cargo.toml files
to ensure public model structs remain constructible when fields are added.
This encourages downstream code to utilize `..Default::default()` for new optional
fields, preventing breaking changes in initializers.
