### PR TITLE
feat(eventhubs): add tracing spans and structured logging to client (#4592)

### DIFF
--- a/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Other Changes
 
 - Reduced lock contention when a single `ProducerClient` or `ConsumerClient` is shared across threads. The per-path sender, session, and receiver caches no longer serialize on a connection-wide lock: each partition's link attach runs without holding the shared lock, so the partitions on a shared client set up and recover concurrently instead of one at a time, and steady-state sends no longer queue behind an unrelated partition's attach.
+- Added `tracing` span instrumentation and structured-field logging across the connection, producer, consumer, event-processor, and checkpoint paths. Lifecycle events (connection open/close, reconnect outcome, link attach, partition ownership claim/revoke) and failure conditions (receive errors, link-stolen, send/batch rejections, unauthorized fast-fail, token-refresh failures) are now visible at the default `info`/`warn` levels, with diagnostic values attached as structured fields (`partition_id`, `connection_id`, `source_url`, and similar) following a documented level policy. Per-message hot paths stay at `trace`. Credentials are never logged, and event payloads are redacted by `SafeDebug` unless the `azure_core` `debug` feature is enabled. See the README for details and a subscriber example. ([#4592](https://github.com/Azure/azure-sdk-for-rust/issues/4592))
 
 ## 0.14.0 (Unreleased)
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/README.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/README.md
@@ -258,6 +258,34 @@ When you interact with the Azure Event Hubs client library using the Rust SDK, e
 The Event Hubs SDK client uses the [tracing](https://docs.rs/tracing/latest/tracing/) package to
 enable diagnostics.
 
+The crate does not set custom tracing `target=` values. Events are emitted on the standard
+tracing module-path targets, which match the module that produced them (for example,
+`azure_messaging_eventhubs::common::recoverable::connection`). You can filter events by module
+path with `RUST_LOG` or an [`EnvFilter`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html).
+For example, `RUST_LOG=azure_messaging_eventhubs=debug` enables debug-and-above for the whole
+crate, while `RUST_LOG=azure_messaging_eventhubs::common::recoverable=trace` narrows tracing to
+the connection recovery path.
+
+Diagnostic values are attached as structured fields (`connection_id`, `partition_id`, `url`, and
+similar) rather than being interpolated into the message text, so they can be captured and queried
+by structured subscribers. Credentials (tokens, shared-access keys, and connection strings) are
+never logged. Event payloads and message bodies are redacted: the only site that logs a message
+does so at `trace`, and its body and application properties are stripped by `SafeDebug`. Enabling
+the `azure_core` `debug` cargo feature turns that redaction off, so avoid it in production when
+event contents are sensitive.
+
+Events follow a consistent level policy so you can pick the verbosity you need:
+
+* `error` - terminal or fatal failures that abort an operation, plus the exit of a long-lived background task.
+* `warn` - recoverable or anomalous-but-handled conditions, such as a send being rejected,
+  modified, or released, attach failures, retry exhaustion, a recovery action being required, an
+  etag mismatch, a missing management key, or an unauthorized fast-fail.
+* `info` - lifecycle success milestones, such as a connection or link opening, a link attaching, a
+  receiver attaching on a partition, recovery completing, or partition ownership being claimed.
+* `debug` - per-operation bookkeeping, error classification decisions, retry chatter, and internal
+  map updates.
+* `trace` - very-high-frequency or per-message detail, including the hot send path.
+
 ## Contributing
 
 See the [CONTRIBUTING.md] for details on building, testing, and contributing to these libraries.

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
@@ -17,12 +17,19 @@ use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, Mutex as SyncMutex, OnceLock, Weak},
 };
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 // The number of seconds before token expiration that we wake up to refresh the token.
 const TOKEN_REFRESH_BIAS: Duration = Duration::minutes(6); // By default, we refresh tokens 6 minutes before they expire.
 const TOKEN_REFRESH_JITTER_MIN: Duration = Duration::seconds(-5); // Minimum jitter (added from the bias, so a negative number means we refresh before the bias)
 const TOKEN_REFRESH_JITTER_MAX: Duration = Duration::seconds(5); // Maximum jitter (added to the bias)
+
+// Floor delay applied after a pass in which one or more token refreshes failed.
+// A failed refresh leaves the token's `expires_on` unchanged, so its computed
+// refresh_time stays in the past and the next pass would not sleep. Without this
+// floor a persistent failure (credential outage, CBS down) busy-spins, hammering
+// get_token / perform_authorization with no backoff. See PR #4593 review.
+const TOKEN_REFRESH_RETRY_BACKOFF: Duration = Duration::seconds(30);
 
 const EVENTHUBS_AUTHORIZATION_SCOPE: &str = "https://eventhubs.azure.net/.default";
 
@@ -107,7 +114,7 @@ impl Authorizer {
             connection_id = %connection.get_connection_id(),
             path = %path,
         ),
-        err,
+        err(level = "warn"),
     )]
     pub(crate) async fn authorize_path(
         self: &Arc<Self>,
@@ -209,16 +216,17 @@ impl Authorizer {
         // ever returns, every cached token will silently expire. Per-path
         // get_token/authorization failures are handled (logged + retried) inside
         // refresh_tokens(), so reaching here means the loop hit a terminal
-        // condition (e.g. the recoverable connection was dropped, or a poisoned
-        // lock). Surface that at error! rather than warn! since it tears the
-        // refresher down.
+        // condition. An Err is a genuine fault (e.g. a poisoned lock) and is
+        // surfaced at error!. An Ok(()) is the expected clean shutdown: the
+        // recoverable connection was dropped, so there is nothing left to
+        // refresh and info! is the right level.
         let result = self.refresh_tokens().await;
         match result {
             Err(e) => {
                 error!(err = ?e, "Token refresher task exited with error; cached tokens will no longer be refreshed: {e}");
             }
             Ok(()) => {
-                error!("Token refresher task exited; cached tokens will no longer be refreshed.");
+                info!("Token refresher task stopped after the recoverable connection was dropped.");
             }
         }
     }
@@ -373,6 +381,11 @@ impl Authorizer {
             // and continue to the next path; the unrefreshed token will be
             // retried on the next pass.
             let mut updated_tokens = HashMap::new();
+            // Tracks whether any path failed to refresh this pass. A failure
+            // leaves that token's `expires_on` unchanged, so refresh_time stays
+            // in the past and the next pass would not sleep; we back off below to
+            // avoid a no-delay retry storm.
+            let mut refresh_failed = false;
             for (url, previous_expiry) in tokens_to_refresh {
                 let new_token = match self
                     .credential
@@ -387,6 +400,7 @@ impl Authorizer {
                             err = ?e,
                             "Failed to refresh token for path; will retry on next pass: {e}"
                         );
+                        refresh_failed = true;
                         continue;
                     }
                 };
@@ -405,15 +419,19 @@ impl Authorizer {
                 }
 
                 // Create an ephemeral connection to host the authentication.
+                //
+                // A failed upgrade is terminal, not retryable: once the last
+                // strong reference to the RecoverableConnection is dropped the
+                // Weak can never upgrade again, so continuing here would loop
+                // forever with nothing left to refresh against. Stop the task.
                 let connection = match self.recoverable_connection.upgrade() {
                     Some(connection) => connection,
                     None => {
-                        warn!(
-                            path = %url,
+                        info!(
                             operation = "upgrade_connection",
-                            "Recoverable connection has been dropped; skipping token refresh for path, will retry on next pass."
+                            "Recoverable connection has been dropped; stopping token refresher."
                         );
-                        continue;
+                        return Ok(());
                     }
                 };
                 if let Err(e) = self
@@ -426,6 +444,7 @@ impl Authorizer {
                         err = ?e,
                         "Failed to authorize refreshed token for path; will retry on next pass: {e}"
                     );
+                    refresh_failed = true;
                     continue;
                 }
 
@@ -443,6 +462,18 @@ impl Authorizer {
                     scopes.insert(url.clone(), token);
                 }
                 debug!("Updated tokens.");
+            }
+
+            // If any path failed to refresh, its refresh_time is still in the
+            // past, so the top-of-loop sleep would be skipped. Back off for a
+            // bounded interval before retrying so a persistent failure does not
+            // busy-spin on get_token / perform_authorization.
+            if refresh_failed {
+                warn!(
+                    backoff = ?TOKEN_REFRESH_RETRY_BACKOFF,
+                    "One or more token refreshes failed this pass; backing off before retrying."
+                );
+                azure_core::sleep::sleep(TOKEN_REFRESH_RETRY_BACKOFF).await;
             }
         }
     }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
