### PR TITLE
Preserve cached routing map on transient pkrange fetch failure

### DIFF
--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Bugs Fixed
 
+- Cross-partition query resume now propagates the server continuation to every surviving sub-leaf when a child range carried in the resume cursor has been split between sessions. Previously, only the first sub-leaf received the continuation and the rest restarted from offset zero, re-emitting already-consumed items. ([#TODO-PR](https://github.com/Azure/azure-sdk-for-rust/pull/TODO))
+- A transient failure while refreshing the partition key range cache no longer replaces a known-good cached routing map with an empty placeholder; the previous map is preserved until the next successful refresh. ([#TODO-PR](https://github.com/Azure/azure-sdk-for-rust/pull/TODO))
+
 ### Other Changes
 
 - `CosmosDriver::resolve_container_by_name` no longer issues an extra `read_database` round-trip to discover the database RID. The database RID is now extracted in-process from the encoded byte layout of the container RID returned by the container read. ([#4506](https://github.com/Azure/azure-sdk-for-rust/pull/4506))

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 ### Bugs Fixed
 
-- Cross-partition query resume now propagates the server continuation to every surviving sub-leaf when a child range carried in the resume cursor has been split between sessions. Previously, only the first sub-leaf received the continuation and the rest restarted from offset zero, re-emitting already-consumed items. ([#4549](https://github.com/Azure/azure-sdk-for-rust/pull/4549))
 - A transient failure while refreshing the partition key range cache no longer replaces a known-good cached routing map with an empty placeholder; the previous map is preserved until the next successful refresh. ([#4549](https://github.com/Azure/azure-sdk-for-rust/pull/4549))
 
 ### Other Changes

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -10,8 +10,8 @@
 
 ### Bugs Fixed
 
-- Cross-partition query resume now propagates the server continuation to every surviving sub-leaf when a child range carried in the resume cursor has been split between sessions. Previously, only the first sub-leaf received the continuation and the rest restarted from offset zero, re-emitting already-consumed items. ([#TODO-PR](https://github.com/Azure/azure-sdk-for-rust/pull/TODO))
-- A transient failure while refreshing the partition key range cache no longer replaces a known-good cached routing map with an empty placeholder; the previous map is preserved until the next successful refresh. ([#TODO-PR](https://github.com/Azure/azure-sdk-for-rust/pull/TODO))
+- Cross-partition query resume now propagates the server continuation to every surviving sub-leaf when a child range carried in the resume cursor has been split between sessions. Previously, only the first sub-leaf received the continuation and the rest restarted from offset zero, re-emitting already-consumed items. ([#4549](https://github.com/Azure/azure-sdk-for-rust/pull/4549))
+- A transient failure while refreshing the partition key range cache no longer replaces a known-good cached routing map with an empty placeholder; the previous map is preserved until the next successful refresh. ([#4549](https://github.com/Azure/azure-sdk-for-rust/pull/4549))
 
 ### Other Changes
 

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/partition_key_range_cache.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/partition_key_range_cache.rs
@@ -207,7 +207,9 @@ impl PartitionKeyRangeCache {
     /// Otherwise, the new ranges are merged via [`ContainerRoutingMap::try_combine`].
     ///
     /// Returns a routing map for the container. If the initial fetch fails or
-    /// returns invalid ranges, an empty routing map is cached and returned.
+    /// returns invalid ranges, the previously cached routing map is preserved
+    /// when one exists; only when there is no previous map to fall back to is
+    /// an empty routing map cached and returned.
     pub(crate) async fn try_lookup<F, Fut>(
         &self,
         container: &ContainerReference,

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/partition_key_range_cache.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/partition_key_range_cache.rs
@@ -300,11 +300,17 @@ where
         let result = match fetch_pk_ranges(container.clone(), continuation.clone()).await {
             Some(r) => r,
             None => {
+                // Falling back to the previously cached map (when one exists)
+                // mirrors the merge branch below and avoids regressing the
+                // cache to empty on a single transient fetch failure.
                 tracing::warn!(
-                    "Failed to fetch partition key ranges from service (iteration {})",
+                    "Failed to fetch partition key ranges from service (iteration {}); \
+                     falling back to previous routing map if available",
                     iteration
                 );
-                return ContainerRoutingMap::empty();
+                return previous_routing_map
+                    .map(|p| (*p).clone())
+                    .unwrap_or_else(ContainerRoutingMap::empty);
             }
         };
 
@@ -867,5 +873,67 @@ mod tests {
             .unwrap();
         assert_eq!(map2.ranges().len(), 1);
         assert_eq!(map2.ranges()[0].id, "0");
+    }
+
+    #[tokio::test]
+    async fn force_refresh_with_transient_fetch_failure_preserves_previous_map() {
+        // A force-refresh that hits a transient fetch failure on iteration 0
+        // must NOT regress the cached routing map to empty: the cached map is
+        // the only thing keeping routing decisions working until the next
+        // successful refresh.
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+
+        let cache = PartitionKeyRangeCache::new();
+        let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
+
+        // Seed the cache with two ranges via a successful initial lookup.
+        let seeded = cache
+            .try_lookup(&container, false, two_range_fetch)
+            .await
+            .unwrap();
+        assert_eq!(seeded.ranges().len(), 2);
+
+        // Force-refresh with a fetcher that fails on the first call.
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let count = call_count.clone();
+        let failing_fetch = move |_container: ContainerReference, _continuation: Option<String>| {
+            let count = count.clone();
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                None
+            }
+        };
+
+        let refreshed = cache
+            .try_lookup(&container, true, failing_fetch)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "failing fetcher should be invoked exactly once before fallback"
+        );
+        assert_eq!(
+            refreshed.ranges().len(),
+            2,
+            "force-refresh on transient failure must preserve the previously cached map"
+        );
+        assert_eq!(refreshed.ranges()[0].id, "0");
+        assert_eq!(refreshed.ranges()[1].id, "1");
+
+        // The cached entry observed by a subsequent non-refresh lookup must
+        // also be the preserved map, not the empty placeholder that would
+        // result from the previous bug.
+        let after = cache
+            .try_lookup(&container, false, |_, _| async {
+                panic!("non-refresh lookup must hit cache, not call fetcher")
+            })
+            .await
+            .unwrap();
+        assert_eq!(after.ranges().len(), 2);
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/dataflow/planner.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/dataflow/planner.rs
@@ -251,10 +251,21 @@ pub(crate) async fn build_sequential_drain(
                 }
             }
 
-            // Carry the server continuation to every leaf node, because
-            // we don't know which ones have been drained. The service does, and will
-            // just return empty pages for those if needed.
-            let initial_continuation = resume.as_mut().and_then(|c| c.server_continuation.take());
+            // Carry the server continuation to every leaf inside the cursor's
+            // original child-range scope: after a split, the original child has
+            // fanned out into multiple sub-ranges and we don't know which ones
+            // have been drained — the service does, and emits empty pages for
+            // any already-drained sub-range. Leaves entirely past
+            // `current_max_epk` are fresh and must NOT carry the continuation.
+            let initial_continuation = resume.as_ref().and_then(|c| {
+                if c.server_continuation.is_some()
+                    && resolved_range.range.min_inclusive() < &c.current_max_epk
+                {
+                    c.server_continuation.clone()
+                } else {
+                    None
+                }
+            });
             let range = intersect_feed_ranges(&resolved_range.range, &feed_range).expect(
                 "topology provider must return ranges that overlap the query plan EPK range",
             );
@@ -268,6 +279,14 @@ pub(crate) async fn build_sequential_drain(
                 target,
                 initial_continuation,
             )));
+        }
+
+        // The cursor's stored continuation belongs to a single original child
+        // range and must not bleed into leaves built for subsequent
+        // `query_range`s. After processing all resolved ranges for the current
+        // `query_range`, drop it.
+        if let Some(c) = resume.as_mut() {
+            c.server_continuation = None;
         }
     }
 
@@ -961,7 +980,51 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resume_propagates_server_continuation_to_first_surviving_leaf_only() {
+    async fn resume_propagates_server_continuation_to_every_surviving_leaf_after_split() {
+        // Cursor was suspended inside a single physical partition that has since
+        // been split into two child ranges. Every leaf overlapping the original
+        // cursor scope must carry the saved continuation, otherwise the
+        // continuation-less leaves execute a fresh query and re-emit items the
+        // caller has already consumed.
+        let plan = plan_with_ranges(vec![qr("", "FF")]);
+        let op = cross_partition_query_operation();
+        let mut topology = MockTopologyProvider::new(vec![Ok(vec![
+            rr("", "55", "pk-a"),
+            rr("55", "70", "pk-b1"),
+            rr("70", "AA", "pk-b2"),
+            rr("AA", "FF", "pk-c"),
+        ])]);
+
+        let resume = PipelineNodeState::SequentialDrain {
+            current_min_epk: "55".to_owned(),
+            current_max_epk: "AA".to_owned(),
+            left_most: Box::new(PipelineNodeState::Request {
+                server_continuation: Some("server-token-xyz".to_owned()),
+            }),
+        };
+
+        let pipeline = build_sequential_drain(&plan, &mut topology, &Arc::new(op), Some(resume))
+            .await
+            .unwrap();
+        assert_drain_requests_with_partitions_and_continuation(
+            pipeline,
+            &[
+                ("55", "70", "pk-b1", "55", "70", Some("server-token-xyz")),
+                ("70", "AA", "pk-b2", "70", "AA", Some("server-token-xyz")),
+                ("AA", "FF", "pk-c", "AA", "FF", None),
+            ],
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_does_not_leak_continuation_into_fresh_leaves_past_cursor_scope() {
+        // Defensive regression guard for the cursor-scope bound. Topology
+        // unchanged across sessions: the cursor sits exactly on the middle
+        // child. The leaf for that child must carry the continuation; the
+        // leaf for the following (fresh) child must not. Note: the pre-fix
+        // `Option::take()` behavior happens to produce the same result for
+        // this exact shape; the test instead pins the scope-check contract
+        // so a future refactor cannot regress to "clone into every leaf".
         let plan = plan_with_ranges(vec![qr("", "FF")]);
         let op = cross_partition_query_operation();
         let mut topology = MockTopologyProvider::new(vec![Ok(vec![
@@ -981,16 +1044,88 @@ mod tests {
         let pipeline = build_sequential_drain(&plan, &mut topology, &Arc::new(op), Some(resume))
             .await
             .unwrap();
-        let snapshot = pipeline.snapshot_state();
-        let PipelineNodeState::SequentialDrain { left_most, .. } = snapshot else {
-            panic!("expected SequentialDrain snapshot, got {snapshot:?}");
-        };
-        assert_eq!(
-            *left_most,
-            PipelineNodeState::Request {
+        assert_drain_requests_with_partitions_and_continuation(
+            pipeline,
+            &[
+                ("55", "AA", "pk-b", "55", "AA", Some("server-token-xyz")),
+                ("AA", "FF", "pk-c", "AA", "FF", None),
+            ],
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_does_not_leak_continuation_across_query_ranges() {
+        // Two disjoint query-plan ranges. The cursor sits in the first range;
+        // every leaf the second range produces must start fresh.
+        // Pins the contract across disjoint ranges -- a defensive guard
+        // since the second range's leaves are also past `current_max_epk`
+        // and would be filtered by the scope check alone.
+        let plan = plan_with_ranges(vec![qr("", "55"), qr("80", "FF")]);
+        let op = cross_partition_query_operation();
+        let mut topology = MockTopologyProvider::new(vec![
+            Ok(vec![rr("", "30", "pk-a"), rr("30", "55", "pk-b")]),
+            Ok(vec![rr("80", "C0", "pk-c"), rr("C0", "FF", "pk-d")]),
+        ]);
+
+        let resume = PipelineNodeState::SequentialDrain {
+            current_min_epk: "30".to_owned(),
+            current_max_epk: "55".to_owned(),
+            left_most: Box::new(PipelineNodeState::Request {
                 server_continuation: Some("server-token-xyz".to_owned()),
-            },
-            "front leaf must carry the resumed server continuation",
+            }),
+        };
+
+        let pipeline = build_sequential_drain(&plan, &mut topology, &Arc::new(op), Some(resume))
+            .await
+            .unwrap();
+        assert_drain_requests_with_partitions_and_continuation(
+            pipeline,
+            &[
+                ("30", "55", "pk-b", "30", "55", Some("server-token-xyz")),
+                ("80", "C0", "pk-c", "80", "C0", None),
+                ("C0", "FF", "pk-d", "C0", "FF", None),
+            ],
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_clears_continuation_between_overlapping_query_ranges() {
+        // Exercises the end-of-`for query_range` reset specifically. The
+        // second query-plan range overlaps the cursor's child scope, so its
+        // first leaf (`min_inclusive=40 < current_max_epk=55`) would pass
+        // the per-leaf scope check and inherit the continuation if the
+        // cursor were not cleared between query ranges. Cosmos query plans
+        // do not normally produce overlapping ranges, but the planner
+        // contract is "continuations belong to the cursor's originating
+        // query range" -- this test pins that contract.
+        let plan = plan_with_ranges(vec![qr("", "55"), qr("40", "FF")]);
+        let op = cross_partition_query_operation();
+        let mut topology = MockTopologyProvider::new(vec![
+            Ok(vec![rr("", "30", "pk-a"), rr("30", "55", "pk-b")]),
+            Ok(vec![rr("40", "C0", "pk-c"), rr("C0", "FF", "pk-d")]),
+        ]);
+
+        let resume = PipelineNodeState::SequentialDrain {
+            current_min_epk: "30".to_owned(),
+            current_max_epk: "55".to_owned(),
+            left_most: Box::new(PipelineNodeState::Request {
+                server_continuation: Some("server-token-xyz".to_owned()),
+            }),
+        };
+
+        let pipeline = build_sequential_drain(&plan, &mut topology, &Arc::new(op), Some(resume))
+            .await
+            .unwrap();
+        assert_drain_requests_with_partitions_and_continuation(
+            pipeline,
+            &[
+                ("30", "55", "pk-b", "30", "55", Some("server-token-xyz")),
+                // pk-c starts at 40 which is < cursor.current_max_epk=55, but
+                // it belongs to a fresh query-plan range so the continuation
+                // must NOT propagate.
+                ("40", "C0", "pk-c", "40", "C0", None),
+                ("C0", "FF", "pk-d", "C0", "FF", None),
+            ],
         );
     }
 

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/dataflow/planner.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/dataflow/planner.rs
@@ -251,21 +251,10 @@ pub(crate) async fn build_sequential_drain(
                 }
             }
 
-            // Carry the server continuation to every leaf inside the cursor's
-            // original child-range scope: after a split, the original child has
-            // fanned out into multiple sub-ranges and we don't know which ones
-            // have been drained — the service does, and emits empty pages for
-            // any already-drained sub-range. Leaves entirely past
-            // `current_max_epk` are fresh and must NOT carry the continuation.
-            let initial_continuation = resume.as_ref().and_then(|c| {
-                if c.server_continuation.is_some()
-                    && resolved_range.range.min_inclusive() < &c.current_max_epk
-                {
-                    c.server_continuation.clone()
-                } else {
-                    None
-                }
-            });
+            // Carry the server continuation to every leaf node, because
+            // we don't know which ones have been drained. The service does, and will
+            // just return empty pages for those if needed.
+            let initial_continuation = resume.as_mut().and_then(|c| c.server_continuation.take());
             let range = intersect_feed_ranges(&resolved_range.range, &feed_range).expect(
                 "topology provider must return ranges that overlap the query plan EPK range",
             );
@@ -279,14 +268,6 @@ pub(crate) async fn build_sequential_drain(
                 target,
                 initial_continuation,
             )));
-        }
-
-        // The cursor's stored continuation belongs to a single original child
-        // range and must not bleed into leaves built for subsequent
-        // `query_range`s. After processing all resolved ranges for the current
-        // `query_range`, drop it.
-        if let Some(c) = resume.as_mut() {
-            c.server_continuation = None;
         }
     }
 
@@ -980,51 +961,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resume_propagates_server_continuation_to_every_surviving_leaf_after_split() {
-        // Cursor was suspended inside a single physical partition that has since
-        // been split into two child ranges. Every leaf overlapping the original
-        // cursor scope must carry the saved continuation, otherwise the
-        // continuation-less leaves execute a fresh query and re-emit items the
-        // caller has already consumed.
-        let plan = plan_with_ranges(vec![qr("", "FF")]);
-        let op = cross_partition_query_operation();
-        let mut topology = MockTopologyProvider::new(vec![Ok(vec![
-            rr("", "55", "pk-a"),
-            rr("55", "70", "pk-b1"),
-            rr("70", "AA", "pk-b2"),
-            rr("AA", "FF", "pk-c"),
-        ])]);
-
-        let resume = PipelineNodeState::SequentialDrain {
-            current_min_epk: "55".to_owned(),
-            current_max_epk: "AA".to_owned(),
-            left_most: Box::new(PipelineNodeState::Request {
-                server_continuation: Some("server-token-xyz".to_owned()),
-            }),
-        };
-
-        let pipeline = build_sequential_drain(&plan, &mut topology, &Arc::new(op), Some(resume))
-            .await
-            .unwrap();
-        assert_drain_requests_with_partitions_and_continuation(
-            pipeline,
-            &[
-                ("55", "70", "pk-b1", "55", "70", Some("server-token-xyz")),
-                ("70", "AA", "pk-b2", "70", "AA", Some("server-token-xyz")),
-                ("AA", "FF", "pk-c", "AA", "FF", None),
-            ],
-        );
-    }
-
-    #[tokio::test]
-    async fn resume_does_not_leak_continuation_into_fresh_leaves_past_cursor_scope() {
-        // Defensive regression guard for the cursor-scope bound. Topology
-        // unchanged across sessions: the cursor sits exactly on the middle
-        // child. The leaf for that child must carry the continuation; the
-        // leaf for the following (fresh) child must not. Note: the pre-fix
-        // `Option::take()` behavior happens to produce the same result for
-        // this exact shape; the test instead pins the scope-check contract
-        // so a future refactor cannot regress to "clone into every leaf".
+    async fn resume_propagates_server_continuation_to_first_surviving_leaf_only() {
         let plan = plan_with_ranges(vec![qr("", "FF")]);
         let op = cross_partition_query_operation();
         let mut topology = MockTopologyProvider::new(vec![Ok(vec![
@@ -1044,88 +981,16 @@ mod tests {
         let pipeline = build_sequential_drain(&plan, &mut topology, &Arc::new(op), Some(resume))
             .await
             .unwrap();
-        assert_drain_requests_with_partitions_and_continuation(
-            pipeline,
-            &[
-                ("55", "AA", "pk-b", "55", "AA", Some("server-token-xyz")),
-                ("AA", "FF", "pk-c", "AA", "FF", None),
-            ],
-        );
-    }
-
-    #[tokio::test]
-    async fn resume_does_not_leak_continuation_across_query_ranges() {
-        // Two disjoint query-plan ranges. The cursor sits in the first range;
-        // every leaf the second range produces must start fresh.
-        // Pins the contract across disjoint ranges -- a defensive guard
-        // since the second range's leaves are also past `current_max_epk`
-        // and would be filtered by the scope check alone.
-        let plan = plan_with_ranges(vec![qr("", "55"), qr("80", "FF")]);
-        let op = cross_partition_query_operation();
-        let mut topology = MockTopologyProvider::new(vec![
-            Ok(vec![rr("", "30", "pk-a"), rr("30", "55", "pk-b")]),
-            Ok(vec![rr("80", "C0", "pk-c"), rr("C0", "FF", "pk-d")]),
-        ]);
-
-        let resume = PipelineNodeState::SequentialDrain {
-            current_min_epk: "30".to_owned(),
-            current_max_epk: "55".to_owned(),
-            left_most: Box::new(PipelineNodeState::Request {
-                server_continuation: Some("server-token-xyz".to_owned()),
-            }),
+        let snapshot = pipeline.snapshot_state();
+        let PipelineNodeState::SequentialDrain { left_most, .. } = snapshot else {
+            panic!("expected SequentialDrain snapshot, got {snapshot:?}");
         };
-
-        let pipeline = build_sequential_drain(&plan, &mut topology, &Arc::new(op), Some(resume))
-            .await
-            .unwrap();
-        assert_drain_requests_with_partitions_and_continuation(
-            pipeline,
-            &[
-                ("30", "55", "pk-b", "30", "55", Some("server-token-xyz")),
-                ("80", "C0", "pk-c", "80", "C0", None),
-                ("C0", "FF", "pk-d", "C0", "FF", None),
-            ],
-        );
-    }
-
-    #[tokio::test]
-    async fn resume_clears_continuation_between_overlapping_query_ranges() {
-        // Exercises the end-of-`for query_range` reset specifically. The
-        // second query-plan range overlaps the cursor's child scope, so its
-        // first leaf (`min_inclusive=40 < current_max_epk=55`) would pass
-        // the per-leaf scope check and inherit the continuation if the
-        // cursor were not cleared between query ranges. Cosmos query plans
-        // do not normally produce overlapping ranges, but the planner
-        // contract is "continuations belong to the cursor's originating
-        // query range" -- this test pins that contract.
-        let plan = plan_with_ranges(vec![qr("", "55"), qr("40", "FF")]);
-        let op = cross_partition_query_operation();
-        let mut topology = MockTopologyProvider::new(vec![
-            Ok(vec![rr("", "30", "pk-a"), rr("30", "55", "pk-b")]),
-            Ok(vec![rr("40", "C0", "pk-c"), rr("C0", "FF", "pk-d")]),
-        ]);
-
-        let resume = PipelineNodeState::SequentialDrain {
-            current_min_epk: "30".to_owned(),
-            current_max_epk: "55".to_owned(),
-            left_most: Box::new(PipelineNodeState::Request {
+        assert_eq!(
+            *left_most,
+            PipelineNodeState::Request {
                 server_continuation: Some("server-token-xyz".to_owned()),
-            }),
-        };
-
-        let pipeline = build_sequential_drain(&plan, &mut topology, &Arc::new(op), Some(resume))
-            .await
-            .unwrap();
-        assert_drain_requests_with_partitions_and_continuation(
-            pipeline,
-            &[
-                ("30", "55", "pk-b", "30", "55", Some("server-token-xyz")),
-                // pk-c starts at 40 which is < cursor.current_max_epk=55, but
-                // it belongs to a fresh query-plan range so the continuation
-                // must NOT propagate.
-                ("40", "C0", "pk-c", "40", "C0", None),
-                ("C0", "FF", "pk-d", "C0", "FF", None),
-            ],
+            },
+            "front leaf must carry the resumed server continuation",
         );
     }
 

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/emulator_tests/driver_fault_injection.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/emulator_tests/driver_fault_injection.rs
@@ -331,3 +331,101 @@ pub async fn fault_injection_connection_error() -> Result<(), Box<dyn Error>> {
     })
     .await
 }
+
+/// Verifies that a transient failure on a force-refresh of the partition-key
+/// range cache does NOT regress the cached routing map to empty.
+///
+/// Scenario:
+/// 1. Install (but disable) a one-shot `ServiceUnavailable` fault on
+///    `MetadataPartitionKeyRanges`.
+/// 2. Warm the routing-map cache successfully (fault disabled).
+/// 3. Enable the fault, then force-refresh the cache. The fetch fails.
+/// 4. Assert the post-refresh routing map is still populated, proving the
+///    cache kept the previously cached map rather than replacing it with an
+///    empty placeholder that would break routing until the next explicit
+///    invalidation.
+#[tokio::test]
+#[cfg_attr(
+    not(any(test_category = "emulator", test_category = "emulator_vnext")),
+    ignore = "requires test_category 'emulator' or 'emulator_vnext'"
+)]
+pub async fn pkrange_refresh_transient_failure_preserves_cached_routing_map(
+) -> Result<(), Box<dyn Error>> {
+    let condition = FaultInjectionConditionBuilder::new()
+        .with_operation_type(FaultOperationType::MetadataPartitionKeyRanges)
+        .build();
+
+    let result = FaultInjectionResultBuilder::new()
+        .with_error(FaultInjectionErrorType::ServiceUnavailable)
+        .with_probability(1.0)
+        .build();
+
+    let rule = Arc::new(
+        FaultInjectionRuleBuilder::new("pkrange-refresh-transient", result)
+            .with_condition(condition)
+            .with_hit_limit(1)
+            .build(),
+    );
+    // Start disabled so the warmup below isn't intercepted; we enable the
+    // rule immediately before force-refreshing so the failure is guaranteed
+    // to land on the refresh path under test.
+    rule.disable();
+    let rules = vec![Arc::clone(&rule)];
+
+    DriverTestClient::run_with_unique_db_and_fault_injection(rules, async |context, database| {
+        let container_name = context.unique_container_name();
+        let container = context
+            .create_container(&database, &container_name, "/pk")
+            .await?;
+
+        // Warmup: fault is disabled, this populates the cache with real ranges.
+        let warmed = context
+            .resolve_all_partition_key_ranges(&container, false)
+            .await?;
+        assert!(
+            warmed.is_some_and(|r| !r.is_empty()),
+            "warmup resolve must populate the routing map"
+        );
+        assert_eq!(
+            rule.hit_count(),
+            0,
+            "warmup must not have triggered the disabled fault"
+        );
+
+        // Arm the fault and force-refresh. With the fix in place, the refresh
+        // sees the transient failure but preserves the previously cached map.
+        rule.enable();
+        let refreshed = context
+            .resolve_all_partition_key_ranges(&container, true)
+            .await?;
+
+        assert!(
+            refreshed.is_some(),
+            "force-refresh on transient failure must not return None"
+        );
+        let ranges = refreshed.unwrap();
+        assert!(
+            !ranges.is_empty(),
+            "force-refresh on transient failure must preserve the previously cached \
+             routing map -- empty ranges indicate the cache regressed to empty"
+        );
+
+        assert_eq!(
+            rule.hit_count(),
+            1,
+            "force-refresh must have triggered the fault exactly once"
+        );
+
+        // A subsequent non-refresh lookup must still see the populated cache.
+        let after = context
+            .resolve_all_partition_key_ranges(&container, false)
+            .await?;
+        assert!(
+            after.is_some_and(|r| !r.is_empty()),
+            "subsequent non-refresh lookup must observe the preserved routing map"
+        );
+
+        Ok(())
+    })
+    .await
+}

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/framework/test_client.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/framework/test_client.rs
@@ -531,6 +531,28 @@ impl DriverTestRunContext {
         Ok(result)
     }
 
+    /// Resolves all partition key ranges for a container, optionally forcing
+    /// a refresh of the cached routing map. Exposes the driver's internal
+    /// `resolve_all_partition_key_ranges` for tests that need to exercise the
+    /// pkrange-cache refresh path directly.
+    pub async fn resolve_all_partition_key_ranges(
+        &self,
+        container: &ContainerReference,
+        force_refresh: bool,
+    ) -> Result<
+        Option<Vec<azure_data_cosmos_driver::models::partition_key_range::PartitionKeyRange>>,
+        Box<dyn Error>,
+    > {
+        let driver = self
+            .client
+            .runtime
+            .get_or_create_driver(self.client.account.clone(), None)
+            .await?;
+        Ok(driver
+            .resolve_all_partition_key_ranges(container, force_refresh)
+            .await)
+    }
+
     /// Validates diagnostics for a successful data plane operation.
     pub fn validate_data_plane_diagnostics(
         &self,


### PR DESCRIPTION
## What

When `try_lookup(force_refresh = true)` is invoked on the partition key
range cache (typically on the 410/PartitionKeyRangeGone hot path),
`fetch_and_build_routing_map` may receive `None` from `fetch_pk_ranges`
on iteration 0 — a transient socket error, 5xx folded to `None`, DNS
hiccup, etc. The early-return branch previously dropped the known-good
`previous_routing_map` on the floor and returned `ContainerRoutingMap::empty()`.
`AsyncCache::get_or_refresh_with` then atomically installed the empty
map as the new cached value, so every subsequent non-refresh lookup
hit the cached empty map without re-fetching, and routing was broken
until something else explicitly invalidated the cache.

This PR makes the early-fetch-failure branch fall back to a clone of
the previous routing map when one exists, mirroring the fallback the
incremental-merge path below already uses on `Ok(None)` / `Err`.

## Tests

- New unit test `force_refresh_with_transient_fetch_failure_preserves_previous_map`
  in `partition_key_range_cache.rs` covers the populated → must-not-regress
  direction (the existing `force_refresh_repopulates_after_empty_cache`
  covers the inverse).
- New emulator integration test
  `pkrange_refresh_transient_failure_preserves_cached_routing_map` in
  `tests/emulator_tests/driver_fault_injection.rs`, gated on
  `test_category = "emulator"` / `"emulator_vnext"`, uses the existing
  `MetadataPartitionKeyRanges` fault-injection rule to force a one-shot
  transient pkrange-fetch failure and verifies routing still works on
  the next operation.
- Adds `DriverTestRunContext::resolve_all_partition_key_ranges` so
  emulator tests can exercise the pkrange-cache refresh path directly.

