### PR TITLE
Gate Cosmos endpoint failback behind a connectivity probe

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bugs Fixed
 
+- Fixed unavailable regional endpoints failing back into the routing rotation purely on a time expiry, with no connectivity check. A firewall-blocked endpoint would be marked available again after the cooldown, have real traffic routed to it, time out on connect, and be re-marked unavailable — a sustained low-throughput loop. Endpoints now only return to rotation after a connectivity probe (an HTTP request through the gateway pipeline; any completed response counts as reachable, only connection-level failures count as unreachable) confirms they are reachable, driven by a background failback loop on the client. The same probe gate is applied to partition-level circuit-breaker failback. ([#4597](https://github.com/Azure/azure-sdk-for-rust/issues/4597))
 - Fixed `410 Gone` responses carrying a partition-key-range routing sub-status (`1000` NameCacheIsStale, `1002` PartitionKeyRangeGone, `1007` CompletingSplit) escaping the retry pipeline as a raw, unclassifiable `410` (returned directly to the caller on writes, or after non-curative cross-region failover on reads). These are now retried within a small bound — flagging a routing-cache refresh so SDK-routing paths re-resolve stale routing information — and, on exhaustion, surfaced as `503 Service Unavailable` with the original sub-status preserved. This aligns the surfaced status with the rest of the Gone family so application-layer retry/circuit-breaker logic (wired for `503`, not `410`) can classify it.
 
 ## 0.31.0 (2026-02-25)

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Added `tokio` feature to `default` features.
 - Changed `default_ttl` and `analytical_storage_ttl` fields on `ContainerProperties` from `Option<Duration>` to `TimeToLive`, a new enum with variants `Forever`, `NoDefault`, and `Seconds(u32)`, to correctly handle the `-1` wire value (TTL enabled with no default expiration).
 
+### Bugs Fixed
+
+- Fixed `410 Gone` responses carrying a partition-key-range routing sub-status (`1000` NameCacheIsStale, `1002` PartitionKeyRangeGone, `1007` CompletingSplit) escaping the retry pipeline as a raw, unclassifiable `410` (returned directly to the caller on writes, or after non-curative cross-region failover on reads). These are now retried within a small bound — flagging a routing-cache refresh so SDK-routing paths re-resolve stale routing information — and, on exhaustion, surfaced as `503 Service Unavailable` with the original sub-status preserved. This aligns the surfaced status with the rest of the Gone family so application-layer retry/circuit-breaker logic (wired for `503`, not `410`) can classify it.
+
 ## 0.31.0 (2026-02-25)
 
 ### Features Added

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client_builder.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client_builder.rs
@@ -274,6 +274,9 @@ impl CosmosClientBuilder {
             Vec::new(),
             pipeline_core.clone(),
         ));
+        // Start the background failback-probe loop so unavailable endpoints only
+        // rejoin the rotation after a connectivity probe confirms reachability.
+        global_endpoint_manager.start_failback_probe_loop();
 
         let global_partition_endpoint_manager: Arc<GlobalPartitionEndpointManager> =
             GlobalPartitionEndpointManager::new(global_endpoint_manager.clone(), false, true);

--- a/sdk/cosmos/azure_data_cosmos/src/handler/retry_handler.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/handler/retry_handler.rs
@@ -4,7 +4,7 @@
 use crate::cosmos_request::CosmosRequest;
 use crate::retry_policies::client_retry_policy::ClientRetryPolicy;
 use crate::retry_policies::metadata_request_retry_policy::MetadataRequestRetryPolicy;
-use crate::retry_policies::{RetryPolicy, RetryResult};
+use crate::retry_policies::{convert_gone_to_service_unavailable, RetryPolicy, RetryResult};
 use crate::routing::global_endpoint_manager::GlobalEndpointManager;
 use crate::routing::global_partition_endpoint_manager::GlobalPartitionEndpointManager;
 use async_trait::async_trait;
@@ -139,7 +139,15 @@ impl RetryHandler for BackOffRetryHandler {
             let retry_result = retry_policy.should_retry(&result).await;
 
             match retry_result {
-                RetryResult::DoNotRetry => return result,
+                RetryResult::DoNotRetry => {
+                    // If the data-plane policy exhausted its partition-key-range Gone
+                    // budget, surface the terminal failure as 503 (preserving the
+                    // original sub-status) instead of letting a raw 410 escape.
+                    if let Some(sub_status) = retry_policy.terminal_gone_substatus() {
+                        return convert_gone_to_service_unavailable(result, sub_status);
+                    }
+                    return result;
+                }
                 RetryResult::Retry { after } => get_async_runtime().sleep(after).await,
             }
         }

--- a/sdk/cosmos/azure_data_cosmos/src/retry_policies/client_retry_policy.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/retry_policies/client_retry_policy.rs
@@ -29,6 +29,13 @@ const MAX_RETRY_COUNT_ON_ENDPOINT_FAILURE: usize = 120;
 /// the endpoint unavailable.
 const MAX_RETRY_COUNT_ON_CONNECTION_FAILURE: usize = 3;
 
+/// Maximum number of in-line retries for the partition-key-range Gone family
+/// (410 with sub-status 1000/1002/1007) before the terminal outcome is surfaced
+/// as 503 Service Unavailable. A small fixed bound (one routing-cache refresh +
+/// one retry) mirrors the dedicated PartitionKeyRangeGone retry policy used by
+/// the other Cosmos SDKs and avoids retry amplification on writes.
+const MAX_RETRY_COUNT_ON_PARTITION_KEY_RANGE_GONE: usize = 1;
+
 /// Context information for routing retry attempts to specific endpoints.
 #[derive(Clone, Debug)]
 struct RetryContext {
@@ -66,6 +73,20 @@ pub(crate) struct ClientRetryPolicy {
     /// Counter tracking the number of consecutive connection failure retry attempts
     /// on the current endpoint before marking it unavailable.
     connection_retry_count: usize,
+
+    /// Counter tracking the number of partition-key-range Gone (410.1000/1002/1007)
+    /// retry attempts for the current request.
+    partition_key_range_gone_retry_count: usize,
+
+    /// When set, the next `before_send_request` flags the request for a routing-cache
+    /// refresh (name cache, partition-key-range and collection routing map) so that
+    /// SDK-routing paths re-resolve a stale routing map instead of replaying it.
+    refresh_routing_on_next_attempt: bool,
+
+    /// Set when the partition-key-range Gone family has exhausted its in-line retry
+    /// budget. Signals the retry handler to surface the terminal failure as
+    /// 503 Service Unavailable while preserving this original Cosmos sub-status.
+    terminal_gone_substatus: Option<SubStatusCode>,
 
     /// Whether the current request is a read operation (true) or write operation (false)
     operation_type: Option<OperationType>,
@@ -117,6 +138,9 @@ impl ClientRetryPolicy {
             session_token_retry_count: 0,
             service_unavailable_retry_count: 0,
             connection_retry_count: 0,
+            partition_key_range_gone_retry_count: 0,
+            refresh_routing_on_next_attempt: false,
+            terminal_gone_substatus: None,
             operation_type: None,
             request: None,
             can_use_multiple_write_locations: false,
@@ -214,6 +238,16 @@ impl ClientRetryPolicy {
         {
             self.partition_key_range_location_cache
                 .try_add_partition_level_location_override(request);
+        }
+
+        // If a prior attempt hit the partition-key-range Gone family, flag the
+        // request so SDK-routing paths refresh the (now demonstrably stale)
+        // routing caches before this attempt instead of replaying the stale map.
+        if self.refresh_routing_on_next_attempt {
+            request.force_name_cache_refresh = true;
+            request.force_partition_key_range_refresh = true;
+            request.force_collection_routing_map_refresh = true;
+            self.refresh_routing_on_next_attempt = false;
         }
 
         self.request = Some(request.clone());
@@ -497,6 +531,45 @@ impl ClientRetryPolicy {
         }
     }
 
+    /// Handles the partition-key-range Gone family (410.1000/1002/1007).
+    ///
+    /// A 410 carrying one of these sub-statuses means the routing information the
+    /// request was resolved against is stale (a split/merge/migration moved the
+    /// range). We retry a small, fixed number of times, flagging a routing-cache
+    /// refresh for the next attempt so SDK-routing paths re-resolve instead of
+    /// replaying the stale map. Once the bound is exhausted we stop retrying and
+    /// record the sub-status so the retry handler can surface the terminal failure
+    /// as 503 Service Unavailable (preserving the sub-status) rather than letting a
+    /// raw, unclassifiable 410 escape to the caller.
+    ///
+    /// Applies to reads and writes alike: a 410 from routing resolution means the
+    /// operation was not applied, so retrying a write is safe.
+    fn should_retry_on_partition_key_range_gone(
+        &mut self,
+        sub_status: SubStatusCode,
+    ) -> RetryResult {
+        self.partition_key_range_gone_retry_count += 1;
+
+        if self.partition_key_range_gone_retry_count <= MAX_RETRY_COUNT_ON_PARTITION_KEY_RANGE_GONE
+        {
+            self.refresh_routing_on_next_attempt = true;
+            return RetryResult::Retry {
+                after: Duration::ZERO,
+            };
+        }
+
+        // Bound exhausted: surface as 503 with the original sub-status preserved.
+        self.terminal_gone_substatus = Some(sub_status);
+        RetryResult::DoNotRetry
+    }
+
+    /// Returns the sub-status to preserve when a terminal partition-key-range Gone
+    /// must be surfaced as 503 Service Unavailable, or `None` if no such conversion
+    /// is pending. Consulted by the retry handler after a `DoNotRetry` decision.
+    pub(crate) fn terminal_gone_substatus(&self) -> Option<SubStatusCode> {
+        self.terminal_gone_substatus
+    }
+
     /// Routes HTTP status codes to appropriate retry handling logic.
     ///
     /// # Summary
@@ -587,6 +660,26 @@ impl ClientRetryPolicy {
             && sub_status_code == Some(SubStatusCode::LEASE_NOT_FOUND)
         {
             return Some(self.should_retry_on_unavailable_endpoint_status_codes());
+        }
+
+        // Gone - partition-key-range staleness family (410.1000 NameCacheIsStale,
+        // 410.1002 PartitionKeyRangeGone, 410.1007 CompletingSplit). This must be
+        // matched on the (Gone, sub-status) tuple: sub-status 1002 is also used by
+        // 404 ReadSessionNotAvailable (handled above), so keying on sub-status
+        // alone would conflate the two. Without this branch a 410.1002 escapes the
+        // pipeline as a raw, unclassifiable 410 (writes) or burns non-curative
+        // cross-region failover (reads). Instead we drive a bounded routing-cache
+        // refresh + retry and, on exhaustion, surface 503 (see the retry handler).
+        if status_code == StatusCode::Gone
+            && matches!(
+                sub_status_code,
+                Some(SubStatusCode::NAME_CACHE_IS_STALE)
+                    | Some(SubStatusCode::PARTITION_KEY_RANGE_GONE)
+                    | Some(SubStatusCode::COMPLETING_SPLIT)
+            )
+        {
+            // sub_status_code is Some in every arm of the match above.
+            return Some(self.should_retry_on_partition_key_range_gone(sub_status_code.unwrap()));
         }
 
         // For read operations, retry on any status code that is not explicitly non-retryable.
@@ -1011,6 +1104,101 @@ mod tests {
             }
             _ => panic!("Expected retry for Gone with LeaseNotFound on write"),
         }
+    }
+
+    #[tokio::test]
+    async fn gone_partition_key_range_retries_then_converts_to_503_read() {
+        let mut policy = create_test_policy_with_preferred_locations();
+        policy.operation_type = Some(OperationType::Read);
+        let error = create_error_with_substatus(
+            StatusCode::Gone,
+            SubStatusCode::PARTITION_KEY_RANGE_GONE.value() as u32,
+        );
+
+        // First 410/1002: bounded retry, routing refresh flagged, no terminal conversion yet.
+        let first = policy.should_retry_error(&error).await;
+        assert!(first.is_retry(), "first 410/1002 should retry");
+        assert_eq!(policy.partition_key_range_gone_retry_count, 1);
+        assert!(policy.refresh_routing_on_next_attempt);
+        assert!(policy.terminal_gone_substatus().is_none());
+
+        // Second 410/1002: bound exhausted -> stop retrying, terminal 503 conversion pending.
+        let second = policy.should_retry_error(&error).await;
+        assert!(!second.is_retry(), "second 410/1002 should stop retrying");
+        assert_eq!(
+            policy.terminal_gone_substatus(),
+            Some(SubStatusCode::PARTITION_KEY_RANGE_GONE),
+            "terminal Gone must surface as 503 preserving sub-status 1002"
+        );
+    }
+
+    #[tokio::test]
+    async fn gone_partition_key_range_retries_then_converts_to_503_write() {
+        // Writes must also recover: a 410 from routing resolution means the
+        // operation was not applied, so a bounded retry is safe (Q4=B).
+        let mut policy = create_test_policy_with_preferred_locations();
+        policy.operation_type = Some(OperationType::Create);
+        let error = create_error_with_substatus(
+            StatusCode::Gone,
+            SubStatusCode::PARTITION_KEY_RANGE_GONE.value() as u32,
+        );
+
+        assert!(
+            policy.should_retry_error(&error).await.is_retry(),
+            "writes must also retry a 410/1002"
+        );
+        assert!(
+            !policy.should_retry_error(&error).await.is_retry(),
+            "writes must stop after the bound and convert"
+        );
+        assert_eq!(
+            policy.terminal_gone_substatus(),
+            Some(SubStatusCode::PARTITION_KEY_RANGE_GONE)
+        );
+    }
+
+    #[tokio::test]
+    async fn gone_name_cache_stale_and_completing_split_take_gone_branch() {
+        for ss in [
+            SubStatusCode::NAME_CACHE_IS_STALE,
+            SubStatusCode::COMPLETING_SPLIT,
+        ] {
+            let mut policy = create_test_policy_with_preferred_locations();
+            policy.operation_type = Some(OperationType::Read);
+            let error = create_error_with_substatus(StatusCode::Gone, ss.value() as u32);
+
+            assert!(
+                policy.should_retry_error(&error).await.is_retry(),
+                "410/{} should take the Gone-family retry branch",
+                ss.value()
+            );
+            assert_eq!(policy.partition_key_range_gone_retry_count, 1);
+            assert!(policy.refresh_routing_on_next_attempt);
+        }
+    }
+
+    #[tokio::test]
+    async fn not_found_session_not_available_not_treated_as_gone() {
+        // 404/1002 ReadSessionNotAvailable shares sub-status 1002 with 410/1002
+        // PartitionKeyRangeGone. It must keep the session-retry path, untouched by
+        // the new Gone-family branch (regression guard for the overloaded 1002).
+        let mut policy = create_test_policy();
+        policy.operation_type = Some(OperationType::Read);
+        let error = create_error_with_substatus(
+            StatusCode::NotFound,
+            SubStatusCode::READ_SESSION_NOT_AVAILABLE.value() as u32,
+        );
+
+        let _ = policy.should_retry_error(&error).await;
+        assert_eq!(
+            policy.session_token_retry_count, 1,
+            "404/1002 must use the session-not-available path"
+        );
+        assert_eq!(
+            policy.partition_key_range_gone_retry_count, 0,
+            "404/1002 must NOT use the Gone-family path"
+        );
+        assert!(policy.terminal_gone_substatus().is_none());
     }
 
     #[tokio::test]

--- a/sdk/cosmos/azure_data_cosmos/src/retry_policies/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/retry_policies/mod.rs
@@ -11,6 +11,7 @@ use crate::retry_policies::client_retry_policy::ClientRetryPolicy;
 use crate::retry_policies::metadata_request_retry_policy::MetadataRequestRetryPolicy;
 use crate::retry_policies::resource_throttle_retry_policy::ResourceThrottleRetryPolicy;
 use azure_core::error::ErrorKind;
+use azure_core::http::headers::Headers;
 use azure_core::http::{RawResponse, StatusCode};
 use azure_core::time::Duration;
 
@@ -124,6 +125,61 @@ impl RetryPolicy {
             RetryPolicy::ResourceThrottle(p) => p.should_retry(response).await,
             RetryPolicy::Metadata(p) => p.should_retry(response).await,
         }
+    }
+
+    /// Returns the Cosmos sub-status to preserve when a terminal partition-key-range
+    /// Gone (410.1000/1002/1007) must be surfaced as 503 Service Unavailable instead
+    /// of a raw 410, or `None` when no such conversion is pending. Only the data-plane
+    /// [`ClientRetryPolicy`] produces this signal.
+    pub fn terminal_gone_substatus(&self) -> Option<SubStatusCode> {
+        match self {
+            RetryPolicy::Client(p) => p.terminal_gone_substatus(),
+            RetryPolicy::ResourceThrottle(_) | RetryPolicy::Metadata(_) => None,
+        }
+    }
+}
+
+/// Rewrites a terminal partition-key-range Gone result (410 with sub-status
+/// 1000/1002/1007) into a 503 Service Unavailable while preserving the original
+/// Cosmos sub-status, so application-layer resilience logic (which is wired for
+/// 503, not 410) can classify and react to it.
+///
+/// Cosmos gateway responses for non-success status codes arrive here as an
+/// `Err(HttpResponse { status: Gone, .. })`; the rare `Ok(RawResponse)` form with a
+/// Gone status is handled too. Any other result is returned unchanged.
+pub(crate) fn convert_gone_to_service_unavailable(
+    result: azure_core::Result<RawResponse>,
+    sub_status: SubStatusCode,
+) -> azure_core::Result<RawResponse> {
+    let mut headers = match &result {
+        Ok(response) if response.status() == StatusCode::Gone => response.headers().clone(),
+        Err(err) if err.http_status() == Some(StatusCode::Gone) => Headers::new(),
+        // Not a Gone result: leave it untouched.
+        _ => return result,
+    };
+    headers.insert(SUB_STATUS, sub_status.to_string());
+
+    match result {
+        Ok(_) => Ok(RawResponse::from_bytes(
+            StatusCode::ServiceUnavailable,
+            headers,
+            Vec::new(),
+        )),
+        Err(_) => Err(azure_core::Error::with_message(
+            ErrorKind::HttpResponse {
+                status: StatusCode::ServiceUnavailable,
+                error_code: Some("ServiceUnavailable".to_string()),
+                raw_response: Some(Box::new(RawResponse::from_bytes(
+                    StatusCode::ServiceUnavailable,
+                    headers,
+                    Vec::new(),
+                ))),
+            },
+            format!(
+                "partition key range is gone (sub-status {sub_status}); routing information was stale \
+                 and could not be refreshed within the retry budget, surfaced as 503 Service Unavailable"
+            ),
+        )),
     }
 }
 
@@ -282,5 +338,67 @@ mod tests {
     fn credential_is_not_sent() {
         let err = azure_core::Error::with_message(ErrorKind::Credential, "auth failed");
         assert_eq!(err.request_sent_status(), RequestSentStatus::NotSent);
+    }
+
+    fn gone_error_with_substatus(value: &str) -> azure_core::Error {
+        let mut headers = azure_core::http::headers::Headers::new();
+        headers.insert(SUB_STATUS, value.to_string());
+        let raw = RawResponse::from_bytes(StatusCode::Gone, headers, Vec::new());
+        azure_core::Error::new(
+            ErrorKind::HttpResponse {
+                status: StatusCode::Gone,
+                error_code: None,
+                raw_response: Some(Box::new(raw)),
+            },
+            "partition key range gone",
+        )
+    }
+
+    #[test]
+    fn convert_gone_error_to_service_unavailable_preserves_substatus() {
+        let converted = convert_gone_to_service_unavailable(
+            Err(gone_error_with_substatus("1002")),
+            SubStatusCode::PARTITION_KEY_RANGE_GONE,
+        );
+        let err = converted.expect_err("a Gone error must remain an error");
+        assert_eq!(err.http_status(), Some(StatusCode::ServiceUnavailable));
+        assert_eq!(
+            get_substatus_code_from_error(&err),
+            Some(SubStatusCode::PARTITION_KEY_RANGE_GONE),
+            "the original sub-status must be preserved on the 503"
+        );
+    }
+
+    #[test]
+    fn convert_gone_ok_response_to_service_unavailable_preserves_substatus() {
+        let mut headers = azure_core::http::headers::Headers::new();
+        headers.insert(SUB_STATUS, "1002");
+        let response = RawResponse::from_bytes(StatusCode::Gone, headers, Vec::new());
+
+        let converted = convert_gone_to_service_unavailable(
+            Ok(response),
+            SubStatusCode::PARTITION_KEY_RANGE_GONE,
+        )
+        .expect("ok response must remain ok");
+        assert_eq!(converted.status(), StatusCode::ServiceUnavailable);
+        assert_eq!(
+            get_substatus_code_from_response(&converted),
+            Some(SubStatusCode::PARTITION_KEY_RANGE_GONE)
+        );
+    }
+
+    #[test]
+    fn convert_leaves_non_gone_results_untouched() {
+        let response = RawResponse::from_bytes(
+            StatusCode::Ok,
+            azure_core::http::headers::Headers::new(),
+            Vec::new(),
+        );
+        let converted = convert_gone_to_service_unavailable(
+            Ok(response),
+            SubStatusCode::PARTITION_KEY_RANGE_GONE,
+        )
+        .expect("non-gone ok stays ok");
+        assert_eq!(converted.status(), StatusCode::Ok);
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/src/routing/global_endpoint_manager.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/routing/global_endpoint_manager.rs
@@ -1,6 +1,7 @@
 //! Concrete (yet unimplemented) GlobalEndpointManager.
 //! All methods currently use `unimplemented!()` as placeholders per request to keep them blank.
 
+use crate::background_task_manager::BackgroundTaskManager;
 use crate::constants::ACCOUNT_PROPERTIES_KEY;
 use crate::cosmos_request::CosmosRequest;
 use crate::models::AccountProperties;
@@ -9,12 +10,28 @@ use crate::regions::RegionName;
 use crate::resource_context::{ResourceLink, ResourceType};
 use crate::routing::async_cache::AsyncCache;
 use crate::routing::location_cache::{LocationCache, RequestOperation};
+use azure_core::async_runtime::get_async_runtime;
+use azure_core::error::ErrorKind;
 use azure_core::http::{Context, Pipeline, Response};
+use azure_core::time::Duration as AzureDuration;
 use azure_core::Error;
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 use url::Url;
+
+/// Interval (in seconds) at which the background failback loop probes endpoints
+/// whose unavailability cooldown has elapsed.
+const FAILBACK_PROBE_INTERVAL_SECS: i64 = 60;
+
+/// Returns `true` if the error indicates the endpoint could not be reached
+/// (the connection itself failed), as opposed to the service returning a
+/// response. Mirrors the connection-failure classification used by the client
+/// retry policy.
+fn is_connection_failure(error: &Error) -> bool {
+    matches!(error.kind(), ErrorKind::Io | ErrorKind::Connection)
+}
 
 /// Manages global endpoint routing, failover, and location awareness for Cosmos DB requests.
 ///
@@ -35,6 +52,12 @@ pub(crate) struct GlobalEndpointManager {
 
     /// Cache for account properties with 600 second TTL to reduce redundant service calls
     account_properties_cache: AsyncCache<&'static str, AccountProperties>,
+
+    /// Manages the background failback-probe task and cancels it when dropped.
+    background_task_manager: BackgroundTaskManager,
+
+    /// Guards against starting the background failback-probe loop more than once.
+    probe_loop_active: AtomicBool,
 }
 
 impl GlobalEndpointManager {
@@ -76,6 +99,114 @@ impl GlobalEndpointManager {
             location_cache,
             pipeline,
             account_properties_cache,
+            background_task_manager: BackgroundTaskManager::new(),
+            probe_loop_active: AtomicBool::new(false),
+        }
+    }
+
+    /// Starts the background failback-probe loop if it is not already running.
+    ///
+    /// # Summary
+    /// Spawns a single background task (tracked by the [`BackgroundTaskManager`], cancelled
+    /// when this manager — and thus the client — is dropped) that periodically probes
+    /// endpoints whose unavailability cooldown has elapsed. Only endpoints that pass a
+    /// connectivity probe are returned to the routing rotation, preventing real traffic from
+    /// being repeatedly failed back to an endpoint that is still unreachable (e.g.
+    /// firewall-blocked). Safe to call multiple times; subsequent calls are no-ops.
+    ///
+    /// Takes `self: &Arc<Self>` because the spawned task holds a [`Weak`] reference and must
+    /// not keep the manager alive on its own.
+    pub(crate) fn start_failback_probe_loop(self: &Arc<Self>) {
+        // Atomically transition from not-running to running; if it was already
+        // running, another caller started the loop.
+        if self
+            .probe_loop_active
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return;
+        }
+
+        let weak_self = Arc::downgrade(self);
+        // Capture a Weak<Self> (not Arc<Self>) so the loop does not prevent the
+        // GlobalEndpointManager from being dropped.
+        self.background_task_manager.spawn(Box::pin(async move {
+            Self::failback_probe_loop(weak_self).await;
+        }));
+    }
+
+    /// Runs the background loop that probes cooled-down unavailable endpoints.
+    ///
+    /// The loop exits when `weak_self.upgrade()` returns `None` (the owning client has been
+    /// dropped, which drops the [`BackgroundTaskManager`] and cancels this task).
+    async fn failback_probe_loop(weak_self: Weak<Self>) {
+        let interval = AzureDuration::seconds(FAILBACK_PROBE_INTERVAL_SECS);
+
+        loop {
+            get_async_runtime().sleep(interval).await;
+
+            let strong = match weak_self.upgrade() {
+                Some(s) => s,
+                None => return,
+            };
+
+            strong.probe_pending_endpoints().await;
+        }
+    }
+
+    /// Probes every endpoint whose cooldown has elapsed and applies the result.
+    ///
+    /// Claims the due endpoints (marking them probe-in-flight) under the cache lock, releases
+    /// the lock, performs the (async) probes, then re-acquires the lock to record each result.
+    /// The lock is never held across an `.await`.
+    async fn probe_pending_endpoints(&self) {
+        let due = {
+            self.location_cache
+                .lock()
+                .unwrap()
+                .take_endpoints_due_for_probe()
+        };
+
+        for endpoint in due {
+            let reachable = self.probe_endpoint(&endpoint).await;
+            self.location_cache
+                .lock()
+                .unwrap()
+                .apply_probe_result(&endpoint, reachable);
+        }
+    }
+
+    /// Probes a single endpoint for connectivity through the gateway pipeline.
+    ///
+    /// # Summary
+    /// Sends a lightweight database-account read to the specified endpoint using the core
+    /// pipeline (which does not run the endpoint-marking retry policy, so a probe never
+    /// recursively marks endpoints unavailable). Connectivity — not the HTTP status — is what
+    /// matters: any completed response (even an error status) means the endpoint is reachable;
+    /// only a connection-level failure (`ErrorKind::Io`/`Connection`) means it is not.
+    ///
+    /// # Arguments
+    /// * `endpoint` - The endpoint URL to probe
+    ///
+    /// # Returns
+    /// `true` if the endpoint is reachable, `false` if the connection failed
+    pub(crate) async fn probe_endpoint(&self, endpoint: &Url) -> bool {
+        let resource_link = ResourceLink::root(ResourceType::DatabaseAccount);
+        let builder = CosmosRequest::builder(OperationType::Read, resource_link.clone());
+        let mut cosmos_request = match builder.build() {
+            Ok(request) => request,
+            Err(_) => return false,
+        };
+        cosmos_request.request_context.location_endpoint_to_route = Some(endpoint.clone());
+        let ctx_owned = Context::default().with_value(resource_link);
+
+        match self
+            .pipeline
+            .send(&ctx_owned, &mut cosmos_request.into_raw_request(), None)
+            .await
+        {
+            Ok(_) => true,
+            Err(error) => !is_connection_failure(&error),
         }
     }
 
@@ -540,6 +671,24 @@ mod tests {
 
         // Read requests should not use multiple write locations
         assert!(!manager.can_use_multiple_write_locations(&request));
+    }
+
+    #[test]
+    fn connection_failures_are_classified_as_unreachable() {
+        // A probe treats connection-level failures (the endpoint could not be
+        // reached) as "unreachable", but any other error (the service replied)
+        // as "reachable".
+        let connection_err =
+            azure_core::Error::with_message(ErrorKind::Connection, "connection refused");
+        let io_err = azure_core::Error::with_message(ErrorKind::Io, "timed out");
+        let http_err = azure_core::Error::with_message(ErrorKind::Other, "service replied");
+
+        assert!(is_connection_failure(&connection_err));
+        assert!(is_connection_failure(&io_err));
+        assert!(
+            !is_connection_failure(&http_err),
+            "a non-connection error means the endpoint was reachable"
+        );
     }
 
     #[test]

--- a/sdk/cosmos/azure_data_cosmos/src/routing/global_partition_endpoint_manager.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/routing/global_partition_endpoint_manager.rs
@@ -235,13 +235,15 @@ impl GlobalPartitionEndpointManager {
         }
     }
 
-    /// Attempts to initiate failback to previously failed endpoints non-deterministically.
+    /// Attempts to initiate failback to previously failed endpoints, gated by a probe.
     ///
     /// Scans `partition_key_range_to_location_for_read_and_write` for partitions whose
     /// first failure occurred more than [`partition_unavailability_duration_secs`] ago.
-    /// Eligible partitions are marked healthy via [`mark_endpoints_to_healthy`], and their
-    /// override entries are removed, allowing future requests to be routed back to the
-    /// original endpoint.
+    /// Before failing a partition back, the previously-failed endpoint is verified with a
+    /// connectivity probe ([`GlobalEndpointManager::probe_endpoint`]); only partitions whose
+    /// endpoint passes the probe have their override entries removed, allowing future requests
+    /// to be routed back to the original endpoint. This prevents repeatedly routing partitions
+    /// back to an endpoint that is still unreachable.
     ///
     /// # Errors
     /// Returns an error if the read lock on the partition map is poisoned.
@@ -288,10 +290,31 @@ impl GlobalPartitionEndpointManager {
             // Mark endpoints as healthy directly
             Self::mark_endpoints_to_healthy(&mut pk_range_to_endpoint_mappings);
 
+            // Probe each unique previously-failed endpoint before failing back, so we do
+            // not route partitions back to an endpoint that is still unreachable (e.g.
+            // firewall-blocked). Connectivity — not HTTP status — is what gates failback.
+            let mut reachability: HashMap<String, bool> = HashMap::new();
+            for (_, (_, original_failed_location, _)) in pk_range_to_endpoint_mappings.iter() {
+                if !reachability.contains_key(original_failed_location) {
+                    let reachable = match Url::parse(original_failed_location) {
+                        Ok(url) => self.global_endpoint_manager.probe_endpoint(&url).await,
+                        // If the stored endpoint can't be parsed we can't probe it; fall
+                        // back to the previous optimistic behavior rather than stranding
+                        // the partition forever.
+                        Err(_) => true,
+                    };
+                    reachability.insert(original_failed_location.clone(), reachable);
+                }
+            }
+
             for (pk_range, (_, original_failed_location, current_health_state)) in
                 pk_range_to_endpoint_mappings
             {
-                if current_health_state == PartitionHealthStatus::Healthy {
+                let reachable = reachability
+                    .get(&original_failed_location)
+                    .copied()
+                    .unwrap_or(false);
+                if current_health_state == PartitionHealthStatus::Healthy && reachable {
                     info!(
                         "Initiating failback to endpoint: {}, for partition key range: {:?}",
                         original_failed_location, pk_range

--- a/sdk/cosmos/azure_data_cosmos/src/routing/location_cache.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/routing/location_cache.rs
@@ -80,6 +80,14 @@ pub(crate) struct LocationUnavailabilityInfo {
     pub last_check_time: SystemTime,
     /// Type of operation(s) for which the endpoint is unavailable
     pub unavailable_operation: RequestOperation,
+    /// Whether a connectivity probe is currently in flight for this endpoint.
+    ///
+    /// Guards against launching more than one probe per endpoint when the
+    /// background failback loop picks up the same endpoint on overlapping
+    /// passes. Defaults to `false` for backwards compatibility with any
+    /// previously-serialized state.
+    #[serde(default)]
+    pub probe_in_flight: bool,
 }
 
 /// Manages location-aware endpoint routing and availability tracking for Cosmos DB requests.
@@ -257,6 +265,7 @@ impl LocationCache {
             if let Some(info) = location_unavailability_info_map.get_mut(endpoint) {
                 // update last check time and operation in unavailability_info_map
                 info.last_check_time = now;
+                info.probe_in_flight = false;
                 if !info.unavailable_operation.includes(operation) {
                     info.unavailable_operation = RequestOperation::All;
                 }
@@ -267,6 +276,7 @@ impl LocationCache {
                     LocationUnavailabilityInfo {
                         last_check_time: now,
                         unavailable_operation: operation,
+                        probe_in_flight: false,
                     },
                 );
             }
@@ -284,24 +294,25 @@ impl LocationCache {
     ///
     /// # Summary
     /// Queries the unavailability map to determine if an endpoint should be avoided for the
-    /// given operation type. Returns true only if the endpoint is marked unavailable for the
-    /// operation AND less than 5 minutes have elapsed since it was marked. After 5 minutes,
-    /// endpoints are automatically considered available again.
+    /// given operation type. Returns true if the endpoint is currently marked unavailable for
+    /// the operation. Unlike the previous time-based behavior, an endpoint is **not** considered
+    /// available again simply because a cooldown elapsed; it remains unavailable until a
+    /// connectivity probe confirms it is reachable (see [`Self::take_endpoints_due_for_probe`]
+    /// and [`Self::apply_probe_result`]). This prevents repeatedly routing real traffic to an
+    /// endpoint that is still unreachable (e.g. firewall-blocked).
     ///
     /// # Arguments
     /// * `endpoint` - The endpoint URL to check
     /// * `operation` - The operation type to check for
     ///
     /// # Returns
-    /// `true` if endpoint is unavailable and not expired, `false` otherwise
+    /// `true` if endpoint is marked unavailable for the operation, `false` otherwise
     pub fn is_endpoint_unavailable(&self, endpoint: &Url, operation: RequestOperation) -> bool {
         let location_unavailability_info_map =
             self.location_unavailability_info_map.read().unwrap();
         if let Some(info) = location_unavailability_info_map.get(endpoint) {
-            // Checks if endpoint is unavailable for the given operation
-            let elapsed =
-                info.last_check_time.elapsed().unwrap_or_default() < DEFAULT_EXPIRATION_TIME;
-            info.unavailable_operation.includes(operation) && elapsed
+            // Endpoint stays unavailable until a successful probe clears the entry.
+            info.unavailable_operation.includes(operation)
         } else {
             false
         }
@@ -448,9 +459,8 @@ impl LocationCache {
     /// # Summary
     /// Rebuilds the read and write endpoint lists by querying preferred locations against
     /// available endpoints from the account. Orders endpoints by preference with available
-    /// endpoints first and unavailable endpoints last. Also removes stale unavailability
-    /// entries older than 5 minutes. Called after marking endpoints unavailable or updating
-    /// account regions.
+    /// endpoints first and unavailable endpoints last. Called after marking endpoints
+    /// unavailable, after a successful probe clears an endpoint, or when account regions change.
     fn refresh_endpoints(&mut self) {
         // Rebuild the preferred-and-availability-ordered endpoint lists so
         // that unavailable endpoints are pushed to the back.  Without this,
@@ -468,8 +478,6 @@ impl LocationCache {
             &self.default_endpoint,
             None,
         );
-
-        self.refresh_stale_endpoints();
     }
 
     /// Converts a list of regions into a location-to-endpoint map and region list.
@@ -571,21 +579,72 @@ impl LocationCache {
         endpoints
     }
 
-    /// Removes stale endpoint unavailability entries older than 5 minutes.
+    /// Returns the endpoints that are due for a connectivity probe and claims them.
     ///
     /// # Summary
-    /// Cleans up the unavailability map by removing entries where more than 5 minutes have
-    /// elapsed since the endpoint was marked unavailable. This allows endpoints to automatically
-    /// recover and be considered available again after the expiration period, enabling retry
-    /// attempts without manual intervention.
-    fn refresh_stale_endpoints(&mut self) {
+    /// Scans the unavailability map for endpoints whose cooldown
+    /// ([`DEFAULT_EXPIRATION_TIME`]) has elapsed and that do not already have a probe in
+    /// flight. Each returned endpoint is atomically marked `probe_in_flight = true` so that
+    /// concurrent or overlapping passes of the background failback loop never launch more
+    /// than one probe per endpoint. The caller is expected to probe each endpoint and report
+    /// the outcome via [`Self::apply_probe_result`].
+    ///
+    /// # Returns
+    /// The list of endpoint URLs that should be probed now.
+    pub(crate) fn take_endpoints_due_for_probe(&mut self) -> Vec<Url> {
+        let mut due = Vec::new();
         let mut location_unavailability_info_map =
             self.location_unavailability_info_map.write().unwrap();
 
-        // Removes endpoints that have not been checked in the last 5 minutes
-        location_unavailability_info_map.retain(|_, info| {
-            info.last_check_time.elapsed().unwrap_or_default() <= DEFAULT_EXPIRATION_TIME
-        });
+        for (endpoint, info) in location_unavailability_info_map.iter_mut() {
+            if info.probe_in_flight {
+                continue;
+            }
+            if info.last_check_time.elapsed().unwrap_or_default() >= DEFAULT_EXPIRATION_TIME {
+                info.probe_in_flight = true;
+                due.push(endpoint.clone());
+            }
+        }
+
+        due
+    }
+
+    /// Applies the result of a connectivity probe for an endpoint.
+    ///
+    /// # Summary
+    /// On a successful probe (`reachable == true`) the endpoint's unavailability entry is
+    /// removed, restoring it to the routing rotation for the operation(s) it was originally
+    /// marked unavailable for (operation-scoped recovery), and the ordered endpoint lists are
+    /// refreshed. On a failed probe the cooldown is reset (`last_check_time = now`) and the
+    /// in-flight flag is cleared so the endpoint becomes eligible for another probe after the
+    /// next cooldown, without thrashing.
+    ///
+    /// # Arguments
+    /// * `endpoint` - The endpoint that was probed
+    /// * `reachable` - Whether the connectivity probe succeeded
+    pub(crate) fn apply_probe_result(&mut self, endpoint: &Url, reachable: bool) {
+        let removed = {
+            let mut location_unavailability_info_map =
+                self.location_unavailability_info_map.write().unwrap();
+
+            if reachable {
+                location_unavailability_info_map.remove(endpoint).is_some()
+            } else if let Some(info) = location_unavailability_info_map.get_mut(endpoint) {
+                info.last_check_time = SystemTime::now();
+                info.probe_in_flight = false;
+                false
+            } else {
+                false
+            }
+        };
+
+        if removed {
+            info!(
+                "Endpoint {} passed connectivity probe; marking available",
+                endpoint
+            );
+            self.refresh_endpoints();
+        }
     }
 }
 
@@ -957,7 +1016,7 @@ mod tests {
     }
 
     #[test]
-    fn refresh_stale_endpoints() {
+    fn expired_endpoint_stays_unavailable_until_probed() {
         // create test cache
         let mut cache = create_test_location_cache();
 
@@ -967,7 +1026,7 @@ mod tests {
         cache.mark_endpoint_unavailable(&endpoint1, RequestOperation::Read);
         cache.mark_endpoint_unavailable(&endpoint2, RequestOperation::Read);
 
-        // simulate stale entry
+        // simulate the cooldown having elapsed for endpoint1
         {
             let mut unavailability_map = cache.location_unavailability_info_map.write().unwrap();
             if let Some(info) = unavailability_map.get_mut(&endpoint1) {
@@ -975,11 +1034,54 @@ mod tests {
             }
         }
 
-        // refresh stale endpoints
-        cache.refresh_stale_endpoints();
+        // Cooldown elapsing alone must NOT make the endpoint available again.
+        assert!(
+            cache.is_endpoint_unavailable(&endpoint1, RequestOperation::Read),
+            "expired endpoint must stay unavailable until a probe confirms reachability"
+        );
 
-        // check that endpoint 1 is marked as available again
+        // The endpoint should now be eligible for a probe (and only it, not endpoint2).
+        let due = cache.take_endpoints_due_for_probe();
+        assert_eq!(due, vec![endpoint1.clone()]);
+
+        // A second call must not re-offer the same endpoint while its probe is in flight.
+        assert!(
+            cache.take_endpoints_due_for_probe().is_empty(),
+            "an endpoint with a probe in flight must not be offered again"
+        );
+
+        // A failed probe keeps it unavailable.
+        cache.apply_probe_result(&endpoint1, false);
+        assert!(cache.is_endpoint_unavailable(&endpoint1, RequestOperation::Read));
+
+        // A successful probe clears it.
+        {
+            let mut unavailability_map = cache.location_unavailability_info_map.write().unwrap();
+            if let Some(info) = unavailability_map.get_mut(&endpoint1) {
+                info.last_check_time = SystemTime::now() - Duration::from_secs(500);
+            }
+        }
+        let due = cache.take_endpoints_due_for_probe();
+        assert_eq!(due, vec![endpoint1.clone()]);
+        cache.apply_probe_result(&endpoint1, true);
         assert!(!cache.is_endpoint_unavailable(&endpoint1, RequestOperation::Read));
+    }
+
+    #[test]
+    fn successful_probe_clears_only_marked_operation() {
+        let mut cache = create_test_location_cache();
+        let endpoint1: Url = "https://location1.documents.example.com".parse().unwrap();
+
+        // Marked unavailable for reads only.
+        cache.mark_endpoint_unavailable(&endpoint1, RequestOperation::Read);
+        assert!(cache.is_endpoint_unavailable(&endpoint1, RequestOperation::Read));
+        // Writes were never marked unavailable on this endpoint.
+        assert!(!cache.is_endpoint_unavailable(&endpoint1, RequestOperation::Write));
+
+        // A successful probe clears the entry (the only operation it was marked for).
+        cache.apply_probe_result(&endpoint1, true);
+        assert!(!cache.is_endpoint_unavailable(&endpoint1, RequestOperation::Read));
+        assert!(!cache.is_endpoint_unavailable(&endpoint1, RequestOperation::Write));
     }
 
     #[test]

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_fault_injection.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_fault_injection.rs
@@ -944,3 +944,66 @@ pub async fn fault_injection_enable_disable_rule() -> Result<(), Box<dyn Error>>
     )
     .await
 }
+
+/// Injecting a partition-key-range Gone (410/1002) on point operations must NOT
+/// surface a raw 410 to the caller. The Gone-family is retried within a small
+/// bound and, on exhaustion, converted to 503 Service Unavailable so application
+/// resilience logic (wired for 503, not 410) can classify it. Regression test for
+/// the Rust sibling of Azure/azure-cosmos-dotnet-v3#5924.
+#[tokio::test]
+pub async fn fault_injection_partition_key_range_gone_surfaces_503() -> Result<(), Box<dyn Error>> {
+    let server_error = FaultInjectionResultBuilder::new()
+        .with_error(FaultInjectionErrorType::PartitionIsGone) // 410 / 1002
+        .with_probability(1.0)
+        .build();
+
+    let condition = FaultInjectionConditionBuilder::new()
+        .with_operation_type(FaultOperationType::ReadItem)
+        .build();
+
+    let rule = FaultInjectionRuleBuilder::new("partition-key-range-gone", server_error)
+        .with_condition(condition)
+        .build();
+
+    let fault_builder = FaultInjectionClientBuilder::new().with_rule(Arc::new(rule));
+
+    TestClient::run_with_unique_db(
+        async |run_context, db_client| {
+            let container_id = format!("Container-{}", Uuid::new_v4());
+            let container_client = run_context
+                .create_container_with_throughput(
+                    db_client,
+                    ContainerProperties::new(container_id.clone(), "/partition_key".into()),
+                    ThroughputProperties::manual(400),
+                )
+                .await?;
+
+            let unique_id = Uuid::new_v4().to_string();
+            let item = create_test_item(&unique_id);
+            let pk = format!("Partition-{}", unique_id);
+            let item_id = format!("Item-{}", unique_id);
+
+            container_client.create_item(&pk, &item, None).await?;
+
+            let fault_client = run_context
+                .fault_client()
+                .expect("fault client should be available");
+            let fault_db_client = fault_client.database_client(db_client.id());
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
+
+            let result = fault_container_client
+                .read_item::<TestItem>(&pk, &item_id, None)
+                .await;
+            let err = result.expect_err("read should fail when partition is gone");
+            assert_eq!(
+                Some(StatusCode::ServiceUnavailable),
+                err.http_status(),
+                "terminal 410/1002 must be surfaced as 503, not a raw 410"
+            );
+
+            Ok(())
+        },
+        Some(TestOptions::new().with_fault_injection_builder(fault_builder)),
+    )
+    .await
+}


### PR DESCRIPTION
Fixes #4597

## Problem

When a regional endpoint is firewall-blocked, the Cosmos SDK failed it back into the routing rotation **purely on a 5-minute time expiry, with no connectivity check** (`LocationCache::is_endpoint_unavailable`). The blocked endpoint would be marked available again, have real traffic routed to it, time out on connect (~3s of retries), and be re-marked unavailable — a sustained low-throughput loop that repeats every cooldown.

## Fix

An unavailable endpoint now only returns to rotation after a **connectivity probe** confirms it is reachable.

- **`location_cache.rs`** — cooldown expiry no longer makes an endpoint available; it only makes it *probe-eligible*. Removed the time-based auto-availability in `is_endpoint_unavailable` and the stale-entry sweep (`refresh_stale_endpoints`). Added:
  - `take_endpoints_due_for_probe` — returns endpoints past their cooldown and claims them (`probe_in_flight`) so at most one probe runs per endpoint.
  - `apply_probe_result` — on success removes the entry (operation-scoped recovery) and refreshes routing; on failure resets the cooldown.
- **`global_endpoint_manager.rs`** — added `probe_endpoint` (a lightweight request through the **core** gateway pipeline, which bypasses the marking retry policy so a probe never recursively marks endpoints; any completed response = reachable, only `ErrorKind::Io`/`Connection` = unreachable) and a background failback-probe loop started by the client builder. The loop reuses the existing `BackgroundTaskManager` + `azure_core::async_runtime` (runtime-agnostic spawn/sleep) — **no new `tokio` dependency**.
- **`global_partition_endpoint_manager.rs`** — the partition-level circuit-breaker failback is gated by the same probe.

### Design notes for reviewers
- **Probe transport is HTTP (gateway mode).** The Rust SDK has no raw-TCP path and uses gateway mode only, so the probe is an HTTP connectivity check rather than the raw TCP probe described in the issue. Connectivity — not HTTP status — is what gates failback.
- **The background loop adds an always-on timer per client** (60s interval), cancelled on client drop via `BackgroundTaskManager`. Flagging this explicitly per review.
- The synchronous, lock-held routing path performs no probe I/O; probes run out-of-band in the async layer.

## Tests
- Rewrote the time-based `refresh_stale_endpoints` unit test as a probe-driven test (expiry alone keeps the endpoint unavailable; a failed probe keeps it unavailable; a successful probe clears it; single-in-flight invariant).
- Added `successful_probe_clears_only_marked_operation` (operation-scoped recovery) and `connection_failures_are_classified_as_unreachable` (probe classification).
- `cargo test` (448 lib + 42 doc tests), `cargo clippy`, and `cargo fmt --check` all pass. (`--all-features` is not buildable in this environment because `hmac_openssl` requires a local OpenSSL; validated with `fault_injection,key_auth` + default features.)
