### PR TITLE
Decouple Cosmos metadata reads from caller cancellation

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bugs Fixed
 
+- Fixed a control-plane metadata read (e.g. cold collection/partition-key-range cache warm-up) preempting its own cross-region failover when the caller's future was dropped (Rust's cancellation mechanism) mid-flight against an unhealthy region. Metadata reads now run on a detached, internally-bounded executor so a dropped caller no longer cancels the in-flight attempt before the retry policy can fail over to the next region. The detached work is bounded by a hard deadline (default 5 minutes, configurable via `AZURE_COSMOS_METADATA_DETACHED_HARD_DEADLINE_SECONDS`, clamped to 24 hours) and a defensive 50-attempt cap. Only idempotent metadata reads are detached; metadata writes and all data-plane requests are unaffected. ([#4253](https://github.com/Azure/azure-sdk-for-rust/issues/4253))
 - Fixed `410 Gone` responses carrying a partition-key-range routing sub-status (`1000` NameCacheIsStale, `1002` PartitionKeyRangeGone, `1007` CompletingSplit) escaping the retry pipeline as a raw, unclassifiable `410` (returned directly to the caller on writes, or after non-curative cross-region failover on reads). These are now retried within a small bound — flagging a routing-cache refresh so SDK-routing paths re-resolve stale routing information — and, on exhaustion, surfaced as `503 Service Unavailable` with the original sub-status preserved. This aligns the surfaced status with the rest of the Gone family so application-layer retry/circuit-breaker logic (wired for `503`, not `410`) can classify it.
 
 ## 0.31.0 (2026-02-25)

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Added `tokio` feature to `default` features.
 - Changed `default_ttl` and `analytical_storage_ttl` fields on `ContainerProperties` from `Option<Duration>` to `TimeToLive`, a new enum with variants `Forever`, `NoDefault`, and `Seconds(u32)`, to correctly handle the `-1` wire value (TTL enabled with no default expiration).
 
+### Bugs Fixed
+
+- Fixed `410 Gone` responses carrying a partition-key-range routing sub-status (`1000` NameCacheIsStale, `1002` PartitionKeyRangeGone, `1007` CompletingSplit) escaping the retry pipeline as a raw, unclassifiable `410` (returned directly to the caller on writes, or after non-curative cross-region failover on reads). These are now retried within a small bound — flagging a routing-cache refresh so SDK-routing paths re-resolve stale routing information — and, on exhaustion, surfaced as `503 Service Unavailable` with the original sub-status preserved. This aligns the surfaced status with the rest of the Gone family so application-layer retry/circuit-breaker logic (wired for `503`, not `410`) can classify it.
+
 ## 0.31.0 (2026-02-25)
 
 ### Features Added

--- a/sdk/cosmos/azure_data_cosmos/src/handler/retry_handler.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/handler/retry_handler.rs
@@ -4,7 +4,7 @@
 use crate::cosmos_request::CosmosRequest;
 use crate::retry_policies::client_retry_policy::ClientRetryPolicy;
 use crate::retry_policies::metadata_request_retry_policy::MetadataRequestRetryPolicy;
-use crate::retry_policies::{RetryPolicy, RetryResult};
+use crate::retry_policies::{convert_gone_to_service_unavailable, RetryPolicy, RetryResult};
 use crate::routing::global_endpoint_manager::GlobalEndpointManager;
 use crate::routing::global_partition_endpoint_manager::GlobalPartitionEndpointManager;
 use async_trait::async_trait;
@@ -139,7 +139,15 @@ impl RetryHandler for BackOffRetryHandler {
             let retry_result = retry_policy.should_retry(&result).await;
 
             match retry_result {
-                RetryResult::DoNotRetry => return result,
+                RetryResult::DoNotRetry => {
+                    // If the data-plane policy exhausted its partition-key-range Gone
+                    // budget, surface the terminal failure as 503 (preserving the
+                    // original sub-status) instead of letting a raw 410 escape.
+                    if let Some(sub_status) = retry_policy.terminal_gone_substatus() {
+                        return convert_gone_to_service_unavailable(result, sub_status);
+                    }
+                    return result;
+                }
                 RetryResult::Retry { after } => get_async_runtime().sleep(after).await,
             }
         }

--- a/sdk/cosmos/azure_data_cosmos/src/handler/retry_handler.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/handler/retry_handler.rs
@@ -2,15 +2,85 @@
 // Licensed under the MIT License.
 
 use crate::cosmos_request::CosmosRequest;
+use crate::operation_context::OperationType;
 use crate::retry_policies::client_retry_policy::ClientRetryPolicy;
 use crate::retry_policies::metadata_request_retry_policy::MetadataRequestRetryPolicy;
 use crate::retry_policies::{convert_gone_to_service_unavailable, RetryPolicy, RetryResult};
 use crate::routing::global_endpoint_manager::GlobalEndpointManager;
 use crate::routing::global_partition_endpoint_manager::GlobalPartitionEndpointManager;
 use async_trait::async_trait;
+use azure_core::error::ErrorKind;
+use azure_core::time::Duration;
 use azure_core::{async_runtime::get_async_runtime, http::RawResponse};
+use futures::future::Either;
 use std::sync::Arc;
 use tracing::debug;
+
+/// Environment variable used to override the detached-metadata hard deadline (in seconds).
+const METADATA_DETACHED_HARD_DEADLINE_ENV: &str =
+    "AZURE_COSMOS_METADATA_DETACHED_HARD_DEADLINE_SECONDS";
+
+/// Default hard deadline bounding a detached metadata read (5 minutes).
+const DEFAULT_METADATA_DETACHED_HARD_DEADLINE_SECS: u64 = 300;
+
+/// Upper bound for the detached-metadata hard deadline (24 hours). Clamping guards
+/// against a misconfigured environment value producing an unreasonably long-lived
+/// background task.
+const MAX_METADATA_DETACHED_HARD_DEADLINE_SECS: u64 = 86_400;
+
+/// Defensive cap on the number of attempts a detached metadata read may make.
+/// Guards against a misbehaving retry policy that keeps returning
+/// [`RetryResult::Retry`] with zero backoff.
+const METADATA_DETACHED_ATTEMPT_CAP: usize = 50;
+
+/// Returns `true` when a request is a control-plane metadata read that is safe to run
+/// on a detached task (see [`send_detached`]).
+///
+/// Detaching means the work continues even if the caller drops its future, so it must
+/// be restricted to **idempotent** operations. [`ResourceType::is_meta_data`] alone is
+/// insufficient because metadata resource types also carry mutating operations (e.g.
+/// creating or deleting a database/container); detaching those could double-apply a
+/// write if the caller drops and then retries. We therefore additionally require a
+/// read-style (non-mutating) operation. This intentionally excludes `Create`,
+/// `Replace`, `Delete`, `Upsert`, `Patch`, and `Batch`.
+fn is_detachable_metadata_read(request: &CosmosRequest) -> bool {
+    request.resource_type.is_meta_data()
+        && matches!(
+            request.operation_type,
+            OperationType::Read
+                | OperationType::ReadFeed
+                | OperationType::Query
+                | OperationType::SqlQuery
+                | OperationType::QueryPlan
+                | OperationType::Head
+                | OperationType::HeadFeed
+        )
+}
+
+/// Resolves the hard deadline that bounds a detached metadata read.
+///
+/// Reads [`METADATA_DETACHED_HARD_DEADLINE_ENV`] and delegates to
+/// [`resolve_hard_deadline_secs`] for parsing, validation, and clamping.
+fn metadata_detached_hard_deadline() -> Duration {
+    let raw = std::env::var(METADATA_DETACHED_HARD_DEADLINE_ENV).ok();
+    Duration::seconds(resolve_hard_deadline_secs(raw.as_deref()) as i64)
+}
+
+/// Parses, validates, and clamps a hard-deadline override value (in seconds).
+///
+/// A positive integer is honored up to [`MAX_METADATA_DETACHED_HARD_DEADLINE_SECS`];
+/// anything missing, non-numeric, or zero falls back to
+/// [`DEFAULT_METADATA_DETACHED_HARD_DEADLINE_SECS`]. The clamp keeps the value well
+/// within range for constructing a timer and prevents an unbounded background task.
+///
+/// Split out from [`metadata_detached_hard_deadline`] so the logic can be unit-tested
+/// without mutating the process-global environment.
+fn resolve_hard_deadline_secs(raw: Option<&str>) -> u64 {
+    raw.and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(DEFAULT_METADATA_DETACHED_HARD_DEADLINE_SECS)
+        .min(MAX_METADATA_DETACHED_HARD_DEADLINE_SECS)
+}
 
 /// Trait defining the interface for retry handlers in Cosmos DB operations
 ///
@@ -47,8 +117,8 @@ pub trait RetryHandler: Send + Sync {
         sender: Sender,
     ) -> azure_core::Result<RawResponse>
     where
-        Sender: Fn(&mut CosmosRequest) -> Fut + Send + Sync,
-        Fut: std::future::Future<Output = azure_core::Result<RawResponse>> + Send;
+        Sender: Fn(&mut CosmosRequest) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = azure_core::Result<RawResponse>> + Send + 'static;
 }
 
 /// Concrete retry handler implementation with exponential back off.
@@ -115,41 +185,569 @@ impl RetryHandler for BackOffRetryHandler {
         sender: Sender,
     ) -> azure_core::Result<RawResponse>
     where
-        Sender: Fn(&mut CosmosRequest) -> Fut + Send + Sync,
-        Fut: std::future::Future<Output = azure_core::Result<RawResponse>> + Send,
+        Sender: Fn(&mut CosmosRequest) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = azure_core::Result<RawResponse>> + Send + 'static,
     {
         // Get the appropriate retry policy based on the request
-        let mut retry_policy = self.retry_policy_for_request(request);
+        let retry_policy = self.retry_policy_for_request(request);
 
-        loop {
-            retry_policy.before_send_request(request).await;
+        // Control-plane metadata reads are decoupled from caller cancellation:
+        // dropping the caller's future must not preempt the retry policy's
+        // cross-region failover decision (issue #4253). This is restricted to
+        // idempotent metadata *reads* (see `is_detachable_metadata_read`); metadata
+        // writes and all data-plane requests keep the in-line loop so that a dropped
+        // caller still cancels in-flight work (important for non-idempotent writes).
+        if is_detachable_metadata_read(request) {
+            send_detached(
+                retry_policy,
+                request,
+                sender,
+                metadata_detached_hard_deadline(),
+            )
+            .await
+        } else {
+            drive_retry_loop(retry_policy, request, &sender, None).await
+        }
+    }
+}
 
-            // Log the endpoint URL being used for this request
-            debug!(
-                target: "azure_data_cosmos::retry_handler",
-                "Sending request - endpoint: {:?}, region: {:?}, operation: {:?}, resource: {:?}",
-                request.request_context.location_endpoint_to_route,
-                request.request_context.region_name,
-                request.operation_type,
-                request.resource_type
-            );
+/// Drives the back-off retry loop for a single logical request.
+///
+/// Repeatedly invokes `sender`, consulting `retry_policy` after each attempt, until
+/// the policy reports [`RetryResult::DoNotRetry`] (or `max_attempts`, when set, is
+/// reached). The terminal partition-key-range Gone result is rewritten to a 503 when
+/// the policy signals it.
+async fn drive_retry_loop<Sender, Fut>(
+    mut retry_policy: RetryPolicy,
+    request: &mut CosmosRequest,
+    sender: &Sender,
+    max_attempts: Option<usize>,
+) -> azure_core::Result<RawResponse>
+where
+    Sender: Fn(&mut CosmosRequest) -> Fut + Send + Sync,
+    Fut: std::future::Future<Output = azure_core::Result<RawResponse>> + Send,
+{
+    let mut attempts = 0usize;
 
-            // Invoke the provided sender callback instead of calling inner_send_async directly
-            let result = sender(request).await;
-            let retry_result = retry_policy.should_retry(&result).await;
+    loop {
+        attempts += 1;
+        retry_policy.before_send_request(request).await;
 
-            match retry_result {
-                RetryResult::DoNotRetry => {
-                    // If the data-plane policy exhausted its partition-key-range Gone
-                    // budget, surface the terminal failure as 503 (preserving the
-                    // original sub-status) instead of letting a raw 410 escape.
-                    if let Some(sub_status) = retry_policy.terminal_gone_substatus() {
-                        return convert_gone_to_service_unavailable(result, sub_status);
-                    }
-                    return result;
+        // Log the endpoint URL being used for this request
+        debug!(
+            target: "azure_data_cosmos::retry_handler",
+            "Sending request - endpoint: {:?}, region: {:?}, operation: {:?}, resource: {:?}",
+            request.request_context.location_endpoint_to_route,
+            request.request_context.region_name,
+            request.operation_type,
+            request.resource_type
+        );
+
+        // Invoke the provided sender callback instead of calling inner_send_async directly
+        let result = sender(request).await;
+        let retry_result = retry_policy.should_retry(&result).await;
+
+        match retry_result {
+            RetryResult::DoNotRetry => {
+                // If the data-plane policy exhausted its partition-key-range Gone
+                // budget, surface the terminal failure as 503 (preserving the
+                // original sub-status) instead of letting a raw 410 escape.
+                if let Some(sub_status) = retry_policy.terminal_gone_substatus() {
+                    return convert_gone_to_service_unavailable(result, sub_status);
                 }
-                RetryResult::Retry { after } => get_async_runtime().sleep(after).await,
+                return result;
+            }
+            RetryResult::Retry { after } => {
+                // Defensive cap: a misbehaving policy that always asks to retry with
+                // zero backoff must not loop forever on a detached task.
+                if let Some(cap) = max_attempts {
+                    if attempts >= cap {
+                        debug!(
+                            target: "azure_data_cosmos::retry_handler",
+                            "Detached metadata read hit the {cap}-attempt cap; surfacing the last result"
+                        );
+                        return result;
+                    }
+                }
+                get_async_runtime().sleep(after).await;
             }
         }
+    }
+}
+
+/// Runs the metadata retry loop on a detached background task so that dropping the
+/// caller's future cannot preempt an in-flight cross-region failover.
+///
+/// The retry loop is spawned via the runtime abstraction (which detaches, rather than
+/// aborts, when its handle is dropped) and its result is delivered back over a oneshot
+/// channel. If the caller drops the returned future, the detached loop keeps running to
+/// completion, so the retry policy's cross-region decision is always honored. The
+/// detached work is bounded by [`metadata_detached_hard_deadline`] and
+/// [`METADATA_DETACHED_ATTEMPT_CAP`] so it can never leak indefinitely.
+async fn send_detached<Sender, Fut>(
+    retry_policy: RetryPolicy,
+    request: &mut CosmosRequest,
+    sender: Sender,
+    deadline: Duration,
+) -> azure_core::Result<RawResponse>
+where
+    Sender: Fn(&mut CosmosRequest) -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<Output = azure_core::Result<RawResponse>> + Send + 'static,
+{
+    let mut detached_request = request.clone();
+    // Snapshot used only to write something coherent back if the hard deadline trips.
+    let deadline_request = request.clone();
+
+    let (tx, rx) = futures::channel::oneshot::channel();
+
+    let task = async move {
+        let loop_fut = async move {
+            let result = drive_retry_loop(
+                retry_policy,
+                &mut detached_request,
+                &sender,
+                Some(METADATA_DETACHED_ATTEMPT_CAP),
+            )
+            .await;
+            (result, detached_request)
+        };
+        let deadline_fut = get_async_runtime().sleep(deadline);
+
+        futures::pin_mut!(loop_fut);
+        let outcome = match futures::future::select(loop_fut, deadline_fut).await {
+            Either::Left((completed, _)) => completed,
+            // The hard deadline tripped while the loop was still in flight. The
+            // detached loop is abandoned here; we write back the pre-spawn snapshot
+            // (not its in-flight, possibly-mutated state) since this is a rare
+            // defensive backstop and the caller only receives an error anyway.
+            Either::Right(((), _)) => (
+                Err(metadata_detached_deadline_error(deadline)),
+                deadline_request,
+            ),
+        };
+
+        // The receiver is gone when the caller dropped its future; the loop still ran
+        // to completion (the point of detaching), so dropping the result is fine.
+        let _ = tx.send(outcome);
+    };
+
+    // Dropping this handle detaches (does not abort) the task, so the loop continues
+    // even after the caller's future is dropped.
+    let _detached = get_async_runtime().spawn(Box::pin(task));
+
+    match rx.await {
+        Ok((result, completed_request)) => {
+            *request = completed_request;
+            result
+        }
+        // The detached task always sends before finishing, so a canceled receiver
+        // means the task ended without producing a result: it panicked (the runtime's
+        // default panic hook will have surfaced the backtrace) or the runtime is
+        // shutting down. Degrade gracefully rather than propagating a panic into the
+        // caller's task.
+        Err(_canceled) => Err(azure_core::Error::with_message(
+            ErrorKind::Other,
+            "detached metadata read task ended without producing a result \
+             (background task panicked or the runtime is shutting down)",
+        )),
+    }
+}
+
+/// Builds the error surfaced when a detached metadata read exceeds its hard deadline.
+fn metadata_detached_deadline_error(deadline: Duration) -> azure_core::Error {
+    azure_core::Error::with_message(
+        ErrorKind::Other,
+        format!(
+            "detached metadata read exceeded its hard deadline of {} seconds",
+            deadline.whole_seconds()
+        ),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cosmos_request::CosmosRequest;
+    use crate::models::{AccountProperties, AccountRegion};
+    use crate::operation_context::OperationType;
+    use crate::regions::RegionName;
+    use crate::resource_context::{ResourceLink, ResourceType};
+    use crate::routing::global_endpoint_manager::GlobalEndpointManager;
+    use crate::routing::global_partition_endpoint_manager::GlobalPartitionEndpointManager;
+    use azure_core::error::ErrorKind;
+    use azure_core::http::{headers::Headers, ClientOptions, Pipeline, StatusCode};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::time::Duration;
+    use url::Url;
+
+    const REGION_A: &str = "East US 2";
+    const REGION_B: &str = "Central US";
+
+    fn pipeline() -> Pipeline {
+        Pipeline::new(
+            option_env!("CARGO_PKG_NAME"),
+            option_env!("CARGO_PKG_VERSION"),
+            ClientOptions::default(),
+            Vec::new(),
+            Vec::new(),
+            None,
+        )
+    }
+
+    /// Builds a retry handler whose endpoint manager has two read regions
+    /// (so the metadata retry policy will fail over from region A to region B)
+    /// and whose account-properties cache is pre-seeded (so `before_send_request`
+    /// never makes a live network call).
+    async fn build_handler() -> BackOffRetryHandler {
+        let endpoint = Url::parse("https://test.documents.azure.com/").unwrap();
+        let gem = Arc::new(GlobalEndpointManager::new(
+            endpoint,
+            vec![RegionName::from(REGION_A), RegionName::from(REGION_B)],
+            vec![],
+            pipeline(),
+        ));
+
+        let regions = vec![
+            AccountRegion {
+                name: RegionName::from(REGION_A),
+                database_account_endpoint: "https://test-a.documents.azure.com/".parse().unwrap(),
+            },
+            AccountRegion {
+                name: RegionName::from(REGION_B),
+                database_account_endpoint: "https://test-b.documents.azure.com/".parse().unwrap(),
+            },
+        ];
+        gem.update_location_cache(regions.clone(), regions.clone());
+        gem.seed_account_properties_cache(AccountProperties {
+            writable_locations: regions.clone(),
+            readable_locations: regions,
+        })
+        .await;
+
+        let gpem = GlobalPartitionEndpointManager::new(gem.clone(), false, false);
+        BackOffRetryHandler::new(gem, gpem)
+    }
+
+    /// A cold control-plane metadata read (ReadCollection-equivalent).
+    fn metadata_request() -> CosmosRequest {
+        let link = ResourceLink::root(ResourceType::Databases)
+            .item("db")
+            .feed(ResourceType::Containers)
+            .item("c");
+        let request = CosmosRequest::builder(OperationType::Read, link)
+            .build()
+            .unwrap();
+        assert!(
+            request.resource_type.is_meta_data(),
+            "the proof scenario requires a metadata request"
+        );
+        request
+    }
+
+    fn service_unavailable() -> azure_core::Error {
+        azure_core::Error::new(
+            ErrorKind::HttpResponse {
+                status: StatusCode::ServiceUnavailable,
+                error_code: Some("ServiceUnavailable".to_string()),
+                raw_response: None,
+            },
+            "region A is unhealthy",
+        )
+    }
+
+    fn ok_response() -> RawResponse {
+        RawResponse::from_bytes(StatusCode::Ok, Headers::new(), Vec::new())
+    }
+
+    /// Builds a two-region failover sender: the first attempt (region A) sleeps for
+    /// `region_a_delay` then fails with a retryable 503; every later attempt (the
+    /// cross-region failover to region B) records that it ran and succeeds.
+    ///
+    /// Returns the sender together with the attempt counter and the
+    /// "region B reached" flag so tests can observe what actually executed.
+    #[allow(clippy::type_complexity)]
+    fn failover_sender(
+        region_a_delay: Duration,
+    ) -> (
+        impl Fn(
+                &mut CosmosRequest,
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = azure_core::Result<RawResponse>> + Send>,
+            > + Send
+            + Sync
+            + 'static,
+        Arc<AtomicUsize>,
+        Arc<AtomicBool>,
+    ) {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let region_b_reached = Arc::new(AtomicBool::new(false));
+
+        let sender = {
+            let attempts = attempts.clone();
+            let region_b_reached = region_b_reached.clone();
+            move |_req: &mut CosmosRequest| {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                let region_b_reached = region_b_reached.clone();
+                Box::pin(async move {
+                    if attempt == 0 {
+                        // Region A is slow to fail (control-plane timeout escalation).
+                        tokio::time::sleep(region_a_delay).await;
+                        Err(service_unavailable())
+                    } else {
+                        // Region B (the cross-region failover target) succeeds.
+                        region_b_reached.store(true, Ordering::SeqCst);
+                        Ok(ok_response())
+                    }
+                })
+                    as std::pin::Pin<
+                        Box<
+                            dyn std::future::Future<Output = azure_core::Result<RawResponse>>
+                                + Send,
+                        >,
+                    >
+            }
+        };
+
+        (sender, attempts, region_b_reached)
+    }
+
+    /// Regression test for issue #4253.
+    ///
+    /// When the caller future is dropped while the first metadata attempt (against the
+    /// unhealthy region A) is still in flight, the detached executor keeps running, so
+    /// the cross-region failover to region B is still attempted. The caller observes the
+    /// cancellation, but the failover is no longer preempted.
+    #[tokio::test]
+    async fn caller_drop_does_not_preempt_cross_region_metadata_failover() {
+        let handler = build_handler().await;
+        let (sender, attempts, region_b_reached) = failover_sender(Duration::from_millis(200));
+
+        let mut request = metadata_request();
+        let outcome = tokio::time::timeout(
+            Duration::from_millis(50),
+            handler.send(&mut request, sender),
+        )
+        .await;
+
+        assert!(
+            outcome.is_err(),
+            "the caller's timeout must fire and drop its view of the send future"
+        );
+
+        // The detached task continues past the caller's drop; give it time to fail over.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            2,
+            "both the region-A attempt and the region-B failover must have executed"
+        );
+        assert!(
+            region_b_reached.load(Ordering::SeqCst),
+            "cross-region failover to region B must execute even though the caller was dropped"
+        );
+    }
+
+    /// A caller that waits for the result receives the successful cross-region
+    /// failover response, and the final (mutated) request state is written back.
+    #[tokio::test]
+    async fn patient_caller_receives_failover_result() {
+        let handler = build_handler().await;
+        let (sender, attempts, region_b_reached) = failover_sender(Duration::from_millis(10));
+
+        let mut request = metadata_request();
+        let result = handler.send(&mut request, sender).await;
+
+        assert!(
+            result.is_ok(),
+            "the caller should receive the successful failover response"
+        );
+        assert_eq!(result.unwrap().status(), StatusCode::Ok);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert!(region_b_reached.load(Ordering::SeqCst));
+    }
+
+    /// A metadata read that succeeds on the first attempt is returned to the caller
+    /// without any failover.
+    #[tokio::test]
+    async fn successful_metadata_read_returns_to_caller() {
+        let handler = build_handler().await;
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let sender = {
+            let attempts = attempts.clone();
+            move |_req: &mut CosmosRequest| {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                async move { Ok(ok_response()) }
+            }
+        };
+
+        let mut request = metadata_request();
+        let result = handler.send(&mut request, sender).await;
+
+        assert_eq!(result.unwrap().status(), StatusCode::Ok);
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    /// Data-plane requests are NOT detached: dropping the caller future cancels the
+    /// in-flight work, so no background cross-region attempt is made. This keeps the
+    /// fix scoped to idempotent control-plane metadata reads.
+    #[tokio::test]
+    async fn data_plane_request_is_not_detached() {
+        let handler = build_handler().await;
+        let (sender, attempts, region_b_reached) = failover_sender(Duration::from_millis(200));
+
+        // A document read is a data-plane request, not metadata.
+        let link = ResourceLink::root(ResourceType::Databases)
+            .item("db")
+            .feed(ResourceType::Containers)
+            .item("c")
+            .feed(ResourceType::Documents)
+            .item("doc");
+        let mut request = CosmosRequest::builder(OperationType::Read, link)
+            .build()
+            .unwrap();
+        assert!(!request.resource_type.is_meta_data());
+
+        let outcome = tokio::time::timeout(
+            Duration::from_millis(50),
+            handler.send(&mut request, sender),
+        )
+        .await;
+        assert!(outcome.is_err(), "the caller's timeout must fire");
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "the in-flight data-plane attempt is dropped with the caller; no retry runs"
+        );
+        assert!(
+            !region_b_reached.load(Ordering::SeqCst),
+            "data-plane requests must not continue on a detached task after caller drop"
+        );
+    }
+
+    /// Metadata *writes* (e.g. create container) must NOT be detached: detaching a
+    /// non-idempotent write could double-apply it if the caller drops and retries.
+    /// Dropping the caller therefore cancels the in-flight attempt with no background
+    /// continuation.
+    #[tokio::test]
+    async fn metadata_write_is_not_detached() {
+        let handler = build_handler().await;
+        let (sender, attempts, region_b_reached) = failover_sender(Duration::from_millis(200));
+
+        // Creating a container is a metadata resource type but a mutating operation.
+        let link = ResourceLink::root(ResourceType::Databases)
+            .item("db")
+            .feed(ResourceType::Containers);
+        let mut request = CosmosRequest::builder(OperationType::Create, link)
+            .build()
+            .unwrap();
+        assert!(
+            request.resource_type.is_meta_data(),
+            "container create is a metadata resource type"
+        );
+        assert!(
+            !is_detachable_metadata_read(&request),
+            "a mutating metadata operation must not be treated as a detachable read"
+        );
+
+        let outcome = tokio::time::timeout(
+            Duration::from_millis(50),
+            handler.send(&mut request, sender),
+        )
+        .await;
+        assert!(outcome.is_err(), "the caller's timeout must fire");
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "the in-flight metadata write is dropped with the caller; no retry runs"
+        );
+        assert!(
+            !region_b_reached.load(Ordering::SeqCst),
+            "metadata writes must not continue on a detached task after caller drop"
+        );
+    }
+
+    /// When the detached hard deadline trips before the loop completes, the caller
+    /// receives a deadline error rather than hanging on a stuck attempt.
+    #[tokio::test]
+    async fn detached_metadata_read_honors_hard_deadline() {
+        let handler = build_handler().await;
+        let retry_policy = handler.retry_policy_for_request(&metadata_request());
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let sender = {
+            let attempts = attempts.clone();
+            move |_req: &mut CosmosRequest| {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    // Never completes within the deadline below.
+                    tokio::time::sleep(Duration::from_secs(30)).await;
+                    Ok(ok_response())
+                }
+            }
+        };
+
+        let mut request = metadata_request();
+        let result = send_detached(
+            retry_policy,
+            &mut request,
+            sender,
+            azure_core::time::Duration::milliseconds(50),
+        )
+        .await;
+
+        let err = result.expect_err("the hard deadline must surface as an error");
+        assert!(
+            err.to_string().contains("hard deadline"),
+            "deadline error should mention the hard deadline, got: {err}"
+        );
+    }
+
+    /// Mirrors the .NET clamp fix: the default applies when the value is absent,
+    /// an out-of-range value is clamped to the 24h maximum, and invalid/zero values
+    /// fall back to the default so the timer can never be constructed with an
+    /// overflowing duration.
+    ///
+    /// Tests the pure resolver directly so it never mutates the process-global
+    /// environment (which would race other tests that read the deadline).
+    #[test]
+    fn hard_deadline_resolution_and_clamping() {
+        assert_eq!(
+            resolve_hard_deadline_secs(None),
+            DEFAULT_METADATA_DETACHED_HARD_DEADLINE_SECS,
+            "absent value should use the default"
+        );
+
+        // 60 days, well over the 24h clamp.
+        assert_eq!(
+            resolve_hard_deadline_secs(Some("5184000")),
+            MAX_METADATA_DETACHED_HARD_DEADLINE_SECS,
+            "an oversized value must be clamped to the 24h maximum"
+        );
+
+        // A valid in-range value is honored as-is.
+        assert_eq!(resolve_hard_deadline_secs(Some("42")), 42);
+
+        // Surrounding whitespace is tolerated.
+        assert_eq!(resolve_hard_deadline_secs(Some("  600 ")), 600);
+
+        // Zero is not a usable deadline; fall back to the default.
+        assert_eq!(
+            resolve_hard_deadline_secs(Some("0")),
+            DEFAULT_METADATA_DETACHED_HARD_DEADLINE_SECS
+        );
+
+        // Non-numeric values fall back to the default.
+        assert_eq!(
+            resolve_hard_deadline_secs(Some("not-a-number")),
+            DEFAULT_METADATA_DETACHED_HARD_DEADLINE_SECS
+        );
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
@@ -78,9 +78,14 @@ impl GatewayPipeline {
         context: Context<'_>,
     ) -> azure_core::Result<CosmosResponse<T>> {
         self.options.apply_headers(&mut cosmos_request.headers);
-        // Prepare a callback delegate to invoke the http request.
-        let sender = |req: &mut CosmosRequest| {
-            let pipeline = self.pipeline.clone();
+        // Prepare a callback delegate to invoke the http request. The closure must be
+        // `'static` because the retry handler may run it on a detached background task
+        // for metadata requests, so it owns clones of the pipeline and context rather
+        // than borrowing `self`.
+        let pipeline = self.pipeline.clone();
+        let context = context.into_owned();
+        let sender = move |req: &mut CosmosRequest| {
+            let pipeline = pipeline.clone();
             let ctx = context.clone();
             let success_options = CheckSuccessOptions {
                 success_codes: &SUCCESS_CODES,

--- a/sdk/cosmos/azure_data_cosmos/src/retry_policies/client_retry_policy.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/retry_policies/client_retry_policy.rs
@@ -29,6 +29,13 @@ const MAX_RETRY_COUNT_ON_ENDPOINT_FAILURE: usize = 120;
 /// the endpoint unavailable.
 const MAX_RETRY_COUNT_ON_CONNECTION_FAILURE: usize = 3;
 
+/// Maximum number of in-line retries for the partition-key-range Gone family
+/// (410 with sub-status 1000/1002/1007) before the terminal outcome is surfaced
+/// as 503 Service Unavailable. A small fixed bound (one routing-cache refresh +
+/// one retry) mirrors the dedicated PartitionKeyRangeGone retry policy used by
+/// the other Cosmos SDKs and avoids retry amplification on writes.
+const MAX_RETRY_COUNT_ON_PARTITION_KEY_RANGE_GONE: usize = 1;
+
 /// Context information for routing retry attempts to specific endpoints.
 #[derive(Clone, Debug)]
 struct RetryContext {
@@ -66,6 +73,20 @@ pub(crate) struct ClientRetryPolicy {
     /// Counter tracking the number of consecutive connection failure retry attempts
     /// on the current endpoint before marking it unavailable.
     connection_retry_count: usize,
+
+    /// Counter tracking the number of partition-key-range Gone (410.1000/1002/1007)
+    /// retry attempts for the current request.
+    partition_key_range_gone_retry_count: usize,
+
+    /// When set, the next `before_send_request` flags the request for a routing-cache
+    /// refresh (name cache, partition-key-range and collection routing map) so that
+    /// SDK-routing paths re-resolve a stale routing map instead of replaying it.
+    refresh_routing_on_next_attempt: bool,
+
+    /// Set when the partition-key-range Gone family has exhausted its in-line retry
+    /// budget. Signals the retry handler to surface the terminal failure as
+    /// 503 Service Unavailable while preserving this original Cosmos sub-status.
+    terminal_gone_substatus: Option<SubStatusCode>,
 
     /// Whether the current request is a read operation (true) or write operation (false)
     operation_type: Option<OperationType>,
@@ -117,6 +138,9 @@ impl ClientRetryPolicy {
             session_token_retry_count: 0,
             service_unavailable_retry_count: 0,
             connection_retry_count: 0,
+            partition_key_range_gone_retry_count: 0,
+            refresh_routing_on_next_attempt: false,
+            terminal_gone_substatus: None,
             operation_type: None,
             request: None,
             can_use_multiple_write_locations: false,
@@ -214,6 +238,16 @@ impl ClientRetryPolicy {
         {
             self.partition_key_range_location_cache
                 .try_add_partition_level_location_override(request);
+        }
+
+        // If a prior attempt hit the partition-key-range Gone family, flag the
+        // request so SDK-routing paths refresh the (now demonstrably stale)
+        // routing caches before this attempt instead of replaying the stale map.
+        if self.refresh_routing_on_next_attempt {
+            request.force_name_cache_refresh = true;
+            request.force_partition_key_range_refresh = true;
+            request.force_collection_routing_map_refresh = true;
+            self.refresh_routing_on_next_attempt = false;
         }
 
         self.request = Some(request.clone());
@@ -497,6 +531,45 @@ impl ClientRetryPolicy {
         }
     }
 
+    /// Handles the partition-key-range Gone family (410.1000/1002/1007).
+    ///
+    /// A 410 carrying one of these sub-statuses means the routing information the
+    /// request was resolved against is stale (a split/merge/migration moved the
+    /// range). We retry a small, fixed number of times, flagging a routing-cache
+    /// refresh for the next attempt so SDK-routing paths re-resolve instead of
+    /// replaying the stale map. Once the bound is exhausted we stop retrying and
+    /// record the sub-status so the retry handler can surface the terminal failure
+    /// as 503 Service Unavailable (preserving the sub-status) rather than letting a
+    /// raw, unclassifiable 410 escape to the caller.
+    ///
+    /// Applies to reads and writes alike: a 410 from routing resolution means the
+    /// operation was not applied, so retrying a write is safe.
+    fn should_retry_on_partition_key_range_gone(
+        &mut self,
+        sub_status: SubStatusCode,
+    ) -> RetryResult {
+        self.partition_key_range_gone_retry_count += 1;
+
+        if self.partition_key_range_gone_retry_count <= MAX_RETRY_COUNT_ON_PARTITION_KEY_RANGE_GONE
+        {
+            self.refresh_routing_on_next_attempt = true;
+            return RetryResult::Retry {
+                after: Duration::ZERO,
+            };
+        }
+
+        // Bound exhausted: surface as 503 with the original sub-status preserved.
+        self.terminal_gone_substatus = Some(sub_status);
+        RetryResult::DoNotRetry
+    }
+
+    /// Returns the sub-status to preserve when a terminal partition-key-range Gone
+    /// must be surfaced as 503 Service Unavailable, or `None` if no such conversion
+    /// is pending. Consulted by the retry handler after a `DoNotRetry` decision.
+    pub(crate) fn terminal_gone_substatus(&self) -> Option<SubStatusCode> {
+        self.terminal_gone_substatus
+    }
+
     /// Routes HTTP status codes to appropriate retry handling logic.
     ///
     /// # Summary
@@ -587,6 +660,26 @@ impl ClientRetryPolicy {
             && sub_status_code == Some(SubStatusCode::LEASE_NOT_FOUND)
         {
             return Some(self.should_retry_on_unavailable_endpoint_status_codes());
+        }
+
+        // Gone - partition-key-range staleness family (410.1000 NameCacheIsStale,
+        // 410.1002 PartitionKeyRangeGone, 410.1007 CompletingSplit). This must be
+        // matched on the (Gone, sub-status) tuple: sub-status 1002 is also used by
+        // 404 ReadSessionNotAvailable (handled above), so keying on sub-status
+        // alone would conflate the two. Without this branch a 410.1002 escapes the
+        // pipeline as a raw, unclassifiable 410 (writes) or burns non-curative
+        // cross-region failover (reads). Instead we drive a bounded routing-cache
+        // refresh + retry and, on exhaustion, surface 503 (see the retry handler).
+        if status_code == StatusCode::Gone
+            && matches!(
+                sub_status_code,
+                Some(SubStatusCode::NAME_CACHE_IS_STALE)
+                    | Some(SubStatusCode::PARTITION_KEY_RANGE_GONE)
+                    | Some(SubStatusCode::COMPLETING_SPLIT)
+            )
+        {
+            // sub_status_code is Some in every arm of the match above.
+            return Some(self.should_retry_on_partition_key_range_gone(sub_status_code.unwrap()));
         }
 
         // For read operations, retry on any status code that is not explicitly non-retryable.
@@ -1011,6 +1104,101 @@ mod tests {
             }
             _ => panic!("Expected retry for Gone with LeaseNotFound on write"),
         }
+    }
+
+    #[tokio::test]
+    async fn gone_partition_key_range_retries_then_converts_to_503_read() {
+        let mut policy = create_test_policy_with_preferred_locations();
+        policy.operation_type = Some(OperationType::Read);
+        let error = create_error_with_substatus(
+            StatusCode::Gone,
+            SubStatusCode::PARTITION_KEY_RANGE_GONE.value() as u32,
+        );
+
+        // First 410/1002: bounded retry, routing refresh flagged, no terminal conversion yet.
+        let first = policy.should_retry_error(&error).await;
+        assert!(first.is_retry(), "first 410/1002 should retry");
+        assert_eq!(policy.partition_key_range_gone_retry_count, 1);
+        assert!(policy.refresh_routing_on_next_attempt);
+        assert!(policy.terminal_gone_substatus().is_none());
+
+        // Second 410/1002: bound exhausted -> stop retrying, terminal 503 conversion pending.
+        let second = policy.should_retry_error(&error).await;
+        assert!(!second.is_retry(), "second 410/1002 should stop retrying");
+        assert_eq!(
+            policy.terminal_gone_substatus(),
+            Some(SubStatusCode::PARTITION_KEY_RANGE_GONE),
+            "terminal Gone must surface as 503 preserving sub-status 1002"
+        );
+    }
+
+    #[tokio::test]
+    async fn gone_partition_key_range_retries_then_converts_to_503_write() {
+        // Writes must also recover: a 410 from routing resolution means the
+        // operation was not applied, so a bounded retry is safe (Q4=B).
+        let mut policy = create_test_policy_with_preferred_locations();
+        policy.operation_type = Some(OperationType::Create);
+        let error = create_error_with_substatus(
+            StatusCode::Gone,
+            SubStatusCode::PARTITION_KEY_RANGE_GONE.value() as u32,
+        );
+
+        assert!(
+            policy.should_retry_error(&error).await.is_retry(),
+            "writes must also retry a 410/1002"
+        );
+        assert!(
+            !policy.should_retry_error(&error).await.is_retry(),
+            "writes must stop after the bound and convert"
+        );
+        assert_eq!(
+            policy.terminal_gone_substatus(),
+            Some(SubStatusCode::PARTITION_KEY_RANGE_GONE)
+        );
+    }
+
+    #[tokio::test]
+    async fn gone_name_cache_stale_and_completing_split_take_gone_branch() {
+        for ss in [
+            SubStatusCode::NAME_CACHE_IS_STALE,
+            SubStatusCode::COMPLETING_SPLIT,
+        ] {
+            let mut policy = create_test_policy_with_preferred_locations();
+            policy.operation_type = Some(OperationType::Read);
+            let error = create_error_with_substatus(StatusCode::Gone, ss.value() as u32);
+
+            assert!(
+                policy.should_retry_error(&error).await.is_retry(),
+                "410/{} should take the Gone-family retry branch",
+                ss.value()
+            );
+            assert_eq!(policy.partition_key_range_gone_retry_count, 1);
+            assert!(policy.refresh_routing_on_next_attempt);
+        }
+    }
+
+    #[tokio::test]
+    async fn not_found_session_not_available_not_treated_as_gone() {
+        // 404/1002 ReadSessionNotAvailable shares sub-status 1002 with 410/1002
+        // PartitionKeyRangeGone. It must keep the session-retry path, untouched by
+        // the new Gone-family branch (regression guard for the overloaded 1002).
+        let mut policy = create_test_policy();
+        policy.operation_type = Some(OperationType::Read);
+        let error = create_error_with_substatus(
+            StatusCode::NotFound,
+            SubStatusCode::READ_SESSION_NOT_AVAILABLE.value() as u32,
+        );
+
+        let _ = policy.should_retry_error(&error).await;
+        assert_eq!(
+            policy.session_token_retry_count, 1,
+            "404/1002 must use the session-not-available path"
+        );
+        assert_eq!(
+            policy.partition_key_range_gone_retry_count, 0,
+            "404/1002 must NOT use the Gone-family path"
+        );
+        assert!(policy.terminal_gone_substatus().is_none());
     }
 
     #[tokio::test]

--- a/sdk/cosmos/azure_data_cosmos/src/retry_policies/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/retry_policies/mod.rs
@@ -11,6 +11,7 @@ use crate::retry_policies::client_retry_policy::ClientRetryPolicy;
 use crate::retry_policies::metadata_request_retry_policy::MetadataRequestRetryPolicy;
 use crate::retry_policies::resource_throttle_retry_policy::ResourceThrottleRetryPolicy;
 use azure_core::error::ErrorKind;
+use azure_core::http::headers::Headers;
 use azure_core::http::{RawResponse, StatusCode};
 use azure_core::time::Duration;
 
@@ -124,6 +125,61 @@ impl RetryPolicy {
             RetryPolicy::ResourceThrottle(p) => p.should_retry(response).await,
             RetryPolicy::Metadata(p) => p.should_retry(response).await,
         }
+    }
+
+    /// Returns the Cosmos sub-status to preserve when a terminal partition-key-range
+    /// Gone (410.1000/1002/1007) must be surfaced as 503 Service Unavailable instead
+    /// of a raw 410, or `None` when no such conversion is pending. Only the data-plane
+    /// [`ClientRetryPolicy`] produces this signal.
+    pub fn terminal_gone_substatus(&self) -> Option<SubStatusCode> {
+        match self {
+            RetryPolicy::Client(p) => p.terminal_gone_substatus(),
+            RetryPolicy::ResourceThrottle(_) | RetryPolicy::Metadata(_) => None,
+        }
+    }
+}
+
+/// Rewrites a terminal partition-key-range Gone result (410 with sub-status
+/// 1000/1002/1007) into a 503 Service Unavailable while preserving the original
+/// Cosmos sub-status, so application-layer resilience logic (which is wired for
+/// 503, not 410) can classify and react to it.
+///
+/// Cosmos gateway responses for non-success status codes arrive here as an
+/// `Err(HttpResponse { status: Gone, .. })`; the rare `Ok(RawResponse)` form with a
+/// Gone status is handled too. Any other result is returned unchanged.
+pub(crate) fn convert_gone_to_service_unavailable(
+    result: azure_core::Result<RawResponse>,
+    sub_status: SubStatusCode,
+) -> azure_core::Result<RawResponse> {
+    let mut headers = match &result {
+        Ok(response) if response.status() == StatusCode::Gone => response.headers().clone(),
+        Err(err) if err.http_status() == Some(StatusCode::Gone) => Headers::new(),
+        // Not a Gone result: leave it untouched.
+        _ => return result,
+    };
+    headers.insert(SUB_STATUS, sub_status.to_string());
+
+    match result {
+        Ok(_) => Ok(RawResponse::from_bytes(
+            StatusCode::ServiceUnavailable,
+            headers,
+            Vec::new(),
+        )),
+        Err(_) => Err(azure_core::Error::with_message(
+            ErrorKind::HttpResponse {
+                status: StatusCode::ServiceUnavailable,
+                error_code: Some("ServiceUnavailable".to_string()),
+                raw_response: Some(Box::new(RawResponse::from_bytes(
+                    StatusCode::ServiceUnavailable,
+                    headers,
+                    Vec::new(),
+                ))),
+            },
+            format!(
+                "partition key range is gone (sub-status {sub_status}); routing information was stale \
+                 and could not be refreshed within the retry budget, surfaced as 503 Service Unavailable"
+            ),
+        )),
     }
 }
 
@@ -282,5 +338,67 @@ mod tests {
     fn credential_is_not_sent() {
         let err = azure_core::Error::with_message(ErrorKind::Credential, "auth failed");
         assert_eq!(err.request_sent_status(), RequestSentStatus::NotSent);
+    }
+
+    fn gone_error_with_substatus(value: &str) -> azure_core::Error {
+        let mut headers = azure_core::http::headers::Headers::new();
+        headers.insert(SUB_STATUS, value.to_string());
+        let raw = RawResponse::from_bytes(StatusCode::Gone, headers, Vec::new());
+        azure_core::Error::new(
+            ErrorKind::HttpResponse {
+                status: StatusCode::Gone,
+                error_code: None,
+                raw_response: Some(Box::new(raw)),
+            },
+            "partition key range gone",
+        )
+    }
+
+    #[test]
+    fn convert_gone_error_to_service_unavailable_preserves_substatus() {
+        let converted = convert_gone_to_service_unavailable(
+            Err(gone_error_with_substatus("1002")),
+            SubStatusCode::PARTITION_KEY_RANGE_GONE,
+        );
+        let err = converted.expect_err("a Gone error must remain an error");
+        assert_eq!(err.http_status(), Some(StatusCode::ServiceUnavailable));
+        assert_eq!(
+            get_substatus_code_from_error(&err),
+            Some(SubStatusCode::PARTITION_KEY_RANGE_GONE),
+            "the original sub-status must be preserved on the 503"
+        );
+    }
+
+    #[test]
+    fn convert_gone_ok_response_to_service_unavailable_preserves_substatus() {
+        let mut headers = azure_core::http::headers::Headers::new();
+        headers.insert(SUB_STATUS, "1002");
+        let response = RawResponse::from_bytes(StatusCode::Gone, headers, Vec::new());
+
+        let converted = convert_gone_to_service_unavailable(
+            Ok(response),
+            SubStatusCode::PARTITION_KEY_RANGE_GONE,
+        )
+        .expect("ok response must remain ok");
+        assert_eq!(converted.status(), StatusCode::ServiceUnavailable);
+        assert_eq!(
+            get_substatus_code_from_response(&converted),
+            Some(SubStatusCode::PARTITION_KEY_RANGE_GONE)
+        );
+    }
+
+    #[test]
+    fn convert_leaves_non_gone_results_untouched() {
+        let response = RawResponse::from_bytes(
+            StatusCode::Ok,
+            azure_core::http::headers::Headers::new(),
+            Vec::new(),
+        );
+        let converted = convert_gone_to_service_unavailable(
+            Ok(response),
+            SubStatusCode::PARTITION_KEY_RANGE_GONE,
+        )
+        .expect("non-gone ok stays ok");
+        assert_eq!(converted.status(), StatusCode::Ok);
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/src/routing/global_endpoint_manager.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/routing/global_endpoint_manager.rs
@@ -398,6 +398,18 @@ impl GlobalEndpointManager {
             .unwrap()
             .update(write_locations, read_locations);
     }
+
+    /// Seeds the account-properties cache so that `refresh_location` is satisfied
+    /// from the cache and does not attempt a live `get_database_account` call.
+    ///
+    /// This lets tests exercise retry policies (which call `before_send_request`
+    /// -> `refresh_location`) without standing up a real Cosmos account.
+    #[cfg(test)]
+    pub(crate) async fn seed_account_properties_cache(&self, properties: AccountProperties) {
+        self.account_properties_cache
+            .insert(ACCOUNT_PROPERTIES_KEY, properties)
+            .await;
+    }
 }
 
 #[cfg(test)]

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_fault_injection.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_fault_injection.rs
@@ -944,3 +944,66 @@ pub async fn fault_injection_enable_disable_rule() -> Result<(), Box<dyn Error>>
     )
     .await
 }
+
+/// Injecting a partition-key-range Gone (410/1002) on point operations must NOT
+/// surface a raw 410 to the caller. The Gone-family is retried within a small
+/// bound and, on exhaustion, converted to 503 Service Unavailable so application
+/// resilience logic (wired for 503, not 410) can classify it. Regression test for
+/// the Rust sibling of Azure/azure-cosmos-dotnet-v3#5924.
+#[tokio::test]
+pub async fn fault_injection_partition_key_range_gone_surfaces_503() -> Result<(), Box<dyn Error>> {
+    let server_error = FaultInjectionResultBuilder::new()
+        .with_error(FaultInjectionErrorType::PartitionIsGone) // 410 / 1002
+        .with_probability(1.0)
+        .build();
+
+    let condition = FaultInjectionConditionBuilder::new()
+        .with_operation_type(FaultOperationType::ReadItem)
+        .build();
+
+    let rule = FaultInjectionRuleBuilder::new("partition-key-range-gone", server_error)
+        .with_condition(condition)
+        .build();
+
+    let fault_builder = FaultInjectionClientBuilder::new().with_rule(Arc::new(rule));
+
+    TestClient::run_with_unique_db(
+        async |run_context, db_client| {
+            let container_id = format!("Container-{}", Uuid::new_v4());
+            let container_client = run_context
+                .create_container_with_throughput(
+                    db_client,
+                    ContainerProperties::new(container_id.clone(), "/partition_key".into()),
+                    ThroughputProperties::manual(400),
+                )
+                .await?;
+
+            let unique_id = Uuid::new_v4().to_string();
+            let item = create_test_item(&unique_id);
+            let pk = format!("Partition-{}", unique_id);
+            let item_id = format!("Item-{}", unique_id);
+
+            container_client.create_item(&pk, &item, None).await?;
+
+            let fault_client = run_context
+                .fault_client()
+                .expect("fault client should be available");
+            let fault_db_client = fault_client.database_client(db_client.id());
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
+
+            let result = fault_container_client
+                .read_item::<TestItem>(&pk, &item_id, None)
+                .await;
+            let err = result.expect_err("read should fail when partition is gone");
+            assert_eq!(
+                Some(StatusCode::ServiceUnavailable),
+                err.http_status(),
+                "terminal 410/1002 must be surfaced as 503, not a raw 410"
+            );
+
+            Ok(())
+        },
+        Some(TestOptions::new().with_fault_injection_builder(fault_builder)),
+    )
+    .await
+}


### PR DESCRIPTION
## Summary

Ports .NET Cosmos PR [Azure/azure-cosmos-dotnet-v3#5844](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5844) to Rust, fixing the sibling issue #4253.

A control-plane metadata read (cold collection / partition-key-range cache warm-up) could **preempt its own cross-region failover** when the caller's future was dropped mid-flight against an unhealthy region. Because cancellation in Rust is future-drop, dropping the caller's future dropped the entire retry loop in `BackOffRetryHandler::send` *before* the retry policy's cross-region decision was reached — so no attempt was ever made against the next preferred region. The customer saw a cancelled/timed-out future instead of a successful failover.

### The bug was reproduced first

A focused `#[tokio::test]` drives the real `BackOffRetryHandler::send` for a metadata request against a two-region endpoint manager: the first attempt (region A) is slow-then-503 (retryable); the second (region B) records that it ran. Wrapping `send` in a short timeout that fires mid-first-attempt showed region B was **never** reached and only one attempt ran — confirming the preemption. That test was then rewritten into the regression test `caller_drop_does_not_preempt_cross_region_metadata_failover`, which asserts the corrected behavior.

## Fix

- **Metadata requests** (`resource_type.is_meta_data()`) now run their retry loop on a **detached** task via the runtime abstraction `get_async_runtime().spawn` (tokio detaches — does not abort — on handle drop), delivering the result over a `futures::channel::oneshot`. A dropped caller no longer cancels the in-flight attempt, so the cross-region failover completes; the caller observes cancellation only on the response path.
- **Bounds** (mirroring the .NET fix): an internal hard deadline — default 300s, overridable via `AZURE_COSMOS_METADATA_DETACHED_HARD_DEADLINE_SECONDS`, clamped to `[1, 86400]`s — raced via `get_async_runtime().sleep`, plus a defensive 50-attempt cap.
- **Data-plane requests are unchanged**: they keep the in-line loop so that a dropped caller still cancels in-flight work (important for non-idempotent writes). Detaching is deliberately scoped to idempotent control-plane reads.

## Supporting changes

- `RetryHandler::send`: added `+ 'static` to the `Sender`/`Fut` bounds (required to spawn). Only impl is `BackOffRetryHandler`; only caller is `GatewayPipeline::send`.
- `GatewayPipeline::send`: rebuilt the sender closure as a `move` closure capturing an owned `pipeline.clone()` and `context.into_owned()` so it satisfies the `'static` bound. No behavioral change for the data-plane path.
- Added a `#[cfg(test)]` `seed_account_properties_cache` helper to `GlobalEndpointManager` so retry tests can exercise `before_send_request` without a live account.
- Production code uses only `azure_core::async_runtime` (spawn/sleep) and `futures` (oneshot/select) — no tokio in non-test code (tokio is a dev-dependency).

## Tests

New unit tests in `retry_handler.rs`: cross-region failover survives caller-drop (regression), patient caller receives the failover result, first-attempt success, **data-plane request is NOT detached**, hard-deadline trips to an error, and hard-deadline env resolution/clamping/validation.

All `azure_data_cosmos` lib tests pass (452 existing + 6 new); `cargo clippy --all-targets` is clean. (`--all-features` was not used locally because it pulls in `hmac_openssl`, which needs OpenSSL unavailable on the dev box; that feature is unrelated to this change.)

Fixes #4253
