### PR TITLE
refactor(amqp): add AmqpSessionOptions::with_unbounded_windows helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,28 +333,6 @@ dependencies = [
 
 [[package]]
 name = "azure_core_amqp"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15daabffc2fcce01c54333137e40b216f5be8401b3a1bdafe1a633972f7346e9"
-dependencies = [
- "async-trait",
- "azure_core 1.0.0",
- "fe2o3-amqp",
- "fe2o3-amqp-cbs",
- "fe2o3-amqp-ext",
- "fe2o3-amqp-management",
- "fe2o3-amqp-types",
- "serde",
- "serde_amqp",
- "serde_bytes",
- "tokio",
- "tracing",
- "typespec 1.0.0",
- "typespec_macros 1.0.0",
-]
-
-[[package]]
-name = "azure_core_amqp"
 version = "1.1.0-beta.1"
 dependencies = [
  "async-trait",
@@ -679,7 +657,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "azure_core 1.0.0",
- "azure_core_amqp 1.0.0",
+ "azure_core_amqp",
  "azure_core_test 0.1.0",
  "azure_identity 1.0.0",
  "azure_messaging_eventhubs",
@@ -726,7 +704,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "azure_core 1.0.0",
- "azure_core_amqp 1.0.0",
+ "azure_core_amqp",
  "azure_core_test 0.1.0",
  "azure_identity 1.0.0",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,12 +60,8 @@ version = "1.0.0"
 [workspace.dependencies.azure_core_macros]
 version = "1.0.0"
 
-# Path-coupled so eventhubs and servicebus can build against this unreleased
-# beta and call AmqpSessionOptions::with_unbounded_windows (issue #4570). The
-# path is stripped when the consumer crates are packed for release.
 [workspace.dependencies.azure_core_amqp]
-version = "1.1.0-beta.1"
-path = "sdk/core/azure_core_amqp"
+version = "1.0.0"
 
 [workspace.dependencies.azure_core_opentelemetry]
 # azure_core_opentelemetry should only ever be in dev-dependencies herein

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,12 @@ version = "1.0.0"
 [workspace.dependencies.azure_core_macros]
 version = "1.0.0"
 
+# Path-coupled so eventhubs and servicebus can build against this unreleased
+# beta and call AmqpSessionOptions::with_unbounded_windows (issue #4570). The
+# path is stripped when the consumer crates are packed for release.
 [workspace.dependencies.azure_core_amqp]
-version = "1.0.0"
+version = "1.1.0-beta.1"
+path = "sdk/core/azure_core_amqp"
 
 [workspace.dependencies.azure_core_opentelemetry]
 # azure_core_opentelemetry should only ever be in dev-dependencies herein

--- a/sdk/core/azure_core_amqp/CHANGELOG.md
+++ b/sdk/core/azure_core_amqp/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added `AmqpSessionOptions::with_unbounded_windows()`, a shared constructor that sets both session flow-control windows to `u32::MAX` for messaging crates that defer backpressure to per-link credit.
+- Added `AmqpSessionOptions::with_unbounded_windows()`, a shared constructor that sets both session flow-control windows to `u32::MAX` for messaging crates that rely on per-link credit for flow control.
 
 ### Breaking Changes
 

--- a/sdk/core/azure_core_amqp/CHANGELOG.md
+++ b/sdk/core/azure_core_amqp/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added `AmqpSessionOptions::with_unbounded_windows()`, a shared constructor that sets both session flow-control windows to `u32::MAX` for messaging crates that defer backpressure to per-link credit.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/azure_core_amqp/src/session.rs
+++ b/sdk/core/azure_core_amqp/src/session.rs
@@ -46,10 +46,10 @@ impl AmqpSessionOptions {
     /// Session options that disable session-level flow control by maxing both
     /// the incoming and outgoing windows.
     ///
-    /// Messaging crates (such as Event Hubs and Service Bus) defer backpressure
-    /// to per-link credit and therefore want unbounded session windows. The
-    /// generic [`Default`] implementation deliberately stays `None` for both
-    /// windows so non-messaging consumers are unaffected.
+    /// Messaging crates (such as Event Hubs and Service Bus) rely on per-link
+    /// credit for flow control and therefore want unbounded session windows.
+    /// The generic [`Default`] implementation deliberately stays `None` for
+    /// both windows so non-messaging consumers are unaffected.
     pub fn with_unbounded_windows() -> Self {
         Self {
             incoming_window: Some(u32::MAX),

--- a/sdk/core/azure_core_amqp/src/session.rs
+++ b/sdk/core/azure_core_amqp/src/session.rs
@@ -42,7 +42,22 @@ pub struct AmqpSessionOptions {
     pub buffer_size: Option<usize>,
 }
 
-impl AmqpSessionOptions {}
+impl AmqpSessionOptions {
+    /// Session options that disable session-level flow control by maxing both
+    /// the incoming and outgoing windows.
+    ///
+    /// Messaging crates (such as Event Hubs and Service Bus) defer backpressure
+    /// to per-link credit and therefore want unbounded session windows. The
+    /// generic [`Default`] implementation deliberately stays `None` for both
+    /// windows so non-messaging consumers are unaffected.
+    pub fn with_unbounded_windows() -> Self {
+        Self {
+            incoming_window: Some(u32::MAX),
+            outgoing_window: Some(u32::MAX),
+            ..Default::default()
+        }
+    }
+}
 
 /// A trait for AMQP Session operations.
 #[async_trait::async_trait]
@@ -130,5 +145,15 @@ mod tests {
         );
 
         assert_eq!(session_options.buffer_size, Some(1024));
+    }
+
+    #[test]
+    fn test_with_unbounded_windows() {
+        let session_options = AmqpSessionOptions::with_unbounded_windows();
+        assert_eq!(session_options.incoming_window, Some(u32::MAX));
+        assert_eq!(session_options.outgoing_window, Some(u32::MAX));
+        // Everything else stays at the generic `Default` (`None`).
+        assert_eq!(session_options.next_outgoing_id, None);
+        assert_eq!(session_options.handle_max, None);
     }
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
@@ -21,7 +21,8 @@ async-lock.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 azure_core = { workspace = true, default-features = false }
-azure_core_amqp.workspace = true
+# Unreleased: needs AmqpSessionOptions::with_unbounded_windows from 1.1.0-beta.1 (issue #4570).
+azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.1.0-beta.1" }
 futures.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
@@ -31,7 +32,7 @@ tracing.workspace = true
 rustc_version.workspace = true
 
 [dev-dependencies]
-azure_core_amqp = { workspace = true, features = ["test"] }
+azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.1.0-beta.1", features = ["test"] }
 azure_core_test = { workspace = true, features = ["tracing"] }
 azure_identity.workspace = true
 azure_messaging_eventhubs = { path = ".", features = [

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -470,11 +470,7 @@ impl RecoverableConnection {
                 session
                     .begin(
                         connection.as_ref(),
-                        Some(AmqpSessionOptions {
-                            incoming_window: Some(u32::MAX),
-                            outgoing_window: Some(u32::MAX),
-                            ..Default::default()
-                        }),
+                        Some(AmqpSessionOptions::with_unbounded_windows()),
                     )
                     .await?;
                 Ok::<_, AmqpError>(Arc::new(session))

--- a/sdk/servicebus/azure_messaging_servicebus/Cargo.toml
+++ b/sdk/servicebus/azure_messaging_servicebus/Cargo.toml
@@ -21,7 +21,8 @@ async-lock.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 azure_core = { workspace = true, default-features = false }
-azure_core_amqp.workspace = true
+# Unreleased: needs AmqpSessionOptions::with_unbounded_windows from 1.1.0-beta.1 (issue #4570).
+azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.1.0-beta.1" }
 futures.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
@@ -33,7 +34,7 @@ tracing.workspace = true
 default = ["azure_core_amqp/default"]
 
 [dev-dependencies]
-azure_core_amqp = { workspace = true, features = ["test"] }
+azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.1.0-beta.1", features = ["test"] }
 azure_core_test = { workspace = true, features = ["tracing"] }
 azure_identity.workspace = true
 serde_json.workspace = true

--- a/sdk/servicebus/azure_messaging_servicebus/src/receiver.rs
+++ b/sdk/servicebus/azure_messaging_servicebus/src/receiver.rs
@@ -795,11 +795,7 @@ impl Receiver {
                 session
                     .begin(
                         self.connection.as_ref(),
-                        Some(azure_core_amqp::AmqpSessionOptions {
-                            incoming_window: Some(u32::MAX),
-                            outgoing_window: Some(u32::MAX),
-                            ..Default::default()
-                        }),
+                        Some(azure_core_amqp::AmqpSessionOptions::with_unbounded_windows()),
                     )
                     .await
                     .map_err(|e| {


### PR DESCRIPTION
## Summary

Hoists the duplicated AMQP session-window defaults into a shared helper on `azure_core_amqp`, as requested in #4570 (raised in review on #4446 and scoped out of it).

Event Hubs (`get_session`) and Service Bus (`ensure_session`) each constructed `AmqpSessionOptions` inline with both flow-control windows set to `u32::MAX`, disabling session-level flow control so backpressure is deferred to per-link credit (which both crates require). The value was duplicated with no shared source of truth or documented rationale.

This adds `AmqpSessionOptions::with_unbounded_windows()` in `azure_core_amqp` and calls it from both sites. The produced options are byte-for-byte identical to the previous inline values, so behavior is unchanged. The generic `Default` deliberately stays `None` for both windows: maximal windows are a messaging-specific choice, and `azure_core_amqp` is the generic AMQP layer.

## One decision worth a look

The new API lives in the unreleased `azure_core_amqp` 1.1.0-beta.1, but the workspace dependency was decoupled to the published 1.0.0 post-GA (no `path`). To let the two consumer crates build against the new method in a single green PR, I re-added `path` to the `[workspace.dependencies.azure_core_amqp]` entry and bumped its requirement to the beta. The only consumers of `azure_core_amqp` are eventhubs and servicebus, so the coupling is contained, and the path is stripped when those crates are packed for release. If you'd rather publish `azure_core_amqp` 1.1.0-beta.1 first and bump the consumers separately, I can split this instead.

## Changes

- `azure_core_amqp`: new `with_unbounded_windows()` constructor + unit test; CHANGELOG entry under Unreleased / Features Added.
- Event Hubs and Service Bus: call sites replaced with the helper (each keeps its existing import path).
- Root `Cargo.toml` / `Cargo.lock`: path-couple `azure_core_amqp` to the local beta.

The two messaging crates' CHANGELOGs are intentionally untouched (no behavior or public-API change there).

## Validation (from repo root)

- `cargo build -p azure_core_amqp -p azure_messaging_eventhubs -p azure_messaging_servicebus`
- `cargo test -p azure_core_amqp` (110 passed, incl. new `test_with_unbounded_windows`)
- `cargo clippy --all-targets -p azure_core_amqp -p azure_messaging_eventhubs -p azure_messaging_servicebus -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo doc -p azure_core_amqp --no-deps`

cspell/taplo/cargo-deny were not run locally (tools not installed); relied on CI. No new dictionary words introduced.

Closes #4570