### PR TITLE
[Storage] `BlobClient::download_into()`

### DIFF
--- a/sdk/storage/azure_storage_blob/assets.json
+++ b/sdk/storage/azure_storage_blob/assets.json
@@ -1,6 +1,6 @@
 {
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
-  "Tag": "rust/azure_storage_blob_2f17520363",
+  "Tag": "rust/azure_storage_blob_f224f06616",
   "TagPrefix": "rust/azure_storage_blob"
 }

--- a/sdk/storage/azure_storage_blob/perf/download_blob_test.rs
+++ b/sdk/storage/azure_storage_blob/perf/download_blob_test.rs
@@ -19,8 +19,6 @@ use azure_storage_blob_test::get_test_credential;
 use bytes::BytesMut;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 
-use crate::extensions::{OnceLockExt, RecordingExt};
-
 enum CollectOptions {
     Stream,
     Core,

--- a/sdk/storage/azure_storage_blob/perf/download_blob_test.rs
+++ b/sdk/storage/azure_storage_blob/perf/download_blob_test.rs
@@ -19,6 +19,8 @@ use azure_storage_blob_test::get_test_credential;
 use bytes::BytesMut;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 
+use crate::extensions::{OnceLockExt, RecordingExt};
+
 enum CollectOptions {
     Stream,
     Core,
@@ -248,17 +250,7 @@ impl PerfTest for DownloadBlobTest {
     }
 
     async fn cleanup(&self, _context: Arc<TestContext>) -> azure_core::Result<()> {
-        // Cleanup code after running the test
-        let mut iterator = self.client.get().unwrap().list_blobs(None)?;
-        while let Some(blob) = iterator.try_next().await? {
-            let blob_client = self
-                .client
-                .get()
-                .unwrap()
-                .blob_client(blob.name.as_ref().unwrap());
-            let _result = blob_client.delete(None).await?;
-        }
-
+        self.client.get().unwrap().delete(None).await?;
         Ok(())
     }
 }

--- a/sdk/storage/azure_storage_blob/perf/download_into_blob_test.rs
+++ b/sdk/storage/azure_storage_blob/perf/download_into_blob_test.rs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use std::{
+    hint::black_box,
+    sync::{Arc, OnceLock},
+};
+
+use azure_core_test::{
+    perf::{
+        CreatePerfTestReturn, PerfRunner, PerfTest, PerfTestMetadata, PerfTestOption,
+        PerfTestOptionKind,
+    },
+    TestContext,
+};
+use azure_storage_blob::BlobContainerClient;
+use bytes::Bytes;
+use futures::{FutureExt, TryStreamExt};
+
+use crate::extensions::{OnceLockExt, RecordingExt};
+
+const DEFAULT_NUM_BLOBS: usize = 5;
+
+pub struct DownloadIntoBlobTest {
+    num_blobs: usize,
+    blob_len: usize,
+    endpoint: Option<String>,
+    client: OnceLock<BlobContainerClient>,
+}
+
+impl DownloadIntoBlobTest {
+    fn create_test(runner: PerfRunner) -> CreatePerfTestReturn {
+        async move {
+            let endpoint: Option<String> = runner.try_get_test_arg("endpoint")?;
+
+            Ok(Box::new(Self {
+                num_blobs: runner
+                    .try_get_test_arg("num_blobs")?
+                    .unwrap_or(DEFAULT_NUM_BLOBS),
+                blob_len: runner
+                    .try_get_test_arg("blob_len")?
+                    .expect("size argument is mandatory"),
+                endpoint,
+                client: OnceLock::new(),
+            }) as Box<dyn PerfTest>)
+        }
+        .boxed()
+    }
+
+    pub fn test_metadata() -> PerfTestMetadata {
+        PerfTestMetadata {
+            name: "download_into_blob",
+            description: "Download blobs from a container directly into memory buffers.",
+            options: vec![
+                PerfTestOption {
+                    name: "num_blobs",
+                    display_message: "The number of blobs to download",
+                    mandatory: false,
+                    short_activator: Some('c'),
+                    long_activator: "count",
+                    expected_args_len: 1,
+                    option_type: PerfTestOptionKind::Usize,
+                    ..Default::default()
+                },
+                PerfTestOption {
+                    name: "blob_len",
+                    display_message: "The length of each blob in bytes",
+                    mandatory: true,
+                    short_activator: Some('s'),
+                    long_activator: "size",
+                    expected_args_len: 1,
+                    option_type: PerfTestOptionKind::Usize,
+                    ..Default::default()
+                },
+                PerfTestOption {
+                    name: "endpoint",
+                    display_message: "The endpoint of the blob storage",
+                    mandatory: false,
+                    short_activator: Some('e'),
+                    long_activator: "endpoint",
+                    expected_args_len: 1,
+                    ..Default::default()
+                },
+            ],
+            create_test: Self::create_test,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl PerfTest for DownloadIntoBlobTest {
+    async fn setup(&self, context: Arc<TestContext>) -> azure_core::Result<()> {
+        let container_client = self.client.try_get_or_init(|| {
+            context
+                .recording()
+                .get_container_client(self.endpoint.clone())
+        })?;
+        container_client.create(None).await?;
+
+        for i in 0..self.num_blobs {
+            let blob_name = format!("blob-{}", i);
+            let blob_client = container_client.blob_client(&blob_name);
+            let body = vec![0u8; self.blob_len];
+            let body_bytes = Bytes::from(body);
+            let _ = blob_client.upload(body_bytes.into(), None).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn run(&self, _context: Arc<TestContext>) -> azure_core::Result<()> {
+        // TODO large buffer allocation and drop is now getting measured
+        let mut buffer = vec![0u8; self.blob_len];
+
+        let mut blob_list = self.client.get().unwrap().list_blobs(None)?;
+        while let Some(blob_item) = blob_list.try_next().await? {
+            self.client
+                .get()
+                .unwrap()
+                .blob_client(blob_item.name.unwrap().as_ref())
+                .download_into(&mut buffer, None)
+                .await?;
+            black_box(&buffer);
+        }
+        todo!()
+    }
+
+    async fn cleanup(&self, _context: Arc<TestContext>) -> azure_core::Result<()> {
+        self.client.get().unwrap().delete(None).await?;
+        Ok(())
+    }
+}

--- a/sdk/storage/azure_storage_blob/perf/download_into_blob_test.rs
+++ b/sdk/storage/azure_storage_blob/perf/download_into_blob_test.rs
@@ -3,45 +3,57 @@
 
 use std::{
     hint::black_box,
+    num::NonZero,
     sync::{Arc, OnceLock},
 };
 
 use azure_core_test::{
-    perf::{
-        CreatePerfTestReturn, PerfRunner, PerfTest, PerfTestMetadata, PerfTestOption,
-        PerfTestOptionKind,
-    },
+    perf::{CreatePerfTestReturn, PerfRunner, PerfTest, PerfTestMetadata},
     TestContext,
 };
-use azure_storage_blob::BlobContainerClient;
+use azure_storage_blob::{models::BlobClientDownloadOptions, BlobContainerClient};
 use bytes::Bytes;
-use futures::{FutureExt, TryStreamExt};
+use futures::{lock::Mutex, FutureExt, TryStreamExt};
 
-use crate::extensions::{OnceLockExt, RecordingExt};
+use crate::{
+    extensions::{OnceLockExt, RecordingExt},
+    options,
+};
 
 const DEFAULT_NUM_BLOBS: usize = 5;
 
 pub struct DownloadIntoBlobTest {
-    num_blobs: usize,
-    blob_len: usize,
+    count: usize,
+    size: usize,
+    concurrency: Option<NonZero<usize>>,
+    partition_size: Option<NonZero<usize>>,
     endpoint: Option<String>,
     client: OnceLock<BlobContainerClient>,
+    buffer: Mutex<Vec<u8>>,
 }
 
 impl DownloadIntoBlobTest {
     fn create_test(runner: PerfRunner) -> CreatePerfTestReturn {
         async move {
-            let endpoint: Option<String> = runner.try_get_test_arg("endpoint")?;
+            let endpoint = runner.try_get_test_arg("endpoint")?;
+            let size = runner
+                .try_get_test_arg("blob_len")?
+                .expect("size argument is mandatory");
 
             Ok(Box::new(Self {
-                num_blobs: runner
+                count: runner
                     .try_get_test_arg("num_blobs")?
                     .unwrap_or(DEFAULT_NUM_BLOBS),
-                blob_len: runner
-                    .try_get_test_arg("blob_len")?
-                    .expect("size argument is mandatory"),
+                size,
+                concurrency: runner
+                    .try_get_test_arg::<usize>("concurrency")?
+                    .and_then(NonZero::new),
+                partition_size: runner
+                    .try_get_test_arg::<usize>("partition-size")?
+                    .and_then(NonZero::new),
                 endpoint,
                 client: OnceLock::new(),
+                buffer: Mutex::new(vec![0; size]),
             }) as Box<dyn PerfTest>)
         }
         .boxed()
@@ -52,37 +64,22 @@ impl DownloadIntoBlobTest {
             name: "download_into_blob",
             description: "Download blobs from a container directly into memory buffers.",
             options: vec![
-                PerfTestOption {
-                    name: "num_blobs",
-                    display_message: "The number of blobs to download",
-                    mandatory: false,
-                    short_activator: Some('c'),
-                    long_activator: "count",
-                    expected_args_len: 1,
-                    option_type: PerfTestOptionKind::Usize,
-                    ..Default::default()
-                },
-                PerfTestOption {
-                    name: "blob_len",
-                    display_message: "The length of each blob in bytes",
-                    mandatory: true,
-                    short_activator: Some('s'),
-                    long_activator: "size",
-                    expected_args_len: 1,
-                    option_type: PerfTestOptionKind::Usize,
-                    ..Default::default()
-                },
-                PerfTestOption {
-                    name: "endpoint",
-                    display_message: "The endpoint of the blob storage",
-                    mandatory: false,
-                    short_activator: Some('e'),
-                    long_activator: "endpoint",
-                    expected_args_len: 1,
-                    ..Default::default()
-                },
+                options::count(),
+                options::collect(),
+                options::size(),
+                options::concurrency(),
+                options::partition_size(),
+                options::endpoint(),
             ],
             create_test: Self::create_test,
+        }
+    }
+
+    fn download_options(&self) -> BlobClientDownloadOptions<'_> {
+        BlobClientDownloadOptions {
+            parallel: self.concurrency,
+            partition_size: self.partition_size,
+            ..Default::default()
         }
     }
 }
@@ -97,10 +94,10 @@ impl PerfTest for DownloadIntoBlobTest {
         })?;
         container_client.create(None).await?;
 
-        for i in 0..self.num_blobs {
+        for i in 0..self.count {
             let blob_name = format!("blob-{}", i);
             let blob_client = container_client.blob_client(&blob_name);
-            let body = vec![0u8; self.blob_len];
+            let body = vec![0u8; self.size];
             let body_bytes = Bytes::from(body);
             let _ = blob_client.upload(body_bytes.into(), None).await?;
         }
@@ -109,18 +106,15 @@ impl PerfTest for DownloadIntoBlobTest {
     }
 
     async fn run(&self, _context: Arc<TestContext>) -> azure_core::Result<()> {
-        // TODO large buffer allocation and drop is now getting measured
-        let mut buffer = vec![0u8; self.blob_len];
-
         let mut blob_list = self.client.get().unwrap().list_blobs(None)?;
         while let Some(blob_item) = blob_list.try_next().await? {
             self.client
                 .get()
                 .unwrap()
                 .blob_client(blob_item.name.unwrap().as_ref())
-                .download_into(&mut buffer, None)
+                .download_into(&mut self.buffer.lock().await, Some(self.download_options()))
                 .await?;
-            black_box(&buffer);
+            black_box(&self.buffer.lock().await);
         }
         todo!()
     }

--- a/sdk/storage/azure_storage_blob/perf/download_into_blob_test.rs
+++ b/sdk/storage/azure_storage_blob/perf/download_into_blob_test.rs
@@ -37,12 +37,12 @@ impl DownloadIntoBlobTest {
         async move {
             let endpoint = runner.try_get_test_arg("endpoint")?;
             let size = runner
-                .try_get_test_arg("blob_len")?
+                .try_get_test_arg("size")?
                 .expect("size argument is mandatory");
 
             Ok(Box::new(Self {
                 count: runner
-                    .try_get_test_arg("num_blobs")?
+                    .try_get_test_arg("count")?
                     .unwrap_or(DEFAULT_NUM_BLOBS),
                 size,
                 concurrency: runner
@@ -116,7 +116,7 @@ impl PerfTest for DownloadIntoBlobTest {
                 .await?;
             black_box(&self.buffer.lock().await);
         }
-        todo!()
+        Ok(())
     }
 
     async fn cleanup(&self, _context: Arc<TestContext>) -> azure_core::Result<()> {

--- a/sdk/storage/azure_storage_blob/perf/extensions.rs
+++ b/sdk/storage/azure_storage_blob/perf/extensions.rs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use azure_core::{http::Url, Result};
+use azure_core_test::Recording;
+use azure_storage_blob::BlobContainerClient;
+
+pub trait OnceLockExt {
+    type Output;
+
+    /// Emulate nightly `get_or_try_init()`.
+    fn try_get_or_init<F>(&self, init: F) -> Result<&Self::Output>
+    where
+        F: FnOnce() -> Result<Self::Output>;
+}
+
+impl<T> OnceLockExt for std::sync::OnceLock<T> {
+    type Output = T;
+
+    fn try_get_or_init<F>(&self, init: F) -> Result<&Self::Output>
+    where
+        F: FnOnce() -> Result<Self::Output>,
+    {
+        if let Some(value) = self.get() {
+            return Ok(value);
+        }
+        match init() {
+            Ok(value) => {
+                // If set fails, another thread beat us to initialization. That's not a problem.
+                let _ = self.set(value);
+                Ok(self.get().expect("just ensured value is set"))
+            }
+            // Another thread may have initialized in this time.
+            // Try to get from them just in case, otherwise return init error.
+            Err(e) => self.get().ok_or(e),
+        }
+    }
+}
+
+pub trait RecordingExt {
+    fn get_container_client(&self, endpoint: Option<String>) -> Result<BlobContainerClient>;
+}
+
+impl RecordingExt for Recording {
+    fn get_container_client(&self, endpoint: Option<String>) -> Result<BlobContainerClient> {
+        let endpoint = endpoint.unwrap_or_else(|| {
+            format!(
+                "https://{}.blob.core.windows.net",
+                self.var("AZURE_STORAGE_ACCOUNT_NAME", None)
+            )
+        });
+        println!("Using endpoint: {}", endpoint);
+        let mut container_url = Url::parse(&endpoint)?;
+        container_url
+            .path_segments_mut()
+            .expect("endpoint must be a valid base URL")
+            .push(&format!("perf-container-{}", azure_core::Uuid::new_v4()));
+        BlobContainerClient::new(container_url, Some(self.credential()), None)
+    }
+}

--- a/sdk/storage/azure_storage_blob/perf/extensions.rs
+++ b/sdk/storage/azure_storage_blob/perf/extensions.rs
@@ -4,6 +4,7 @@
 use azure_core::{http::Url, Result};
 use azure_core_test::Recording;
 use azure_storage_blob::BlobContainerClient;
+use azure_storage_blob_test::get_test_credential;
 
 pub trait OnceLockExt {
     type Output;
@@ -55,6 +56,6 @@ impl RecordingExt for Recording {
             .path_segments_mut()
             .expect("endpoint must be a valid base URL")
             .push(&format!("perf-container-{}", azure_core::Uuid::new_v4()));
-        BlobContainerClient::new(container_url, Some(self.credential()), None)
+        BlobContainerClient::new(container_url, Some(get_test_credential(self)), None)
     }
 }

--- a/sdk/storage/azure_storage_blob/perf/perf_tests.rs
+++ b/sdk/storage/azure_storage_blob/perf/perf_tests.rs
@@ -2,12 +2,16 @@
 // Licensed under the MIT License.
 
 mod download_blob_test;
+mod download_into_blob_test;
+mod extensions;
+/// list_blob performance test.
 mod list_blob_test;
 mod options;
 mod upload_blob_test;
 
 use azure_core_test::perf::PerfRunner;
 use download_blob_test::DownloadBlobTest;
+use download_into_blob_test::DownloadIntoBlobTest;
 use list_blob_test::ListBlobTest;
 use upload_blob_test::UploadBlobTest;
 
@@ -20,6 +24,7 @@ async fn main() -> azure_core::Result<()> {
             ListBlobTest::test_metadata(),
             UploadBlobTest::test_metadata(),
             DownloadBlobTest::test_metadata(),
+            DownloadIntoBlobTest::test_metadata(),
         ],
     )?;
 

--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -19,8 +19,7 @@ use azure_core::{
     error::ErrorKind,
     http::{
         policies::{auth::BearerTokenAuthorizationPolicy, Policy},
-        AsyncRawResponse, ClientMethodOptions, Etag, NoFormat, Pipeline, RequestContent,
-        StatusCode, Url, UrlExt,
+        AsyncRawResponse, Etag, NoFormat, Pipeline, RequestContent, StatusCode, Url, UrlExt,
     },
     tracing, Bytes, Result,
 };
@@ -189,44 +188,49 @@ impl BlobClient {
         let partition_size = options
             .partition_size
             .unwrap_or(crate::partitioned_transfer::defaults::DEFAULT_DOWNLOAD_PARTITION_SIZE);
-        // Construct exhaustively to catch new options.
-        let get_range_options = BlobClientDownloadInternalOptions {
-            encryption_algorithm: options.encryption_algorithm,
-            encryption_key: options.encryption_key,
-            encryption_key_sha256: options.encryption_key_sha256,
-            if_match: options.if_match,
-            if_modified_since: options.if_modified_since,
-            if_none_match: options.if_none_match,
-            if_tags: options.if_tags,
-            if_unmodified_since: options.if_unmodified_since,
-            lease_id: options.lease_id,
-            // requires into_owned due to BlobClientDownloadBehavior w/ 'static Behavior
-            method_options: ClientMethodOptions {
-                context: options.method_options.context.into_owned(),
-            },
-            range: None,
-            range_get_content_crc64: options.range_get_content_crc64,
-            range_get_content_md5: options.range_get_content_md5,
-            snapshot: options.snapshot,
-            structured_body_type: None,
-            timeout: options.timeout,
-            version_id: options.version_id,
-        };
+        let range = options.range.clone();
         let inner_client = GeneratedBlobClient {
             endpoint: self.endpoint.clone(),
             pipeline: self.pipeline.clone(),
             version: self.version.clone(),
             tracer: self.tracer.clone(),
         };
-        let behavior = BlobClientDownloadBehavior::new(inner_client, get_range_options);
-        let response = partitioned_transfer::download(
-            options.range,
+        let behavior = BlobClientDownloadBehavior::new(inner_client, options.into());
+        let response =
+            partitioned_transfer::download(range, parallel, partition_size, Arc::new(behavior))
+                .await?;
+        BlobClientDownloadResult::from_headers(response)
+    }
+
+    #[tracing::function("Storage.Blob.Blob.download")]
+    pub async fn download_into(
+        &self,
+        buffer: &mut [u8],
+        options: Option<BlobClientDownloadOptions<'_>>,
+    ) -> Result<usize> {
+        let options = options.unwrap_or_default();
+        let parallel = options
+            .parallel
+            .unwrap_or_else(crate::partitioned_transfer::defaults::default_concurrency);
+        let partition_size = options
+            .partition_size
+            .unwrap_or(crate::partitioned_transfer::defaults::DEFAULT_DOWNLOAD_PARTITION_SIZE);
+        let range = options.range.clone();
+        let inner_client = GeneratedBlobClient {
+            endpoint: self.endpoint.clone(),
+            pipeline: self.pipeline.clone(),
+            version: self.version.clone(),
+            tracer: self.tracer.clone(),
+        };
+        let behavior = BlobClientDownloadBehavior::new(inner_client, options.into());
+        partitioned_transfer::download_into(
+            buffer,
+            range,
             parallel,
             partition_size,
             Arc::new(behavior),
         )
-        .await?;
-        BlobClientDownloadResult::from_headers(response)
+        .await
     }
 
     /// Uploads content to a block blob, overwriting any existing blob by default.

--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -4,11 +4,13 @@
 pub use crate::generated::clients::{BlobClient, BlobClientOptions};
 
 use crate::{
-    generated::clients::BlobClient as GeneratedBlobClient,
-    generated::models::BlobClientDownloadInternalOptions,
+    generated::{
+        clients::BlobClient as GeneratedBlobClient, models::BlobClientDownloadInternalOptions,
+    },
     models::{
-        BlobClientDownloadOptions, BlobClientDownloadResult, BlobClientUploadOptions,
-        BlobClientUploadResult, HttpRange, StorageErrorCode,
+        BlobClientDownloadIntoResult, BlobClientDownloadOptions, BlobClientDownloadResult,
+        BlobClientUploadOptions, BlobClientUploadResult, BlobDownloadProperties, HttpRange,
+        StorageErrorCode,
     },
     partitioned_transfer::{self, PartitionedDownloadBehavior},
     AppendBlobClient, BlockBlobClient, PageBlobClient,
@@ -210,8 +212,7 @@ impl BlobClient {
     ///
     /// This operation performs a managed (multi-part) download, splitting the blob into
     /// parallel range requests for better performance on large blobs. The downloaded bytes are
-    /// written directly into the provided `buffer` and the number of bytes written is returned
-    /// in the result.
+    /// written directly into the provided `buffer`.
     ///
     /// # Arguments
     ///
@@ -229,7 +230,7 @@ impl BlobClient {
         &self,
         buffer: &mut [u8],
         options: Option<BlobClientDownloadOptions<'_>>,
-    ) -> Result<usize> {
+    ) -> Result<BlobClientDownloadIntoResult> {
         let options = options.unwrap_or_default();
         let parallel = options
             .parallel
@@ -245,14 +246,19 @@ impl BlobClient {
             tracer: self.tracer.clone(),
         };
         let behavior = BlobClientDownloadBehavior::new(inner_client, options.into());
-        partitioned_transfer::download_into(
+        let (_, headers, len) = partitioned_transfer::download_into(
             buffer,
             range,
             parallel,
             partition_size,
             Arc::new(behavior),
         )
-        .await
+        .await?;
+        Ok(BlobClientDownloadIntoResult {
+            len,
+            properties: BlobDownloadProperties::from_headers(&headers)?,
+            headers,
+        })
     }
 
     /// Uploads content to a block blob, overwriting any existing blob by default.

--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -166,6 +166,10 @@ impl BlobClient {
     /// [`BlobClientDownloadResult::properties`] and [`BlobClientDownloadResult::headers`]
     /// reflect only the initial response's metadata and properties.
     ///
+    /// If the streamed bytes of this blob are to be collected into contiguous memory,
+    /// consider instead calling [`BlobClient::download_into`] with a pre-allocated buffer
+    /// to avoid unnecessary copies and allocations.
+    ///
     /// # Arguments
     ///
     /// * `options` - Optional configuration for the request.
@@ -202,7 +206,25 @@ impl BlobClient {
         BlobClientDownloadResult::from_headers(response)
     }
 
-    #[tracing::function("Storage.Blob.Blob.download")]
+    /// Downloads a blob and its contents from the service.
+    ///
+    /// This operation performs a managed (multi-part) download, splitting the blob into
+    /// parallel range requests for better performance on large blobs. The downloaded bytes are
+    /// written directly into the provided `buffer` and the number of bytes written is returned
+    /// in the result.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer` - Destination buffer to write the downloaded blob data into.
+    /// * `options` - Optional configuration for the request.
+    ///
+    /// # Notes
+    ///
+    /// By default, storage clients create their HTTP transport via
+    /// [`azure_core::http::new_http_client()`] with automatic decompression disabled.
+    /// If you set a custom transport in [`BlobClientOptions`] without also disabling
+    /// automatic decompression, partitioned downloads may not succeed.
+    #[tracing::function("Storage.Blob.Blob.download_into")]
     pub async fn download_into(
         &self,
         buffer: &mut [u8],

--- a/sdk/storage/azure_storage_blob/src/models/download_result.rs
+++ b/sdk/storage/azure_storage_blob/src/models/download_result.rs
@@ -38,6 +38,22 @@ pub struct BlobClientDownloadResult {
     pub headers: Headers,
 }
 
+/// Result of a `BlobClient::download_into()` operation.
+#[derive(SafeDebug)]
+pub struct BlobClientDownloadIntoResult {
+    /// The length of data written to the provided buffer.
+    pub len: usize,
+
+    /// Blob properties parsed from the initial response.
+    pub properties: BlobDownloadProperties,
+
+    /// All headers from the initial response.
+    ///
+    /// Use this to access headers that are not surfaced as named fields, such as
+    /// `x-ms-request-id`, `x-ms-client-request-id`, and more.
+    pub headers: Headers,
+}
+
 /// Blob properties parsed from the initial response headers of a `BlobClient::download()` operation.
 #[derive(SafeDebug)]
 pub struct BlobDownloadProperties {
@@ -180,7 +196,7 @@ impl BlobClientDownloadResult {
 }
 
 impl BlobDownloadProperties {
-    fn from_headers(headers: &Headers) -> azure_core::Result<Self> {
+    pub(crate) fn from_headers(headers: &Headers) -> azure_core::Result<Self> {
         let (metadata, object_replication_rules) =
             crate::parsers::parse_metadata_and_replication_headers(headers);
         Ok(Self {

--- a/sdk/storage/azure_storage_blob/src/models/method_options.rs
+++ b/sdk/storage/azure_storage_blob/src/models/method_options.rs
@@ -9,7 +9,10 @@ use azure_core::{
 };
 use time::OffsetDateTime;
 
-use crate::models::{AccessTier, EncryptionAlgorithmType, HttpRange, ImmutabilityPolicyMode};
+use crate::models::{
+    AccessTier, BlobClientDownloadInternalOptions, EncryptionAlgorithmType, HttpRange,
+    ImmutabilityPolicyMode,
+};
 
 /// Options to be passed to `BlobClient::download()`
 #[derive(Clone, Default, SafeDebug)]
@@ -76,6 +79,34 @@ pub struct BlobClientDownloadOptions<'a> {
 
     /// Specifies the version ID of the blob.
     pub version_id: Option<String>,
+}
+
+impl<'a> From<BlobClientDownloadOptions<'a>> for BlobClientDownloadInternalOptions<'_> {
+    fn from(value: BlobClientDownloadOptions) -> Self {
+        // Construct exhaustively to catch new options.
+        Self {
+            encryption_algorithm: value.encryption_algorithm,
+            encryption_key: value.encryption_key,
+            encryption_key_sha256: value.encryption_key_sha256,
+            if_match: value.if_match,
+            if_modified_since: value.if_modified_since,
+            if_none_match: value.if_none_match,
+            if_tags: value.if_tags,
+            if_unmodified_since: value.if_unmodified_since,
+            lease_id: value.lease_id,
+            // requires into_owned due to BlobClientDownloadBehavior w/ 'static Behavior
+            method_options: ClientMethodOptions {
+                context: value.method_options.context.into_owned(),
+            },
+            range: None,
+            range_get_content_crc64: value.range_get_content_crc64,
+            range_get_content_md5: value.range_get_content_md5,
+            snapshot: value.snapshot,
+            structured_body_type: None,
+            timeout: value.timeout,
+            version_id: value.version_id,
+        }
+    }
 }
 
 /// Options to be passed to `BlockBlobClient::upload()`

--- a/sdk/storage/azure_storage_blob/src/models/mod.rs
+++ b/sdk/storage/azure_storage_blob/src/models/mod.rs
@@ -15,7 +15,9 @@ pub(crate) mod response_ext;
 mod upload_result;
 
 pub use crate::generated::models::*;
-pub use download_result::{BlobClientDownloadResult, BlobDownloadProperties};
+pub use download_result::{
+    BlobClientDownloadIntoResult, BlobClientDownloadResult, BlobDownloadProperties,
+};
 pub use method_options::BlobClientDownloadOptions;
 pub use method_options::BlockBlobClientUploadOptions;
 pub use method_options::BlockBlobClientUploadOptions as BlobClientUploadOptions;

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
@@ -410,11 +410,9 @@ fn start_initial_download_task_channel(
     destination_offset: usize,
     sender: UnboundedSender<Result<(usize, Bytes), Error>>,
 ) -> SpawnedTask {
-    get_async_runtime().spawn(Box::pin(body_to_channel(
-        initial_response.into_body(),
-        destination_offset,
-        sender,
-    )))
+    get_async_runtime().spawn(Box::pin(async move {
+        body_to_channel(initial_response.into_body(), destination_offset, sender).await;
+    }))
 }
 
 /// Spawns a worker to request the given range and stream it through a channel.
@@ -447,30 +445,35 @@ fn start_download_task_channel<Behavior: PartitionedDownloadBehavior + Send + Sy
     }))
 }
 
+/// Takes an AsyncResponseBody and streams it through a channel, using the given `destination_offset`
+/// to calculate the offset for each individual Bytes message.
+///
+///
 async fn body_to_channel(
     mut body: AsyncResponseBody,
     mut destination_offset: usize,
     mut sender: UnboundedSender<Result<(usize, Bytes), Error>>,
-) {
+) -> std::result::Result<(), mpsc::SendError> {
     const CHANNEL_BATCH_LEN: usize = 8;
     let mut batch_counter = BatchCounter::<CHANNEL_BATCH_LEN>::new();
     while let Some(result) = body.next().await {
         match result {
             Ok(bytes) => {
                 let bytes_len = bytes.len();
-                let _res = sender.feed(Ok((destination_offset, bytes))).await;
+                sender.feed(Ok((destination_offset, bytes))).await?;
                 destination_offset += bytes_len;
                 if batch_counter.eval() {
-                    let _res = sender.flush().await;
+                    sender.flush().await?;
                 }
             }
             Err(err) => {
-                let _res = sender.send(Err(err)).await;
+                sender.send(Err(err)).await?;
                 return;
             }
         };
     }
-    let _res = sender.flush().await;
+    sender.flush().await?;
+    Ok(());
 }
 
 /// Performs a `transfer_range()` call with the given range. If this results in a

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
@@ -213,86 +213,49 @@ where
      * Assuming we can copy bytes in memory faster than the network can produce them, there should
      * be no significant buildup of memory in this channel.
      */
-    let (tx, mut rx) = mpsc::unbounded();
-    let mut tx_opt = Some(tx);
-    let mut download_workers = Vec::with_capacity(parallel);
-    // the starting offset of the overall download range
-    // bytes at this position are written to position 0 of `buffer`
-    let src_offset = response_analysis.overall_download_range.start;
+    let (mut tx, mut rx) = mpsc::unbounded();
+    // worker that does nothing but monitor active downloads and spawn new ones
+    let downloads_manager_handle = get_async_runtime().spawn(Box::pin(async move {
+        // the starting offset of the overall download range
+        // bytes at this position are written to position 0 of `buffer`
+        let src_offset = response_analysis.overall_download_range.start;
 
-    download_workers.push(start_initial_download_task_channel(
-        initial_response,
-        0,
-        tx_opt
-            .as_ref()
-            .ok_or_else(|| Error::with_message(ErrorKind::Other, "Channel closed unexpectedly."))?
-            .clone(),
-    ));
+        let mut download_workers = Vec::with_capacity(parallel);
+        download_workers.push(start_initial_download_task_channel(
+            initial_response,
+            0,
+            tx.clone(),
+        ));
+
+        while let Some(range) = response_analysis.remaining_download_ranges.pop_front() {
+            while download_workers.len() >= parallel {
+                (_, _, download_workers) = future::select_all(download_workers).await;
+            }
+            download_workers.push(start_download_task_channel(
+                client.clone(),
+                range.clone(),
+                range.start - src_offset,
+                etag_lock.clone(),
+                tx.clone(),
+            ));
+        }
+        if let Err(error) = future::try_join_all(download_workers).await {
+            _ = tx.send(Err(map_spawned_task_error(error))).await;
+        }
+    }));
 
     let mut total_read = 0;
-    loop {
-        while download_workers.len() < parallel {
-            if let Some(range) = response_analysis.remaining_download_ranges.pop_front() {
-                download_workers.push(start_download_task_channel(
-                    client.clone(),
-                    range.clone(),
-                    range.start - src_offset,
-                    etag_lock.clone(),
-                    tx_opt
-                        .as_ref()
-                        .ok_or_else(|| {
-                            Error::with_message(ErrorKind::Other, "Channel closed unexpectedly.")
-                        })?
-                        .clone(),
-                ));
-            } else {
-                // No more transmitters needed.
-                // Drop this one to ensure channel closes when expected.
-                tx_opt = None;
-                break;
-            }
+    while let Ok(msg) = rx.recv().await {
+        let (write_offset, bytes) = msg?;
+        if write_offset
+            .checked_add(bytes.len())
+            .ok_or_else(insufficient_buffer_err)?
+            > buffer.len()
+        {
+            return Err(insufficient_buffer_err());
         }
-
-        // Read Bytes from channel and prune join handles for worker tasks
-        match future::select(rx.recv(), future::select_all(download_workers)).await {
-            // Received download bytes from channel. Write them to buffer.
-            Either::Left((Ok(Ok((write_offset, bytes))), select_download_workers)) => {
-                if write_offset
-                    .checked_add(bytes.len())
-                    .ok_or_else(insufficient_buffer_err)?
-                    > buffer.len()
-                {
-                    return Err(insufficient_buffer_err());
-                }
-                buffer[write_offset..write_offset + bytes.len()].copy_from_slice(&bytes);
-                total_read += bytes.len();
-                download_workers = select_download_workers.into_inner();
-            }
-            // Received download error from channel. Fail overall operation.
-            Either::Left((Ok(Err(download_err)), _)) => {
-                return Err(download_err);
-            }
-            // All channel items have been recieved and all senders have been closed.
-            // Complete download.
-            Either::Left((Err(_recv_err), select_download_workers)) => {
-                // A worker could have failed to report an error through the channel.
-                // Join on all workers before returning success.
-                future::try_join_all(select_download_workers.into_inner())
-                    .await
-                    .map_err(map_spawned_task_error)?;
-                drop(rx);
-                break;
-            }
-            // A worker completed with success.
-            // Prune its handle and allow loop to start another.
-            Either::Right(((Ok(()), _, remaining_worker_handles), _)) => {
-                download_workers = remaining_worker_handles;
-            }
-            // A worker joined with error. Fail overall operation.
-            Either::Right(((Err(worker_join_err), _, _remaining_worker_handles), _)) => {
-                return Err(map_spawned_task_error(worker_join_err));
-            }
-        };
+        buffer[write_offset..write_offset + bytes.len()].copy_from_slice(&bytes);
+        total_read += bytes.len();
     }
 
     let expected_total_read = response_analysis.overall_download_range.len();
@@ -305,6 +268,9 @@ where
             ),
         ));
     }
+    downloads_manager_handle
+        .await
+        .map_err(map_spawned_task_error)?;
     Ok(total_read)
 }
 

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use azure_core::{
     async_runtime::{get_async_runtime, SpawnedTask},
     error::ErrorKind,
-    http::{AsyncRawResponse, AsyncResponseBody, Etag, StatusCode},
+    http::{headers::Headers, AsyncRawResponse, AsyncResponseBody, Etag, StatusCode},
     Error,
 };
 use bytes::Bytes;
@@ -155,7 +155,7 @@ pub(crate) async fn download_into<Behavior>(
     parallel: NonZero<usize>,
     partition_size: NonZero<usize>,
     client: Arc<Behavior>,
-) -> AzureResult<usize>
+) -> AzureResult<(StatusCode, Headers, usize)>
 where
     Behavior: PartitionedDownloadBehavior + Send + Sync + 'static,
 {
@@ -176,14 +176,20 @@ where
     let (initial_response, response_analysis) =
         get_initial_response_and_analyze(range, partition_size, client.clone()).await?;
 
-    let _status = initial_response.status();
+    let status = initial_response.status();
     let headers = initial_response.headers().clone();
     let etag_lock = headers.get_optional_str(&"etag".into()).map(Etag::from);
 
     let mut response_analysis = match response_analysis {
         Some(a) => a,
         // if no response analysis, no subsequent gets, therefore just copy to buffer and return
-        None => return initial_response.into_body().collect_into(buffer).await,
+        None => {
+            return initial_response
+                .into_body()
+                .collect_into(buffer)
+                .await
+                .map(|read| (status, headers, read))
+        }
     };
 
     // fail fast for buffer overflow
@@ -202,7 +208,7 @@ where
                 .collect_into(&mut buffer[total_read..])
                 .await?;
         }
-        return Ok(total_read);
+        return Ok((status, headers, total_read));
     }
 
     /* There's no sound way to have parallel workers operate on a borrowed buffer. Instead, we will
@@ -214,7 +220,7 @@ where
      * be no significant buildup of memory in this channel.
      */
     let (mut tx, mut rx) = mpsc::unbounded();
-    // worker that does nothing but monitor active downloads and spawn new ones
+    // worker that does nothing but monitor active download workers and spawn new ones
     let downloads_manager_handle = get_async_runtime().spawn(Box::pin(async move {
         // the starting offset of the overall download range
         // bytes at this position are written to position 0 of `buffer`
@@ -271,7 +277,8 @@ where
     downloads_manager_handle
         .await
         .map_err(map_spawned_task_error)?;
-    Ok(total_read)
+
+    Ok((status, headers, total_read))
 }
 
 async fn get_initial_response_and_analyze<Behavior>(
@@ -397,6 +404,7 @@ fn start_download_task_buffer<Behavior: PartitionedDownloadBehavior + Send + Syn
 }
 
 /// Spawns a worker to take the given raw response and stream it through a channel.
+/// Worker terminates gracefully on download error or channel send error.
 ///
 /// # Arguments
 ///
@@ -411,11 +419,12 @@ fn start_initial_download_task_channel(
     sender: UnboundedSender<Result<(usize, Bytes), Error>>,
 ) -> SpawnedTask {
     get_async_runtime().spawn(Box::pin(async move {
-        body_to_channel(initial_response.into_body(), destination_offset, sender).await;
+        _ = body_to_channel(initial_response.into_body(), destination_offset, sender).await;
     }))
 }
 
 /// Spawns a worker to request the given range and stream it through a channel.
+/// Worker terminates gracefully on download error or channel send error.
 ///
 /// # Arguments
 ///
@@ -434,21 +443,17 @@ fn start_download_task_channel<Behavior: PartitionedDownloadBehavior + Send + Sy
     mut sender: UnboundedSender<Result<(usize, Bytes), Error>>,
 ) -> SpawnedTask {
     get_async_runtime().spawn(Box::pin(async move {
-        let response = match client.transfer_range(Some(range), etag_lock).await {
-            Ok(response) => response,
-            Err(err) => {
-                let _res = sender.send(Err(err)).await;
-                return;
-            }
+        _ = match client.transfer_range(Some(range), etag_lock).await {
+            Ok(response) => body_to_channel(response.into_body(), destination_offset, sender).await,
+            Err(err) => sender.send(Err(err)).await,
         };
-        body_to_channel(response.into_body(), destination_offset, sender).await;
     }))
 }
 
 /// Takes an AsyncResponseBody and streams it through a channel, using the given `destination_offset`
 /// to calculate the offset for each individual Bytes message.
-///
-///
+/// When recieving an error from `body`, sends that error through the channel and terminates.
+/// Immediately returns on error sending a message through the channel.
 async fn body_to_channel(
     mut body: AsyncResponseBody,
     mut destination_offset: usize,
@@ -467,13 +472,11 @@ async fn body_to_channel(
                 }
             }
             Err(err) => {
-                sender.send(Err(err)).await?;
-                return;
+                return sender.send(Err(err)).await;
             }
         };
     }
-    sender.flush().await?;
-    Ok(());
+    sender.flush().await
 }
 
 /// Performs a `transfer_range()` call with the given range. If this results in a
@@ -827,7 +830,7 @@ mod tests {
             let download_len = download_range.map_or(DATA_LEN, |r| r.1 - r.0);
             let dst = &mut buffer[..download_len];
 
-            let copied = download_into(
+            let (_, _, copied) = download_into(
                 dst,
                 download_range.map(|r| (r.0..r.1).into()),
                 PARALLEL.try_into().unwrap(),
@@ -958,7 +961,7 @@ mod tests {
             let download_len = download_range.map_or(DATA_LEN, |r| r.1 - r.0);
             let dst = &mut buffer[..download_len];
 
-            let copied = download_into(
+            let (_, _, copied) = download_into(
                 dst,
                 download_range.map(|r| (r.0..r.1).into()),
                 parallel.try_into().unwrap(),
@@ -1043,7 +1046,7 @@ mod tests {
         let data = get_random_data(0);
         let mock = Arc::new(MockPartitionedDownloadBehavior::new(data.clone(), None));
 
-        let copied =
+        let (_, _, copied) =
             download_into(&mut [0; 1024], None, parallel, partition_len, mock.clone()).await?;
 
         assert_eq!(copied, 0);

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
@@ -176,7 +176,7 @@ where
     let (initial_response, response_analysis) =
         get_initial_response_and_analyze(range, partition_size, client.clone()).await?;
 
-    let status = initial_response.status();
+    let _status = initial_response.status();
     let headers = initial_response.headers().clone();
     let etag_lock = headers.get_optional_str(&"etag".into()).map(Etag::from);
 
@@ -1251,6 +1251,39 @@ mod tests {
         .await;
 
         assert!(download_result.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn download_into_insufficient_buffer() -> AzureResult<()> {
+        const DATA_LEN: usize = 1024;
+        let data = get_random_data(DATA_LEN);
+        for (buffer_len, range) in [
+            (0, None),
+            (DATA_LEN - 1, None),
+            (DATA_LEN / 2, None),
+            (0, Some(0..1)),
+            (0, Some(101..102)),
+            (0, Some(0..DATA_LEN)),
+            (DATA_LEN - 1, Some(0..DATA_LEN)),
+            (DATA_LEN / 2, Some(0..DATA_LEN / 2 + 1)),
+        ] {
+            let http_range = range.map(HttpRange::from);
+            for parallel in [1, 8] {
+                for partition_len in [DATA_LEN * 2, DATA_LEN / 8] {
+                    let download_result = download_into(
+                        &mut vec![0; buffer_len],
+                        http_range.clone(),
+                        NonZero::new(parallel).unwrap(),
+                        NonZero::new(partition_len).unwrap(),
+                        Arc::new(MockPartitionedDownloadBehavior::new(data.clone(), None)),
+                    )
+                    .await;
+                    assert!(download_result.is_err(), "Expected error for buffer_len: {}, range: {:?}, parallel: {}, partition_len: {}", buffer_len, http_range, parallel, partition_len);
+                }
+            }
+        }
 
         Ok(())
     }

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
@@ -17,14 +17,14 @@ use async_trait::async_trait;
 use azure_core::{
     async_runtime::{get_async_runtime, SpawnedTask},
     error::ErrorKind,
-    http::{AsyncRawResponse, Etag, StatusCode},
+    http::{AsyncRawResponse, AsyncResponseBody, Etag, StatusCode},
     Error,
 };
 use bytes::Bytes;
 use futures::{
     channel::mpsc::{self, UnboundedReceiver, UnboundedSender},
     future::{self, Either},
-    SinkExt,
+    SinkExt, StreamExt,
 };
 
 use crate::models::{drains::SequentialBoundedDrain, http_ranges::ContentRange};
@@ -96,7 +96,7 @@ where
     // start with one initial download task at index 0
     let active_tasks_counter = Arc::new(AtomicUsize::new(1));
     let mut next_task_index = 1;
-    let mut task_bucket = vec![start_initial_download_task(
+    let mut task_bucket = vec![start_initial_download_task_buffer(
         initial_response,
         tx.clone(),
         active_tasks_counter.clone(),
@@ -122,7 +122,7 @@ where
                         next_task_index += 1;
                         active_tasks_counter.fetch_add(1, Ordering::Relaxed);
                         let t = tx_opt.as_ref().ok_or_else(||Error::with_message(ErrorKind::Other, "Channel closed unexpectedly."))?.clone();
-                        task_bucket.push(start_download_task(client.clone(), range, etag_lock.clone(), t, active_tasks_counter.clone(), i));
+                        task_bucket.push(start_download_task_buffer(client.clone(), range, etag_lock.clone(), t, active_tasks_counter.clone(), i));
                     }
                     None => {
                         // if ranges are finished, we'll never need to clone the transmitter again.
@@ -147,6 +147,165 @@ where
     };
 
     Ok(AsyncRawResponse::new(status, headers, Box::pin(stream)))
+}
+
+pub(crate) async fn download_into<Behavior>(
+    buffer: &mut [u8],
+    range: Option<HttpRange>,
+    parallel: NonZero<usize>,
+    partition_size: NonZero<usize>,
+    client: Arc<Behavior>,
+) -> AzureResult<usize>
+where
+    Behavior: PartitionedDownloadBehavior + Send + Sync + 'static,
+{
+    let insufficient_buffer_err =
+        || Error::with_message(ErrorKind::Other, "Insufficient buffer length.");
+
+    let range: Option<Range<usize>> = range.map(|hr| {
+        let start = hr.offset() as usize;
+        let end = match hr.length() {
+            Some(len) => start + len as usize,
+            None => usize::MAX,
+        };
+        start..end
+    });
+    let parallel = parallel.get();
+    let partition_size = partition_size.get();
+
+    let (initial_response, response_analysis) =
+        get_initial_response_and_analyze(range, partition_size, client.clone()).await?;
+
+    let status = initial_response.status();
+    let headers = initial_response.headers().clone();
+    let etag_lock = headers.get_optional_str(&"etag".into()).map(Etag::from);
+
+    let mut response_analysis = match response_analysis {
+        Some(a) => a,
+        // if no response analysis, no subsequent gets, therefore just copy to buffer and return
+        None => return initial_response.into_body().collect_into(buffer).await,
+    };
+
+    // fail fast for buffer overflow
+    if response_analysis.overall_download_range.len() > buffer.len() {
+        return Err(insufficient_buffer_err());
+    }
+
+    // if no real parallelism, just sequentially go through the ranges and write to buffer
+    if parallel == 1 {
+        let mut total_read = initial_response.into_body().collect_into(buffer).await?;
+        for range in response_analysis.remaining_download_ranges {
+            total_read += client
+                .transfer_range(Some(range), etag_lock.clone())
+                .await?
+                .into_body()
+                .collect_into(&mut buffer[total_read..])
+                .await?;
+        }
+        return Ok(total_read);
+    }
+
+    /* There's no sound way to have parallel workers operate on a borrowed buffer. Instead, we will
+     * parllelize only the reading from download streams, sending the resulting Bytes straight into
+     * a channel.
+     * Back here, we will asynchronously, but without concurrency, poll that channel and write the
+     * Bytes it produces into the borrowed destination buffer.
+     * Assuming we can copy bytes in memory faster than the network can produce them, there should
+     * be no significant buildup of memory in this channel.
+     */
+    let (tx, mut rx) = mpsc::unbounded();
+    let mut tx_opt = Some(tx);
+    let mut download_workers = Vec::with_capacity(parallel);
+    // the starting offset of the overall download range
+    // bytes at this position are written to position 0 of `buffer`
+    let src_offset = response_analysis.overall_download_range.start;
+
+    download_workers.push(start_initial_download_task_channel(
+        initial_response,
+        0,
+        tx_opt
+            .as_ref()
+            .ok_or_else(|| Error::with_message(ErrorKind::Other, "Channel closed unexpectedly."))?
+            .clone(),
+    ));
+
+    let mut total_read = 0;
+    loop {
+        while download_workers.len() < parallel {
+            if let Some(range) = response_analysis.remaining_download_ranges.pop_front() {
+                download_workers.push(start_download_task_channel(
+                    client.clone(),
+                    range.clone(),
+                    range.start - src_offset,
+                    etag_lock.clone(),
+                    tx_opt
+                        .as_ref()
+                        .ok_or_else(|| {
+                            Error::with_message(ErrorKind::Other, "Channel closed unexpectedly.")
+                        })?
+                        .clone(),
+                ));
+            } else {
+                // No more transmitters needed.
+                // Drop this one to ensure channel closes when expected.
+                tx_opt = None;
+                break;
+            }
+        }
+
+        // Read Bytes from channel and prune join handles for worker tasks
+        match future::select(rx.recv(), future::select_all(download_workers)).await {
+            // Received download bytes from channel. Write them to buffer.
+            Either::Left((Ok(Ok((write_offset, bytes))), select_download_workers)) => {
+                if write_offset
+                    .checked_add(bytes.len())
+                    .ok_or_else(insufficient_buffer_err)?
+                    > buffer.len()
+                {
+                    return Err(insufficient_buffer_err());
+                }
+                buffer[write_offset..write_offset + bytes.len()].copy_from_slice(&bytes);
+                total_read += bytes.len();
+                download_workers = select_download_workers.into_inner();
+            }
+            // Received download error from channel. Fail overall operation.
+            Either::Left((Ok(Err(download_err)), _)) => {
+                return Err(download_err);
+            }
+            // All channel items have been recieved and all senders have been closed.
+            // Complete download.
+            Either::Left((Err(_recv_err), select_download_workers)) => {
+                // A worker could have failed to report an error through the channel.
+                // Join on all workers before returning success.
+                future::try_join_all(select_download_workers.into_inner())
+                    .await
+                    .map_err(map_spawned_task_error)?;
+                drop(rx);
+                break;
+            }
+            // A worker completed with success.
+            // Prune its handle and allow loop to start another.
+            Either::Right(((Ok(()), _, remaining_worker_handles), _)) => {
+                download_workers = remaining_worker_handles;
+            }
+            // A worker joined with error. Fail overall operation.
+            Either::Right(((Err(worker_join_err), _, _remaining_worker_handles), _)) => {
+                return Err(map_spawned_task_error(worker_join_err));
+            }
+        };
+    }
+
+    let expected_total_read = response_analysis.overall_download_range.len();
+    if expected_total_read != total_read {
+        return Err(Error::with_message(
+            ErrorKind::Other,
+            format!(
+                "Download incomplete. Expected to read {} bytes, but read {} bytes. Bytes may not have been written to buffer in the correct positions.",
+                expected_total_read, total_read
+            ),
+        ));
+    }
+    Ok(total_read)
 }
 
 async fn get_initial_response_and_analyze<Behavior>(
@@ -223,7 +382,7 @@ async fn await_message_while_joining_workers<T>(
 
 /// Spawns a worker to take the given raw response and stream it into a buffer.
 /// That buffer result is then sent through sender with chunk index 0.
-fn start_initial_download_task(
+fn start_initial_download_task_buffer(
     initial_response: AsyncRawResponse,
     mut sender: UnboundedSender<Result<(usize, Bytes), Error>>,
     active_tasks_counter: Arc<AtomicUsize>,
@@ -244,7 +403,7 @@ fn start_initial_download_task(
 
 /// Spawns a worker to request the given range and stream it into a buffer.
 /// That buffer result is then sent through sender with the given chunk index.
-fn start_download_task<Behavior: PartitionedDownloadBehavior + Send + Sync + 'static>(
+fn start_download_task_buffer<Behavior: PartitionedDownloadBehavior + Send + Sync + 'static>(
     client: Arc<Behavior>,
     range: Range<usize>,
     etag_lock: Option<Etag>,
@@ -269,6 +428,83 @@ fn start_download_task<Behavior: PartitionedDownloadBehavior + Send + Sync + 'st
         active_tasks_counter.fetch_sub(1, Ordering::Relaxed);
         let _send_res = sender.send(res.map(|_| (chunk_idx, dst.into()))).await;
     }))
+}
+
+/// Spawns a worker to take the given raw response and stream it through a channel.
+///
+/// # Arguments
+///
+/// - initial_response: the initial download response to stream into a channel.
+/// - destination_offset: offset in the final destination buffer that this response is meant to be
+///   written into.
+/// - sender: channel to send network Bytes through along with the destination buffer offset to
+///   write those exact bytes to.
+fn start_initial_download_task_channel(
+    initial_response: AsyncRawResponse,
+    destination_offset: usize,
+    sender: UnboundedSender<Result<(usize, Bytes), Error>>,
+) -> SpawnedTask {
+    get_async_runtime().spawn(Box::pin(body_to_channel(
+        initial_response.into_body(),
+        destination_offset,
+        sender,
+    )))
+}
+
+/// Spawns a worker to request the given range and stream it through a channel.
+///
+/// # Arguments
+///
+/// - client: Client to request a range from.
+/// - range: The range to request.
+/// - destination_offset: offset in the final destination buffer that the response is meant to be
+///   written into.
+/// - etag_lock: etag to lock on for this ranged request.
+/// - sender: channel to send network Bytes through along with the destination buffer offset to
+///   write those exact bytes to.
+fn start_download_task_channel<Behavior: PartitionedDownloadBehavior + Send + Sync + 'static>(
+    client: Arc<Behavior>,
+    range: Range<usize>,
+    destination_offset: usize,
+    etag_lock: Option<Etag>,
+    mut sender: UnboundedSender<Result<(usize, Bytes), Error>>,
+) -> SpawnedTask {
+    get_async_runtime().spawn(Box::pin(async move {
+        let response = match client.transfer_range(Some(range), etag_lock).await {
+            Ok(response) => response,
+            Err(err) => {
+                let _res = sender.send(Err(err)).await;
+                return;
+            }
+        };
+        body_to_channel(response.into_body(), destination_offset, sender).await;
+    }))
+}
+
+async fn body_to_channel(
+    mut body: AsyncResponseBody,
+    mut destination_offset: usize,
+    mut sender: UnboundedSender<Result<(usize, Bytes), Error>>,
+) {
+    const CHANNEL_BATCH_LEN: usize = 8;
+    let mut batch_counter = BatchCounter::<CHANNEL_BATCH_LEN>::new();
+    while let Some(result) = body.next().await {
+        match result {
+            Ok(bytes) => {
+                let bytes_len = bytes.len();
+                let _res = sender.feed(Ok((destination_offset, bytes))).await;
+                destination_offset += bytes_len;
+                if batch_counter.eval() {
+                    let _res = sender.flush().await;
+                }
+            }
+            Err(err) => {
+                let _res = sender.send(Err(err)).await;
+                return;
+            }
+        };
+    }
+    let _res = sender.flush().await;
 }
 
 /// Performs a `transfer_range()` call with the given range. If this results in a
@@ -340,6 +576,21 @@ fn analyze_initial_response(
 
 fn map_spawned_task_error(err: Box<dyn std::error::Error + Send>) -> Error {
     Error::with_message(ErrorKind::Other, err.to_string())
+}
+
+/// Counter which evaluates to true exactly every n evaluations.
+struct BatchCounter<const LEN: usize> {
+    count: usize,
+}
+impl<const LEN: usize> BatchCounter<LEN> {
+    fn new() -> Self {
+        Self { count: 0 }
+    }
+    /// Evaluates to true every n evaluations, otherwise false.
+    fn eval(&mut self) -> bool {
+        self.count = (self.count + 1) % LEN;
+        self.count == 0
+    }
 }
 
 trait DownloadRangeFuture: Future + Send {}
@@ -587,6 +838,43 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn download_into_single_range() -> AzureResult<()> {
+        const DATA_LEN: usize = 1024;
+        const PARALLEL: usize = 2;
+
+        let data = get_random_data(DATA_LEN);
+        let mut buffer = [0; DATA_LEN];
+
+        for SingleRangeArgSet {
+            partition_len,
+            download_range,
+        } in single_range_args(DATA_LEN)
+        {
+            let mock = Arc::new(MockPartitionedDownloadBehavior::new(data.clone(), None));
+            for elem in buffer.iter_mut() {
+                *elem = 0;
+            }
+            let download_len = download_range.map_or(DATA_LEN, |r| r.1 - r.0);
+            let dst = &mut buffer[..download_len];
+
+            let copied = download_into(
+                dst,
+                download_range.map(|r| (r.0..r.1).into()),
+                PARALLEL.try_into().unwrap(),
+                partition_len.try_into().unwrap(),
+                mock.clone(),
+            )
+            .await?;
+
+            assert_eq!(copied, download_len);
+            assert_eq!(dst, download_range.map_or(&data[..], |r| &data[r.0..r.1]));
+            assert_eq!(mock.invocations.lock().await.len(), 1);
+        }
+
+        Ok(())
+    }
+
     struct MultiRangeArgSet {
         pub parallel: usize,
         pub partition_len: usize,
@@ -681,6 +969,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn download_into_multi_range() -> AzureResult<()> {
+        const DATA_LEN: usize = 4096;
+
+        let data = get_random_data(DATA_LEN);
+        let mut buffer = [0; DATA_LEN];
+
+        for MultiRangeArgSet {
+            parallel,
+            partition_len,
+            download_range,
+            expected_parts,
+        } in multi_range_args(DATA_LEN)
+        {
+            let mock = Arc::new(MockPartitionedDownloadBehavior::new(data.clone(), None));
+            for elem in buffer.iter_mut() {
+                *elem = 0;
+            }
+            let download_len = download_range.map_or(DATA_LEN, |r| r.1 - r.0);
+            let dst = &mut buffer[..download_len];
+
+            let copied = download_into(
+                dst,
+                download_range.map(|r| (r.0..r.1).into()),
+                parallel.try_into().unwrap(),
+                partition_len.try_into().unwrap(),
+                mock.clone(),
+            )
+            .await?;
+
+            assert_eq!(
+                copied, download_len,
+                "Data mismatch. partition_len={}. download_range={:?}, expected_parts={}",
+                partition_len, download_range, expected_parts
+            );
+            assert_eq!(
+                dst,
+                download_range.map_or(&data[..], |r| &data[r.0..r.1]),
+                "Data mismatch. partition_len={}. download_range={:?}, expected_parts={}",
+                partition_len,
+                download_range,
+                expected_parts
+            );
+            assert_eq!(
+                mock.invocations.lock().await.len(),
+                expected_parts,
+                "Unexpected invocation count. partition_len={}. download_range={:?}, expected_parts={}",
+                partition_len,
+                download_range,
+                expected_parts);
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn download_ranges_parallel_maintain_order() -> AzureResult<()> {
         let segments: usize = 20;
         let partition_size = NonZero::new(3).unwrap();
@@ -725,6 +1068,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn download_into_empty_resource() -> AzureResult<()> {
+        let parallel = NonZero::new(1).unwrap();
+        let partition_len = NonZero::new(MB).unwrap();
+        let data = get_random_data(0);
+        let mock = Arc::new(MockPartitionedDownloadBehavior::new(data.clone(), None));
+
+        let copied =
+            download_into(&mut [0; 1024], None, parallel, partition_len, mock.clone()).await?;
+
+        assert_eq!(copied, 0);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn download_etag_lock() -> AzureResult<()> {
         let configured_etag = Some(Etag::from("some_etag"));
         let data_len: usize = 1024;
@@ -745,6 +1103,51 @@ mod tests {
             .into_body()
             .collect()
             .await?;
+
+        let mut invocations: VecDeque<_> = mock.invocations.lock().await.iter().cloned().collect();
+
+        // Assert first request doesn't supply a lock, as it hasn't received a tag to lock on yet.
+        match invocations.pop_front().unwrap() {
+            MockPartitionedDownloadBehaviorInvocation::TransferRange(_, received_etag) => {
+                assert_eq!(received_etag, None)
+            }
+        };
+
+        // Assert subsequent requests supply the correct lock.
+        assert!(!invocations.is_empty());
+        match invocations.pop_front().unwrap() {
+            MockPartitionedDownloadBehaviorInvocation::TransferRange(_, received_etag) => {
+                assert_eq!(received_etag, configured_etag)
+            }
+        };
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn download_into_etag_lock() -> AzureResult<()> {
+        let configured_etag = Some(Etag::from("some_etag"));
+        const DATA_LEN: usize = 1024;
+        let partition_len = NonZero::new(DATA_LEN / 4).unwrap();
+        let parallel = NonZero::new(2).unwrap();
+
+        let data = get_random_data(DATA_LEN);
+        let mock = Arc::new(MockPartitionedDownloadBehavior::new(
+            data.clone(),
+            Some(MockOptions {
+                etag: configured_etag.clone(),
+                ..Default::default()
+            }),
+        ));
+
+        download_into(
+            &mut [0; DATA_LEN],
+            None,
+            parallel,
+            partition_len,
+            mock.clone(),
+        )
+        .await?;
 
         let mut invocations: VecDeque<_> = mock.invocations.lock().await.iter().cloned().collect();
 
@@ -797,6 +1200,49 @@ mod tests {
                     .collect()
                     .await
             },
+            async {
+                sleep(Duration::from_millis(etag_edit_delay_ms)).await;
+                *mock.clone().etag.lock().await = configured_etag_2;
+            },
+        )
+        .await;
+
+        assert!(download_result.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn download_into_fails_on_etag_update() -> AzureResult<()> {
+        let configured_etag_1 = Some(Etag::from("some_etag"));
+        let configured_etag_2 = Some(Etag::from("another_etag"));
+        const DATA_LEN: usize = 2048;
+        let total_partitions = 8;
+        let partition_len = NonZero::new(DATA_LEN / total_partitions).unwrap();
+        let parallel = NonZero::new(1).unwrap();
+
+        let individual_request_delay_ms = 5;
+        let etag_edit_delay_ms = individual_request_delay_ms * total_partitions as u64 / 2;
+
+        let data = get_random_data(DATA_LEN);
+        let mock = Arc::new(MockPartitionedDownloadBehavior::new(
+            data.clone(),
+            Some(MockOptions {
+                etag: configured_etag_1.clone(),
+                delay_millis_range: Some(
+                    individual_request_delay_ms..individual_request_delay_ms + 1,
+                ),
+            }),
+        ));
+
+        let (download_result, _) = futures::future::join(
+            download_into(
+                &mut [0; DATA_LEN],
+                None,
+                parallel,
+                partition_len,
+                mock.clone(),
+            ),
             async {
                 sleep(Duration::from_millis(etag_edit_delay_ms)).await;
                 *mock.clone().etag.lock().await = configured_etag_2;

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
@@ -165,7 +165,7 @@ where
     let missing_bytes_err = |expected: usize, actual: usize| {
         Error::with_message(
             ErrorKind::Other,
-            format!("Download incomplete. Expected to read {expected} bytes, but read actual bytes. Bytes may not have been written to buffer in the correct positions."),
+            format!("Download incomplete. Expected to read {expected} bytes, but read {actual} bytes. Bytes may not have been written to buffer in the correct positions."),
         )
     };
 

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
@@ -212,7 +212,7 @@ where
     }
 
     /* There's no sound way to have parallel workers operate on a borrowed buffer. Instead, we will
-     * parllelize only the reading from download streams, sending the resulting Bytes straight into
+     * parallelize only the reading from download streams, sending the resulting Bytes straight into
      * a channel.
      * Back here, we will asynchronously, but without concurrency, poll that channel and write the
      * Bytes it produces into the borrowed destination buffer.
@@ -452,7 +452,7 @@ fn start_download_task_channel<Behavior: PartitionedDownloadBehavior + Send + Sy
 
 /// Takes an AsyncResponseBody and streams it through a channel, using the given `destination_offset`
 /// to calculate the offset for each individual Bytes message.
-/// When recieving an error from `body`, sends that error through the channel and terminates.
+/// When receiving an error from `body`, sends that error through the channel and terminates.
 /// Immediately returns on error sending a message through the channel.
 async fn body_to_channel(
     mut body: AsyncResponseBody,

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
@@ -162,6 +162,13 @@ where
     let insufficient_buffer_err =
         || Error::with_message(ErrorKind::Other, "Insufficient buffer length.");
 
+    let missing_bytes_err = |expected: usize, actual: usize| {
+        Error::with_message(
+            ErrorKind::Other,
+            format!("Download incomplete. Expected to read {expected} bytes, but read actual bytes. Bytes may not have been written to buffer in the correct positions."),
+        )
+    };
+
     let range: Option<Range<usize>> = range.map(|hr| {
         let start = hr.offset() as usize;
         let end = match hr.length() {
@@ -207,6 +214,10 @@ where
                 .into_body()
                 .collect_into(&mut buffer[total_read..])
                 .await?;
+        }
+        let expected_total_read = response_analysis.overall_download_range.len();
+        if expected_total_read != total_read {
+            return Err(missing_bytes_err(expected_total_read, total_read));
         }
         return Ok((status, headers, total_read));
     }
@@ -266,13 +277,7 @@ where
 
     let expected_total_read = response_analysis.overall_download_range.len();
     if expected_total_read != total_read {
-        return Err(Error::with_message(
-            ErrorKind::Other,
-            format!(
-                "Download incomplete. Expected to read {} bytes, but read {} bytes. Bytes may not have been written to buffer in the correct positions.",
-                expected_total_read, total_read
-            ),
-        ));
+        return Err(missing_bytes_err(expected_total_read, total_read));
     }
     downloads_manager_handle
         .await

--- a/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
+++ b/sdk/storage/azure_storage_blob/src/partitioned_transfer/download.rs
@@ -160,7 +160,7 @@ where
     Behavior: PartitionedDownloadBehavior + Send + Sync + 'static,
 {
     let insufficient_buffer_err =
-        || Error::with_message(ErrorKind::Other, "Insufficient buffer length.");
+        || Error::with_message(ErrorKind::Io, "Insufficient buffer length.");
 
     let missing_bytes_err = |expected: usize, actual: usize| {
         Error::with_message(
@@ -187,16 +187,13 @@ where
     let headers = initial_response.headers().clone();
     let etag_lock = headers.get_optional_str(&"etag".into()).map(Etag::from);
 
-    let mut response_analysis = match response_analysis {
-        Some(a) => a,
-        // if no response analysis, no subsequent gets, therefore just copy to buffer and return
-        None => {
-            return initial_response
-                .into_body()
-                .collect_into(buffer)
-                .await
-                .map(|read| (status, headers, read))
-        }
+    // if no response analysis, no subsequent gets, therefore just copy to buffer and return
+    let Some(mut response_analysis) = response_analysis else {
+        return initial_response
+            .into_body()
+            .collect_into(buffer)
+            .await
+            .map(|read| (status, headers, read));
     };
 
     // fail fast for buffer overflow

--- a/sdk/storage/azure_storage_blob/tests/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client.rs
@@ -981,6 +981,61 @@ async fn test_managed_download(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[recorded::test]
+async fn test_managed_download_into(ctx: TestContext) -> Result<(), Box<dyn Error>> {
+    let request_count = Arc::new(AtomicUsize::new(0));
+    let count_policy = Arc::new(TestPolicy::count_requests(request_count.clone(), None));
+
+    let recording = ctx.recording();
+    let container_client = get_container_client(
+        recording,
+        true,
+        StorageAccount::Standard,
+        Some(BlobContainerClientOptions::default().with_per_call_policy(count_policy.clone())),
+    )
+    .await?;
+    let blob_client = container_client.blob_client(&get_blob_name(recording));
+
+    for TestManagedDownloadArgSet {
+        data_len,
+        parallel,
+        partition_len,
+        download_range,
+        expected_gets,
+    } in test_managed_download_args()
+    {
+        let data: Vec<u8> = (0..data_len).map(|_| recording.random()).collect();
+        blob_client
+            .upload(RequestContent::from(data.to_vec()), None)
+            .await?;
+        let download_len = download_range.map_or(data_len, |r| min(data_len, r.1) - r.0);
+        let mut buffer = vec![0; download_len];
+
+        request_count.store(0, Ordering::Relaxed);
+        let _scope = count_policy.check_request_scope();
+        let copied = blob_client
+            .download_into(
+                &mut buffer,
+                Some(BlobClientDownloadOptions {
+                    partition_size: Some(NonZero::new(partition_len).unwrap()),
+                    parallel: Some(NonZero::new(parallel).unwrap()),
+                    range: download_range.map(|r| (r.0..r.1).into()),
+                    ..Default::default()
+                }),
+            )
+            .await?;
+
+        assert_eq!(copied, download_len);
+        assert_eq!(
+            &buffer,
+            download_range.map_or(&data[..], |r| &data[r.0..min(r.1, data.len())])
+        );
+        assert_eq!(request_count.load(Ordering::Relaxed), expected_gets);
+    }
+
+    Ok(())
+}
+
 // TODO edge case where a range was requested on a 0-length blob
 #[recorded::test]
 async fn test_managed_download_empty(ctx: TestContext) -> Result<(), Box<dyn Error>> {
@@ -1012,6 +1067,37 @@ async fn test_managed_download_empty(ctx: TestContext) -> Result<(), Box<dyn Err
     let downloaded_data = downloaded_data.freeze();
 
     assert_eq!(downloaded_data.len(), 0);
+    // 1 op with a range, 1 op without after the first one fails
+    assert_eq!(request_count.load(Ordering::Relaxed), 2);
+
+    Ok(())
+}
+
+// TODO edge case where a range was requested on a 0-length blob
+#[recorded::test]
+async fn test_managed_download_into_empty(ctx: TestContext) -> Result<(), Box<dyn Error>> {
+    let request_count = Arc::new(AtomicUsize::new(0));
+    let count_policy = Arc::new(TestPolicy::count_requests(request_count.clone(), None));
+
+    let recording = ctx.recording();
+    let container_client = get_container_client(
+        recording,
+        true,
+        StorageAccount::Standard,
+        Some(BlobContainerClientOptions::default().with_per_call_policy(count_policy.clone())),
+    )
+    .await?;
+    let blob_client = container_client.blob_client(&get_blob_name(recording));
+
+    blob_client
+        .upload(RequestContent::from(vec![]), None)
+        .await?;
+
+    request_count.store(0, Ordering::Relaxed);
+    let _scope = count_policy.check_request_scope();
+    let copied = blob_client.download_into(&mut [0; 1024], None).await?;
+
+    assert_eq!(copied, 0);
     // 1 op with a range, 1 op without after the first one fails
     assert_eq!(request_count.load(Ordering::Relaxed), 2);
 
@@ -1054,6 +1140,66 @@ async fn test_managed_download_etag_lock(ctx: TestContext) -> Result<(), Box<dyn
             .await?
             .body
             .collect()
+            .await?;
+    }
+
+    assert!(request_rx
+        .recv()?
+        .headers()
+        .get_str(&"if-match".into())
+        .is_err());
+
+    let subsequent_requests: Vec<_> = request_rx.try_iter().collect();
+    assert_eq!(subsequent_requests.len(), parts - 1);
+
+    let mut locked_etag = None;
+    for req in subsequent_requests.into_iter() {
+        let req_etag_lock = req.headers().get_str(&"if-match".into())?; // ? tests the value was present
+        match &locked_etag {
+            Some(etag) => assert_eq!(etag, req_etag_lock),
+            None => locked_etag = Some(req_etag_lock.to_string()),
+        }
+    }
+
+    Ok(())
+}
+
+#[recorded::test]
+async fn test_managed_download_into_etag_lock(ctx: TestContext) -> Result<(), Box<dyn Error>> {
+    let data_len = 2048usize;
+    let parts = 9;
+    let partition_len = data_len.div_ceil(parts);
+
+    let (request_tx, request_rx) = mpsc::channel();
+    let capture_policy = Arc::new(TestPolicy::capture(Some(request_tx)));
+
+    let recording = ctx.recording();
+    let container_client = get_container_client(
+        recording,
+        true,
+        StorageAccount::Standard,
+        Some(BlobContainerClientOptions::default().with_per_call_policy(capture_policy.clone())),
+    )
+    .await?;
+    let blob_client = container_client.blob_client(&get_blob_name(recording));
+
+    blob_client
+        .upload(
+            RequestContent::from((0..data_len).map(|_| recording.random()).collect()),
+            None,
+        )
+        .await?;
+
+    {
+        let _capture_scope = capture_policy.check_request_scope();
+        let _ = blob_client
+            .download_into(
+                &mut vec![0; data_len],
+                Some(BlobClientDownloadOptions {
+                    partition_size: Some(NonZero::new(partition_len).unwrap()),
+                    ..Default::default()
+                }),
+            )
             .await?;
     }
 

--- a/sdk/storage/azure_storage_blob/tests/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client.rs
@@ -1013,7 +1013,7 @@ async fn test_managed_download_into(ctx: TestContext) -> Result<(), Box<dyn Erro
 
         request_count.store(0, Ordering::Relaxed);
         let _scope = count_policy.check_request_scope();
-        let copied = blob_client
+        let download_result = blob_client
             .download_into(
                 &mut buffer,
                 Some(BlobClientDownloadOptions {
@@ -1025,7 +1025,7 @@ async fn test_managed_download_into(ctx: TestContext) -> Result<(), Box<dyn Erro
             )
             .await?;
 
-        assert_eq!(copied, download_len);
+        assert_eq!(download_result.len, download_len);
         assert_eq!(
             &buffer,
             download_range.map_or(&data[..], |r| &data[r.0..min(r.1, data.len())])
@@ -1095,9 +1095,9 @@ async fn test_managed_download_into_empty(ctx: TestContext) -> Result<(), Box<dy
 
     request_count.store(0, Ordering::Relaxed);
     let _scope = count_policy.check_request_scope();
-    let copied = blob_client.download_into(&mut [0; 1024], None).await?;
+    let download_result = blob_client.download_into(&mut [0; 1024], None).await?;
 
-    assert_eq!(copied, 0);
+    assert_eq!(download_result.len, 0);
     // 1 op with a range, 1 op without after the first one fails
     assert_eq!(request_count.load(Ordering::Relaxed), 2);
 


### PR DESCRIPTION
Introduces `BlobClient::download_into(&self, &mut [u8], Option<BlobClientDownloadOptions<'_>)`, a companion method to `BlobClient::download(&self, Option<BlobClientDownloadOptions<'_>>)`. Where `download` returns a stream of `Bytes`, `download_into` writes the downloaded bytes into the provided slice.

`download_into()` uses 100% safe rust code.

## Compare Methods

### Both `download()` and `download_into()`

Both of these methods are "managed downloads" which can be configured with a partition length and a parallel transfers cap. They make an initial ranged download request for an initial partition of the requested content to determine the actual size of the blob, if it exists, and make note of the resource's etag. From there, they determine the remining partitions to download and manage multiple downloads at a time.

All new downloads use the initially fetched etag for conditional access. Any failures result in a fast failure of the entire operation.

### `download()` (existing method)

For each partition, an async worker is spawned to handle its download with true concurrency. The worker initializes a new buffer and writes the partition contents to this buffer. It then sends this partition buffer back to the orchestrator: a stream which maintains a queue of partition buffers to return as the next stream item. The orchestrator resequences the partition buffers in the correct order and yields the next sequential buffer when it becomes available.

### `download_into` (new method)

For each partition, an async worker is spawned to handle its download with true concurrency. The worker is configured with the offset to the destination buffer that its partition will be written to. For each `Bytes` returned from the raw download stream, the worker calculates the offset for that specific buffer, based on the overall partition offset, and sends this pair to the orchestrator. The orchestrator is a tight loop that reads from a channel supplied by all its workers, writing each individual `Bytes` from the various raw download streams to the offset sent with it. The method returns once all bytes are written.

## Performance Notes

Performance was compared between `download_into()` and comparable usage of `download()`: consuming the resulting stream and writing its bytes into memory.

In this comparison, `download_into()` has been observed to perform consistently faster (up to 28% in some cases). This was tested across file sizes from tens of kilobytes to dozens of gigabytes.

Memory usage and churn is significantly lower in `download_into()`. It skips all of the contiguous partition buffers of `download()`, which must be allocated and deallocated for each partition. `download()` currently maintains up to `2 * parallel`-many of these contiguous partition buffers in a queue at a given time.

### Channel Buildup (is not a real problem)

The mpsc channel which tranports `Bytes` between download workers and buffer writer is unbounded and can theoretically fill up with items over time. There is no "back off" code to prevent this. Worker tasks will fill this channel as fast as they can and new tasks will be spawned up to configured limits as fast as they can.

For backup to actually occur, the "main" task would need to be slower at copying bytes within memory than all other workers combined can read from the network. In terms of pure operation speed, this is impossible. However, if the async runtime were to starve the main task, this buildup could occur. Under tokio, no such buildup has been observed.