### PR TITLE
fix(eventhubs): abort Authorizer token-refresh task on connection tea…

### DIFF
--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
@@ -78,6 +78,28 @@ impl Authorizer {
         scopes.clear();
     }
 
+    /// Aborts the background token-refresh task, if one was ever started.
+    ///
+    /// The refresh task (spawned lazily by [`authorize_path`](Self::authorize_path))
+    /// owns an `Arc<Self>` and parks in a long `sleep` until shortly before the
+    /// next token expiry — typically tens of minutes. While it is alive it keeps
+    /// the `Authorizer`, its cached `AccessToken`s, and its credential from being
+    /// reclaimed, even after the owning [`RecoverableConnection`] has been torn
+    /// down. That orphaned-task-plus-token retention is a multi-KB leak per
+    /// open/close cycle (it grows with every producer/consumer that is rebuilt).
+    ///
+    /// Aborting the task lets it drop its `Arc<Self>` so the `Authorizer` is
+    /// reclaimed as soon as the connection's strong reference goes away. Callers
+    /// invoke this during connection teardown ([`RecoverableConnection::close_connection`]
+    /// and its `Drop`). It is deliberately *not* called on the recovery path,
+    /// where the same task is reused against the rebuilt connection.
+    pub(crate) fn stop_refresh_task(&self) {
+        if let Some(task) = self.authorization_refresher.get() {
+            debug!("Aborting authorization refresh task.");
+            task.abort();
+        }
+    }
+
     #[cfg(test)]
     fn disable_authorization(&self) -> Result<()> {
         use crate::EventHubsError;

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/authorizer.rs
@@ -13,7 +13,10 @@ use azure_core_amqp::{AmqpClaimsBasedSecurityApis as _, AmqpError};
 use rand::{rng, RngExt};
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex as SyncMutex, OnceLock, Weak},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex as SyncMutex, OnceLock, Weak,
+    },
 };
 use tracing::{debug, trace, warn};
 