@@ -463,7 +463,6 @@ mod tests {
     use azure_core::{credentials::TokenRequestOptions, http::Url, time::OffsetDateTime, Result};
     use azure_core_test::{recorded, TestContext};
     use std::sync::Arc;
-    use tracing::info;
 
     // Helper struct to mock token credential
     #[derive(Debug)]
@@ -665,7 +664,7 @@ mod tests {
         let current_count = mock_credential.get_token_get_count();
         assert_eq!(current_count, 1);
 
-        debug!("Sleeping for 15 seconds to allow token to expire and be refreshed. Current token count: {current_count}");
+        trace!("Sleeping for 15 seconds to allow token to expire and be refreshed. Current token count: {current_count}");
 
         // Sleep a bit to ensure we will have refreshed the token - since the token expires in 20 seconds,
         // we will refresh it between 8 and 12 seconds before the expiration time. If we wait for 13 seconds,
@@ -674,13 +673,13 @@ mod tests {
 
         // Verify that the token get count has increased, indicating a refresh was attempted
         let final_count = mock_credential.get_token_get_count();
-        debug!("After sleeping, token count: {final_count}");
+        trace!("After sleeping, token count: {final_count}");
 
         assert!(
             final_count >= 2,
             "Expected token get count to be greater or equal to 2, but got {final_count}"
         );
-        info!("Final token get count: {final_count}");
+        trace!("Final token get count: {final_count}");
         Ok(())
     }
 
@@ -737,7 +736,7 @@ mod tests {
         // between 14 and 16 seconds from now.
 
         // The second token expires after the first token.
-        debug!("Sleeping for 10 seconds to establish separation between token_refresh_1 and token_refresh_2.");
+        trace!("Sleeping for 10 seconds to establish separation between token_refresh_1 and token_refresh_2.");
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
         // Authorize the second path, which will store the token
@@ -754,18 +753,18 @@ mod tests {
 
         // Token_refresh_1 will be refreshed between 4 and 6 seconds from now.
         // Token_refresh_2 will be refreshed between 14 and 16 from now.
-        debug!("Sleeping for 7 seconds to allow token_refresh_1 to expire and be refreshed. Current token count: {current_count}");
+        trace!("Sleeping for 7 seconds to allow token_refresh_1 to expire and be refreshed. Current token count: {current_count}");
         tokio::time::sleep(std::time::Duration::from_secs(7)).await;
 
         // Verify that the token get count has increased, indicating a single refresh was attempted - we refreshed token_refresh_1 but not token_refresh_2.
         let final_count = mock_credential.get_token_get_count();
-        debug!("After sleeping the first time, token count: {final_count}");
+        trace!("After sleeping the first time, token count: {final_count}");
         assert!(
             final_count >= 2,
             "Expected first get token count to be at least 2, but got {final_count}"
         );
 
-        info!("First token expiration get count: {}", final_count);
+        trace!("First token expiration get count: {}", final_count);
         // Token_refresh_1 will be refreshed between 13 and 15 seconds from now.
         // Token_refresh_2 will be refreshed between 7 and 9 seconds from now.
 
@@ -774,12 +773,12 @@ mod tests {
 
         // Verify that the token get count has increased, indicating a single refresh was attempted - we refreshed token_refresh_2.
         let final_count = mock_credential.get_token_get_count();
-        debug!("Getting second token count: {final_count}");
+        trace!("Getting second token count: {final_count}");
         assert!(
             final_count >= 4,
             "Expected second get token count to be 4, but got {final_count}"
         );
-        info!("Second token expiration get count: {}", final_count);
+        trace!("Second token expiration get count: {}", final_count);
 
         Ok(())
     }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
@@ -17,7 +17,7 @@ use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, Mutex as SyncMutex, OnceLock, Weak},
 };
-use tracing::{debug, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 // The number of seconds before token expiration that we wake up to refresh the token.
 const TOKEN_REFRESH_BIAS: Duration = Duration::minutes(6); // By default, we refresh tokens 6 minutes before they expire.
@@ -100,6 +100,15 @@ impl Authorizer {
         Ok(())
     }
 
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            connection_id = %connection.get_connection_id(),
+            path = %path,
+        ),
+        err,
+    )]
     pub(crate) async fn authorize_path(
         self: &Arc<Self>,
         connection: &Arc<RecoverableConnection>,
@@ -194,12 +203,24 @@ impl Authorizer {
             .await
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn refresh_tokens_task(self: Arc<Self>) {
+        // The refresh loop is the only thing keeping cached tokens alive; if it
+        // ever returns, every cached token will silently expire. Per-path
+        // get_token/authorization failures are handled (logged + retried) inside
+        // refresh_tokens(), so reaching here means the loop hit a terminal
+        // condition (e.g. the recoverable connection was dropped, or a poisoned
+        // lock). Surface that at error! rather than warn! since it tears the
+        // refresher down.
         let result = self.refresh_tokens().await;
-        if let Err(e) = result {
-            warn!(err=?e, "Error refreshing tokens: {e}");
+        match result {
+            Err(e) => {
+                error!(err = ?e, "Token refresher task exited with error; cached tokens will no longer be refreshed: {e}");
+            }
+            Ok(()) => {
+                error!("Token refresher task exited; cached tokens will no longer be refreshed.");
+            }
         }
-        debug!("Token refresher task completed.");
     }
 
     /// Refresh the authorization tokens associated with this connection manager.
@@ -343,13 +364,32 @@ impl Authorizer {
                 to_refresh
             };
 
-            // Now refresh tokens without holding the lock to avoid deadlocks
+            // Now refresh tokens without holding the lock to avoid deadlocks.
+            //
+            // A failure to refresh a single path (transient get_token failure,
+            // authorization failure, etc.) must NOT tear down the refresh task:
+            // doing so would let every other cached token silently expire. We
+            // log the failure at warn! with the path and the failing condition
+            // and continue to the next path; the unrefreshed token will be
+            // retried on the next pass.
             let mut updated_tokens = HashMap::new();
             for (url, previous_expiry) in tokens_to_refresh {
-                let new_token = self
+                let new_token = match self
                     .credential
                     .get_token(&[EVENTHUBS_AUTHORIZATION_SCOPE], None)
-                    .await?;
+                    .await
+                {
+                    Ok(token) => token,
+                    Err(e) => {
+                        warn!(
+                            path = %url,
+                            operation = "get_token",
+                            err = ?e,
+                            "Failed to refresh token for path; will retry on next pass: {e}"
+                        );
+                        continue;
+                    }
+                };
 
                 // A credential that cannot renew this token (e.g. a pre-formed
                 // SAS) hands back the same expiry. Re-presenting it would not
@@ -365,11 +405,29 @@ impl Authorizer {
                 }
 
                 // Create an ephemeral connection to host the authentication.
-                let connection = self.recoverable_connection.upgrade().ok_or_else(|| {
-                    AmqpError::with_message("Recoverable connection has been dropped")
-                })?;
-                self.perform_authorization(&connection, &url, &new_token)
-                    .await?;
+                let connection = match self.recoverable_connection.upgrade() {
+                    Some(connection) => connection,
+                    None => {
+                        warn!(
+                            path = %url,
+                            operation = "upgrade_connection",
+                            "Recoverable connection has been dropped; skipping token refresh for path, will retry on next pass."
+                        );
+                        continue;
+                    }
+                };
+                if let Err(e) = self
+                    .perform_authorization(&connection, &url, &new_token)
+                    .await
+                {
+                    warn!(
+                        path = %url,
+                        operation = "perform_authorization",
+                        err = ?e,
+                        "Failed to authorize refreshed token for path; will retry on next pass: {e}"
+                    );
+                    continue;
+                }
 
                 debug!(
                     "Token refreshed for {url}, new expiration time: {}",

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/management.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/management.rs
@@ -10,6 +10,7 @@ use azure_core_amqp::{
     AmqpManagementApis, AmqpOrderedMap, AmqpSimpleValue, AmqpTimestamp, AmqpValue,
 };
 use std::{sync::Arc, time::SystemTime};
+use tracing::warn;
 
 /// Represents an instance of the Event Hubs management client.
 ///
@@ -53,6 +54,15 @@ impl ManagementInstance {
         })
     }
 
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            connection_id = %self.recoverable_connection.get_connection_id(),
+            eventhub = %eventhub,
+        ),
+        err,
+    )]
     pub async fn get_eventhub_properties(&self, eventhub: &str) -> Result<EventHubProperties> {
         let mut application_properties: AmqpOrderedMap<String, AmqpSimpleValue> =
             AmqpOrderedMap::new();
@@ -65,33 +75,67 @@ impl ManagementInstance {
             .await?;
 
         if !response.contains_key(EVENTHUB_PROPERTY_PARTITION_COUNT) {
+            warn!(
+                missing_key = EVENTHUB_PROPERTY_PARTITION_COUNT,
+                "Management response for event hub properties is missing a required key"
+            );
             return Err(EventHubsError::from(ErrorKind::InvalidManagementResponse));
         }
         let name: String = response
             .get(EVENTHUB_PROPERTY_NAME)
-            .ok_or_else(|| EventHubsError::from(ErrorKind::InvalidManagementResponse))?
+            .ok_or_else(|| {
+                warn!(
+                    missing_key = EVENTHUB_PROPERTY_NAME,
+                    "Management response for event hub properties is missing a required key"
+                );
+                EventHubsError::from(ErrorKind::InvalidManagementResponse)
+            })?
             .into();
         let created_at: Option<SystemTime> = Into::<AmqpTimestamp>::into(
             response
                 .get(EVENTHUB_PROPERTY_CREATED_AT)
-                .ok_or_else(|| EventHubsError::from(ErrorKind::InvalidManagementResponse))?
+                .ok_or_else(|| {
+                    warn!(
+                        missing_key = EVENTHUB_PROPERTY_CREATED_AT,
+                        "Management response for event hub properties is missing a required key"
+                    );
+                    EventHubsError::from(ErrorKind::InvalidManagementResponse)
+                })?
                 .clone(),
         )
         .0;
 
         let partition_ids = response
             .get(EVENTHUB_PROPERTY_PARTITION_IDS)
-            .ok_or_else(|| EventHubsError::from(ErrorKind::InvalidManagementResponse))?;
+            .ok_or_else(|| {
+                warn!(
+                    missing_key = EVENTHUB_PROPERTY_PARTITION_IDS,
+                    "Management response for event hub properties is missing a required key"
+                );
+                EventHubsError::from(ErrorKind::InvalidManagementResponse)
+            })?;
 
         let partition_ids = match partition_ids {
             AmqpValue::Array(partition_ids) => partition_ids
                 .iter()
                 .map(|id| match id {
                     AmqpValue::String(id) => Ok(id.clone()),
-                    _ => Err(EventHubsError::from(ErrorKind::InvalidManagementResponse)),
+                    _ => {
+                        warn!(
+                            key = EVENTHUB_PROPERTY_PARTITION_IDS,
+                            "Management response partition id entry is not a string"
+                        );
+                        Err(EventHubsError::from(ErrorKind::InvalidManagementResponse))
+                    }
                 })
                 .collect::<Result<Vec<String>>>()?,
-            _ => return Err(EventHubsError::from(ErrorKind::InvalidManagementResponse)),
+            _ => {
+                warn!(
+                    key = EVENTHUB_PROPERTY_PARTITION_IDS,
+                    "Management response partition ids value is not an array"
+                );
+                return Err(EventHubsError::from(ErrorKind::InvalidManagementResponse));
+            }
         };
         Ok(EventHubProperties {
             name,
@@ -100,6 +144,16 @@ impl ManagementInstance {
         })
     }
 
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            connection_id = %self.recoverable_connection.get_connection_id(),
+            eventhub = %eventhub,
+            partition_id = %partition_id,
+        ),
+        err,
+    )]
     pub async fn get_eventhub_partition_properties(
         &self,
         eventhub: &str,
@@ -117,44 +171,71 @@ impl ManagementInstance {
             .await?;
 
         // Look for the required response properties
-        if !response.contains_key(EVENTHUB_PARTITION_PROPERTIES_TYPE)
-            || !response
-                .contains_key(EVENTHUB_PARTITION_PROPERTIES_LAST_ENQUEUED_SEQUENCE_NUMBER_EPOCH)
-        {
+        if !response.contains_key(EVENTHUB_PARTITION_PROPERTIES_TYPE) {
+            warn!(
+                missing_key = EVENTHUB_PARTITION_PROPERTIES_TYPE,
+                "Management response for partition properties is missing a required key"
+            );
             return Err(EventHubsError::from(ErrorKind::InvalidManagementResponse));
         }
+        if !response.contains_key(EVENTHUB_PARTITION_PROPERTIES_LAST_ENQUEUED_SEQUENCE_NUMBER_EPOCH)
+        {
+            warn!(
+                missing_key = EVENTHUB_PARTITION_PROPERTIES_LAST_ENQUEUED_SEQUENCE_NUMBER_EPOCH,
+                "Management response for partition properties is missing a required key"
+            );
+            return Err(EventHubsError::from(ErrorKind::InvalidManagementResponse));
+        }
+
+        let missing_key = |key: &'static str| {
+            move || {
+                warn!(
+                    missing_key = key,
+                    "Management response for partition properties is missing a required key"
+                );
+                EventHubsError::from(ErrorKind::InvalidManagementResponse)
+            }
+        };
 
         Ok(EventHubPartitionProperties {
             beginning_sequence_number: response
                 .get(EVENTHUB_PARTITION_PROPERTIES_BEGIN_SEQUENCE_NUMBER)
-                .ok_or_else(|| EventHubsError::from(ErrorKind::InvalidManagementResponse))?
+                .ok_or_else(missing_key(
+                    EVENTHUB_PARTITION_PROPERTIES_BEGIN_SEQUENCE_NUMBER,
+                ))?
                 .into(),
             id: response
                 .get(EVENTHUB_PROPERTY_PARTITION)
-                .ok_or_else(|| EventHubsError::from(ErrorKind::InvalidManagementResponse))?
+                .ok_or_else(missing_key(EVENTHUB_PROPERTY_PARTITION))?
                 .into(),
             eventhub: response
                 .get(EVENTHUB_PROPERTY_NAME)
-                .ok_or_else(|| EventHubsError::from(ErrorKind::InvalidManagementResponse))?
+                .ok_or_else(missing_key(EVENTHUB_PROPERTY_NAME))?
                 .into(),
 
             last_enqueued_sequence_number: response
                 .get(EVENTHUB_PARTITION_PROPERTIES_LAST_ENQUEUED_SEQUENCE_NUMBER)
-                .ok_or_else(|| EventHubsError::from(ErrorKind::InvalidManagementResponse))?
+                .ok_or_else(missing_key(
+                    EVENTHUB_PARTITION_PROPERTIES_LAST_ENQUEUED_SEQUENCE_NUMBER,
+                ))?
                 .into(),
             last_enqueued_offset: response
                 .get(EVENTHUB_PARTITION_PROPERTIES_LAST_ENQUEUED_OFFSET)
-                .ok_or_else(|| EventHubsError::from(ErrorKind::InvalidManagementResponse))?
+                .ok_or_else(missing_key(
+                    EVENTHUB_PARTITION_PROPERTIES_LAST_ENQUEUED_OFFSET,
+                ))?
                 .into(),
             last_enqueued_time_utc: Into::<AmqpTimestamp>::into(
                 response
                     .get(EVENTHUB_PARTITION_PROPERTIES_LAST_ENQUEUED_TIME_UTC)
-                    .ok_or_else(|| EventHubsError::from(ErrorKind::InvalidManagementResponse))?,
+                    .ok_or_else(missing_key(
+                        EVENTHUB_PARTITION_PROPERTIES_LAST_ENQUEUED_TIME_UTC,
+                    ))?,
             )
             .0,
             is_empty: response
                 .get(EVENTHUB_PARTITION_PROPERTIES_IS_EMPTY)
-                .ok_or_else(|| EventHubsError::from(ErrorKind::InvalidManagementResponse))?
+                .ok_or_else(missing_key(EVENTHUB_PARTITION_PROPERTIES_IS_EMPTY))?
                 .into(),
         })
     }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/claims_based_security.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/claims_based_security.rs
@@ -90,7 +90,7 @@ impl AmqpClaimsBasedSecurityApis for RecoverableClaimsBasedSecurity {
             operation = "authorize_path",
             expires_on = %expires_on,
         ),
-        err,
+        err(level = "warn"),
     )]
     async fn authorize_path(
         &self,

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/claims_based_security.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/claims_based_security.rs
@@ -71,7 +71,7 @@ impl RecoverableClaimsBasedSecurity {
             operation = "claims_based_security",
             action = ?action,
             err = ?e,
-            "Claims-based-security AMQP operation failed: {e:?}"
+            "Claims-based-security AMQP operation failed."
         );
         action
     }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/claims_based_security.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/claims_based_security.rs
