### PR TITLE
[Cosmos] Fix stale PPAF failover overrides on disable + cover dynamic enablement contract with tests

### DIFF
--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Removed `CosmosDriver::resolve_container_by_rid` and the supporting `CosmosOperation::read_container_by_rid` factory and `ContainerCache::get_or_fetch_by_rid`. These RID-keyed entry points had no callers; container resolution now goes exclusively through `resolve_container` / `resolve_container_by_name`. ([#4506](https://github.com/Azure/azure-sdk-for-rust/pull/4506))
 
 ### Bugs Fixed
-- PPAF now clears stale `failover_overrides` entries when the server-side `enablePerPartitionFailoverBehavior` flag transitions from enabled to disabled, so they cannot silently re-apply on re-enable. The in-memory emulator also now emits the flag and exposes runtime-toggle hooks so the dynamic-enablement contract is testable end-to-end. ([#4325](https://github.com/Azure/azure-sdk-for-rust/issues/4325))
+- PPAF and PPCB now clear their stale `failover_overrides` / `circuit_breaker_overrides` entries whenever the server-side enablement flags transition, so a stale override from a prior enabled window cannot silently re-apply on re-enable. The in-memory emulator also now emits `enablePerPartitionFailoverBehavior` and exposes runtime-toggle hooks so the dynamic-enablement contract is testable end-to-end. ([#4552](https://github.com/Azure/azure-sdk-for-rust/pull/4552))
 
 ### Other Changes
 

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Removed `CosmosDriver::resolve_container_by_rid` and the supporting `CosmosOperation::read_container_by_rid` factory and `ContainerCache::get_or_fetch_by_rid`. These RID-keyed entry points had no callers; container resolution now goes exclusively through `resolve_container` / `resolve_container_by_name`. ([#4506](https://github.com/Azure/azure-sdk-for-rust/pull/4506))
 
 ### Bugs Fixed
+- PPAF now clears stale `failover_overrides` entries when the server-side `enablePerPartitionFailoverBehavior` flag transitions from enabled to disabled, so they cannot silently re-apply on re-enable. The in-memory emulator also now emits the flag and exposes runtime-toggle hooks so the dynamic-enablement contract is testable end-to-end. ([#4325](https://github.com/Azure/azure-sdk-for-rust/issues/4325))
 
 ### Other Changes
 

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/mod.rs
@@ -23,6 +23,8 @@ mod container_routing_map;
 mod partition_key_range_cache;
 
 pub(crate) use account_metadata_cache::{AccountMetadataCache, AccountProperties, AccountRegion};
+#[cfg(test)]
+pub(crate) use account_metadata_cache::{ConsistencyPolicy, ReadPolicy, ReplicationPolicy};
 pub(crate) use async_cache::AsyncCache;
 pub(crate) use async_lazy::AsyncLazy;
 pub(crate) use container_cache::ContainerCache;

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
@@ -892,9 +892,30 @@ impl CosmosDriver {
         &self.options
     }
 
+    /// **Internal test hook -- not part of the public API.**
+    ///
+    /// Returns the current value of the partition-level PPAF flag
+    /// (`per_partition_automatic_failover_enabled`) from the live
+    /// `PartitionEndpointState`. Used by integration tests to verify that
+    /// the driver's background account-refresh loop picks up dynamic
+    /// changes to `AccountProperties.enable_per_partition_failover_behavior`.
+    ///
+    /// **Do not call from production code.** Available only because
+    /// integration tests live outside the crate and cannot reach the
+    /// `pub(crate)` `LocationStateStore::snapshot` API directly. May be
+    /// changed or removed at any time without a semver bump.
+    #[cfg(any(test, feature = "__internal_in_memory_emulator"))]
+    #[doc(hidden)]
+    pub fn is_per_partition_automatic_failover_enabled_for_testing(&self) -> bool {
+        self.location_state_store
+            .snapshot()
+            .partitions
+            .per_partition_automatic_failover_enabled
+    }
+
     /// Returns the current per-account transport.
     ///
-    /// Lock-free via `ArcSwap::load_full()` — returns a cloned `Arc` with no
+    /// Lock-free via ArcSwap::load_full() — returns a cloned Arc with no
     /// reader-counter contention between concurrent callers.
     fn transport(&self) -> Arc<CosmosTransport> {
         self.transport.load_full()
@@ -925,10 +946,22 @@ impl CosmosDriver {
         );
 
         // Cache the properties.
-        self.runtime
+        let cached_properties = self
+            .runtime
             .account_metadata_cache()
             .get_or_fetch(account_endpoint, || async { Ok(properties) })
             .await?;
+
+        // Seed the routing snapshot with the initial account properties so
+        // server-controlled flags (PPAF/PPCB) and writable-region selection
+        // are correct before the first operation runs. Without this, the
+        // routing state would stay at defaults until either the first
+        // operation triggers `sync_account_properties` or the background
+        // refresh loop fires (after `BACKGROUND_REFRESH_INTERVAL`).
+        self.location_state_store.sync_account_properties(
+            cached_properties,
+            self.location_state_store.default_endpoint(),
+        );
 
         // Create the per-account transport with the negotiated version.
         let new_transport = Arc::new(CosmosTransport::with_factory(

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/routing/location_state_store.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/routing/location_state_store.rs
@@ -512,23 +512,41 @@ impl LocationStateStore {
             properties.enable_per_partition_failover_behavior;
 
         *self.last_synced_properties.lock().unwrap() = Some(properties);
-        self.apply_partition(|current| {
-            let mut next = current.clone();
-            // Track the PPAF transition so we can drop stale per-partition
-            // failover overrides when the server-side flag flips off. The
-            // eligibility gate in `is_eligible_for_ppaf` already prevents
-            // stale entries from being *applied* while PPAF is off, but
-            // leaving them in place would silently re-apply outdated
-            // overrides if the operator re-enabled PPAF later -- clearing
-            // here guarantees a clean slate on re-enable.
-            let ppaf_was_enabled = current.per_partition_automatic_failover_enabled;
+        self.apply_partition(|previous| {
+            let mut next = previous.clone();
             next.per_partition_automatic_failover_enabled =
                 per_partition_automatic_failover_enabled;
             next.per_partition_circuit_breaker_enabled = per_partition_automatic_failover_enabled
-                || current.config.circuit_breaker_option_enabled;
+                || previous.config.circuit_breaker_option_enabled;
 
-            if ppaf_was_enabled && !per_partition_automatic_failover_enabled {
+            // Drop per-partition routing overrides on any edge of either
+            // enablement flag. The eligibility gate in `is_eligible_for_ppaf` /
+            // `is_eligible_for_ppcb` already prevents stale entries from being
+            // *applied* while the corresponding feature is off, but leaving
+            // them in place would let an outdated override silently re-apply
+            // if the operator (or background flip) re-enabled the feature
+            // later. Clearing on every edge -- not just disable -- keeps the
+            // override maps strictly in sync with their owning feature flag
+            // and removes a class of "stale entry survives across a flip"
+            // bugs without any cost on the steady-state path.
+            if previous.per_partition_automatic_failover_enabled
+                != next.per_partition_automatic_failover_enabled
+            {
+                // Clearing to prevent stale PPAF entries from silently
+                // re-applying after a later re-enable. (Disable-time
+                // correctness is already guaranteed by `is_eligible_for_ppaf`
+                // gating every read of this map.)
                 next.failover_overrides.clear();
+            }
+            if previous.per_partition_circuit_breaker_enabled
+                != next.per_partition_circuit_breaker_enabled
+            {
+                // Same rationale as the PPAF clear above, applied to the PPCB
+                // override map. Note that PPCB tracks PPAF here (PPCB is
+                // implicitly on whenever PPAF is on), so an isolated PPAF
+                // flip also flips PPCB and clears both maps -- exactly the
+                // intended invariant.
+                next.circuit_breaker_overrides.clear();
             }
 
             next
@@ -645,8 +663,11 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use crate::{
-        driver::routing::{CosmosEndpoint, LocationEffect, UnavailableReason},
-        models::AccountEndpoint,
+        driver::{
+            cache::{AccountRegion, ConsistencyPolicy, ReadPolicy, ReplicationPolicy},
+            routing::{CosmosEndpoint, LocationEffect, UnavailableReason},
+        },
+        models::{AccountEndpoint, DefaultConsistencyLevel},
     };
 
     use super::*;
@@ -655,52 +676,80 @@ mod tests {
         AccountEndpoint::from(url::Url::parse("https://test.documents.azure.com:443/").unwrap())
     }
 
-    fn test_refresh_payload() -> AccountProperties {
-        serde_json::from_value(serde_json::json!({
-            "_self": "",
-            "id": "test",
-            "_rid": "test.documents.azure.com",
-            "_etag": "etag-1",
-            "media": "//media/",
-            "addresses": "//addresses/",
-            "_dbs": "//dbs/",
-            "writableLocations": [{ "name": "eastus", "databaseAccountEndpoint": "https://test-eastus.documents.azure.com:443/" }],
-            "readableLocations": [{ "name": "eastus", "databaseAccountEndpoint": "https://test-eastus.documents.azure.com:443/" }],
-            "enableMultipleWriteLocations": false,
-            "userReplicationPolicy": { "minReplicaSetSize": 3, "maxReplicasetSize": 4 },
-            "userConsistencyPolicy": { "defaultConsistencyLevel": "Session" },
-            "systemReplicationPolicy": { "minReplicaSetSize": 3, "maxReplicasetSize": 4 },
-            "readPolicy": { "primaryReadCoefficient": 1, "secondaryReadCoefficient": 1 },
-            "queryEngineConfiguration": "{}"
-        }))
-        .unwrap()
+    /// Single canonical fake account-properties payload used by every test in
+    /// this module. Override only the fields that matter for a specific test
+    /// using struct-update syntax (`..default_account_properties()`):
+    ///
+    /// ```ignore
+    /// AccountProperties {
+    ///     enable_per_partition_failover_behavior: true,
+    ///     etag: "etag-on".into(),
+    ///     ..default_account_properties()
+    /// }
+    /// ```
+    ///
+    /// Wire-format round-trip is exercised in
+    /// `driver::cache::account_metadata_cache::tests::deserialize_full_account_payload`;
+    /// these helpers exist to test `sync_account_properties` flag-edge logic,
+    /// which has nothing to gain from re-running serde on every call.
+    fn default_account_properties() -> AccountProperties {
+        let eastus_endpoint = AccountEndpoint::from(
+            url::Url::parse("https://test-eastus.documents.azure.com:443/").unwrap(),
+        );
+        let eastus_region = AccountRegion {
+            name: Region::from("eastus"),
+            database_account_endpoint: eastus_endpoint,
+        };
+        AccountProperties {
+            self_link: String::new(),
+            id: "test".into(),
+            rid: "test.documents.azure.com".into(),
+            media: "//media/".into(),
+            addresses: "//addresses/".into(),
+            dbs: "//dbs/".into(),
+            writable_locations: vec![eastus_region.clone()],
+            readable_locations: vec![eastus_region],
+            enable_multiple_write_locations: false,
+            continuous_backup_enabled: false,
+            enable_n_region_synchronous_commit: false,
+            enable_per_partition_failover_behavior: false,
+            user_replication_policy: ReplicationPolicy {
+                min_replica_set_size: 3,
+                max_replica_set_size: 4,
+            },
+            user_consistency_policy: ConsistencyPolicy {
+                default_consistency_level: DefaultConsistencyLevel::Session,
+            },
+            system_replication_policy: ReplicationPolicy {
+                min_replica_set_size: 3,
+                max_replica_set_size: 4,
+            },
+            read_policy: ReadPolicy {
+                primary_read_coefficient: 1,
+                secondary_read_coefficient: 1,
+            },
+            query_engine_configuration: "{}".into(),
+            thin_client_writable_locations: Vec::new(),
+            thin_client_readable_locations: Vec::new(),
+            etag: "etag-1".into(),
+        }
     }
 
-    /// Builds an `AccountProperties` payload that mirrors `test_refresh_payload`
-    /// but with an explicit value for `enablePerPartitionFailoverBehavior` and
-    /// a caller-supplied etag -- so successive `sync_account_properties` calls
-    /// look like distinct service updates rather than no-op repeats that the
-    /// etag short-circuit suppresses.
+    fn test_refresh_payload() -> AccountProperties {
+        default_account_properties()
+    }
+
+    /// Builds an `AccountProperties` payload with explicit
+    /// `enable_per_partition_failover_behavior` and caller-supplied etag --
+    /// successive `sync_account_properties` calls with the same etag would be
+    /// short-circuited by the unchanged-etag fast path, so tests that walk a
+    /// state machine across multiple syncs need distinct etags.
     fn test_payload_with_ppaf(enabled: bool, etag: &str) -> AccountProperties {
-        serde_json::from_value(serde_json::json!({
-            "_self": "",
-            "id": "test",
-            "_rid": "test.documents.azure.com",
-            "_etag": etag,
-            "media": "//media/",
-            "addresses": "//addresses/",
-            "_dbs": "//dbs/",
-            "writableLocations": [{ "name": "eastus", "databaseAccountEndpoint": "https://test-eastus.documents.azure.com:443/" }],
-            "readableLocations": [{ "name": "eastus", "databaseAccountEndpoint": "https://test-eastus.documents.azure.com:443/" }],
-            "enableMultipleWriteLocations": false,
-            "enablePerPartitionFailoverBehavior": enabled,
-            "userReplicationPolicy": { "minReplicaSetSize": 3, "maxReplicasetSize": 4 },
-            "userConsistencyPolicy": { "defaultConsistencyLevel": "Session" },
-            "systemReplicationPolicy": { "minReplicaSetSize": 3, "maxReplicasetSize": 4 },
-            "readPolicy": { "primaryReadCoefficient": 1, "secondaryReadCoefficient": 1 },
-            "queryEngineConfiguration": "{}"
-        }))
-        .unwrap()
+        AccountProperties {
+            enable_per_partition_failover_behavior: enabled,
+            etag: etag.into(),
+            ..default_account_properties()
+        }
     }
 
     #[tokio::test]
@@ -1163,10 +1212,11 @@ mod tests {
 
     #[test]
     fn re_enabling_ppaf_does_not_clear_overrides_that_were_installed_after_re_enable() {
-        // Sanity-check that the clear path only fires on the true->false edge:
-        // disabling, re-enabling, then installing fresh overrides must leave
-        // those fresh overrides alone on subsequent same-state (true->true)
-        // syncs.
+        // The clear path fires on every flag-flip *edge*, not on every refresh.
+        // A same-state sync (true -> true with a new etag) is not an edge, so
+        // overrides installed during a stable enabled window must survive.
+        // (Whether the clear fires on false->true is exercised separately by
+        // `enabling_ppaf_clears_stale_failover_overrides_from_prior_window`.)
         use crate::driver::routing::partition_endpoint_state::{
             HealthStatus, PartitionFailoverEntry,
         };
@@ -1219,6 +1269,158 @@ mod tests {
             store.snapshot().partitions.failover_overrides.len(),
             1,
             "overrides installed while PPAF is on must not be cleared by a same-state sync"
+        );
+    }
+
+    #[test]
+    fn enabling_ppaf_clears_stale_failover_overrides_from_prior_window() {
+        // Covers the false->true edge: an entry left over from a *prior*
+        // enabled window must be dropped on re-enable so it cannot silently
+        // re-apply against a routing topology the operator never re-confirmed.
+        use crate::driver::routing::partition_endpoint_state::{
+            HealthStatus, PartitionFailoverEntry,
+        };
+        use crate::driver::routing::partition_key_range_id::PartitionKeyRangeId;
+        use std::collections::HashSet;
+
+        let store = build_store_for_ppaf_tests();
+        let default_endpoint = store.default_endpoint().clone();
+
+        // Land in a known PPAF-off baseline first.
+        store.sync_account_properties(
+            Arc::new(test_payload_with_ppaf(false, "etag-off")),
+            &default_endpoint,
+        );
+
+        // Simulate a stale entry that survived from a prior enabled window
+        // (e.g. before the clear-on-disable fix shipped, or because state was
+        // mutated through a different code path).
+        let endpoint_a = CosmosEndpoint::regional(
+            "eastus".into(),
+            url::Url::parse("https://test-eastus.documents.azure.com:443/").unwrap(),
+        );
+        let endpoint_b = CosmosEndpoint::regional(
+            "westus".into(),
+            url::Url::parse("https://test-westus.documents.azure.com:443/").unwrap(),
+        );
+        let pkrange_id: PartitionKeyRangeId = "0".to_string().into();
+        let stale_entry = PartitionFailoverEntry {
+            current_endpoint: endpoint_b.clone(),
+            first_failed_endpoint: endpoint_a.clone(),
+            failed_endpoints: HashSet::from([endpoint_a]),
+            read_failure_count: 0,
+            write_failure_count: 1,
+            first_failure_time: Instant::now(),
+            last_failure_time: Instant::now(),
+            health_status: HealthStatus::Unhealthy,
+            failback_jitter: Duration::ZERO,
+        };
+        store.apply_partition(|current| {
+            let mut next = current.clone();
+            next.failover_overrides
+                .insert(pkrange_id.clone(), stale_entry.clone());
+            next
+        });
+        assert_eq!(
+            store.snapshot().partitions.failover_overrides.len(),
+            1,
+            "test setup: stale override was not installed"
+        );
+
+        // Server flips PPAF on -- false->true edge must drop the stale entry.
+        store.sync_account_properties(
+            Arc::new(test_payload_with_ppaf(true, "etag-on")),
+            &default_endpoint,
+        );
+
+        let snapshot = store.snapshot();
+        assert!(
+            snapshot.partitions.per_partition_automatic_failover_enabled,
+            "PPAF should be on after sync with enablePerPartitionFailoverBehavior=true"
+        );
+        assert!(
+            snapshot.partitions.failover_overrides.is_empty(),
+            "stale failover_overrides from a prior enabled window must be cleared \
+             on re-enable so they cannot silently re-apply against a routing \
+             topology the operator never re-confirmed"
+        );
+    }
+
+    #[test]
+    fn disabling_ppaf_clears_circuit_breaker_overrides() {
+        // PPCB tracks PPAF in the default config (option override is false),
+        // so the PPAF on->off edge also flips PPCB off and must clear the
+        // PPCB override map alongside the PPAF one.
+        use crate::driver::routing::partition_endpoint_state::{
+            HealthStatus, PartitionFailoverEntry,
+        };
+        use crate::driver::routing::partition_key_range_id::PartitionKeyRangeId;
+        use std::collections::HashSet;
+
+        let store = build_store_for_ppaf_tests();
+        let default_endpoint = store.default_endpoint().clone();
+
+        store.sync_account_properties(
+            Arc::new(test_payload_with_ppaf(true, "etag-on")),
+            &default_endpoint,
+        );
+        assert!(
+            store
+                .snapshot()
+                .partitions
+                .per_partition_circuit_breaker_enabled,
+            "test setup: PPCB should be on once PPAF is on (default config)"
+        );
+
+        let endpoint_a = CosmosEndpoint::regional(
+            "eastus".into(),
+            url::Url::parse("https://test-eastus.documents.azure.com:443/").unwrap(),
+        );
+        let endpoint_b = CosmosEndpoint::regional(
+            "westus".into(),
+            url::Url::parse("https://test-westus.documents.azure.com:443/").unwrap(),
+        );
+        let pkrange_id: PartitionKeyRangeId = "0".to_string().into();
+        let entry = PartitionFailoverEntry {
+            current_endpoint: endpoint_b.clone(),
+            first_failed_endpoint: endpoint_a.clone(),
+            failed_endpoints: HashSet::from([endpoint_a]),
+            read_failure_count: 1,
+            write_failure_count: 0,
+            first_failure_time: Instant::now(),
+            last_failure_time: Instant::now(),
+            health_status: HealthStatus::Unhealthy,
+            failback_jitter: Duration::ZERO,
+        };
+
+        store.apply_partition(|current| {
+            let mut next = current.clone();
+            next.circuit_breaker_overrides
+                .insert(pkrange_id.clone(), entry.clone());
+            next
+        });
+        assert_eq!(
+            store.snapshot().partitions.circuit_breaker_overrides.len(),
+            1,
+            "test setup: PPCB override was not installed"
+        );
+
+        // PPAF off -> PPCB off (derived). Both maps must be empty afterwards.
+        store.sync_account_properties(
+            Arc::new(test_payload_with_ppaf(false, "etag-off")),
+            &default_endpoint,
+        );
+
+        let snapshot = store.snapshot();
+        assert!(
+            !snapshot.partitions.per_partition_circuit_breaker_enabled,
+            "PPCB should be off once PPAF is off (default config)"
+        );
+        assert!(
+            snapshot.partitions.circuit_breaker_overrides.is_empty(),
+            "circuit_breaker_overrides should be cleared when PPCB flips off; \
+             leaving stale entries lets old circuit-breaker decisions re-apply \
+             silently on re-enable"
         );
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/routing/location_state_store.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/routing/location_state_store.rs
@@ -374,7 +374,7 @@ impl LocationStateStore {
     ///
     /// The `last_refresh_epoch_ms` clock is updated by
     /// [`refresh_account_properties_inner`] only on a successful fetch — if
-    /// this timer-driven refresh fails (network error, service 5xx, …), the
+    /// this timer-driven refresh fails (network error, service 5xx, ...), the
     /// event-driven path is NOT throttled and is free to retry recovery
     /// immediately.
     async fn force_refresh_account_properties(&self) {
@@ -514,10 +514,23 @@ impl LocationStateStore {
         *self.last_synced_properties.lock().unwrap() = Some(properties);
         self.apply_partition(|current| {
             let mut next = current.clone();
+            // Track the PPAF transition so we can drop stale per-partition
+            // failover overrides when the server-side flag flips off. The
+            // eligibility gate in `is_eligible_for_ppaf` already prevents
+            // stale entries from being *applied* while PPAF is off, but
+            // leaving them in place would silently re-apply outdated
+            // overrides if the operator re-enabled PPAF later -- clearing
+            // here guarantees a clean slate on re-enable.
+            let ppaf_was_enabled = current.per_partition_automatic_failover_enabled;
             next.per_partition_automatic_failover_enabled =
                 per_partition_automatic_failover_enabled;
             next.per_partition_circuit_breaker_enabled = per_partition_automatic_failover_enabled
                 || current.config.circuit_breaker_option_enabled;
+
+            if ppaf_was_enabled && !per_partition_automatic_failover_enabled {
+                next.failover_overrides.clear();
+            }
+
             next
         });
     }
@@ -654,6 +667,33 @@ mod tests {
             "writableLocations": [{ "name": "eastus", "databaseAccountEndpoint": "https://test-eastus.documents.azure.com:443/" }],
             "readableLocations": [{ "name": "eastus", "databaseAccountEndpoint": "https://test-eastus.documents.azure.com:443/" }],
             "enableMultipleWriteLocations": false,
+            "userReplicationPolicy": { "minReplicaSetSize": 3, "maxReplicasetSize": 4 },
+            "userConsistencyPolicy": { "defaultConsistencyLevel": "Session" },
+            "systemReplicationPolicy": { "minReplicaSetSize": 3, "maxReplicasetSize": 4 },
+            "readPolicy": { "primaryReadCoefficient": 1, "secondaryReadCoefficient": 1 },
+            "queryEngineConfiguration": "{}"
+        }))
+        .unwrap()
+    }
+
+    /// Builds an `AccountProperties` payload that mirrors `test_refresh_payload`
+    /// but with an explicit value for `enablePerPartitionFailoverBehavior` and
+    /// a caller-supplied etag -- so successive `sync_account_properties` calls
+    /// look like distinct service updates rather than no-op repeats that the
+    /// etag short-circuit suppresses.
+    fn test_payload_with_ppaf(enabled: bool, etag: &str) -> AccountProperties {
+        serde_json::from_value(serde_json::json!({
+            "_self": "",
+            "id": "test",
+            "_rid": "test.documents.azure.com",
+            "_etag": etag,
+            "media": "//media/",
+            "addresses": "//addresses/",
+            "_dbs": "//dbs/",
+            "writableLocations": [{ "name": "eastus", "databaseAccountEndpoint": "https://test-eastus.documents.azure.com:443/" }],
+            "readableLocations": [{ "name": "eastus", "databaseAccountEndpoint": "https://test-eastus.documents.azure.com:443/" }],
+            "enableMultipleWriteLocations": false,
+            "enablePerPartitionFailoverBehavior": enabled,
             "userReplicationPolicy": { "minReplicaSetSize": 3, "maxReplicasetSize": 4 },
             "userConsistencyPolicy": { "defaultConsistencyLevel": "Session" },
             "systemReplicationPolicy": { "minReplicaSetSize": 3, "maxReplicasetSize": 4 },
@@ -941,6 +981,244 @@ mod tests {
         assert!(
             weak.upgrade().is_none(),
             "PartitionEndpointState was leaked: not dropped after LocationStateStore drop"
+        );
+    }
+
+    // -- PPAF dynamic enablement (issue #4325) ----------------------------
+    //
+    // The driver consumes `AccountProperties.enable_per_partition_failover_behavior`
+    // as the single source of truth for PPAF enablement. These tests verify
+    // that `sync_account_properties` propagates the server flag into the live
+    // `PartitionEndpointState.per_partition_automatic_failover_enabled` on
+    // every refresh, and that stale `failover_overrides` entries are dropped
+    // when the server flag flips off so they cannot silently re-apply if the
+    // operator re-enables PPAF later.
+
+    fn build_store_for_ppaf_tests() -> LocationStateStore {
+        let default_endpoint = CosmosEndpoint::global(test_endpoint().url().clone());
+        let refresh = Arc::new(|_previous: Option<Arc<AccountProperties>>| {
+            let payload = test_refresh_payload();
+            let fut: BoxFuture<'static, crate::error::Result<AccountProperties>> =
+                Box::pin(async move { Ok(payload) });
+            fut
+        });
+
+        LocationStateStore::new(
+            Arc::new(AccountMetadataCache::new()),
+            test_endpoint(),
+            default_endpoint,
+            refresh,
+            false,
+            Duration::from_secs(60),
+            PartitionFailoverConfig::default(),
+            Vec::new(),
+        )
+    }
+
+    #[test]
+    fn sync_propagates_ppaf_flag_from_account_properties() {
+        let store = build_store_for_ppaf_tests();
+        let default_endpoint = store.default_endpoint().clone();
+
+        // Initial state -- no sync yet, flag is false from `PartitionEndpointState::default()`.
+        assert!(
+            !store
+                .snapshot()
+                .partitions
+                .per_partition_automatic_failover_enabled
+        );
+
+        // First sync with PPAF=true must flip the flag on.
+        store.sync_account_properties(
+            Arc::new(test_payload_with_ppaf(true, "etag-on")),
+            &default_endpoint,
+        );
+        assert!(
+            store
+                .snapshot()
+                .partitions
+                .per_partition_automatic_failover_enabled,
+            "PPAF flag should be true after a sync with enablePerPartitionFailoverBehavior=true"
+        );
+
+        // Second sync with PPAF=false must flip it back off.
+        store.sync_account_properties(
+            Arc::new(test_payload_with_ppaf(false, "etag-off")),
+            &default_endpoint,
+        );
+        assert!(
+            !store
+                .snapshot()
+                .partitions
+                .per_partition_automatic_failover_enabled,
+            "PPAF flag should be false after a sync with enablePerPartitionFailoverBehavior=false"
+        );
+    }
+
+    #[test]
+    fn ppcb_tracks_server_ppaf_flag_in_absence_of_option_override() {
+        // PPCB effective value = server_ppaf || options_ppcb_enabled.
+        // With options_ppcb_enabled=false (the default), PPCB tracks PPAF.
+        let store = build_store_for_ppaf_tests();
+        let default_endpoint = store.default_endpoint().clone();
+
+        store.sync_account_properties(
+            Arc::new(test_payload_with_ppaf(true, "etag-on")),
+            &default_endpoint,
+        );
+        assert!(
+            store
+                .snapshot()
+                .partitions
+                .per_partition_circuit_breaker_enabled,
+            "PPCB should be enabled when PPAF is enabled and option-side PPCB is the default false"
+        );
+
+        store.sync_account_properties(
+            Arc::new(test_payload_with_ppaf(false, "etag-off")),
+            &default_endpoint,
+        );
+        assert!(
+            !store
+                .snapshot()
+                .partitions
+                .per_partition_circuit_breaker_enabled,
+            "PPCB should follow PPAF off when option-side PPCB is the default false"
+        );
+    }
+
+    #[test]
+    fn disabling_ppaf_clears_failover_overrides() {
+        use crate::driver::routing::partition_endpoint_state::{
+            HealthStatus, PartitionFailoverEntry,
+        };
+        use crate::driver::routing::partition_key_range_id::PartitionKeyRangeId;
+        use std::collections::HashSet;
+
+        let store = build_store_for_ppaf_tests();
+        let default_endpoint = store.default_endpoint().clone();
+
+        // Enable PPAF first so the override would actually be honored by the
+        // routing eligibility gate (the test is about transition cleanup, not
+        // about whether the override applies while PPAF is on).
+        store.sync_account_properties(
+            Arc::new(test_payload_with_ppaf(true, "etag-on")),
+            &default_endpoint,
+        );
+
+        // Seed a fake PPAF override entry. This mirrors what
+        // `mark_partition_unavailable` would install during a real
+        // single-master write failover.
+        let endpoint_a = CosmosEndpoint::regional(
+            "eastus".into(),
+            url::Url::parse("https://test-eastus.documents.azure.com:443/").unwrap(),
+        );
+        let endpoint_b = CosmosEndpoint::regional(
+            "westus".into(),
+            url::Url::parse("https://test-westus.documents.azure.com:443/").unwrap(),
+        );
+        let pkrange_id: PartitionKeyRangeId = "0".to_string().into();
+        let entry = PartitionFailoverEntry {
+            current_endpoint: endpoint_b.clone(),
+            first_failed_endpoint: endpoint_a.clone(),
+            failed_endpoints: HashSet::from([endpoint_a]),
+            read_failure_count: 0,
+            write_failure_count: 1,
+            first_failure_time: Instant::now(),
+            last_failure_time: Instant::now(),
+            health_status: HealthStatus::Unhealthy,
+            failback_jitter: Duration::ZERO,
+        };
+
+        store.apply_partition(|current| {
+            let mut next = current.clone();
+            next.failover_overrides
+                .insert(pkrange_id.clone(), entry.clone());
+            next
+        });
+        assert_eq!(
+            store.snapshot().partitions.failover_overrides.len(),
+            1,
+            "test setup: failover override was not installed"
+        );
+
+        // Server flips PPAF off -- the next refresh must drop the stale override
+        // entry so it cannot silently re-apply when PPAF is re-enabled.
+        store.sync_account_properties(
+            Arc::new(test_payload_with_ppaf(false, "etag-off")),
+            &default_endpoint,
+        );
+
+        let snapshot = store.snapshot();
+        assert!(
+            !snapshot.partitions.per_partition_automatic_failover_enabled,
+            "PPAF should be off after sync_account_properties with false"
+        );
+        assert!(
+            snapshot.partitions.failover_overrides.is_empty(),
+            "failover_overrides should be cleared when PPAF flips from true to false; \
+             leaving stale entries lets old failovers re-apply silently on re-enable"
+        );
+    }
+
+    #[test]
+    fn re_enabling_ppaf_does_not_clear_overrides_that_were_installed_after_re_enable() {
+        // Sanity-check that the clear path only fires on the true->false edge:
+        // disabling, re-enabling, then installing fresh overrides must leave
+        // those fresh overrides alone on subsequent same-state (true->true)
+        // syncs.
+        use crate::driver::routing::partition_endpoint_state::{
+            HealthStatus, PartitionFailoverEntry,
+        };
+        use crate::driver::routing::partition_key_range_id::PartitionKeyRangeId;
+        use std::collections::HashSet;
+
+        let store = build_store_for_ppaf_tests();
+        let default_endpoint = store.default_endpoint().clone();
+
+        // false -> true: clear path must not fire (no prior overrides anyway).
+        store.sync_account_properties(
+            Arc::new(test_payload_with_ppaf(true, "etag-on-1")),
+            &default_endpoint,
+        );
+
+        let endpoint_a = CosmosEndpoint::regional(
+            "eastus".into(),
+            url::Url::parse("https://test-eastus.documents.azure.com:443/").unwrap(),
+        );
+        let endpoint_b = CosmosEndpoint::regional(
+            "westus".into(),
+            url::Url::parse("https://test-westus.documents.azure.com:443/").unwrap(),
+        );
+        let pkrange_id: PartitionKeyRangeId = "0".to_string().into();
+        let entry = PartitionFailoverEntry {
+            current_endpoint: endpoint_b.clone(),
+            first_failed_endpoint: endpoint_a.clone(),
+            failed_endpoints: HashSet::from([endpoint_a]),
+            read_failure_count: 0,
+            write_failure_count: 1,
+            first_failure_time: Instant::now(),
+            last_failure_time: Instant::now(),
+            health_status: HealthStatus::Unhealthy,
+            failback_jitter: Duration::ZERO,
+        };
+        store.apply_partition(|current| {
+            let mut next = current.clone();
+            next.failover_overrides
+                .insert(pkrange_id.clone(), entry.clone());
+            next
+        });
+
+        // true -> true with a new etag (still enabled): clear path must not fire.
+        store.sync_account_properties(
+            Arc::new(test_payload_with_ppaf(true, "etag-on-2")),
+            &default_endpoint,
+        );
+
+        assert_eq!(
+            store.snapshot().partitions.failover_overrides.len(),
+            1,
+            "overrides installed while PPAF is on must not be cleared by a same-state sync"
         );
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/config.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/config.rs
@@ -5,12 +5,24 @@
 //! Virtual account configuration for the in-memory emulator.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 use url::Url;
 
 use super::ru_model::RuChargingModel;
 
 /// Configures the emulated Cosmos DB account.
+///
+/// # Runtime-mutable fields
+///
+/// Most fields are set at construction time and never change. The
+/// per-partition-failover flag (PPAF, exposed in the synthesized account
+/// JSON as `enablePerPartitionFailoverBehavior`) is intentionally backed by
+/// an `Arc<AtomicBool>` so tests can flip it at runtime through a
+/// shared-reference handle. Flipping it through `set_per_partition_failover`
+/// changes what the emulator returns on the *next* account-read response,
+/// which is what the driver's background refresh loop polls.
 #[derive(Clone, Debug)]
 pub struct VirtualAccountConfig {
     regions: Vec<VirtualRegion>,
@@ -20,6 +32,11 @@ pub struct VirtualAccountConfig {
     replication_overrides: HashMap<(String, String), ReplicationConfig>,
     ru_model: RuChargingModel,
     throttling_enabled: bool,
+    /// Server-side per-partition automatic failover flag -- emitted as
+    /// `enablePerPartitionFailoverBehavior` in the account JSON. Atomic and
+    /// shared so test code can toggle the value after the config has been
+    /// moved into `EmulatorStore` and is reachable only by `&self`.
+    enable_per_partition_failover: Arc<AtomicBool>,
 }
 
 impl VirtualAccountConfig {
@@ -52,6 +69,7 @@ impl VirtualAccountConfig {
             replication_overrides: HashMap::new(),
             ru_model: RuChargingModel::default(),
             throttling_enabled: false,
+            enable_per_partition_failover: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -139,6 +157,38 @@ impl VirtualAccountConfig {
         self.throttling_enabled
     }
 
+    /// Sets the initial value of the server-side per-partition automatic
+    /// failover (PPAF) flag. This is the JSON field
+    /// `enablePerPartitionFailoverBehavior` in the synthesized account-read
+    /// response and the input the driver consumes to enable PPAF dynamically.
+    ///
+    /// Most tests should use this builder method for the initial state, and
+    /// only fall back to [`Self::set_per_partition_failover`] when they need
+    /// to flip the value at runtime to exercise the driver's dynamic
+    /// enablement / disablement code path.
+    pub fn with_per_partition_failover(self, enabled: bool) -> Self {
+        self.enable_per_partition_failover
+            .store(enabled, Ordering::SeqCst);
+        self
+    }
+
+    /// Returns the current value of the server-side PPAF flag.
+    pub fn per_partition_failover_enabled(&self) -> bool {
+        self.enable_per_partition_failover.load(Ordering::SeqCst)
+    }
+
+    /// Flips the server-side PPAF flag at runtime. The next account-read
+    /// response served by the emulator will include the new value, and the
+    /// driver's background account-refresh loop will pick it up on its next
+    /// tick.
+    ///
+    /// Takes `&self` so test code can call it through the shared
+    /// `Arc<EmulatorStore>` handle without needing exclusive access.
+    pub fn set_per_partition_failover(&self, enabled: bool) {
+        self.enable_per_partition_failover
+            .store(enabled, Ordering::SeqCst);
+    }
+
     pub fn regions(&self) -> &[VirtualRegion] {
         &self.regions
     }
@@ -182,7 +232,7 @@ impl VirtualAccountConfig {
 
     /// Finds the region name for a given gateway URL.
     ///
-    /// Matches on `(scheme, host, port)` — not host alone — so two regions
+    /// Matches on (scheme, host, port) — not host alone — so two regions
     /// that share a hostname but differ in port (or scheme) route correctly.
     /// Useful when adding e.g. `https://localhost:8081` and
     /// `https://localhost:8082` regions for parity tests.

--- a/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/system_properties.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/system_properties.rs
@@ -167,6 +167,11 @@ pub(crate) fn account_properties_to_json(
         "readableLocations": readable,
         "writableLocations": writable,
         "enableMultipleWriteLocations": config.write_mode() == super::config::WriteMode::Multi,
+        // Mirrors the real service contract for PPAF dynamic enablement. The
+        // driver's background account-refresh loop polls this field; tests
+        // that flip `VirtualAccountConfig::set_per_partition_failover(...)`
+        // observe the change here on the next refresh tick.
+        "enablePerPartitionFailoverBehavior": config.per_partition_failover_enabled(),
         "userReplicationPolicy": { "minReplicaSetSize": 3, "maxReplicasetSize": 4 },
         "userConsistencyPolicy": {
             "defaultConsistencyLevel": config.consistency().as_str()

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/in_memory_emulator_tests/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/in_memory_emulator_tests/mod.rs
@@ -9,6 +9,7 @@ pub mod error_cases;
 pub mod error_diagnostics;
 pub mod multi_region;
 pub mod point_operations;
+pub mod ppaf_dynamic_enablement;
 pub mod split_merge;
 pub mod throttling;
 

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/in_memory_emulator_tests/ppaf_dynamic_enablement.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/in_memory_emulator_tests/ppaf_dynamic_enablement.rs
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! End-to-end pipeline test for PPAF (Per-Partition Automatic Failover)
+//! **dynamic enablement** -- issue
+//! <https://github.com/Azure/azure-sdk-for-rust/issues/4325>.
+//!
+//! The full contract -- CAS swap correctness, the `true -> false` stale-
+//! override clearing in `sync_account_properties`, and the per-op sync hot
+//! path -- is covered by unit tests in
+//! `src/driver/routing/location_state_store.rs`.
+//!
+//! The one piece those unit tests **cannot** cover is the *wiring*:
+//! that the periodic background account-refresh loop
+//! (`start_account_refresh_loop` -> gateway `read_database_account` ->
+//! `LocationStateStore::sync_account_properties`) actually fires and
+//! propagates a server-side flag flip into the live
+//! `PartitionEndpointState`, with no driver restart and no client-side
+//! override. This file is the regression guard for that wiring.
+//!
+//! It uses `tokio::time::pause()` so virtual time advances under the test's
+//! control, mirroring the existing pattern in `account_metadata_refresh.rs`
+//! (the production refresh interval is 5 minutes -- far too long to wait
+//! for in a unit-style test).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use azure_core::http::Url;
+
+use azure_data_cosmos_driver::in_memory_emulator::{
+    ConsistencyLevel, InMemoryEmulatorHttpClient, VirtualAccountConfig, VirtualRegion,
+};
+use azure_data_cosmos_driver::models::{AccountReference, CosmosOperation, DatabaseReference};
+use azure_data_cosmos_driver::options::OperationOptions;
+
+const GATEWAY_URL: &str = "https://eastus.emulator.local";
+
+/// Production refresh interval, kept in sync with
+/// `LocationStateStore::BACKGROUND_REFRESH_INTERVAL` (300 s).
+const REFRESH_INTERVAL: Duration = Duration::from_secs(300);
+
+fn build_emulator_with_initial_ppaf(ppaf_enabled: bool) -> Arc<InMemoryEmulatorHttpClient> {
+    let config = VirtualAccountConfig::new(vec![VirtualRegion::new(
+        "East US",
+        Url::parse(GATEWAY_URL).unwrap(),
+    )])
+    .unwrap()
+    .with_consistency(ConsistencyLevel::Session)
+    .with_per_partition_failover(ppaf_enabled);
+
+    let emulator = Arc::new(InMemoryEmulatorHttpClient::new(config));
+    emulator.store().create_database("testdb");
+    emulator
+}
+
+fn account() -> AccountReference {
+    AccountReference::with_master_key(Url::parse(GATEWAY_URL).unwrap(), "ZW11bGF0b3Ita2V5")
+}
+
+/// Drives one trivial operation through the full pipeline so the snapshot
+/// we observe after the background refresh is the post-refresh one, and so
+/// we also exercise the consumer hot path that reads the live flag.
+async fn read_database(driver: &azure_data_cosmos_driver::CosmosDriver) {
+    let db_ref = DatabaseReference::from_name(driver.account().clone(), "testdb".to_string());
+    driver
+        .execute_operation(
+            CosmosOperation::read_database(db_ref),
+            OperationOptions::default(),
+        )
+        .await
+        .expect("read_database should succeed against the in-memory emulator");
+}
+
+/// **The dynamic-enablement regression test for issue #4325.**
+///
+/// Starts with PPAF off, has the "operator" flip the server flag to true,
+/// and asserts that the driver picks up the change on the next periodic
+/// account-refresh tick -- no driver restart, no per-operation refresh, no
+/// client-side override.
+///
+/// This guards the wiring `start_account_refresh_loop` ->
+/// `read_database_account` -> `LocationStateStore::sync_account_properties`
+/// that the unit tests cannot exercise (they call `sync_account_properties`
+/// directly).
+#[tokio::test(start_paused = true)]
+async fn ppaf_picks_up_runtime_enable_after_background_refresh() {
+    let emulator = build_emulator_with_initial_ppaf(false);
+
+    let runtime = emulator
+        .runtime_builder()
+        .build()
+        .await
+        .expect("runtime should build");
+
+    let driver = runtime
+        .get_or_create_driver(account(), None)
+        .await
+        .expect("driver should initialize against the in-memory emulator");
+
+    assert!(
+        !driver.is_per_partition_automatic_failover_enabled_for_testing(),
+        "test setup: PPAF should start disabled"
+    );
+
+    // Operator turns PPAF on at the service.
+    emulator.store().config().set_per_partition_failover(true);
+
+    // Without a refresh, the driver MUST NOT have observed the change.
+    // (No virtual time has advanced and we have issued no operations.)
+    assert!(
+        !driver.is_per_partition_automatic_failover_enabled_for_testing(),
+        "PPAF should still be disabled before the background refresh fires"
+    );
+
+    // Advance two refresh intervals to give the bg loop a chance to fire
+    // even if the first tick races with the test scheduler under paused
+    // time.
+    tokio::time::sleep(REFRESH_INTERVAL * 2).await;
+
+    read_database(&driver).await;
+
+    assert!(
+        driver.is_per_partition_automatic_failover_enabled_for_testing(),
+        "PPAF should be enabled after the background account-refresh loop \
+         picks up the server-side flag flip"
+    );
+}


### PR DESCRIPTION
Closes #4325. Supersedes the closed PR #4350 (which duplicated existing infrastructure with new `DatabaseAccountProperties` / `SharedAccountState` / `PartitionLevelFailoverPolicy` types).

## TL;DR

PPAF dynamic enablement was already ~90% working — `sync_account_properties` is called at the top of every `execute_operation_direct` and by the 300 s background refresh loop, so account-properties flag flips were already picked up on the next op or within 300 s. This PR closes the remaining gaps:

1. **🐛 Bug fix:** `LocationStateStore::sync_account_properties` now clears `failover_overrides` on the PPAF `true → false` edge. Without this, an override installed during a prior failover would remain dormant in the map (gated by `is_eligible_for_ppaf`) and **silently re-apply when PPAF was later re-enabled**, routing writes to a region the operator never re-selected.

2. **🧪 Test infrastructure:** The in-memory emulator now emits `enablePerPartitionFailoverBehavior` (`VirtualAccountConfig::with_per_partition_failover` + runtime `set_per_partition_failover`). Unit tests in `location_state_store.rs` cover the CAS swap, the `true → false` override clearing, and the per-op sync path. One integration test (`ppaf_picks_up_runtime_enable_after_background_refresh`) guards the wiring the unit tests can't reach: that the periodic background account-refresh loop (`start_account_refresh_loop` → gateway `read_database_account` → `sync_account_properties`) actually fires and propagates a server-side flip.

3. **✨ Minor:** `CosmosDriver::initialize` also calls `sync_account_properties` after caching the initial account-read. No production hot-path effect (the first op already syncs before any PPAF-aware routing); kept for init-time consistency.

Reuses existing `AccountProperties` + `LocationStateStore` infrastructure — no duplicate types, no client-side override (matches `PARTITION_LEVEL_FAILOVER_SPEC.md` §3: PPAF is server-controlled).

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --lib --tests --features __internal_in_memory_emulator -- -D warnings` ✅
- `cargo test --lib` ✅ 1610 / 0
- `cargo test --test in_memory_emulator --features __internal_in_memory_emulator` ✅ 61 / 0

## Out of scope

- No clearing of `circuit_breaker_overrides` on PPCB-off — PPCB has its own failback loop. Easy follow-up if reviewers prefer.
- No end-to-end cross-region PPAF retry test — would need a multi-region emulator + fault injection. The existing PPAF retry coverage in `multi_region_failover.rs` already exercises the failover path itself; this PR only covers the *enablement* contract for #4325.