@@ -44,6 +47,10 @@ impl Default for TokenRefreshTimes {
 pub(crate) struct Authorizer {
     authorization_scopes: RwLock<HashMap<Url, AccessToken>>,
     authorization_refresher: OnceLock<SpawnedTask>,
+    /// Set once `stop_refresh_task` has aborted `authorization_refresher`, so the
+    /// abort (and its log line) run exactly once even though teardown reaches
+    /// `stop_refresh_task` from both `close_connection` and `Drop`.
+    refresher_aborted: AtomicBool,
     /// Bias to apply to token refresh time. This determines how much time we will refresh the token before it expires.
     token_refresh_bias: SyncMutex<TokenRefreshTimes>,
     credential: Arc<dyn TokenCredential>,
@@ -63,6 +70,7 @@ impl Authorizer {
     ) -> Self {
         Self {
             authorization_refresher: OnceLock::new(),
+            refresher_aborted: AtomicBool::new(false),
             authorization_scopes: RwLock::new(HashMap::new()),
             token_refresh_bias: SyncMutex::new(TokenRefreshTimes::default()),
             credential,
@@ -80,23 +88,29 @@ impl Authorizer {
 
     /// Aborts the background token-refresh task, if one was ever started.
     ///
-    /// The refresh task (spawned lazily by [`authorize_path`](Self::authorize_path))
-    /// owns an `Arc<Self>` and parks in a long `sleep` until shortly before the
-    /// next token expiry — typically tens of minutes. While it is alive it keeps
-    /// the `Authorizer`, its cached `AccessToken`s, and its credential from being
-    /// reclaimed, even after the owning [`RecoverableConnection`] has been torn
-    /// down. That orphaned-task-plus-token retention is a multi-KB leak per
-    /// open/close cycle (it grows with every producer/consumer that is rebuilt).
+    /// The refresh task (spawned lazily by `authorize_path`) owns an `Arc<Self>`
+    /// and parks in a long `sleep` until shortly before the next token expiry —
+    /// typically tens of minutes. While it is alive it keeps the `Authorizer`,
+    /// its cached `AccessToken`s, and its credential from being reclaimed, even
+    /// after the owning `RecoverableConnection` has been torn down. That
+    /// orphaned-task-plus-token retention is a multi-KB leak per open/close cycle
+    /// (it grows with every producer/consumer that is rebuilt).
     ///
     /// Aborting the task lets it drop its `Arc<Self>` so the `Authorizer` is
     /// reclaimed as soon as the connection's strong reference goes away. Callers
-    /// invoke this during connection teardown ([`RecoverableConnection::close_connection`]
+    /// invoke this during connection teardown (`RecoverableConnection::close_connection`
     /// and its `Drop`). It is deliberately *not* called on the recovery path,
     /// where the same task is reused against the rebuilt connection.
+    ///
+    /// Idempotent: the graceful path reaches this twice (`close_connection`
+    /// aborts explicitly, then the `RecoverableConnection` `Drop` runs), so only
+    /// the first call actually aborts and logs.
     pub(crate) fn stop_refresh_task(&self) {
         if let Some(task) = self.authorization_refresher.get() {
-            debug!("Aborting authorization refresh task.");
-            task.abort();
+            if !self.refresher_aborted.swap(true, Ordering::Relaxed) {
+                debug!("Aborting authorization refresh task.");
+                task.abort();
+            }
         }
     }
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -245,6 +245,12 @@ impl RecoverableConnection {
     pub(crate) async fn close_connection(self) -> Result<()> {
         trace!("Closing recoverable connection for {}.", self.url);
 
+        // Abort the Authorizer's background token-refresh task first. It holds an
+        // `Arc<Authorizer>` and sleeps until just before token expiry, so without
+        // this the Authorizer and its cached token outlive the connection and leak
+        // a few KB per open/close cycle. See `Authorizer::stop_refresh_task`.
+        self.authorizer.stop_refresh_task();
+
         let mut management_client = self.mgmt_client.lock().await;
         if let Some(management_client) = management_client.take() {
             trace!("Closing management client for {}.", self.url);
@@ -906,6 +912,10 @@ impl RecoverableConnection {
 impl Drop for RecoverableConnection {
     fn drop(&mut self) {
         trace!("Dropping RecoverableConnection for {}", self.url);
+        // Backstop for the drop-without-`close_connection` path: abort the
+        // Authorizer's background token-refresh task so it stops holding the
+        // Authorizer (and its cached token) alive once this connection is gone.
+        self.authorizer.stop_refresh_task();
     }
 }
 


### PR DESCRIPTION
closes #4595 

The per-connection `Authorizer` lazily spawns a background token-refresh task (in `authorize_path`) that owns an `Arc<Authorizer>` and parks in a long `sleep` until shortly before the next token expiry -- often tens of minutes. Neither `RecoverableConnection::close_connection` nor its `Drop` ever stopped that task, so every time a producer/consumer connection was opened and torn down the task -- together with the `Authorizer`, its cached `AccessToken`, and its credential -- was orphaned and leaked. The leak is dead-linear in the number of open/close cycles, which the crate's own recovery path (`recover_from_error`) and any caller-driven reconnect exercise repeatedly.

Add `Authorizer::stop_refresh_task`, which aborts the spawned task via the `SpawnedTask` / `AbortableTask::abort` handle, and call it from `close_connection` and the `RecoverableConnection` `Drop`. Aborting lets the task drop its `Arc<Authorizer>` so the authorizer and its token are reclaimed once the connection's strong reference goes away. The recovery path is left untouched, since it intentionally reuses the same task against the rebuilt connection.

Verified with a tracking-allocator reproducer (open -> send_event -> close in a loop, AAD auth, real Event Hub): net live heap goes from ~5.0 KB/cycle dead-linear growth to flat (~0 B/cycle, bounded) after the fix; all 85 eventhubs unit tests still pass.