@@ -60,13 +60,38 @@ impl RecoverableClaimsBasedSecurity {
     }
 
     fn should_retry_claims_based_security_response(e: &AmqpError) -> ErrorRecoveryAction {
-        warn!("Amqp operation failed: {:?}", e);
-        RecoverableConnection::should_retry_amqp_error(e)
+        let action = RecoverableConnection::should_retry_amqp_error(e);
+        // This classifier is shared by the create and authorize_path CBS paths.
+        // `recover_azure_operation` only hands us the error (a plain `fn`
+        // pointer, not a closure), so we cannot capture the link path here; the
+        // path-scoped context is logged at the call site in `authorize_path`.
+        // Surface the error condition and the resulting retry decision so a
+        // failing CBS round-trip is diagnosable.
+        warn!(
+            operation = "claims_based_security",
+            action = ?action,
+            err = ?e,
+            "Claims-based-security AMQP operation failed: {e:?}"
+        );
+        action
     }
 }
 
 #[async_trait::async_trait]
 impl AmqpClaimsBasedSecurityApis for RecoverableClaimsBasedSecurity {
+    // skip_all keeps the `secret` (the SAS/bearer token) out of the span; only
+    // the safe identifiers are promoted into fields. `expires_on` is a timestamp,
+    // not a credential, so it is safe to record.
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            path = %path,
+            operation = "authorize_path",
+            expires_on = %expires_on,
+        ),
+        err,
+    )]
     async fn authorize_path(
         &self,
         path: String,

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -482,7 +482,7 @@ impl RecoverableConnection {
             connection_id = %self.get_connection_id(),
             source_url = %source_url,
         ),
-        err,
+        err(level = "warn"),
     )]
     async fn get_session(
         self: &Arc<Self>,
@@ -524,7 +524,7 @@ impl RecoverableConnection {
             connection_id = %self.get_connection_id(),
             url = %self.url,
         ),
-        err,
+        err(level = "warn"),
     )]
     async fn create_connection(&self) -> azure_core_amqp::Result<Arc<AmqpConnection>> {
         debug!(
@@ -568,7 +568,7 @@ impl RecoverableConnection {
         level = "debug",
         skip_all,
         fields(connection_id = %self.get_connection_id()),
-        err,
+        err(level = "warn"),
     )]
     pub(super) async fn ensure_amqp_management(
         self: &Arc<Self>,
@@ -596,7 +596,7 @@ impl RecoverableConnection {
         level = "debug",
         skip_all,
         fields(connection_id = %self.get_connection_id()),
-        err,
+        err(level = "warn"),
     )]
     pub(super) async fn ensure_amqp_cbs(
         self: &Arc<Self>,
@@ -617,7 +617,6 @@ impl RecoverableConnection {
             connection_id = %self.get_connection_id(),
             source_url = %source_url,
         ),
-        err,
     )]
     pub(super) async fn ensure_receiver(
         self: &Arc<Self>,
@@ -681,7 +680,6 @@ impl RecoverableConnection {
             connection_id = %self.get_connection_id(),
             path = %path,
         ),
-        err,
     )]
     pub(super) async fn ensure_sender(
         self: &Arc<Self>,

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -909,8 +909,7 @@ impl RecoverableConnection {
                 ) {
                     debug!(
                         condition = ?described_error.condition,
-                        "AMQP described error can be retried: {:?}",
-                        described_error
+                        "AMQP described error can be retried."
                     );
                     ErrorRecoveryAction::RetryAction
                 } else if matches!(
@@ -957,8 +956,7 @@ impl RecoverableConnection {
                 } else {
                     debug!(
                         condition = ?described_error.condition,
-                        "AMQP described error cannot be retried: {:?}",
-                        described_error
+                        "AMQP described error cannot be retried."
                     );
                     ErrorRecoveryAction::ReturnError
                 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -33,7 +33,7 @@ use std::{
     collections::HashMap,
     sync::{Arc, Weak},
 };
-use tracing::{debug, span, trace, warn};
+use tracing::{debug, info, instrument, trace, warn};
 
 /// The AMQP capability string used to negotiate geographic replication features
 /// between client and server. This capability is advertised during AMQP connection setup to indicate
@@ -246,8 +246,21 @@ impl RecoverableConnection {
     /// This method will close the underlying AMQP connection, if it exists. It will also cause all outstanding sends and receives
     /// to complete with an error.
     ///
+    #[instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            connection_id = %self.get_connection_id(),
+            url = %self.url,
+        ),
+        err,
+    )]
     pub(crate) async fn close_connection(self) -> Result<()> {
-        trace!("Closing recoverable connection for {}.", self.url);
+        debug!(
+            connection_id = %self.get_connection_id(),
+            url = %self.url,
+            "Closing recoverable connection."
+        );
 
         let mut management_client = self.mgmt_client.lock().await;
         if let Some(management_client) = management_client.take() {
@@ -340,6 +353,11 @@ impl RecoverableConnection {
                 );
             }
         }
+        info!(
+            connection_id = %self.get_connection_id(),
+            url = %self.url,
+            "Closed recoverable connection."
+        );
         Ok(())
     }
 
@@ -457,6 +475,15 @@ impl RecoverableConnection {
         Ok(())
     }
 
+    #[instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            connection_id = %self.get_connection_id(),
+            source_url = %source_url,
+        ),
+        err,
+    )]
     async fn get_session(
         self: &Arc<Self>,
         source_url: &Url,
@@ -467,7 +494,7 @@ impl RecoverableConnection {
         let cell = self.session_cell(source_url).await;
         let session = cell
             .get_or_try_init(|| async {
-                debug!("Creating session for partition: {:?}", source_url);
+                debug!(source_url = %source_url, "Creating session for partition.");
                 let connection = self.ensure_connection().await?;
 
                 let session = AmqpSession::new();
@@ -480,7 +507,7 @@ impl RecoverableConnection {
                 Ok::<_, AmqpError>(Arc::new(session))
             })
             .await?;
-        debug!("Cloning session for partition {:?}", source_url);
+        debug!(source_url = %source_url, "Cloning session for partition.");
         Ok(session.clone())
     }
 
@@ -490,8 +517,21 @@ impl RecoverableConnection {
         or_init_cell(&self.session_instances, source_url).await
     }
 
+    #[instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            connection_id = %self.get_connection_id(),
+            url = %self.url,
+        ),
+        err,
+    )]
     async fn create_connection(&self) -> azure_core_amqp::Result<Arc<AmqpConnection>> {
-        trace!("Creating connection for {}.", self.url);
+        debug!(
+            connection_id = %self.connection_name,
+            url = %self.url,
+            "Opening AMQP connection."
+        );
         let connection = Arc::new(AmqpConnection::new());
 
         connection
@@ -516,9 +556,20 @@ impl RecoverableConnection {
                 }),
             )
             .await?;
+        info!(
+            connection_id = %self.connection_name,
+            url = %self.url,
+            "Opened AMQP connection."
+        );
         Ok(connection)
     }
 
+    #[instrument(
+        level = "debug",
+        skip_all,
+        fields(connection_id = %self.get_connection_id()),
+        err,
+    )]
     pub(super) async fn ensure_amqp_management(
         self: &Arc<Self>,
     ) -> azure_core_amqp::Result<Arc<AmqpManagement>> {
@@ -541,16 +592,15 @@ impl RecoverableConnection {
     }
 
     /// Ensures that the AMQP Claims-Based Security (CBS) client is created and attached.
+    #[instrument(
+        level = "debug",
+        skip_all,
+        fields(connection_id = %self.get_connection_id()),
+        err,
+    )]
     pub(super) async fn ensure_amqp_cbs(
         self: &Arc<Self>,
     ) -> azure_core_amqp::Result<Arc<AmqpClaimsBasedSecurity>> {
-        let span = span!(
-            tracing::Level::DEBUG,
-            "ensure_amqp_cbs",
-            connection_id = self.get_connection_id()
-        );
-        let _enter = span.enter();
-
         let connection = self.ensure_connection().await?;
         let cbs_client = RecoverableClaimsBasedSecurity::create_claims_based_security(
             connection.clone(),
@@ -560,6 +610,15 @@ impl RecoverableConnection {
         Ok(cbs_client)
     }
 
+    #[instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            connection_id = %self.get_connection_id(),
+            source_url = %source_url,
+        ),
+        err,
+    )]
     pub(super) async fn ensure_receiver(
         self: &Arc<Self>,
         source_url: &Url,
@@ -579,15 +638,29 @@ impl RecoverableConnection {
 
                 let session = self.get_session(source_url).await?;
 
-                debug!("Create receiver on partition {source_url}.");
+                debug!(source_url = %source_url, "Creating receiver on partition.");
                 let receiver = AmqpReceiver::new();
-                receiver
+                if let Err(e) = receiver
                     .attach(
                         &session,
                         message_source.clone(),
                         Some(receiver_options.clone()),
                     )
-                    .await?;
+                    .await
+                {
+                    warn!(
+                        connection_id = %self.get_connection_id(),
+                        source_url = %source_url,
+                        err = %e,
+                        "Failed to attach receiver on partition."
+                    );
+                    return Err(e);
+                }
+                info!(
+                    connection_id = %self.get_connection_id(),
+                    source_url = %source_url,
+                    "Attached receiver on partition."
+                );
                 Ok::<_, AmqpError>(Arc::new(receiver))
             })
             .await?;
@@ -601,6 +674,15 @@ impl RecoverableConnection {
         or_init_cell(&self.receiver_instances, source_url).await
     }
 
