### PR TITLE
Surface terminal partition-gone 410 as 503 in Cosmos driver

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write_fault_injection.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write_fault_injection.rs
@@ -172,9 +172,13 @@ pub async fn item_read_fault_injection_timeout() -> Result<(), Box<dyn Error>> {
     ignore = "requires test_category 'multi_write'"
 )]
 pub async fn item_read_fault_injection_partition_is_gone() -> Result<(), Box<dyn Error>> {
+    // An injected 410/1002 PartitionKeyRangeGone drives a forced routing-cache
+    // refresh and retry in the dataflow layer; since the fault keeps firing, the
+    // terminal failure is surfaced as 503 (not a raw 410) so it is classifiable
+    // by application 503-retry logic. See Azure/azure-cosmos-dotnet-v3#5924.
     verify_read_fails_with_injected_error(
         FaultInjectionErrorType::PartitionIsGone,
-        StatusCode::Gone,
+        StatusCode::ServiceUnavailable,
     )
     .await
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Removed `CosmosDriver::resolve_container_by_rid` and the supporting `CosmosOperation::read_container_by_rid` factory and `ContainerCache::get_or_fetch_by_rid`. These RID-keyed entry points had no callers; container resolution now goes exclusively through `resolve_container` / `resolve_container_by_name`. ([#4506](https://github.com/Azure/azure-sdk-for-rust/pull/4506))
 
 ### Bugs Fixed
+- Terminal partition-key-range Gone on a point operation no longer surfaces to the caller as a raw, unclassifiable HTTP 410. A 410 with a partition-routing sub-status (`1002` PartitionKeyRangeGone, `1007` CompletingSplit, `1008` CompletingPartitionMigration) already drives a forced routing-cache refresh and retry in the dataflow layer; if the partition is still gone after that retry, the failure is now surfaced as `503 Service Unavailable` with the original sub-status preserved, so application-layer retry/circuit-breaker logic (wired for 503, not 410) can classify it. Rust sibling of Azure/azure-cosmos-dotnet-v3#5924.
+
 - Data-plane and non-account metadata operations now fall back to the hub/primary write region endpoint instead of the global account endpoint when all regional endpoints are excluded or unavailable. ([#4503](https://github.com/Azure/azure-sdk-for-rust/pull/4503))
 
 - Writes to multi-write Cosmos accounts now send the `x-ms-cosmos-allow-tentative-writes: true` request header (gated on `enableMultipleWriteLocations` from the account metadata). Without this header satellite write regions returned `403 / 3 (WriteForbidden)`, breaking write failover. ([#4500](https://github.com/Azure/azure-sdk-for-rust/pull/4500))

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/dataflow/request.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/dataflow/request.rs
@@ -7,12 +7,41 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::models::{CosmosOperation, CosmosResponse, FeedRange, PartitionKey};
+use crate::error::CosmosError;
+use crate::models::{CosmosOperation, CosmosResponse, CosmosStatus, FeedRange, PartitionKey};
+
+use azure_core::http::StatusCode;
 
 use super::{
     PageResult, PartitionRoutingRefresh, PipelineContext, PipelineNode, PipelineNodeState,
     ResolvedRange,
 };
+
+/// Converts a still-failing partition-topology-change error (HTTP 410 with a
+/// partition-routing sub-status such as 1002 `PartitionKeyRangeGone`) into a
+/// synthetic 503 Service Unavailable, preserving the original sub-status and
+/// chaining the original error as the source.
+///
+/// The dataflow layer reaches this only after it has already forced a routing
+/// refresh and retried, so a terminal 410 means the range is genuinely
+/// unavailable. Surfacing it as a raw 410 leaves it unclassifiable by
+/// application resilience logic, which is wired for 503 — the same defect the
+/// .NET SDK fixed in Azure/azure-cosmos-dotnet-v3#5924. A synthetic error is
+/// required because a wire error pins its status to the response's 410.
+fn partition_gone_as_service_unavailable(error: CosmosError) -> CosmosError {
+    let mut status = CosmosStatus::new(StatusCode::ServiceUnavailable);
+    if let Some(sub_status) = error.status().sub_status() {
+        status = status.with_sub_status(sub_status.value());
+    }
+
+    let mut builder = CosmosError::builder()
+        .with_status(status)
+        .with_context("partition key range is gone after a routing refresh");
+    if let Some(diagnostics) = error.diagnostics() {
+        builder = builder.with_diagnostics(diagnostics);
+    }
+    builder.with_source(error).build()
+}
 
 /// The target of a request node.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -266,7 +295,7 @@ impl Request {
                 // the gateway should have been able to route the request
                 // to the correct partition even if it has split.
                 // But we can do a single retry without forcing a topology refresh to see if it succeeds.
-                context
+                match context
                     .execute_request(
                         &self.operation,
                         self.target.clone(),
@@ -274,7 +303,8 @@ impl Request {
                         continuation,
                     )
                     .await
-                    .map(|response| {
+                {
+                    Ok(response) => {
                         tracing::trace!(
                             target = ?self.target,
                             status = ?response.status(),
@@ -290,8 +320,16 @@ impl Request {
                         } else {
                             response
                         };
-                        self.handle_response(response)
-                    })
+                        Ok(self.handle_response(response))
+                    }
+                    // The forced-refresh retry still hit a gone partition: the
+                    // range is genuinely unavailable. Surface 503 instead of
+                    // letting a raw 410 bubble up to the caller.
+                    Err(retry_error) if retry_error.status().is_partition_topology_change() => {
+                        Err(partition_gone_as_service_unavailable(retry_error))
+                    }
+                    Err(retry_error) => Err(retry_error),
+                }
             }
             RequestTarget::EffectivePartitionKeyRange { .. } => {
                 let range = self
@@ -603,7 +641,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn request_returns_second_logical_partition_key_topology_change() {
+    async fn request_surfaces_503_after_terminal_logical_partition_key_topology_change() {
         let mut request = Request::new(Arc::new(operation()), logical_partition_target(), None);
         let mut executor = MockRequestExecutor::new(vec![Err(gone_error()), Err(gone_error())]);
         let mut topology = NoopTopologyProvider;
@@ -611,7 +649,12 @@ mod tests {
 
         let error = request.next_page(&mut context).await.unwrap_err();
 
-        assert!(error.status().is_partition_topology_change());
+        // The first 410/1002 forces a routing refresh and retries; the second is
+        // terminal, so it must surface as 503 (preserving the sub-status) rather
+        // than bubbling up to the caller as a raw, unclassifiable 410.
+        assert_eq!(error.status().status_code(), StatusCode::ServiceUnavailable);
+        assert_eq!(error.status().sub_status().map(|s| s.value()), Some(1002));
+        assert!(!error.status().is_partition_topology_change());
         assert_eq!(
             executor.refresh_calls,
             vec![
@@ -620,6 +663,34 @@ mod tests {
             ]
         );
         assert_eq!(executor.continuation_calls, vec![None, None]);
+    }
+
+    #[test]
+    fn partition_gone_conversion_preserves_sub_status_and_chains_source() {
+        // Covers a different family member (1007 CompletingSplit) and asserts the
+        // synthetic 503 keeps the sub-status and chains the original as source.
+        let original = CosmosError::builder()
+            .with_status(CosmosStatus::from_parts(
+                StatusCode::Gone,
+                Some(crate::models::SubStatusCode::COMPLETING_SPLIT),
+            ))
+            .with_message("completing split")
+            .build();
+
+        let converted = partition_gone_as_service_unavailable(original);
+
+        assert_eq!(
+            converted.status().status_code(),
+            StatusCode::ServiceUnavailable
+        );
+        assert_eq!(
+            converted.status().sub_status().map(|s| s.value()),
+            Some(1007)
+        );
+        assert!(
+            std::error::Error::source(&converted).is_some(),
+            "the original 410 should be chained as the source"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

When a partition split/merge/migration makes a partition-key-range stale, the gateway returns `410 Gone` with a partition-routing sub-status (`1002` PartitionKeyRangeGone, `1007` CompletingSplit, `1008` CompletingPartitionMigration). The driver's dataflow layer already detects these (`is_partition_topology_change`) and, for a logical-partition-key point operation, forces a routing-cache refresh and retries once. But if the partition is **still gone after that retry**, the raw `410` bubbled up to the caller.

A raw `410` is effectively unclassifiable: application-layer retry / circuit-breaker logic is wired for `503`, not `410`. This is the Rust sibling of Azure/azure-cosmos-dotnet-v3#5924.

## Change

`driver/dataflow/request.rs` — `handle_partition_topology_change` now converts a **terminal** `LogicalPartitionKey` topology-change `410` (i.e. the forced-refresh retry still returned a topology-change `410`) into a synthetic `503 Service Unavailable`, preserving the original Cosmos sub-status and chaining the original error as the source.

- A *synthetic* error is required because a wire error pins its status to the response's `410` (the `CosmosError` builder lets `with_response` win over `with_status`).
- The `NonPartitioned` and `EffectivePartitionKeyRange` (query/feed split) paths are intentionally **unchanged** — the issue is about partitioned point operations, and the EPK path converges via splitting.

## Notes for reviewers

This branch was rebased onto current `main`. The earlier version of this PR targeted the old SDK-side `ClientRetryPolicy`, which `main` has since removed — data-plane retry now lives in `azure_data_cosmos_driver`. The routing-refresh-and-retry half of the original fix already exists upstream; this PR adds only the remaining terminal `410 → 503` conversion.

## Tests / validation

- Updated the terminal-LPK unit test to assert `503` + preserved sub-status (`1002`); added a conversion-helper test covering `1007` and source chaining.
- Corrected the `item_read_fault_injection_partition_is_gone` multi-write test to expect `503`.
- `cargo test -p azure_data_cosmos_driver --lib` → 1766 passed; in-memory emulator suite (63) passed; split/merge (9) passed.
- `cargo clippy -p azure_data_cosmos_driver --all-targets` → clean; `cargo fmt` applied; `azure_data_cosmos` builds against the change.
- CHANGELOG entry added under `azure_data_cosmos_driver` `0.4.0 (Unreleased)` → Bugs Fixed.

Reference: Azure/azure-cosmos-dotnet-v3#5924