### PR TITLE
cosmos: Mark tests with required-features instead of feature flagging imports

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -104,3 +104,27 @@ features = [
   "native_tls",
   "rustls",
 ]
+
+# Explicit [[test]] entries gate the feature-dependent integration test
+# binaries. Cargo silently skips a target whose `required-features` are not
+# all enabled, so `cargo build --tests` / `cargo test` work without
+# `--all-features`. Auto-discovery still picks up every other test root.
+[[test]]
+name = "emulator"
+path = "tests/emulator.rs"
+required-features = ["key_auth", "fault_injection"]
+
+[[test]]
+name = "multi_write"
+path = "tests/multi_write.rs"
+required-features = ["key_auth", "fault_injection"]
+
+[[test]]
+name = "split"
+path = "tests/split.rs"
+required-features = ["key_auth", "fault_injection"]
+
+[[test]]
+name = "in_memory_emulator"
+path = "tests/in_memory_emulator.rs"
+required-features = ["__internal_in_memory_emulator"]

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_backup_endpoints.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_backup_endpoints.rs
@@ -13,8 +13,6 @@
 //! model the multi-endpoint topology backup-endpoint fallback is designed to
 //! exercise.
 
-#![cfg(feature = "key_auth")]
-
 use super::framework;
 
 use azure_data_cosmos::{AccountEndpoint, AccountReference, CosmosClient, RoutingStrategy};

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_batch.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_batch.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#![cfg(feature = "key_auth")]
 
 // Use the shared test framework declared in `tests/emulator/mod.rs`.
 use super::framework;

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_containers.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_containers.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#![cfg(feature = "key_auth")]
 
 // Use the shared test framework declared in `tests/emulator/mod.rs`.
 use super::framework;

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_databases.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_databases.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#![cfg(feature = "key_auth")]
 
 // Use the shared test framework declared in `tests/emulator/mod.rs`.
 use super::framework;

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_fault_injection.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_fault_injection.rs
@@ -4,9 +4,6 @@
 //! Integration tests for fault injection framework.
 //! These tests run against the Cosmos DB emulator.
 
-#![cfg(feature = "key_auth")]
-#![cfg(feature = "fault_injection")]
-
 use super::framework;
 
 use azure_core::{http::StatusCode, Uuid};

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_feed_ranges.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_feed_ranges.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#![cfg(feature = "key_auth")]
 
 use super::framework;
 

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_items.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_items.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#![cfg(feature = "key_auth")]
 
 // Use the shared test framework declared in `tests/emulator/mod.rs`.
 use super::framework;

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_offers.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_offers.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#![cfg(feature = "key_auth")]
 
 // Use the shared test framework declared in `tests/emulator/mod.rs`.
 use super::framework;

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_patch.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_patch.rs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#![cfg(feature = "key_auth")]
 
 // Use the shared test framework declared in `tests/emulator/mod.rs`.
 use super::framework;
 
 use azure_core::{http::StatusCode, Uuid};
 use azure_data_cosmos::clients::ContainerClient;
