### PR TITLE
Send AddSanitizer request bodies to the test proxy

### DIFF
--- a/sdk/core/azure_core_test/src/proxy/client.rs
+++ b/sdk/core/azure_core_test/src/proxy/client.rs
@@ -231,8 +231,7 @@ impl Client {
         request.insert_headers(&sanitizer)?;
         request.add_optional_header(&options.recording_id);
         // Send the sanitizer settings so configured redaction rules reach the test-proxy.
-        let body: Body = sanitizer.try_into()?;
-        request.set_body(body);
+        request.set_json(&sanitizer)?;
         self.pipeline
             .send(
                 &ctx,

--- a/sdk/core/azure_core_test/src/proxy/client.rs
+++ b/sdk/core/azure_core_test/src/proxy/client.rs
@@ -231,7 +231,7 @@ impl Client {
         request.insert_headers(&sanitizer)?;
         request.add_optional_header(&options.recording_id);
         // Send the sanitizer settings so configured redaction rules reach the test-proxy.
-        let body = serde_json::to_vec(&sanitizer)?;
+        let body: Body = sanitizer.try_into()?;
         request.set_body(body);
         self.pipeline
             .send(

--- a/sdk/core/azure_core_test/src/proxy/client.rs
+++ b/sdk/core/azure_core_test/src/proxy/client.rs
@@ -230,6 +230,9 @@ impl Client {
         request.insert_header(CONTENT_TYPE, "application/json");
         request.insert_headers(&sanitizer)?;
         request.add_optional_header(&options.recording_id);
+        // Send the sanitizer settings so configured redaction rules reach the test-proxy.
+        let body = serde_json::to_vec(&sanitizer)?;
+        request.set_body(body);
         self.pipeline
             .send(
                 &ctx,
@@ -356,4 +359,84 @@ pub struct ClientRemoveSanitizersOptions<'a> {
     /// Remove sanitizers only for the given recording ID.
     pub recording_id: Option<&'a RecordingId>,
     pub method_options: ClientMethodOptions<'a>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::sanitizers::HeaderRegexSanitizer, Client};
+    use crate::http::MockHttpClient;
+    use azure_core::{
+        http::{
+            headers::{Headers, CONTENT_TYPE},
+            AsyncRawResponse, ClientOptions, Pipeline, StatusCode, Transport,
+        },
+        Bytes,
+    };
+    use futures::FutureExt as _;
+    use serde_json::{json, Value};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn add_sanitizer_sends_configuration_body() {
+        let mock_client = Arc::new(MockHttpClient::new(|req| {
+            async move {
+                assert_eq!(req.url().path(), "/Admin/AddSanitizer");
+                assert_eq!(req.headers().get_str(&CONTENT_TYPE)?, "application/json");
+                assert_eq!(
+                    req.headers()
+                        .get_str(&super::super::ABSTRACTION_IDENTIFIER)?,
+                    "HeaderRegexSanitizer"
+                );
+
+                // The sanitizer payload carries the redaction rule the proxy must apply.
+                let body = Bytes::from(req.body());
+                let actual: Value =
+                    serde_json::from_slice(body.as_ref()).expect("sanitizer body should be JSON");
+                assert_eq!(
+                    actual,
+                    json!({
+                        "key": "x-ms-copy-source",
+                        "value": "Sanitized",
+                        "regex": "sig=([^&]+)",
+                        "groupForReplace": "1"
+                    })
+                );
+
+                Ok(AsyncRawResponse::from_bytes(
+                    StatusCode::Ok,
+                    Headers::new(),
+                    Vec::new(),
+                ))
+            }
+            .boxed()
+        }));
+        let client = Client {
+            endpoint: "https://localhost".parse().expect("valid endpoint"),
+            pipeline: Pipeline::new(
+                option_env!("CARGO_PKG_NAME"),
+                option_env!("CARGO_PKG_VERSION"),
+                ClientOptions {
+                    transport: Some(Transport::new(mock_client)),
+                    ..Default::default()
+                },
+                Vec::default(),
+                Vec::default(),
+                None,
+            ),
+        };
+
+        client
+            .add_sanitizer(
+                HeaderRegexSanitizer {
+                    key: "x-ms-copy-source".to_string(),
+                    value: Some("Sanitized".to_string()),
+                    regex: Some("sig=([^&]+)".to_string()),
+                    group_for_replace: Some("1".to_string()),
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .expect("add_sanitizer should send sanitizer configuration");
+    }
 }

--- a/sdk/core/azure_core_test/src/proxy/sanitizers.rs
+++ b/sdk/core/azure_core_test/src/proxy/sanitizers.rs
@@ -264,6 +264,7 @@ impl_sanitizer!(RemoveHeaderSanitizer);
 
 #[derive(Clone, Debug, Serialize)]
 pub struct RemoveHeaderSanitizer {
+    #[serde(rename = "headersForRemoval")]
     #[serde(serialize_with = "join")]
     pub headers_for_removal: Vec<&'static str>,
 }
@@ -313,6 +314,83 @@ pub struct UriStringSanitizer {
 #[derive(Clone, Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UriSubscriptionIdSanitizer {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub condition: Option<ApplyCondition>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HeaderRegexSanitizer, RemoveHeaderSanitizer, UriSubscriptionIdSanitizer};
+    use serde_json::json;
+
+    #[test]
+    fn header_regex_serializes_proxy_constructor_fields() {
+        let sanitizer = HeaderRegexSanitizer {
+            key: "x-ms-copy-source".to_string(),
+            value: Some("Sanitized".to_string()),
+            regex: Some("sig=([^&]+)".to_string()),
+            group_for_replace: Some("1".to_string()),
+            ..Default::default()
+        };
+
+        // Match the AddSanitizer constructor parameter names consumed by the test proxy.
+        let actual =
+            serde_json::to_value(sanitizer).expect("header regex sanitizer should serialize");
+        assert_eq!(
+            actual,
+            json!({
+                "key": "x-ms-copy-source",
+                "value": "Sanitized",
+                "regex": "sig=([^&]+)",
+                "groupForReplace": "1"
+            })
+        );
+    }
+
+    #[test]
+    fn remove_header_serializes_proxy_constructor_fields() {
+        let sanitizer = RemoveHeaderSanitizer {
+            headers_for_removal: vec!["Location", "Transfer-Encoding"],
+        };
+
+        // The proxy constructor expects headersForRemoval, not the Rust field name.
+        let actual =
+            serde_json::to_value(sanitizer).expect("remove header sanitizer should serialize");
+        assert_eq!(
+            actual,
+            json!({
+                "headersForRemoval": "Location,Transfer-Encoding"
+            })
+        );
+    }
+
+    #[test]
+    fn uri_subscription_id_omits_absent_optional_fields() {
+        let sanitizer = UriSubscriptionIdSanitizer::default();
+
+        // Omit absent optionals so the proxy constructor can apply its defaults.
+        let actual = serde_json::to_value(sanitizer)
+            .expect("URI subscription ID sanitizer should serialize");
+        assert_eq!(actual, json!({}));
+    }
+
+    #[test]
+    fn uri_subscription_id_serializes_configured_value() {
+        let sanitizer = UriSubscriptionIdSanitizer {
+            value: Some("11111111-1111-1111-1111-111111111111".to_string()),
+            ..Default::default()
+        };
+
+        // Preserve explicitly configured values while still omitting absent optionals.
+        let actual = serde_json::to_value(sanitizer)
+            .expect("URI subscription ID sanitizer should serialize configured fields");
+        assert_eq!(
+            actual,
+            json!({
+                "value": "11111111-1111-1111-1111-111111111111"
+            })
+        );
+    }
 }


### PR DESCRIPTION
Send serialized sanitizer settings in AddSanitizer requests so the test proxy receives the configuration needed to apply custom rules. Also adds local regression coverage for the request body and touched payload serialization.

Validated locally with `cargo test -p azure_core_test --all-features` and `cargo clippy -p azure_core_test --all-features`.