+    #[instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            connection_id = %self.get_connection_id(),
+            path = %path,
+        ),
+        err,
+    )]
     pub(super) async fn ensure_sender(
         self: &Arc<Self>,
         path: &Url,
@@ -617,8 +699,9 @@ impl RecoverableConnection {
 
                 // Retrieve a session for the sender from the session cache.
                 let session = self.get_session(path).await?;
+                debug!(path = %path, "Creating sender on path.");
                 let sender = AmqpSender::new();
-                sender
+                if let Err(e) = sender
                     .attach(
                         &session,
                         format!(
@@ -630,7 +713,21 @@ impl RecoverableConnection {
                         path.to_string(),
                         None,
                     )
-                    .await?;
+                    .await
+                {
+                    warn!(
+                        connection_id = %self.get_connection_id(),
+                        path = %path,
+                        err = %e,
+                        "Failed to attach sender on path."
+                    );
+                    return Err(e);
+                }
+                info!(
+                    connection_id = %self.get_connection_id(),
+                    path = %path,
+                    "Attached sender on path."
+                );
                 Ok::<_, AmqpError>(Arc::new(sender))
             })
             .await?;
@@ -644,40 +741,69 @@ impl RecoverableConnection {
         or_init_cell(&self.sender_instances, path).await
     }
 
+    #[instrument(
+        level = "debug",
+        skip_all,
+        fields(reason = ?reason),
+        err,
+    )]
     pub(super) async fn recover_from_error(
         connection: Weak<RecoverableConnection>,
         reason: ErrorRecoveryAction,
     ) -> azure_core_amqp::error::Result<()> {
         let Some(connection) = connection.upgrade() else {
             warn!(
-                "Connection is None, cannot recover from error: {:?}",
-                reason
+                reason = ?reason,
+                "Connection is None, cannot recover from error."
             );
             return Err(AmqpError::with_message("Missing Connection"));
         };
 
-        warn!(err=?reason, "Recovering from error: {:?}", reason);
+        let connection_id = connection.get_connection_id();
+
+        // Log the error and attempt to recover.
+        warn!(
+            connection_id = %connection_id,
+            reason = ?reason,
+            "Recovering from error."
+        );
 
         let Some(plan) = RecoveryPlan::for_action(&reason) else {
-            warn!("Recover action {reason:?} should already have been handled.");
+            warn!(
+                connection_id = %connection_id,
+                reason = ?reason,
+                "Recover action should already have been handled."
+            );
             return Err(AmqpError::with_message(format!(
                 "Unknown error recovery action: {reason:?}"
             )));
         };
 
-        debug!("Applying recovery plan {plan:?} for {reason:?}");
+        debug!(
+            connection_id = %connection_id,
+            reason = ?reason,
+            "Applying recovery plan {plan:?}."
+        );
         connection.apply_recovery_plan(plan).await;
+        info!(
+            connection_id = %connection_id,
+            reason = ?reason,
+            "Recovery complete."
+        );
         Ok(())
     }
 
     /// Side-effecting half of `recover_from_error`: takes the locks and clears
     /// whichever caches the [`RecoveryPlan`] flagged.
     async fn apply_recovery_plan(&self, plan: RecoveryPlan) {
+        let connection_id = self.get_connection_id();
         if plan.drop_connection {
             self.connections.lock().await.take();
+            debug!(connection_id = %connection_id, "Recovery: dropped AMQP connection.");
         }
         if plan.clear_authorizer {
             self.authorizer.clear().await;
+            debug!(connection_id = %connection_id, "Recovery: cleared authorizer tokens.");
         }
         // Clearing a cache drops its per-path `OnceCell` entries, so the next
         // `ensure_*` for a path re-inits a fresh cell against the new connection.
@@ -687,16 +813,26 @@ impl RecoverableConnection {
         // Closing that window (invalidating in-flight work immediately via a
         // recovery generation counter) is tracked in #4454.
         if plan.clear_sessions {
-            self.session_instances.write().await.clear();
+            let mut sessions = self.session_instances.write().await;
+            let count = sessions.len();
+            sessions.clear();
+            debug!(connection_id = %connection_id, count, "Recovery: cleared cached sessions.");
         }
         if plan.clear_senders {
-            self.sender_instances.write().await.clear();
+            let mut senders = self.sender_instances.write().await;
+            let count = senders.len();
+            senders.clear();
+            debug!(connection_id = %connection_id, count, "Recovery: cleared cached senders.");
         }
         if plan.clear_receivers {
-            self.receiver_instances.write().await.clear();
+            let mut receivers = self.receiver_instances.write().await;
+            let count = receivers.len();
+            receivers.clear();
+            debug!(connection_id = %connection_id, count, "Recovery: cleared cached receivers.");
         }
         if plan.drop_mgmt_client {
             self.mgmt_client.lock().await.take();
+            debug!(connection_id = %connection_id, "Recovery: dropped management client.");
         }
     }
 
@@ -734,11 +870,14 @@ impl RecoverableConnection {
             | AmqpErrorKind::ConnectionDropped(_)
             | AmqpErrorKind::FramingError(_)
             | AmqpErrorKind::IdleTimeoutElapsed(_) => {
-                debug!("Connection dropped error: {}", amqp_error);
+                debug!(err = %amqp_error, "Connection dropped error, will reconnect connection.");
                 ErrorRecoveryAction::ReconnectConnection
             }
             AmqpErrorKind::SessionClosedByRemote(_) | AmqpErrorKind::SessionDetachedByRemote(_) => {
-                debug!("Session dropped error: {}", amqp_error);
+                debug!(
+                    "Session dropped error, will reconnect session: {}",
+                    amqp_error
+                );
                 ErrorRecoveryAction::ReconnectSession
             }
             AmqpErrorKind::LinkClosedByRemote(_)
@@ -749,12 +888,15 @@ impl RecoverableConnection {
                 // TransferLimitExceeded means more transfers were sent than the
                 // link's credit allowed. Reattaching resets link credit; a full
                 // session/connection reconnect is unnecessary.
-                debug!("Link state error: {}", amqp_error);
+                debug!(err = %amqp_error, "Link state error, will reconnect link.");
                 ErrorRecoveryAction::ReconnectLink
             }
             AmqpErrorKind::SendRejected => ErrorRecoveryAction::ReturnError,
             AmqpErrorKind::AmqpDescribedError(described_error) => {
-                debug!("AMQP described error: {:?}", described_error);
+                debug!(
+                    condition = ?described_error.condition,
+                    "AMQP described error."
+                );
                 if matches!(
                     described_error.condition,
                     AmqpErrorCondition::ResourceLimitExceeded
@@ -765,7 +907,11 @@ impl RecoverableConnection {
                         | AmqpErrorCondition::InternalError
                         | AmqpErrorCondition::OperationCancelled
                 ) {
-                    debug!("AMQP described error can be retried: {:?}", described_error);
+                    debug!(
+                        condition = ?described_error.condition,
+                        "AMQP described error can be retried: {:?}",
+                        described_error
+                    );
                     ErrorRecoveryAction::RetryAction
                 } else if matches!(
                     described_error.condition,
@@ -773,8 +919,8 @@ impl RecoverableConnection {
                         | AmqpErrorCondition::ConnectionFramingError
                 ) {
                     debug!(
-                        "AMQP described error requires reconnect: {:?}",
-                        described_error
+                        condition = ?described_error.condition,
+                        "AMQP described error requires reconnect."
                     );
                     ErrorRecoveryAction::ReconnectConnection
                 } else if matches!(
@@ -789,9 +935,11 @@ impl RecoverableConnection {
                     // pre-expiry renewal), not something to recover by reconnecting on a 401.
                     // Routing this to ReconnectConnection would turn a fast failure into N
                     // full reconnect + re-auth cycles before the error finally surfaces.
-                    debug!(
-                        "AMQP described error is an auth failure; not retrying: {:?}",
-                        described_error
+                    // Authorization failures are terminal fast-fails the caller cannot
+                    // recover from; surface them at warn! with the condition.
+                    warn!(
+                        condition = ?described_error.condition,
+                        "AMQP unauthorized-access error, will not retry."
                     );
                     ErrorRecoveryAction::ReturnError
                 } else if matches!(
@@ -802,12 +950,13 @@ impl RecoverableConnection {
                     // failing. Reattach. (LinkStolen was previously classified as a retry,
                     // which guaranteed N spins through the backoff before bailing.)
                     debug!(
-                        "AMQP described error requires link reattach: {:?}",
-                        described_error
+                        condition = ?described_error.condition,
+                        "AMQP described error requires link reattach."
                     );
                     ErrorRecoveryAction::ReconnectLink
                 } else {
                     debug!(
+                        condition = ?described_error.condition,
                         "AMQP described error cannot be retried: {:?}",
                         described_error
                     );

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/management.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/management.rs
@@ -12,7 +12,7 @@ use azure_core_amqp::{
     AmqpSessionApis, AmqpSimpleValue, AmqpValue,
 };
 use std::sync::{Arc, Weak};
-use tracing::trace;
+use tracing::{debug, instrument, trace};
 
 pub(crate) struct RecoverableManagementClient {
     recoverable_connection: Weak<RecoverableConnection>,
@@ -33,13 +33,19 @@ impl RecoverableManagementClient {
         RecoverableConnection::should_retry_amqp_error(e)
     }
 
+    #[instrument(
+        level = "debug",
+        skip_all,
+        fields(connection_id = %connection.get_connection_id()),
+        err,
+    )]
     pub(super) async fn create_management_client(
         connection: Arc<RecoverableConnection>,
         retry_options: &RetryOptions,
     ) -> Result<Arc<AmqpManagement>> {
         // Clients must call ensure_connection before calling ensure_management_client.
 
-        trace!("Create management session.");
+        debug!("Creating management session.");
         recover_azure_operation(
             || async {
                 let amqp_connection = connection.ensure_connection().await.map_err(|e| {
@@ -52,7 +58,7 @@ impl RecoverableManagementClient {
 
                 let session = AmqpSession::new();
                 session.begin(amqp_connection.as_ref(), None).await?;
-                trace!("Session created.");
+                debug!("Management session created.");
 
                 let management_path = connection.url.to_string() + "/$management";
                 let management_path =
@@ -65,11 +71,11 @@ impl RecoverableManagementClient {
                         AmqpError::from(azure_core::Error::with_error(
                             AzureErrorKind::Other,
                             e,
-                            "Error ensuring connection",
+                            "Error authorizing management path",
                         ))
                     })?;
 
-                trace!("Create management client.");
+                debug!("Creating management client.");
                 let management = Arc::new(AmqpManagement::new(
                     session,
                     "eventhubs_management".to_string(),

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/receiver.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/receiver.rs
@@ -10,7 +10,7 @@ use azure_core_amqp::{
 };
 use futures::{select, FutureExt};
 use std::sync::Weak;
-use tracing::debug;
+use tracing::{debug, instrument, trace};
 
 pub(crate) struct RecoverableReceiver {
     recoverable_connection: Weak<RecoverableConnection>,
@@ -71,6 +71,9 @@ impl AmqpReceiverApis for RecoverableReceiver {
         unimplemented!("AmqpReceiverClient does not support credit_mode operation");
     }
 
+    // Hot per-event path: trace level and no `err` attribute to avoid per-delivery
+    // error spam; carry only the partition source URL for correlation.
+    #[instrument(level = "trace", skip_all, fields(source_url = %self.source_url))]
     async fn receive_delivery(&self) -> Result<azure_core_amqp::AmqpDelivery> {
         let retry_options = {
             self.recoverable_connection
@@ -81,7 +84,7 @@ impl AmqpReceiverApis for RecoverableReceiver {
         };
         let delivery = recover_azure_operation(
             || async move {
-                debug!("Starting receive_delivery operation");
+                trace!(source_url = %self.source_url, "Starting receive_delivery operation.");
                 let receiver = {
                     let connection = self
                         .recoverable_connection

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/sender.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/sender.rs
@@ -11,7 +11,7 @@ use azure_core_amqp::{
     AmqpSenderApis, AmqpSenderOptions, AmqpSession, AmqpTarget,
 };
 use std::sync::{Arc, Weak};
-use tracing::warn;
+use tracing::{instrument, warn};
 
 /// Thin wrapper around the [`AmqpSenderApis`] trait that implements the retry functionality.
 ///
@@ -44,6 +44,9 @@ impl RecoverableSender {
 
 #[async_trait::async_trait]
 impl AmqpSenderApis for RecoverableSender {
+    // Hot per-message path: trace level, skip the message body (never log payloads),
+    // and no `err` attribute to avoid per-message error spam.
+    #[instrument(level = "trace", skip_all, fields(path = %self.path))]
     async fn send<M>(&self, message: M, options: Option<AmqpSendOptions>) -> Result<AmqpSendOutcome>
     where
         M: Into<AmqpMessage> + std::fmt::Debug + Send,
@@ -81,12 +84,21 @@ impl AmqpSenderApis for RecoverableSender {
                             // If the error is described, return it as an AmqpDescribedError to let the retry logic
                             // handle it appropriately.
                             if let Some(described) = error {
-                                warn!("Send rejected: {:?}", described);
+                                warn!(
+                                    path = %path,
+                                    condition = ?described.condition,
+                                    "Send rejected by remote: {:?}",
+                                    described
+                                );
                                 Err(AmqpError::from(AmqpErrorKind::AmqpDescribedError(
                                     described,
                                 )))
                             } else {
                                 // The server rejected the error but didn't provide a specific error.
+                                warn!(
+                                    path = %path,
+                                    "Send rejected by remote with no described error."
+                                );
                                 Err(AmqpError::from(AmqpErrorKind::SendRejected))
                             }
                         }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/sender.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/sender.rs
@@ -87,8 +87,7 @@ impl AmqpSenderApis for RecoverableSender {
                                 warn!(
                                     path = %path,
                                     condition = ?described.condition,
-                                    "Send rejected by remote: {:?}",
-                                    described
+                                    "Send rejected by remote."
                                 );
                                 Err(AmqpError::from(AmqpErrorKind::AmqpDescribedError(
                                     described,

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/retry.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/retry.rs
@@ -6,7 +6,7 @@
 use azure_core::{sleep, time::Duration};
 use rand::random;
 use std::{fmt::Debug, pin::Pin};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// Type alias for recovery operation function to reduce complexity
 pub(crate) type RecoveryOperation<C, E> = fn(
@@ -104,14 +104,20 @@ where
             }
             Err(err) => {
                 let time_since_start = start_time.elapsed();
-                info!("Operation failed with error: {}, checking for retry.", err);
+                debug!(
+                    err = %err,
+                    current_retry,
+                    "Operation failed, checking for retry."
+                );
                 // Check if we've exhausted our retries
                 if current_retry >= options.max_retries
                     || time_since_start >= options.max_total_elapsed
                 {
                     warn!(
-                        "Maximum retries ({}) reached or time elapsed ({:?}), returning error: {:?}",
-                        options.max_retries, time_since_start, err
+                        err = ?err,
+                        max_retries = options.max_retries,
+                        elapsed = ?time_since_start,
+                        "Maximum retries reached or time elapsed, returning error."
                     );
                     return Err(err);
                 }
@@ -131,12 +137,12 @@ where
                         );
                         let sleep_duration = Duration::milliseconds(sleep_ms as i64);
 
-                        info!(
-                            "Operation failed with error: {:?}. Retrying after {:?} (retry {}/{})",
-                            err,
-                            sleep_duration,
-                            current_retry + 1,
-                            options.max_retries
+                        debug!(
+                            err = ?err,
+                            backoff = ?sleep_duration,
+                            retry = current_retry + 1,
+                            max_retries = options.max_retries,
+                            "Operation failed, retrying after backoff."
                         );
 
                         // Wait for the backoff duration
@@ -148,17 +154,36 @@ where
                         // Continue to retry
                     }
                     ErrorRecoveryAction::ReturnError => {
-                        warn!("Error is not retryable, returning: {:?}", err);
+                        warn!(err = ?err, "Error is not retryable, returning.");
                         return Err(err);
                     }
                     _ => {
-                        warn!("Error requires special handling: {:?}", err);
-                        // Handle special error cases (e.g., reconnecting). If no recovery action is provided,
-                        // return the error.
+                        warn!(
+                            error_category = ?error_category,
+                            err = ?err,
+                            "Error requires recovery, attempting recovery action."
+                        );
+                        // Handle recoverable error cases (reconnecting connection, session, or
+                        // link). If no recovery action is provided, return the error.
                         if let (Some(recover_operation), Some(context)) =
                             (recover_operation, context.clone())
                         {
-                            recover_operation(context, error_category).await?;
+                            match recover_operation(context, error_category.clone()).await {
+                                Ok(()) => {
+                                    info!(
+                                        error_category = ?error_category,
+                                        "Recovery action succeeded."
+                                    );
+                                }
+                                Err(recovery_err) => {
+                                    warn!(
+                                        error_category = ?error_category,
+                                        err = ?recovery_err,
+                                        "Recovery action failed."
+                                    );
+                                    return Err(recovery_err);
+                                }
+                            }
                         } else {
                             return Err(err);
                         }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/event_receiver.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/event_receiver.rs
@@ -17,16 +17,45 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
-use tracing::trace;
+use tracing::{debug, trace, warn, Instrument};
 
 /// Maps `amqp:link:stolen` (broker-initiated epoch displacement) on the
 /// receive path to the typed `ConsumerDisconnected` variant. Other errors
 /// pass through unchanged.
-fn translate_receive_error(error: AmqpError) -> EventHubsError {
+///
+/// `partition_id` and `source_url` are accepted purely for diagnostics so the
+/// silent failure path (link-stolen displacement and other receive errors) is
+/// logged with the partition/link context before the error propagates.
+fn translate_receive_error(
+    error: AmqpError,
+    partition_id: &str,
+    source_url: &Url,
+) -> EventHubsError {
     if let AmqpErrorKind::AmqpDescribedError(described) = error.kind() {
         if matches!(described.condition, AmqpErrorCondition::LinkStolen) {
+            // Broker displaced this consumer (a higher epoch/owner attached).
+            // Recoverable on the processor path, so warn rather than error.
+            warn!(
+                partition_id = %partition_id,
+                source_url = %source_url,
+                condition = ?described.condition,
+                "Receiver link stolen by the broker (epoch displacement); mapping to ConsumerDisconnected."
+            );
             return EventHubsError::from(ErrorKind::ConsumerDisconnected(Some(described.clone())));
         }
+        warn!(
+            partition_id = %partition_id,
+            source_url = %source_url,
+            condition = ?described.condition,
+            "Receive delivery failed with an AMQP error condition."
+        );
+    } else {
+        warn!(
+            partition_id = %partition_id,
+            source_url = %source_url,
+            err = ?error,
+            "Receive delivery failed."
+        );
     }
     EventHubsError::from(error)
 }
@@ -143,26 +172,57 @@ impl EventReceiver {
     /// ```
     ///
     pub fn stream_events(&self) -> impl Stream<Item = Result<ReceivedEventData>> + '_ {
+        // Attach a span to the returned stream rather than using
+        // `#[tracing::instrument]` on this sync fn: the attribute would only span
+        // the stream's *construction* (which returns immediately), leaving the
+        // receive loop's awaits and events with no parent span. Instrumenting each
+        // awaited future with this span keeps per-partition correlation for the loop.
+        let span = tracing::debug_span!(
+            "stream_events",
+            connection_id = %self.connection.get_connection_id(),
+            partition_id = %self.partition_id,
+            source_url = %self.source_url,
+        );
         Box::pin(try_stream! {
             loop {
                 // Stop here if `request_close` has been called; otherwise
                 // `get_receiver` below would reattach a new link.
                 if self.closed.load(Ordering::Acquire) {
+                    span.in_scope(|| debug!(
+                        partition_id = %self.partition_id,
+                        source_url = %self.source_url,
+                        "Event stream terminating: receiver was closed by request_close()."
+                    ));
                     Err(EventHubsError::from(ErrorKind::ConsumerDisconnected(None)))?;
                 }
 
+                // Instrument each awaited operation with the stream's span so the
+                // receive loop is parented under it on every poll (see the span
+                // construction above for why this is not a fn-level attribute).
                 let receiver = self.connection.get_receiver(&self.source_url,
                     self.message_source.clone(),
                     self.receiver_options.clone(),
                     self.timeout
-                ).await?;
+                ).instrument(span.clone()).await?;
 
-                let delivery = receiver.receive_delivery().await.map_err(translate_receive_error)?;
+                let delivery = receiver
+                    .receive_delivery()
+                    .instrument(span.clone())
+                    .await
+                    .map_err(|e| translate_receive_error(e, &self.partition_id, &self.source_url))?;
 
                 // Now that we have a delivery, we can process it.
                 let message = delivery.into_message();
                 let message = ReceivedEventData::from(message);
-                trace!("Received message: {:?}", message);
+                // SENSITIVE-DATA: `{:?}` on a ReceivedEventData dumps the
+                // raw AMQP message, including the customer payload body and any PII in
+                // application properties. This is redacted by the SafeDebug derive ONLY
+                // when the azure_core / typespec `debug` cargo feature is OFF (the
+                // default). If a downstream build enables that feature, this trace will
+                // emit full message bodies. Keep this at trace! and prefer logging only
+                // sequence_number / offset / partition_id at higher levels. See the
+                // matching note on EventData/ReceivedEventData in models/event_data.rs.
+                span.in_scope(|| trace!("Received message: {:?}", message));
                 yield message;
             }
         })

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -25,7 +25,7 @@ use std::{
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
-use tracing::{debug, trace};
+use tracing::{info, trace};
 
 /// A client that can be used to receive events from an Event Hub.
 pub struct ConsumerClient {
@@ -235,6 +235,17 @@ impl ConsumerClient {
     ///     Ok(())
     /// }
     /// ```
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            connection_id = %self.recoverable_connection.get_connection_id(),
+            partition_id = %partition_id,
+            consumer_group = %self.consumer_group,
+            eventhub = %self.eventhub,
+        ),
+        err,
+    )]
     pub async fn open_receiver_on_partition(
         &self,
         partition_id: String,
@@ -249,8 +260,9 @@ impl ConsumerClient {
         let start_expression = StartPosition::start_expression(&options.start_position);
 
         trace!(
-            "Opening receiver on url {} partition {partition_id}.",
-            self.endpoint
+            partition_id = %partition_id,
+            source_url = %self.endpoint,
+            "Opening receiver on partition."
         );
 
         let source_url = format!("{}/Partitions/{}", self.endpoint, partition_id);
@@ -284,7 +296,13 @@ impl ConsumerClient {
             ..Default::default()
         };
 
-        debug!("Receiver attached on partition {partition_id}.");
+        info!(
+            partition_id = %partition_id,
+            consumer_group = %self.consumer_group,
+            eventhub = %self.eventhub,
+            source_url = %source_url,
+            "Receiver attached on partition."
+        );
         Ok(EventReceiver::new(
             self.recoverable_connection.clone(),
             receiver_options,

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -25,7 +25,7 @@ use std::{
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
-use tracing::{info, trace};
+use tracing::{info, trace, warn};
 
 /// A client that can be used to receive events from an Event Hub.
 pub struct ConsumerClient {
@@ -146,16 +146,27 @@ impl ConsumerClient {
     /// }
     /// ```
     pub async fn close(self) -> Result<()> {
-        trace!("Closing consumer client for {}.", self.endpoint);
+        let connection_id = self.recoverable_connection.get_connection_id().to_string();
+        trace!(
+            connection_id = %connection_id,
+            source_url = %self.endpoint,
+            "Closing consumer client."
+        );
         let recoverable_connection =
             Arc::try_unwrap(self.recoverable_connection).map_err(|_| {
+                warn!(
+                    connection_id = %connection_id,
+                    source_url = %self.endpoint,
+                    "Could not close consumer recoverable connection, multiple references exist."
+                );
                 EventHubsError::with_message(
                     "Could not close consumer recoverable connection, multiple references exist",
                 )
             })?;
         trace!(
-            "No references to connection, closing connection for {}.",
-            self.endpoint
+            connection_id = %connection_id,
+            source_url = %self.endpoint,
+            "No references to connection, closing connection."
         );
         recoverable_connection.close_connection().await?;
         Ok(())

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/load_balancer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/load_balancer.rs
@@ -1005,10 +1005,10 @@ pub(crate) mod tests {
                     .load_balance(&all_partition_ids)
                     .await?;
 
-                info!("Too Few ownerships: {:?}", ownerships);
+                trace!("Too Few ownerships: {:?}", ownerships);
                 let mut owned_partitions = map_to_strings(&ownerships, |o| o.partition_id.clone());
                 owned_partitions.sort();
-                info!(
+                trace!(
                     "Claimed ownership of partitions: {}",
                     owned_partitions.join(", ")
                 );
@@ -1043,13 +1043,13 @@ pub(crate) mod tests {
                 ])
                 .await?;
 
-            info!(
+            trace!(
                 "Expiring ownership for partition {}",
                 middle_ownership.partition_id
             );
             relinquish_ownership(checkpoint_store.clone(), &middle_ownership).await?;
 
-            info!("Load balancing with strategy: {:?}", strategy);
+            trace!("Load balancing with strategy: {:?}", strategy);
             let load_balancer = LoadBalancer::new(
                 checkpoint_store.clone(),
                 new_test_consumer_client_details(CLIENT_B),
@@ -1070,12 +1070,12 @@ pub(crate) mod tests {
 
     #[recorded::test]
     async fn unit_test_load_balancer_balanced(_ctx: TestContext) -> Result<()> {
-        info!("Unit test for load balancer");
+        trace!("Unit test for load balancer");
 
         //cspell: ignore abbc abbcc aaaabbb
         for state in ["abc", "abbc", "abbcc"] {
             for owner in ["a", "b", "c"] {
-                info!("Layout {state} with owner {owner}");
+                trace!("Layout {state} with owner {owner}");
 
                 let (lb, parts) = create_load_balancer_for_unit_tests(state, owner).await?;
                 let load_balancer_info = lb
@@ -1089,7 +1089,7 @@ pub(crate) mod tests {
             }
         }
 
-        info!("Balanced with unequal ownership");
+        trace!("Balanced with unequal ownership");
         let (lb, parts) = create_load_balancer_for_unit_tests("aaaabbb", "a").await?;
         let load_balancer_info = lb
             .get_available_partitions(&parts.iter().map(String::as_str).collect::<Vec<&str>>())
@@ -1117,12 +1117,12 @@ pub(crate) mod tests {
 
     #[recorded::test]
     async fn unit_test_load_balancer_unbalanced(_ctx: TestContext) -> Result<()> {
-        info!("Unit test for load balancer (unbalanced)");
+        trace!("Unit test for load balancer (unbalanced)");
 
         //cspell: ignore aaaabb aaabbbcccd aaabbbccde aaaabbc
 
         {
-            info!("A new owner enters the field.");
+            trace!("A new owner enters the field.");
             let (load_balancer, partitions) =
                 create_load_balancer_for_unit_tests("abb", "c").await?;
             let load_balancer_info = load_balancer
@@ -1138,7 +1138,7 @@ pub(crate) mod tests {
         }
 
         {
-            info!("deficit, single partition");
+            trace!("deficit, single partition");
             // Existing owner needs to steal a partition.
             let (load_balancer, partitions) =
                 create_load_balancer_for_unit_tests("aaaabb", "b").await?;
@@ -1154,7 +1154,7 @@ pub(crate) mod tests {
             assert_eq!("..b.bb", load_balance_result);
         }
         {
-            info!("deficit, multiple partitions");
+            trace!("deficit, multiple partitions");
             let (load_balancer, partitions) =
                 create_load_balancer_for_unit_tests("aaabbbcccd", "d").await?;
             let load_balancer_info = load_balancer
@@ -1170,7 +1170,7 @@ pub(crate) mod tests {
         }
 
         {
-            info!("deficit, multiple owners");
+            trace!("deficit, multiple owners");
             let (load_balancer, partitions) =
                 create_load_balancer_for_unit_tests("aaabbbccde", "d").await?;
             let load_balancer_info = load_balancer
@@ -1186,7 +1186,7 @@ pub(crate) mod tests {
         }
 
         {
-            info!("can grab an extra partition");
+            trace!("can grab an extra partition");
             let (load_balancer, partitions) =
                 create_load_balancer_for_unit_tests("aaaabbc", "b").await?;
             let load_balancer_info = load_balancer
@@ -1232,7 +1232,7 @@ pub(crate) mod tests {
 
         let owned_as_string = ownerships_as_string(&ownerships, partition_count);
 
-        info!("Claimed ownership of partitions: {}", owned_as_string);
+        trace!("Claimed ownership of partitions: {}", owned_as_string);
 
         Ok(owned_as_string)
     }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/load_balancer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/load_balancer.rs
@@ -16,7 +16,7 @@ use std::{
     sync::{Arc, Mutex, MutexGuard},
     time::SystemTime,
 };
-use tracing::{debug, trace};
+use tracing::{debug, info, trace};
 
 /// LoadBalancerInfo contains information about the current ownership of partitions
 /// and the partitions that are unowned or expired.
@@ -283,9 +283,11 @@ impl LoadBalancer {
         ours.append(&mut random_ownerships);
 
         if ours.len() < load_balancer_info.max_allowed {
-            debug!("Not enough expired or unowned partitions, will need to steal from other processors. Stealing up to {} partitions.",
-                load_balancer_info.max_allowed - ours.len());
-            debug!("Stealing from {:?}", load_balancer_info.above_max);
+            info!(
+                count = load_balancer_info.max_allowed - ours.len(),
+                "Not enough expired or unowned partitions, will need to steal from other processors."
+            );
+            debug!(above_max = ?load_balancer_info.above_max, "Stealing from above-max owners.");
             random_ownerships = self.get_random_ownerships(
                 &load_balancer_info.above_max,
                 load_balancer_info.max_allowed - ours.len(),
@@ -326,8 +328,19 @@ impl LoadBalancer {
     ///
     /// # Errors
     /// Returns an error if the load balancing process fails.
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            eventhub = %self.consumer_client_details.eventhub_name,
+            consumer_group = %self.consumer_client_details.consumer_group,
+            fully_qualified_namespace = %self.consumer_client_details.fully_qualified_namespace,
+            owner_id = %self.consumer_client_details.client_id,
+        ),
+        err,
+    )]
     pub async fn load_balance(&self, partition_ids: &[&str]) -> Result<Vec<Ownership>> {
-        debug!("Load balance for partitions: {}", partition_ids.join(", "));
+        debug!(partitions = %partition_ids.join(", "), "Load balance for partitions.");
         let load_balancer_info = self.get_available_partitions(partition_ids).await?;
         trace!(
             "[{}] Load balancer info: {:?}",
@@ -346,9 +359,10 @@ impl LoadBalancer {
                     );
                     let ownership = self.balanced_load_balancer(&load_balancer_info)?;
                     if let Some(ownership) = ownership {
-                        debug!(
-                            "[{}] Claiming ownership of partition: {}",
-                            self.consumer_client_details.client_id, ownership.partition_id
+                        info!(
+                            owner_id = %self.consumer_client_details.client_id,
+                            partition_id = %ownership.partition_id,
+                            "Claiming ownership of partition."
                         );
                         ownerships.push(ownership);
                     }
@@ -359,11 +373,11 @@ impl LoadBalancer {
                         self.consumer_client_details.client_id
                     );
                     ownerships = self.greedy_load_balancer(&load_balancer_info)?;
-                    debug!(
-                        "[{}] Claiming ownership of {} partitions: {}",
-                        self.consumer_client_details.client_id,
-                        ownerships.len(),
-                        Self::partitions_for_ownership(&ownerships)
+                    info!(
+                        owner_id = %self.consumer_client_details.client_id,
+                        count = ownerships.len(),
+                        partitions = %Self::partitions_for_ownership(&ownerships),
+                        "Claiming ownership of partitions."
                     );
                 }
             }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/partition_client.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/partition_client.rs
@@ -68,8 +68,9 @@ impl PartitionClient {
         if let Some(receiver) = self.event_receiver.get() {
             if let Err(e) = receiver.request_close().await {
                 warn!(
-                    "Failed to close event receiver during revocation for partition {}: {:?}",
-                    self.partition_id, e
+                    partition_id = %self.partition_id,
+                    err = ?e,
+                    "Failed to close event receiver during revocation for partition."
                 );
             }
         }
@@ -87,8 +88,16 @@ impl PartitionClient {
             Box::pin(event_receiver.stream_events())
                 as Pin<Box<dyn Stream<Item = Result<ReceivedEventData>> + '_>>
         } else {
+            warn!(
+                partition_id = %self.partition_id,
+                "stream_events called but event receiver is not set for this partition; \
+                 returning an error stream."
+            );
             Box::pin(futures::stream::once(std::future::ready(Err(
-                EventHubsError::with_message("Event receiver is not set for this partition."),
+                EventHubsError::with_message(format!(
+                    "Event receiver is not set for partition {}.",
+                    self.partition_id
+                )),
             ))))
         }
     }
@@ -116,17 +125,17 @@ impl PartitionClient {
     pub async fn close(mut self) -> Result<()> {
         // Detach the event receiver
         if let Some(event_receiver) = self.event_receiver.take() {
-            debug!("Closing event receiver for partition {}", self.partition_id);
+            debug!(partition_id = %self.partition_id, "Closing event receiver for partition.");
             event_receiver.close().await?;
         } else {
-            debug!("Event receiver not set for partition {}", self.partition_id);
+            debug!(partition_id = %self.partition_id, "Event receiver not set for partition.");
         }
         // Remove the partition client from the processor.
         let consumers = self.consumers.upgrade();
         if let Some(consumers) = consumers {
             debug!(
-                "Removing client for partition {} from the consumers map.",
-                self.partition_id
+                partition_id = %self.partition_id,
+                "Removing client for partition from the consumers map."
             );
             consumers.remove_partition_client(&self.partition_id)?;
         }
@@ -170,6 +179,12 @@ impl PartitionClient {
             }
         }
 
+        debug!(
+            partition_id = %self.partition_id,
+            sequence_number = ?sequence_number_option,
+            offset = ?offset_option,
+            "Updating checkpoint for partition."
+        );
         let checkpoint = Checkpoint {
             fully_qualified_namespace: self.client_details.fully_qualified_namespace.clone(),
             event_hub_name: self.client_details.eventhub_name.clone(),
@@ -194,8 +209,8 @@ impl PartitionClient {
         // Set the event receiver
         self.event_receiver.set(event_receiver).map_err(|_| {
             warn!(
-                "Event receiver already set for partition {}",
-                self.partition_id
+                partition_id = %self.partition_id,
+                "Event receiver already set for partition."
             );
             // If the event receiver is already set, return an error
             EventHubsError::with_message(format!(
@@ -210,8 +225,8 @@ impl PartitionClient {
 impl Drop for PartitionClient {
     fn drop(&mut self) {
         trace!(
-            "Dropping PartitionClient for partition {}",
-            self.partition_id
+            partition_id = %self.partition_id,
+            "Dropping PartitionClient for partition."
         );
     }
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/processor.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/processor.rs
@@ -109,31 +109,31 @@ impl ProcessorConsumersMap {
         partition_id: &str,
         partition_client: Arc<PartitionClient>,
     ) -> Result<bool> {
-        info!("Adding partition client for partition: {}", partition_id);
+        debug!(partition_id = %partition_id, "Adding partition client for partition.");
         let mut consumers = self
             .consumers
             .lock()
             .map_err(|_| EventHubsError::with_message("Could not lock consumers mutex."))?;
         if consumers.contains_key(partition_id) {
-            info!(
-                "Partition client already exists for partition: {}",
-                partition_id
+            debug!(
+                partition_id = %partition_id,
+                "Partition client already exists for partition."
             );
             return Ok(false);
         }
         consumers.insert(partition_id.to_string(), Arc::downgrade(&partition_client));
-        info!("Consumers for partition: {:?}", consumers.keys());
+        debug!(partitions = ?consumers.keys(), "Consumers for partition.");
         Ok(true)
     }
 
     pub fn remove_partition_client(&self, partition_id: &str) -> Result<()> {
-        info!("Removing partition client for partition: {}", partition_id);
+        debug!(partition_id = %partition_id, "Removing partition client for partition.");
         let mut consumers = self
             .consumers
             .lock()
             .map_err(|_| EventHubsError::with_message("Could not lock consumers mutex."))?;
         consumers.remove(partition_id);
-        info!("Consumers for partition now: {:?}", consumers.keys());
+        debug!(partitions = ?consumers.keys(), "Consumers for partition now.");
         Ok(())
     }
 
@@ -284,7 +284,7 @@ impl EventProcessor {
                     debug!("Event processor dispatched successfully.");
                 }
                 Err(e) => {
-                    info!("Error dispatching event processor: {:?}", e);
+                    error!(err = ?e, "Error dispatching event processor.");
                     return Err(e);
                 }
             }
@@ -323,6 +323,17 @@ impl EventProcessor {
         }
     }
 
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            eventhub = %self.client_details.eventhub_name,
+            consumer_group = %self.client_details.consumer_group,
+            fully_qualified_namespace = %self.client_details.fully_qualified_namespace,
+            owner_id = %self.client_details.client_id,
+        ),
+        err,
+    )]
     async fn dispatch(
         &self,
         partition_ids: &[&str],
@@ -333,7 +344,7 @@ impl EventProcessor {
 
         let ownerships = load_balancer.load_balance(partition_ids).await;
         let ownerships = ownerships.map_err(|e| {
-            error!("Error in load balancing: {:?}", e);
+            error!(err = ?e, "Error in load balancing.");
             e
         })?;
 
@@ -347,15 +358,15 @@ impl EventProcessor {
             .collect();
         if !stolen.is_empty() {
             info!(
-                "Partitions no longer owned, revoking: {}",
-                stolen.join(", ")
+                partitions = %stolen.join(", "),
+                "Partitions no longer owned, revoking."
             );
             consumers.revoke_partition_clients(&stolen).await?;
         }
 
         let checkpoints = self.get_checkpoint_map().await;
         let checkpoints = checkpoints.map_err(|e| {
-            error!("Error in getting checkpoint map: {:?}", e);
+            error!(err = ?e, "Error in getting checkpoint map.");
             e
         })?;
 
@@ -372,7 +383,7 @@ impl EventProcessor {
                 )
                 .await;
             if let Err(e) = err {
-                error!("Error adding partition client: {:?}", e);
+                error!(err = ?e, "Error adding partition client.");
                 return Err(e);
             }
         }
@@ -380,13 +391,19 @@ impl EventProcessor {
         Ok(())
     }
 
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(partition_id = %partition_id),
+        err,
+    )]
     async fn add_partition_client(
         &self,
         partition_id: String,
         checkpoints: &HashMap<String, Checkpoint>,
         consumers: Weak<ProcessorConsumersMap>,
     ) -> Result<()> {
-        info!("Add partition client for partition ID: {:?}", partition_id);
+        debug!(partition_id = %partition_id, "Add partition client for partition.");
 
         let partition_client = Arc::new(PartitionClient::new(
             partition_id.clone(),
@@ -401,8 +418,8 @@ impl EventProcessor {
                 .await?
             {
                 debug!(
-                    "Partition client already exists for partition: {}, ignoring.",
-                    partition_id
+                    partition_id = %partition_id,
+                    "Partition client already exists for partition, ignoring."
                 );
                 return Ok(());
             }
@@ -416,8 +433,9 @@ impl EventProcessor {
         // Since we can only have a single EventReceiver on a partition, we don't actually attempt to create the receiver until
         let start_position = self.get_start_position(&partition_id, checkpoints);
         debug!(
-            "Start position for partition {}: {:?}",
-            partition_id, start_position
+            partition_id = %partition_id,
+            start_position = ?start_position,
+            "Start position for partition."
         );
         let receiver = self
             .consumer_client
@@ -437,18 +455,23 @@ impl EventProcessor {
         let receiver = match receiver {
             Ok(r) => r,
             Err(e) => {
-                error!("Error opening receiver for partition client: {:?}", e);
+                error!(
+                    partition_id = %partition_id,
+                    err = ?e,
+                    "Error opening receiver for partition client."
+                );
                 if let Some(strong_consumers) = consumers.upgrade() {
                     let _ = strong_consumers.remove_partition_client(&partition_id);
                 }
                 return Err(e);
             }
         };
-        info!("Receiver opened for partition client: {:?}", &partition_id);
+        info!(partition_id = %partition_id, "Receiver opened for partition client.");
         if let Err(e) = partition_client.set_event_receiver(receiver) {
             error!(
-                "Error setting event receiver for partition {}: {:?}",
-                partition_id, e
+                partition_id = %partition_id,
+                err = ?e,
+                "Error setting event receiver for partition."
             );
             if let Some(strong_consumers) = consumers.upgrade() {
                 let _ = strong_consumers.remove_partition_client(&partition_id);
@@ -456,7 +479,7 @@ impl EventProcessor {
             return Err(e);
         }
 
-        info!("Adding partition client to queue.");
+        debug!(partition_id = %partition_id, "Adding partition client to queue.");
 
         // Send the partition client to the next partition client receiver
         {
@@ -468,9 +491,9 @@ impl EventProcessor {
                 ))
             })?;
         }
-        info!(
-            "add_partition_client: Partition client added for partition: {:?}",
-            partition_id
+        debug!(
+            partition_id = %partition_id,
+            "add_partition_client: Partition client added for partition."
         );
 
         Ok(())
@@ -481,7 +504,7 @@ impl EventProcessor {
     /// This method returns the next available partition client.
     pub async fn next_partition_client(&self) -> Result<Arc<PartitionClient>> {
         // Implement the function or remove it if not needed
-        info!("next_partition_client: Waiting to receive the next partition client.",);
+        debug!("next_partition_client: Waiting to receive the next partition client.");
 
         {
             // Wait for the next partition client to be available
@@ -490,9 +513,9 @@ impl EventProcessor {
                 EventHubsError::with_message("No next partition client available: ")
             })?;
 
-            info!(
-                "next_partition_client: Returning partition client for partition {:?}.",
-                next_client.get_partition_id()
+            debug!(
+                partition_id = %next_client.get_partition_id(),
+                "next_partition_client: Returning partition client for partition."
             );
             Ok(next_client)
         }
@@ -505,17 +528,17 @@ impl EventProcessor {
         let mut clients = self.next_partition_clients.lock().await;
         while let Ok(client) = clients.try_recv() {
             info!(
-                "Closing partition client for partition: {}",
-                client.get_partition_id()
+                partition_id = %client.get_partition_id(),
+                "Closing partition client for partition."
             );
             let client = Arc::try_unwrap(client).map_err(|_| {
                 EventHubsError::with_message("Partition client still has multiple references.")
             })?;
             let res = client.close().await;
             if let Err(e) = res {
-                error!("Failed to close partition client: {:?}", e);
+                error!(err = ?e, "Failed to close partition client.");
             } else {
-                info!("Partition client closed successfully");
+                info!("Partition client closed successfully.");
             }
         }
 
@@ -523,9 +546,9 @@ impl EventProcessor {
         info!("Closing consumer client.");
         let res = self.consumer_client.close().await;
         if let Err(e) = res {
-            error!("Failed to close consumer client: {:?}", e);
+            error!(err = ?e, "Failed to close consumer client.");
         } else {
-            info!("Consumer client closed successfully");
+            info!("Consumer client closed successfully.");
         }
         Ok(())
     }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/in_memory_checkpoint_store.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/in_memory_checkpoint_store.rs
@@ -7,7 +7,7 @@ use azure_core::{
 };
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use tracing::{trace, warn};
+use tracing::{error, trace, warn};
 
 /// An in-memory checkpoint store for Event Hubs.
 /// This store is used to manage checkpoints and ownerships in memory.
@@ -63,13 +63,25 @@ impl InMemoryCheckpointStore {
         )?;
         trace!("Update ownership for key {}", key);
         if store.contains_key(&key) {
-            if ownership.etag != store.get(&key).unwrap().etag {
-                warn!("ETag mismatch {}", key);
+            let actual_etag = store.get(&key).unwrap().etag.clone();
+            if ownership.etag != actual_etag {
+                warn!(
+                    partition_id = %ownership.partition_id,
+                    expected_etag = ?ownership.etag,
+                    actual_etag = ?actual_etag,
+                    "ETag mismatch claiming ownership for key {}",
+                    key
+                );
                 return Err(Error::with_message(
                     AzureErrorKind::Other,
                     format!("ETag mismatch for partition {key}"),
                 ));
             }
+            // NOTE: this renewal path stores the caller's record verbatim instead
+            // of rotating the ETag and refreshing `last_modified_time` the way the
+            // new-ownership branch below (and the blob store) do. The load-balancer
+            // test helpers currently depend on that to seed expired ownership, so
+            // changing it is not a one-liner. Tracked in #4594.
             store.insert(key.clone(), ownership.clone());
             trace!("Updated ownership for key {}", key);
             Ok(ownership.clone())
@@ -149,6 +161,11 @@ impl CheckpointStore for InMemoryCheckpointStore {
             checkpoint.partition_id
         );
         let mut checkpoints = self.checkpoints.lock().map_err(|e| {
+            error!(
+                partition_id = %checkpoint.partition_id,
+                error = %e,
+                "Checkpoint store lock is poisoned; cannot update checkpoint"
+            );
             Error::with_message(
                 AzureErrorKind::Other,
                 format!("Failed to lock checkpoint store: {}", e),

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/models/event_data.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/models/event_data.rs
@@ -33,6 +33,13 @@ use std::{
 /// println!("{:?}", event_data);
 /// ```
 ///
+// SENSITIVE-DATA: SafeDebug redacts the `#[safe(false)]` fields
+// (body, properties) ONLY when the azure_core / typespec `debug` cargo feature
+// is OFF (the default). If that feature is enabled, `{:?}` on an EventData dumps
+// the full customer payload body and any PII in application properties. Do not
+// log whole EventData values at info/debug; prefer sequence_number / offset /
+// partition_id. Do not change the SafeDebug derive or the `#[safe(...)]`
+// attributes to "fix" this; the gating is intentional.
 #[derive(Default, PartialEq, Clone, SafeDebug)]
 #[safe(true)]
 pub struct EventData {
@@ -157,6 +164,13 @@ impl From<EventData> for AmqpMessage {
 /// Represents the data associated with an event received from an Event Hub.
 ///
 /// This struct provides the event data, enqueued time, offset, sequence number, partition key, and system properties of the event.
+// SENSITIVE-DATA: The manual `Debug` impl below prints the raw AMQP
+// message, which carries the full customer payload body and any PII. That body
+// is redacted by SafeDebug ONLY while the azure_core / typespec `debug` cargo
+// feature is OFF (the default). If a build enables that feature, `{:?}` on a
+// ReceivedEventData (e.g. the trace! in consumer/event_receiver.rs) emits the
+// full payload. Keep such logging at trace! and prefer logging only
+// sequence_number() / offset() / partition_key() at higher levels.
 pub struct ReceivedEventData {
     message: AmqpMessage,
     event_data: OnceLock<EventData>,

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
@@ -6,7 +6,7 @@ use crate::{error::Result, models::EventData, EventHubsError};
 use azure_core::{http::Url, Error, Uuid};
 use azure_core_amqp::{AmqpMessage, AmqpSenderApis, AmqpSymbol};
 use std::sync::Mutex;
-use tracing::debug;
+use tracing::{debug, warn};
 
 /// Represents the options that can be set when adding event data to an [`EventDataBatch`].
 pub struct AddEventDataOptions {}
@@ -73,12 +73,25 @@ impl<'a> EventDataBatch<'a> {
         }
     }
 
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            partition_id = self.partition_id.as_deref().unwrap_or("<auto>"),
+        ),
+        err,
+    )]
     pub(crate) async fn attach(&mut self) -> Result<()> {
-        let sender = self.producer.ensure_sender(self.get_batch_path()?).await?;
+        let path = self.get_batch_path()?;
+        let sender = self.producer.ensure_sender(path.clone()).await?;
         self.max_size_in_bytes = sender.max_message_size().await?.ok_or_else(|| {
+            warn!(
+                path = %path,
+                "The sender link did not report a maximum message size; cannot size the batch."
+            );
             Error::with_message(
                 azure_core::error::ErrorKind::Other,
-                "No message size available.",
+                "No maximum message size available from the sender link.",
             )
         })?;
         Ok(())
@@ -267,10 +280,10 @@ impl<'a> EventDataBatch<'a> {
     pub(crate) fn get_messages(&self) -> AmqpMessage {
         let mut batch_state = self.batch_state.lock().unwrap();
 
-        let mut batch_envelope = batch_state
-            .batch_envelope
-            .clone()
-            .expect("Batch envelope should have been created when getting messages.");
+        let mut batch_envelope = batch_state.batch_envelope.clone().expect(
+            "Batch envelope is missing when getting messages; \
+             send_batch was called on an empty batch (add at least one event before sending).",
+        );
 
         // Move the messages out of the batch state into a local variable so we
         // can subsequently move it to the message body.

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
@@ -137,9 +137,19 @@ impl ProducerClient {
     ///
     /// Note that dropping the ProducerClient will also close the connection.
     pub async fn close(self) -> Result<()> {
-        trace!("Closing producer client for {}.", self.endpoint);
+        let connection_id = self.connection.get_connection_id().to_string();
+        trace!(
+            connection_id = %connection_id,
+            url = %self.endpoint,
+            "Closing producer client."
+        );
         Arc::try_unwrap(self.connection)
             .map_err(|_| {
+                warn!(
+                    connection_id = %connection_id,
+                    url = %self.endpoint,
+                    "Could not close producer recoverable connection, multiple references exist."
+                );
                 Error::with_message(
                     AzureErrorKind::Other,
                     "Could not close producer recoverable connection, multiple references exist",

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
@@ -20,7 +20,7 @@ use azure_core_amqp::{
 };
 use batch::{EventDataBatch, EventDataBatchOptions};
 use std::{fmt::Debug, sync::Arc};
-use tracing::trace;
+use tracing::{trace, warn};
 
 /// Types used to collect messages into a "batch" before submitting them to an Event Hub.
 pub(crate) mod batch;
@@ -192,6 +192,19 @@ impl ProducerClient {
     /// Note:
     /// - The message is sent to the service unmodified.
     ///
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            connection_id = %self.connection.get_connection_id(),
+            eventhub = %self.eventhub,
+            partition_id = options
+                .as_ref()
+                .and_then(|o| o.partition_id.as_deref())
+                .unwrap_or("<auto>"),
+        ),
+        err,
+    )]
     pub async fn send_message<M>(
         &self,
         message: M,
@@ -206,7 +219,7 @@ impl ProducerClient {
             let target_url = format!("{}/Partitions/{}", self.base_url(), partition_id);
             target = Url::parse(&target_url).map_err(azure_core::Error::from)?;
         }
-        let sender = self.connection.get_sender(target).await?;
+        let sender = self.connection.get_sender(target.clone()).await?;
 
         let outcome = sender
             .send(
@@ -220,19 +233,42 @@ impl ProducerClient {
         match outcome {
             AmqpSendOutcome::Accepted => Ok(()),
             AmqpSendOutcome::Rejected(reason) => {
-                trace!("Send was rejected: {:?}", reason);
                 if let Some(reason) = reason {
+                    warn!(
+                        path = %target,
+                        condition = ?reason.condition,
+                        description = reason.description.as_deref().unwrap_or_default(),
+                        "Send was rejected by the Event Hub."
+                    );
                     return Err(AmqpError::from(AmqpErrorKind::AmqpDescribedError(reason)).into());
                 }
+                warn!(
+                    path = %target,
+                    "Send was rejected by the Event Hub with no described error."
+                );
                 Err(EventHubsError::with_message(
                     "Send was rejected by the Event Hub.",
                 ))
             }
             AmqpSendOutcome::Modified(reason) => {
-                trace!("Send was modified: {:?}", reason);
+                // Modified is treated as success (the return type is unchanged), but the
+                // message was not durably accepted as sent, so surface it for diagnosis.
+                warn!(
+                    path = %target,
+                    modification = ?reason,
+                    "Send was modified by the Event Hub; not durably accepted."
+                );
                 Ok(())
             }
-            AmqpSendOutcome::Released => Ok(()),
+            AmqpSendOutcome::Released => {
+                // Released is treated as success (the return type is unchanged), but the
+                // message was released without being durably accepted; surface it.
+                warn!(
+                    path = %target,
+                    "Send was released by the Event Hub; not durably accepted."
+                );
+                Ok(())
+            }
         }
     }
 
@@ -313,12 +349,22 @@ impl ProducerClient {
     /// }
     /// ```
     ///
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            connection_id = %self.connection.get_connection_id(),
+            eventhub = %self.eventhub,
+        ),
+        err,
+    )]
     pub async fn send_batch(
         &self,
         batch: EventDataBatch<'_>,
         #[allow(unused_variables)] options: Option<SendBatchOptions>,
     ) -> Result<()> {
-        let sender = self.connection.get_sender(batch.get_batch_path()?).await?;
+        let path = batch.get_batch_path()?;
+        let sender = self.connection.get_sender(path.clone()).await?;
 
         let messages = batch.get_messages();
         let outcome = sender
@@ -333,21 +379,44 @@ impl ProducerClient {
         match outcome {
             AmqpSendOutcome::Accepted => Ok(()),
             AmqpSendOutcome::Rejected(reason) => {
-                trace!("Batch was rejected: {:?}", reason);
                 if let Some(reason) = reason {
+                    warn!(
+                        path = %path,
+                        condition = ?reason.condition,
+                        description = reason.description.as_deref().unwrap_or_default(),
+                        "Batch was rejected by the Event Hub."
+                    );
                     return Err(EventHubsError::from(AmqpError::from(
                         AmqpErrorKind::AmqpDescribedError(reason),
                     )));
                 }
+                warn!(
+                    path = %path,
+                    "Batch was rejected by the Event Hub with no described error."
+                );
                 Err(EventHubsError::with_message(
                     "Batch was rejected by the Event Hub.",
                 ))
             }
             AmqpSendOutcome::Modified(reason) => {
-                trace!("Batch was modified: {:?}", reason);
+                // Modified is treated as success (the return type is unchanged), but the
+                // batch was not durably accepted as sent, so surface it for diagnosis.
+                warn!(
+                    path = %path,
+                    modification = ?reason,
+                    "Batch was modified by the Event Hub; not durably accepted."
+                );
                 Ok(())
             }
-            AmqpSendOutcome::Released => Ok(()),
+            AmqpSendOutcome::Released => {
+                // Released is treated as success (the return type is unchanged), but the
+                // batch was released without being durably accepted; surface it.
+                warn!(
+                    path = %path,
+                    "Batch was released by the Event Hub; not durably accepted."
+                );
+                Ok(())
+            }
         }
     }
 

--- a/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/src/checkpoint_store.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/src/checkpoint_store.rs
@@ -25,7 +25,7 @@ use azure_storage_blob::{
 use futures::TryStreamExt;
 use std::{collections::HashMap, sync::Arc};
 use time::OffsetDateTime;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Azure Blob Storage implementation of the [`CheckpointStore`] trait.
 ///
@@ -142,6 +142,7 @@ impl BlobCheckpointStore {
 #[async_trait::async_trait]
 impl CheckpointStore for BlobCheckpointStore {
     /// Claims ownership of the specified partitions.
+    #[tracing::instrument(level = "debug", skip_all, fields(partition_count = ownerships.len()), err)]
     async fn claim_ownership(&self, ownerships: &[Ownership]) -> Result<Vec<Ownership>> {
         debug!("Claiming ownership for {} partitions", ownerships.len());
 
@@ -167,15 +168,34 @@ impl CheckpointStore for BlobCheckpointStore {
             let (last_modified_time, etag) = match set_metadata_result {
                 Ok((last_modified_time, etag)) => (last_modified_time, etag),
                 Err(e) if e.http_status() == Some(StatusCode::PreconditionFailed) => {
-                    debug!("PreconditionFailed error for blob {}", blob_name);
+                    info!(
+                        event = "claim-conflict",
+                        partition_id = %ownership.partition_id,
+                        owner_id = ?ownership.owner_id,
+                        etag = ?ownership.etag,
+                        blob_name = %blob_name,
+                        "Lost ownership claim: precondition (etag) failed"
+                    );
                     (None, None)
                 }
                 Err(e) if e.http_status() == Some(StatusCode::Conflict) => {
-                    debug!("Blob already exists, skipping");
+                    info!(
+                        event = "claim-conflict",
+                        partition_id = %ownership.partition_id,
+                        owner_id = ?ownership.owner_id,
+                        etag = ?ownership.etag,
+                        blob_name = %blob_name,
+                        "Lost ownership claim: blob already exists"
+                    );
                     (None, None)
                 }
                 Err(e) => {
-                    warn!("Error claiming ownership for blob {}: {}", blob_name, e);
+                    warn!(
+                        partition_id = %ownership.partition_id,
+                        blob_name = %blob_name,
+                        error = %e,
+                        "Error claiming ownership for blob"
+                    );
                     return Err(e);
                 }
             };
@@ -197,6 +217,16 @@ impl CheckpointStore for BlobCheckpointStore {
     }
 
     /// Lists all checkpoints for the specified Event Hub and consumer group.
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            fully_qualified_namespace = %namespace,
+            eventhub = %event_hub_name,
+            consumer_group = %consumer_group,
+        ),
+        err,
+    )]
     async fn list_checkpoints(
         &self,
         namespace: &str,
@@ -230,7 +260,6 @@ impl CheckpointStore for BlobCheckpointStore {
         };
 
         while let Some(blob) = blobs.try_next().await? {
-            debug!("Blob body: {blob:?}");
             let mut checkpoint = checkpoint.clone();
             if let Some(name) = &blob.name {
                 checkpoint.partition_id = name
@@ -247,6 +276,13 @@ impl CheckpointStore for BlobCheckpointStore {
                     }
                 }
             }
+            debug!(
+                blob_name = ?blob.name,
+                partition_id = %checkpoint.partition_id,
+                sequence_number = ?checkpoint.sequence_number,
+                offset = ?checkpoint.offset,
+                "Parsed checkpoint blob"
+            );
 
             checkpoints.push(checkpoint);
         }
@@ -256,6 +292,16 @@ impl CheckpointStore for BlobCheckpointStore {
     }
 
     /// Lists all ownerships for the specified Event Hub and consumer group.
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            fully_qualified_namespace = %namespace,
+            eventhub = %event_hub_name,
+            consumer_group = %consumer_group,
+        ),
+        err,
+    )]
     async fn list_ownerships(
         &self,
         namespace: &str,
@@ -288,7 +334,6 @@ impl CheckpointStore for BlobCheckpointStore {
         };
 
         while let Some(blob) = blobs.try_next().await? {
-            debug!("Blob body: {blob:?}");
             let mut ownership = ownership.clone();
             if let Some(name) = &blob.name {
                 ownership.partition_id = name
@@ -306,6 +351,13 @@ impl CheckpointStore for BlobCheckpointStore {
                 ownership.etag = properties.etag.clone();
                 ownership.last_modified_time = properties.last_modified;
             }
+            debug!(
+                blob_name = ?blob.name,
+                partition_id = %ownership.partition_id,
+                owner_id = ?ownership.owner_id,
+                etag = ?ownership.etag,
+                "Parsed ownership blob"
+            );
 
             ownerships.push(ownership);
         }
@@ -315,7 +367,25 @@ impl CheckpointStore for BlobCheckpointStore {
     }
 
     /// Updates the checkpoint for a specific partition.
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            partition_id = %checkpoint.partition_id,
+            eventhub = %checkpoint.event_hub_name,
+            consumer_group = %checkpoint.consumer_group,
+            sequence_number = ?checkpoint.sequence_number,
+            offset = ?checkpoint.offset,
+        ),
+    )]
     async fn update_checkpoint(&self, checkpoint: Checkpoint) -> Result<()> {
+        debug!(
+            partition_id = %checkpoint.partition_id,
+            sequence_number = ?checkpoint.sequence_number,
+            offset = ?checkpoint.offset,
+            "Updating checkpoint"
+        );
+        let partition_id = checkpoint.partition_id.clone();
         let blob_name = Checkpoint::get_checkpoint_blob_name(
             &checkpoint.fully_qualified_namespace,
             &checkpoint.event_hub_name,
@@ -329,8 +399,18 @@ impl CheckpointStore for BlobCheckpointStore {
         if let Some(offset) = checkpoint.offset {
             metadata.insert(OFFSET.to_string(), offset);
         }
-        self.set_checkpoint_metadata_on_blob(&blob_name, metadata)
-            .await?;
+        if let Err(e) = self
+            .set_checkpoint_metadata_on_blob(&blob_name, metadata)
+            .await
+        {
+            error!(
+                partition_id = %partition_id,
+                blob_name = %blob_name,
+                error = %e,
+                "Failed to persist checkpoint to blob storage"
+            );
+            return Err(e);
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Closes #4592.

## Summary

The Event Hubs client has many log calls but no `tracing` spans and almost no structured fields. At default levels an operator can see that a reconnect started but not what was torn down, against which partition, or whether it succeeded. Concurrent per-partition work interleaves into a flat stream that cannot be filtered. This change adds spans on the lifecycle paths and promotes high-value events to levels that run in practice, with no change to the public API.

## Motivation

Without spans and structured fields, the lifecycle paths are effectively opaque under load. Reconnect outcomes, the affected partition, and per-partition work cannot be correlated or filtered, which makes diagnosing live behavior difficult.

## Changes

Spans use plain `#[tracing::instrument]` rather than the `azure_core` distributed-tracing macros. Those macros inject a `tracer` field and rewrite constructor and method signatures for the HTTP pipeline, which this hand-written AMQP crate does not have and which would break SemVer. Full OpenTelemetry integration (`SpanKind::Producer/Consumer`, `az.namespace`, `messaging.*` attributes) is a larger, separate change and remains a follow-up.

- `#[tracing::instrument]` (skip_all plus safe identifier fields only) on the connect/send/receive/recover, management, and checkpoint paths.
- Reconnect outcome is now logged; transport open/close is promoted to `info!`; `UnauthorizedAccess` is promoted to `warn!` with the AMQP condition.
- Consumer receive failures and link-stolen events are logged with `partition_id`/`source_url`/condition; producer rejections are logged at `warn!` with target; `Released`/`Modified` are no longer silent.
- The token refresher logs and continues on transient errors instead of silently dying.
- Blob `update_checkpoint` and etag-conflict claims are observable; in-memory store lock poisoning is logged.
- A structured field vocabulary and a level policy are applied crate-wide; the `SafeDebug` payload-redaction feature gate is guarded with `AIDEV-NOTE`s; full blob dumps are replaced with field-only logs.
- The README Logging section documents the conventions and that tokens, payloads, and message bodies are never logged.

No public API, signature, or return-type change (one private fn gained two diagnostic params).

## Test plan

- [x] `cargo build` + `clippy -D warnings` + `fmt` clean on both eventhubs crates
- [x] Offline unit tests pass (74); all integration binaries compile
- [ ] Live integration tests (creds-gated) exercised in CI
- [ ] Eyeball span/field output against the `eventhubs_tracing_subscriber` example