-#[cfg(feature = "fault_injection")]
 use azure_data_cosmos::fault_injection::{
     CustomResponseBuilder, FaultInjectionConditionBuilder, FaultInjectionResultBuilder,
     FaultInjectionRuleBuilder, FaultOperationType,
@@ -15,12 +13,10 @@ use azure_data_cosmos::fault_injection::{
 use azure_data_cosmos::models::{ContainerProperties, ItemResponse};
 use azure_data_cosmos::{PatchInstructions, PatchItemOptions, PatchOperation};
 use framework::TestClient;
-#[cfg(feature = "fault_injection")]
 use framework::TestOptions;
 use framework::TestRunContext;
 use serde::{Deserialize, Serialize};
 use std::error::Error;
-#[cfg(feature = "fault_injection")]
 use std::sync::Arc;
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
@@ -242,7 +238,6 @@ pub async fn patch_item_honors_max_attempts_option() -> Result<(), Box<dyn Error
 /// Build a [`FaultInjectionRule`] that returns a synthetic 412 for every
 /// `ReplaceItem` request, with an optional `hit_limit` to cap how many
 /// times it fires.
-#[cfg(feature = "fault_injection")]
 fn build_replace_412_rule(
     name: &str,
     hit_limit: Option<u32>,
@@ -268,7 +263,6 @@ fn build_replace_412_rule(
 /// container is bound to the fault-injection-aware `CosmosClient` exposed
 /// by `run_context.fault_client()`, so calls through it are subject to the
 /// fault rules registered on `TestOptions`.
-#[cfg(feature = "fault_injection")]
 async fn setup_fault_injected_container(
     run_context: &TestRunContext,
     db_client: &azure_data_cosmos::clients::DatabaseClient,
@@ -307,7 +301,6 @@ async fn setup_fault_injected_container(
 /// surface.
 ///
 /// Mirrors the driver-level emulator test `cosmos_patch_412_retry`.
-#[cfg(feature = "fault_injection")]
 #[tokio::test]
 #[cfg_attr(
     not(any(test_category = "emulator", test_category = "emulator_vnext")),
@@ -373,7 +366,6 @@ pub async fn patch_item_412_retry_succeeds() -> Result<(), Box<dyn Error>> {
 /// `PreconditionFailed` error.
 ///
 /// Mirrors the driver-level emulator test `cosmos_patch_412_exhaustion`.
-#[cfg(feature = "fault_injection")]
 #[tokio::test]
 #[cfg_attr(
     not(any(test_category = "emulator", test_category = "emulator_vnext")),

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_proxy.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_proxy.rs
@@ -4,8 +4,6 @@
 //! Integration tests verifying proxy configuration behavior.
 //! These tests run against the Cosmos DB emulator.
 
-#![cfg(feature = "key_auth")]
-
 use super::framework;
 
 use framework::{TestClient, CONNECTION_STRING_ENV_VAR, EMULATOR_CONNECTION_STRING};

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_query.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_query.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#![cfg(feature = "key_auth")]
 
 // Use the shared test framework declared in `tests/emulator/mod.rs`.
 use super::framework;

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_response_metadata.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_response_metadata.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#![cfg(feature = "key_auth")]
 
 // Use the shared test framework declared in `tests/emulator/mod.rs`.
 use super::framework;

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
@@ -14,7 +14,6 @@
 //!
 //! The framework allows tests to easily run against real Cosmos DB instances, the local emulator, or a mock server using test-proxy.
 
-#[cfg(feature = "fault_injection")]
 pub mod mock_account;
 pub mod test_client;
 pub mod test_data;

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
@@ -3,9 +3,6 @@
 
 // cspell:ignore: TEAMPROJECTID
 
-#![cfg_attr(not(feature = "key_auth"), allow(dead_code))]
-#![cfg(feature = "fault_injection")]
-
 use azure_core::{http::StatusCode, Uuid};
 use azure_data_cosmos::clients::ContainerClient;
 use azure_data_cosmos::fault_injection::FaultInjectionRule;

--- a/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator.rs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// The whole test binary is gated behind `__internal_in_memory_emulator`.
-// Cargo does not gate dev-dependencies by feature, so dev-deps that are only
-// used by the emulator tests (e.g. `uuid`) would otherwise be pulled into the
-// dependency graph for every `cargo test` invocation. Gating the entire
-// translation unit keeps those deps unused when the feature is off.
-#![cfg(feature = "__internal_in_memory_emulator")]
+// The `__internal_in_memory_emulator` feature is required for this test
+// binary; it is enforced via `required-features` in `Cargo.toml`. That keeps
+// the entire translation unit (and its dev-only deps such as `uuid`) out of
+// the build when the feature is off.
 
 mod in_memory_emulator_tests;

--- a/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#![cfg(feature = "key_auth")]
 
 use super::framework;
 

--- a/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write_fault_injection.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write_fault_injection.rs
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#![cfg(feature = "key_auth")]
-#![cfg(feature = "fault_injection")]
 
 use super::framework;
 

--- a/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write_retry_policies.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write_retry_policies.rs
@@ -9,9 +9,6 @@
 //! - Write operations (create, upsert, replace, delete) do NOT retry across
 //!   regions on 408 errors.
 
-#![cfg(feature = "key_auth")]
-#![cfg(feature = "fault_injection")]
-
 use super::framework;
 
 use azure_core::http::StatusCode;

--- a/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_query_split.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_query_split.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#![cfg(feature = "key_auth")]
 
 use crate::split_tests::framework::InconclusiveError;
 

--- a/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_split_offers.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_split_offers.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#![cfg(feature = "key_auth")]
 
 use super::framework;
 

--- a/sdk/cosmos/azure_data_cosmos_driver/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_driver/Cargo.toml
@@ -112,3 +112,25 @@ features = [
   "rustls",
   "tokio",
 ]
+
+# Explicit [[test]] entries gate the feature-dependent integration test
+# binaries. Cargo silently skips a target whose `required-features` are not
+# all enabled, so `cargo build --tests` / `cargo test` work without
+# `--all-features`. Auto-discovery still picks up every other test root.
+# `multi_write` is intentionally omitted here because it is gated on the
+# custom `test_category = "multi_write"` cfg (set via RUSTFLAGS), which
+# `required-features` cannot express.
+[[test]]
+name = "multi_region_failover"
+path = "tests/multi_region_failover.rs"
+required-features = ["fault_injection"]
+
+[[test]]
+name = "gateway_query_plan_comparison"
+path = "tests/gateway_query_plan_comparison.rs"
+required-features = ["__internal_testing"]
+
+[[test]]
+name = "in_memory_emulator"
+path = "tests/in_memory_emulator.rs"
+required-features = ["__internal_in_memory_emulator"]

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/gateway_query_plan_comparison.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/gateway_query_plan_comparison.rs
@@ -17,7 +17,6 @@
 //!
 //! Run with: `AZURE_COSMOS_CONNECTION_STRING=... cargo test -p azure_data_cosmos_driver --features __internal_testing --test gateway_query_plan_comparison`
 
-#![cfg(feature = "__internal_testing")]
 // The framework module is shared across test binaries; not all exports are used
 // by every binary.
 #![allow(dead_code, unused_imports)]

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/in_memory_emulator.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/in_memory_emulator.rs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// The whole test binary is gated behind `__internal_in_memory_emulator`.
-// Cargo does not gate dev-dependencies by feature, so dev-deps that are only
-// used by the emulator tests (e.g. `uuid`) would otherwise be pulled into the
-// dependency graph for every `cargo test` invocation. Gating the entire
-// translation unit keeps those deps unused when the feature is off.
-#![cfg(feature = "__internal_in_memory_emulator")]
+// The `__internal_in_memory_emulator` feature is required for this test
+// binary; it is enforced via `required-features` in `Cargo.toml`. That keeps
+// the entire translation unit (and its dev-only deps such as `uuid`) out of
+// the build when the feature is off.
 
 mod in_memory_emulator_tests;

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/multi_region_failover.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/multi_region_failover.rs
@@ -11,8 +11,6 @@
 //! `AZURE_COSMOS_CONNECTION_STRING` exported by the bicep template; if it is unset
 //! the tests skip cleanly via `DriverTestClient::run_with_*`.
 
-#![cfg(feature = "fault_injection")]
-
 use azure_core::http::StatusCode;
 use azure_data_cosmos_driver::driver::CosmosDriverRuntime;
 use azure_data_cosmos_driver::error::CosmosError;


### PR DESCRIPTION
Fixes #4528 

By gating our tests on `required-features` in the Cargo.toml, they just get ignored when running without the required feature. That's good enough for allowing `cargo test --workspace` to work without `--all-features`. The CI still uses `--all-features` so there's no loss of coverage.