### PR TITLE
[Cosmos] Fix diagnostics activity_id null on transport failure and cpu empty sentinel

### DIFF
--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Bugs Fixed
 
 - Fixed duplicate items being returned on cross-partition query resume after a physical partition split. When a cross-partition query was paused, serialized to a continuation token, and resumed after the underlying partition had split, the resumed iterator could re-emit items the caller had already consumed on a prior page. The continuation token now records per-range sibling state and is correctly propagated to every surviving leaf after a split. ([#4550](https://github.com/Azure/azure-sdk-for-rust/pull/4550))
+- Fixed two diagnostics-fidelity gaps surfaced in transport-failure diagnostics. The per-attempt `activity_id` is now seeded from the operation-level activity ID placed on the wire (`x-ms-activity-id`), so an attempt that fails at the transport layer (no response received) records the ID that was sent instead of serializing `null`; the success path still overwrites it with the response-header echo. The `system_usage.cpu` field now serializes as a structured object (`{ "samples": [...], "status": "available" | "unavailable" }`) matching the .NET/Java SDKs, instead of the type-punned literal string `"empty"` when the CPU sampler has no samples. ([#4573](https://github.com/Azure/azure-sdk-for-rust/issues/4573))
 
 ### Other Changes
 

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -14,7 +14,8 @@
 ### Bugs Fixed
 
 - Fixed duplicate items being returned on cross-partition query resume after a physical partition split. When a cross-partition query was paused, serialized to a continuation token, and resumed after the underlying partition had split, the resumed iterator could re-emit items the caller had already consumed on a prior page. The continuation token now records per-range sibling state and is correctly propagated to every surviving leaf after a split. ([#4550](https://github.com/Azure/azure-sdk-for-rust/pull/4550))
-- Fixed two diagnostics-fidelity gaps surfaced in transport-failure diagnostics. The per-attempt `activity_id` is now seeded from the operation-level activity ID placed on the wire (`x-ms-activity-id`), so an attempt that fails at the transport layer (no response received) records the ID that was sent instead of serializing `null`; the success path still overwrites it with the response-header echo. The `system_usage.cpu` field now serializes as a structured object (`{ "samples": [...], "status": "available" | "unavailable" }`) matching the .NET/Java SDKs, instead of the type-punned literal string `"empty"` when the CPU sampler has no samples. ([#4573](https://github.com/Azure/azure-sdk-for-rust/issues/4573))
+- Fixed per-attempt `activity_id` in diagnostics serializing as `null` on transport failures; it is now seeded from the operation-level activity ID. ([#4602](https://github.com/Azure/azure-sdk-for-rust/pull/4602))
+- Fixed `system_usage.cpu` in diagnostics emitting the literal string `"empty"`; it now serializes as a structured `{ samples, status }` object when no CPU samples are available. ([#4602](https://github.com/Azure/azure-sdk-for-rust/pull/4602))
 
 ### Other Changes
 

--- a/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/diagnostics_context.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/diagnostics_context.rs
@@ -400,14 +400,6 @@ pub struct RequestDiagnostics {
     pub(crate) request_charge: RequestCharge,
 
     /// Activity ID for this attempt.
-    ///
-    /// Seeded at request start with the operation-level activity ID attached to
-    /// the outgoing request as `x-ms-activity-id` (an operation may override it
-    /// with its own header), then overwritten by the response-header echo on
-    /// success. If the attempt fails before a response is received — including
-    /// transport failures classified as [`RequestSentStatus::NotSent`] that
-    /// never reached the wire — the seeded value is retained, so an attempt is
-    /// never serialized with a `null` activity ID.
     activity_id: Option<ActivityId>,
 
     /// Session token from response (for session consistency).
@@ -1404,13 +1396,6 @@ impl DiagnosticsContextBuilder {
             transport_http_version,
             endpoint,
         );
-        // Seed the per-attempt activity ID with the operation-level activity ID.
-        // In the common case this is the value attached to the outgoing request
-        // as `x-ms-activity-id` (an operation may override it with its own
-        // header). On a successful response it is overwritten by the
-        // response-header echo in `record_response`; if the attempt fails before
-        // a response is received it ensures the attempt still records an activity
-        // ID instead of serializing `null`.
         request.with_activity_id(self.activity_id.clone());
         let handle = RequestHandle(self.requests.len());
         self.requests.push(request);
@@ -3152,10 +3137,6 @@ mod tests {
         let ctx = builder.complete();
 
         let json = ctx.to_json_string(Some(DiagnosticsVerbosity::Detailed));
-        assert!(
-            !json.contains("\"cpu\":\"empty\"") && !json.contains("\"cpu\": \"empty\""),
-            "cpu must not serialize the 'empty' sentinel string.\nActual:\n{json}"
-        );
         let actual = normalize_diagnostics_json(json);
         let expected: serde_json::Value = serde_json::json!({
             "activity_id": "test-system-usage-empty",

--- a/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/diagnostics_context.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/diagnostics_context.rs
@@ -401,12 +401,13 @@ pub struct RequestDiagnostics {
 
     /// Activity ID for this attempt.
     ///
-    /// Seeded at request start from the operation-level activity ID (the value
-    /// placed on the wire as `x-ms-activity-id`, unless the operation overrides
-    /// it with its own header), then overwritten by the response-header echo on
-    /// success. On a transport failure (no response is received) the seeded
-    /// value is retained, so an attempt is never serialized with a `null`
-    /// activity ID.
+    /// Seeded at request start with the operation-level activity ID attached to
+    /// the outgoing request as `x-ms-activity-id` (an operation may override it
+    /// with its own header), then overwritten by the response-header echo on
+    /// success. If the attempt fails before a response is received — including
+    /// transport failures classified as [`RequestSentStatus::NotSent`] that
+    /// never reached the wire — the seeded value is retained, so an attempt is
+    /// never serialized with a `null` activity ID.
     activity_id: Option<ActivityId>,
 
     /// Session token from response (for session consistency).
@@ -1404,11 +1405,12 @@ impl DiagnosticsContextBuilder {
             endpoint,
         );
         // Seed the per-attempt activity ID with the operation-level activity ID.
-        // In the common case this is the value the SDK places on the wire as
-        // `x-ms-activity-id` (an operation may override it with its own header).
-        // On a successful response it is overwritten by the response-header echo
-        // in `record_response`; on a transport failure (no response) it ensures
-        // the attempt still records an activity ID instead of serializing `null`.
+        // In the common case this is the value attached to the outgoing request
+        // as `x-ms-activity-id` (an operation may override it with its own
+        // header). On a successful response it is overwritten by the
+        // response-header echo in `record_response`; if the attempt fails before
+        // a response is received it ensures the attempt still records an activity
+        // ID instead of serializing `null`.
         request.with_activity_id(self.activity_id.clone());
         let handle = RequestHandle(self.requests.len());
         self.requests.push(request);

--- a/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/diagnostics_context.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/diagnostics_context.rs
@@ -401,11 +401,12 @@ pub struct RequestDiagnostics {
 
     /// Activity ID for this attempt.
     ///
-    /// Seeded at request start from the operation-level activity ID placed on
-    /// the wire (`x-ms-activity-id`), then overwritten by the response-header
-    /// echo on success. On a transport failure (no response is received) the
-    /// seeded value is retained, so an attempt is never serialized with a
-    /// `null` activity ID.
+    /// Seeded at request start from the operation-level activity ID (the value
+    /// placed on the wire as `x-ms-activity-id`, unless the operation overrides
+    /// it with its own header), then overwritten by the response-header echo on
+    /// success. On a transport failure (no response is received) the seeded
+    /// value is retained, so an attempt is never serialized with a `null`
+    /// activity ID.
     activity_id: Option<ActivityId>,
 
     /// Session token from response (for session consistency).
@@ -1402,11 +1403,12 @@ impl DiagnosticsContextBuilder {
             transport_http_version,
             endpoint,
         );
-        // Seed the per-attempt activity ID with the operation-level ID that the
-        // SDK places on the wire (`x-ms-activity-id`). On a successful response
-        // this is overwritten by the response-header echo in `record_response`;
-        // on a transport failure (no response) it ensures the attempt still
-        // records the ID we sent instead of serializing `null`.
+        // Seed the per-attempt activity ID with the operation-level activity ID.
+        // In the common case this is the value the SDK places on the wire as
+        // `x-ms-activity-id` (an operation may override it with its own header).
+        // On a successful response it is overwritten by the response-header echo
+        // in `record_response`; on a transport failure (no response) it ensures
+        // the attempt still records an activity ID instead of serializing `null`.
         request.with_activity_id(self.activity_id.clone());
         let handle = RequestHandle(self.requests.len());
         self.requests.push(request);
@@ -2746,6 +2748,52 @@ mod tests {
             requests[0].activity_id(),
             Some(&echoed),
             "a successful response must record the response-header activity id"
+        );
+    }
+
+    #[test]
+    fn multi_attempt_failed_then_succeeded_keep_independent_activity_ids() {
+        // A failed attempt retains its seeded operation-level id while a later
+        // successful attempt records the response-header echo. The failed
+        // attempt's id must not be perturbed by the later success.
+        let op_activity_id = ActivityId::from_string("op-activity-id".to_string());
+        let echoed = ActivityId::from_string("echoed-activity-id".to_string());
+        let mut builder = DiagnosticsContextBuilder::new(op_activity_id.clone(), make_options());
+
+        let failed = builder.start_test_request(
+            ExecutionContext::Initial,
+            Some(Region::WEST_US_2),
+            "https://test.documents.azure.com",
+        );
+        builder.fail_transport_request(
+            failed,
+            "connection refused",
+            RequestSentStatus::Sent,
+            CosmosStatus::TRANSPORT_GENERATED_503,
+        );
+
+        let succeeded = builder.start_test_request(
+            ExecutionContext::Retry,
+            Some(Region::WEST_US_2),
+            "https://test.documents.azure.com",
+        );
+        let headers = CosmosResponseHeaders {
+            activity_id: Some(echoed.clone()),
+            ..Default::default()
+        };
+        builder.record_response(succeeded, StatusCode::Ok, &headers);
+
+        let ctx = builder.complete();
+        let requests = ctx.requests();
+        assert_eq!(
+            requests[0].activity_id(),
+            Some(&op_activity_id),
+            "the failed attempt must retain the seeded operation-level activity id"
+        );
+        assert_eq!(
+            requests[1].activity_id(),
+            Some(&echoed),
+            "the succeeded attempt must record the response-header echo"
         );
     }
 

--- a/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/diagnostics_context.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/diagnostics_context.rs
@@ -399,7 +399,13 @@ pub struct RequestDiagnostics {
     /// Request charge (RU) for this individual request.
     pub(crate) request_charge: RequestCharge,
 
-    /// Activity ID from response headers.
+    /// Activity ID for this attempt.
+    ///
+    /// Seeded at request start from the operation-level activity ID placed on
+    /// the wire (`x-ms-activity-id`), then overwritten by the response-header
+    /// echo on success. On a transport failure (no response is received) the
+    /// seeded value is retained, so an attempt is never serialized with a
+    /// `null` activity ID.
     activity_id: Option<ActivityId>,
 
     /// Session token from response (for session consistency).
@@ -1119,20 +1125,63 @@ struct TruncatedOutput<'a> {
     message: &'static str,
 }
 
+/// Status of the CPU sample history in a [`SystemUsageSnapshot`].
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CpuUsageStatus {
+    /// At least one CPU sample was collected.
+    Available,
+    /// No CPU samples were available (cold start, or the sampler is not running
+    /// in the host environment).
+    Unavailable,
+}
+
+/// Recent CPU load history, serialized as a structured object.
+///
+/// Replaces the previous behavior of serializing a human-readable string (which
+/// emitted the literal `"empty"` sentinel when no samples existed). Mirrors the
+/// structured CPU history shape used by the .NET and Java SDKs, so downstream
+/// JSON consumers always see an object with a `samples` array and a `status`.
+///
+/// # Examples
+///
+/// - With samples: `{ "samples": ["(45.3%)", "(50.1%)"], "status": "available" }`
+/// - Without samples: `{ "samples": [], "status": "unavailable" }`
+#[derive(Clone, Debug, Serialize)]
+struct CpuUsageHistory {
+    /// Recent CPU load samples, oldest first (empty when none were collected).
+    samples: Vec<String>,
+    /// Whether any CPU samples were available.
+    status: CpuUsageStatus,
+}
+
+impl CpuUsageHistory {
+    /// Builds a CPU history from formatted sample strings, deriving the status
+    /// from whether any samples are present.
+    fn from_samples(samples: Vec<String>) -> Self {
+        let status = if samples.is_empty() {
+            CpuUsageStatus::Unavailable
+        } else {
+            CpuUsageStatus::Available
+        };
+        Self { samples, status }
+    }
+}
+
 /// Snapshot of system CPU and memory usage at a point in time.
 ///
 /// Captured lazily on first serialization of a [`DiagnosticsContext`] and
 /// included in the JSON output under `"system_usage"`.
 ///
 /// Field names mirror the Java SDK's `CosmosDiagnosticsSystemUsageSnapshot`:
-/// - `"cpu"` – Recent CPU load history (e.g. `"(45.3%), (50.1%), ..."`)
+/// - `"cpu"` – Recent CPU load history as a structured object (`{ samples, status }`)
 /// - `"memory_available_mb"` – Most recent available memory in MB
 /// - `"processor_count"` – Number of logical CPUs available to the process
 /// - `"cpu_overloaded"` – Whether the CPU is considered overloaded
 #[derive(Clone, Debug, Serialize)]
 struct SystemUsageSnapshot {
-    /// Recent CPU load history formatted as a human-readable string.
-    cpu: String,
+    /// Recent CPU load history as a structured object.
+    cpu: CpuUsageHistory,
     /// Available memory in megabytes (most recent sample).
     #[serde(skip_serializing_if = "Option::is_none")]
     memory_available_mb: Option<u64>,
@@ -1147,7 +1196,7 @@ impl SystemUsageSnapshot {
     fn capture(monitor: &CpuMemoryMonitor) -> Self {
         let history = monitor.snapshot();
         Self {
-            cpu: history.to_string(),
+            cpu: CpuUsageHistory::from_samples(history.cpu_sample_strings()),
             memory_available_mb: history.latest_memory_mb(),
             processor_count: std::thread::available_parallelism()
                 .map(|n| n.get())
@@ -1159,13 +1208,13 @@ impl SystemUsageSnapshot {
     /// Creates a snapshot with fixed, deterministic values for testing.
     #[cfg(test)]
     fn new_for_test(
-        cpu: String,
+        cpu_samples: Vec<String>,
         memory_available_mb: Option<u64>,
         processor_count: usize,
         cpu_overloaded: bool,
     ) -> Self {
         Self {
-            cpu,
+            cpu: CpuUsageHistory::from_samples(cpu_samples),
             memory_available_mb,
             processor_count,
             cpu_overloaded,
@@ -1345,7 +1394,7 @@ impl DiagnosticsContextBuilder {
         transport_http_version: TransportHttpVersion,
         endpoint: &CosmosEndpoint,
     ) -> RequestHandle {
-        let request = RequestDiagnostics::new(
+        let mut request = RequestDiagnostics::new(
             execution_context,
             pipeline_type,
             transport_security,
@@ -1353,6 +1402,12 @@ impl DiagnosticsContextBuilder {
             transport_http_version,
             endpoint,
         );
+        // Seed the per-attempt activity ID with the operation-level ID that the
+        // SDK places on the wire (`x-ms-activity-id`). On a successful response
+        // this is overwritten by the response-header echo in `record_response`;
+        // on a transport failure (no response) it ensures the attempt still
+        // records the ID we sent instead of serializing `null`.
+        request.with_activity_id(self.activity_id.clone());
         let handle = RequestHandle(self.requests.len());
         self.requests.push(request);
         handle
@@ -2372,7 +2427,7 @@ mod tests {
                         "endpoint": "https://test.documents.azure.com/",
                         "status": "200",
                         "request_charge": 1.0,
-                        "activity_id": null,
+                        "activity_id": "test-id",
                         "session_token": null,
                         "server_duration_ms": null,
                         "duration_ms": 0,
@@ -2401,7 +2456,7 @@ mod tests {
                         "endpoint": "https://test.documents.azure.com/",
                         "status": "200",
                         "request_charge": 1.0,
-                        "activity_id": null,
+                        "activity_id": "test-id",
                         "session_token": null,
                         "server_duration_ms": null,
                         "duration_ms": 0,
@@ -2636,6 +2691,62 @@ mod tests {
         let status = requests[0].status();
         assert_eq!(status, &CosmosStatus::TRANSPORT_GENERATED_503);
         assert_eq!(requests[0].error(), Some("connection refused"));
+    }
+
+    #[test]
+    fn transport_failure_records_sent_activity_id_not_null() {
+        // (A) On a transport failure there is no response, so `record_response`
+        // never runs. The per-attempt activity_id must still be populated with
+        // the operation-level id the SDK placed on the wire, rather than `null`.
+        let activity_id = ActivityId::from_string("op-activity-id".to_string());
+        let mut builder = DiagnosticsContextBuilder::new(activity_id.clone(), make_options());
+        let handle = builder.start_test_request(
+            ExecutionContext::Initial,
+            Some(Region::WEST_US_2),
+            "https://test.documents.azure.com",
+        );
+        builder.fail_transport_request(
+            handle,
+            "connection refused",
+            RequestSentStatus::Sent,
+            CosmosStatus::TRANSPORT_GENERATED_503,
+        );
+
+        let ctx = builder.complete();
+        let requests = ctx.requests();
+        assert_eq!(
+            requests[0].activity_id(),
+            Some(&activity_id),
+            "a transport-failed attempt must record the activity id sent on the wire"
+        );
+    }
+
+    #[test]
+    fn successful_response_overwrites_seeded_activity_id_with_header_echo() {
+        // (A) The success path is unchanged: `record_response` overwrites the
+        // seeded operation-level id with the activity id echoed in the response
+        // headers (the same value in the common case).
+        let op_activity_id = ActivityId::from_string("op-activity-id".to_string());
+        let echoed = ActivityId::from_string("echoed-activity-id".to_string());
+        let mut builder = DiagnosticsContextBuilder::new(op_activity_id, make_options());
+        let handle = builder.start_test_request(
+            ExecutionContext::Initial,
+            Some(Region::WEST_US_2),
+            "https://test.documents.azure.com",
+        );
+        let headers = CosmosResponseHeaders {
+            activity_id: Some(echoed.clone()),
+            ..Default::default()
+        };
+        builder.record_response(handle, StatusCode::Ok, &headers);
+
+        let ctx = builder.complete();
+        let requests = ctx.requests();
+        assert_eq!(
+            requests[0].activity_id(),
+            Some(&echoed),
+            "a successful response must record the response-header activity id"
+        );
     }
 
     #[test]
@@ -2939,7 +3050,7 @@ mod tests {
         );
         builder.set_operation_status(StatusCode::Ok, None);
         builder.set_test_system_usage(SystemUsageSnapshot::new_for_test(
-            "(50.0%), (60.0%)".to_string(),
+            vec!["(50.0%)".to_string(), "(60.0%)".to_string()],
             Some(4096),
             4,
             false,
@@ -2954,7 +3065,10 @@ mod tests {
             "total_request_charge": 0.0,
             "request_count": 0,
             "system_usage": {
-                "cpu": "(50.0%), (60.0%)",
+                "cpu": {
+                    "samples": ["(50.0%)", "(60.0%)"],
+                    "status": "available"
+                },
                 "memory_available_mb": 4096,
                 "processor_count": 4,
                 "cpu_overloaded": false
@@ -2964,6 +3078,53 @@ mod tests {
         assert_eq!(
             actual, expected,
             "JSON with system_usage mismatch.\nActual:\n{json}"
+        );
+    }
+
+    #[test]
+    fn json_system_usage_without_cpu_samples_is_structured_not_empty_sentinel() {
+        // When the CPU sampler has no samples (cold start, or not running in the
+        // host environment), the `cpu` field must serialize as a structured
+        // object with an empty `samples` array and `status: "unavailable"` -
+        // never the legacy literal string "empty" (a type-punned sentinel that
+        // breaks downstream JSON consumers).
+        let mut builder = DiagnosticsContextBuilder::new(
+            ActivityId::from_string("test-system-usage-empty".to_string()),
+            make_options(),
+        );
+        builder.set_operation_status(StatusCode::Ok, None);
+        builder.set_test_system_usage(SystemUsageSnapshot::new_for_test(
+            Vec::new(),
+            None,
+            4,
+            false,
+        ));
+        let ctx = builder.complete();
+
+        let json = ctx.to_json_string(Some(DiagnosticsVerbosity::Detailed));
+        assert!(
+            !json.contains("\"cpu\":\"empty\"") && !json.contains("\"cpu\": \"empty\""),
+            "cpu must not serialize the 'empty' sentinel string.\nActual:\n{json}"
+        );
+        let actual = normalize_diagnostics_json(json);
+        let expected: serde_json::Value = serde_json::json!({
+            "activity_id": "test-system-usage-empty",
+            "total_duration_ms": 0,
+            "total_request_charge": 0.0,
+            "request_count": 0,
+            "system_usage": {
+                "cpu": {
+                    "samples": [],
+                    "status": "unavailable"
+                },
+                "processor_count": 4,
+                "cpu_overloaded": false
+            },
+            "requests": []
+        });
+        assert_eq!(
+            actual, expected,
+            "JSON with empty system_usage cpu mismatch.\nActual:\n{json}"
         );
     }
 

--- a/sdk/cosmos/azure_data_cosmos_driver/src/system/cpu_memory.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/system/cpu_memory.rs
@@ -232,11 +232,9 @@ impl CpuMemoryHistory {
 
 impl std::fmt::Display for CpuMemoryHistory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let cpu_entries: Vec<String> = self
-            .samples
-            .iter()
-            .filter_map(|s| s.cpu.map(|cpu| format!("({cpu})")))
-            .collect();
+        // Reuse the same sample formatting as the serialized diagnostics
+        // (`cpu_sample_strings`) so the human-readable and JSON views can't drift.
+        let cpu_entries = self.cpu_sample_strings();
         if cpu_entries.is_empty() {
             write!(f, "empty")
         } else {

--- a/sdk/cosmos/azure_data_cosmos_driver/src/system/cpu_memory.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/system/cpu_memory.rs
@@ -197,6 +197,20 @@ impl CpuMemoryHistory {
         self.samples.last().and_then(|s| s.cpu)
     }
 
+    /// Returns the recorded CPU samples formatted as human-readable entries
+    /// (e.g. `["(45.3%)", "(50.1%)"]`), oldest first.
+    ///
+    /// Empty when no CPU samples have been collected (cold start or the sampler
+    /// is not running in the host environment). Used to serialize the
+    /// `system_usage.cpu` diagnostics field as a structured value instead of a
+    /// sentinel string.
+    pub(crate) fn cpu_sample_strings(&self) -> Vec<String> {
+        self.samples
+            .iter()
+            .filter_map(|s| s.cpu.map(|cpu| format!("({cpu})")))
+            .collect()
+    }
+
     /// Returns the most recent available memory in megabytes, if any sample exists.
     pub(crate) fn latest_memory_mb(&self) -> Option<u64> {
         self.samples.last().and_then(|s| s.available_mb)


### PR DESCRIPTION
Fixes #4573

Two independent, low-blast-radius diagnostics-fidelity gaps in
`azure_data_cosmos_driver`, surfaced together by a captured 503 transport-failure
DR-drill diagnostic. Both are observability-output fixes (no data-plane/wire change).

## (A) Per-attempt `activity_id` was `null` on transport failures

The per-attempt `RequestDiagnostics.activity_id` was only ever written by
`record_response`, from response headers. A `transport_failed` attempt receives no
response, so `record_response` never ran and the field serialized as `null` —
exactly the failures where operators most need to correlate with backend logs.

`start_request` now seeds the per-attempt `activity_id` from the operation-level
`ctx.activity_id` the SDK places on the wire (`x-ms-activity-id`). The success path
is unchanged: `record_response` still overwrites it with the response-header echo
(the same value in the common case).

Out of scope (per the issue): minting a fresh activity-id per retry attempt.

## (B) `system_usage.cpu` was the literal string `"empty"`

When the CPU sampler had no samples (cold start, or not running in the host
environment), `cpu` serialized as the type-punned sentinel string `"empty"` via
`CpuMemoryHistory`'s `Display`, breaking downstream JSON consumers expecting a
number/object.

`system_usage.cpu` now serializes as a structured object matching the .NET/Java
SDKs (whose field names `SystemUsageSnapshot` already documents mirroring):

```jsonc
// empty
"cpu": { "samples": [], "status": "unavailable" }
// populated
"cpu": { "samples": ["(50.0%)", "(60.0%)"], "status": "available" }
```

Implemented via a new `CpuUsageHistory`/`CpuUsageStatus` type and
`CpuMemoryHistory::cpu_sample_strings()`. The `Display` impl is retained for
human/log output but is no longer the source of the serialized value.

## Tests

- `transport_failure_records_sent_activity_id_not_null` — a transport-failed
  attempt records the sent id, not `null`.
- `successful_response_overwrites_seeded_activity_id_with_header_echo` — success
  path still echoes the response-header id.
- `json_system_usage_without_cpu_samples_is_structured_not_empty_sentinel` — empty
  CPU history serializes as the structured object, never `"empty"`.
- Updated `json_with_system_usage` and `to_json_detailed` for the new shapes.

`cargo fmt`, `cargo clippy --all-features --all-targets` (0 warnings), and
`cargo test --all-features --lib` (1914 passed) are clean.

A CHANGELOG entry was added under 0.5.0 (Unreleased).
