### PR TITLE
Hedge cold container-metadata reads across regions (#4253)

### DIFF
--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bugs Fixed
 
+- Extended cross-region hedging to cover the container/collection metadata read (`DocumentCollection` point reads). A cold container-cache warm-up routed to a slow or unhealthy preferred region could stall the read — and any operation blocked on it — past the caller's timeout, with the cross-region failover never reached if the caller gave up first. Hedging now speculatively dispatches the read to a second preferred region once the hedge threshold elapses, so a healthy region returns within the caller's deadline. This uses the existing structural hedging mechanism (no detached background tasks) and applies only to idempotent reads; container writes and feed reads are unaffected. ([#4253](https://github.com/Azure/azure-sdk-for-rust/issues/4253))
 - Fixed duplicate items being returned on cross-partition query resume after a physical partition split. When a cross-partition query was paused, serialized to a continuation token, and resumed after the underlying partition had split, the resumed iterator could re-emit items the caller had already consumed on a prior page. The continuation token now records per-range sibling state and is correctly propagated to every surviving leaf after a split. ([#4550](https://github.com/Azure/azure-sdk-for-rust/pull/4550))
 
 ### Other Changes

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Bugs Fixed
 
-- Extended cross-region hedging to cover the container/collection metadata read (`DocumentCollection` point reads). A cold container-cache warm-up routed to a slow or unhealthy preferred region could stall the read — and any operation blocked on it — past the caller's timeout, with the cross-region failover never reached if the caller gave up first. Hedging now speculatively dispatches the read to a second preferred region once the hedge threshold elapses, so a healthy region returns within the caller's deadline. This uses the existing structural hedging mechanism (no detached background tasks) and applies only to idempotent reads; container writes and feed reads are unaffected. ([#4253](https://github.com/Azure/azure-sdk-for-rust/issues/4253))
+- Made container/collection metadata point reads (`DocumentCollection`) hedge-eligible (idempotent reads only), preventing cold container-cache warm-up stalls on an unhealthy preferred region. ([#4253](https://github.com/Azure/azure-sdk-for-rust/issues/4253))
 - Fixed duplicate items being returned on cross-partition query resume after a physical partition split. When a cross-partition query was paused, serialized to a continuation token, and resumed after the underlying partition had split, the resumed iterator could re-emit items the caller had already consumed on a prior page. The continuation token now records per-range sibling state and is correctly propagated to every surviving leaf after a split. ([#4550](https://github.com/Azure/azure-sdk-for-rust/pull/4550))
 
 ### Other Changes

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/hedging_eligibility.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/hedging_eligibility.rs
@@ -30,16 +30,24 @@ use crate::{
 /// this constant is the upper bound.
 const DEFAULT_THRESHOLD_CAP: Duration = Duration::from_millis(1000);
 
-/// Resource types eligible for cross-region hedging in the current phase.
+/// Resource types eligible for cross-region hedging.
 ///
-/// Subsequent phases widen this single constant — no other change to
-/// [`should_hedge`] is required.
-const HEDGEABLE_RESOURCE_TYPES: &[ResourceType] = &[ResourceType::Document];
+/// `Document` covers data-plane reads. `DocumentCollection` covers the
+/// control-plane container/collection metadata read that warms a cold
+/// container cache — hedging it across regions keeps a slow or unhealthy
+/// preferred region from stalling the read (and any operation blocked on it)
+/// past the caller's timeout, which is the cross-region-failover-preemption
+/// scenario in issue #4253. Both are idempotent reads.
+///
+/// Subsequent phases may widen this single constant further — no other change
+/// to [`should_hedge`] is required.
+const HEDGEABLE_RESOURCE_TYPES: &[ResourceType] =
+    &[ResourceType::Document, ResourceType::DocumentCollection];
 
 /// Operation types eligible for cross-region hedging in the current phase.
 ///
 /// Future phases will append feed-style operations
-/// (`Query` / `ReadFeed` / `QueryPlan`) and metadata reads.
+/// (`Query` / `ReadFeed` / `QueryPlan`).
 const HEDGEABLE_OPERATION_TYPES: &[OperationType] = &[OperationType::Read];
 
 /// Returns `true` when the operation is eligible for cross-region hedging.
@@ -324,6 +332,26 @@ mod tests {
         CosmosOperation::read_database(db)
     }
 
+    fn read_container_operation() -> CosmosOperation {
+        CosmosOperation::read_container(fake_container_reference())
+    }
+
+    fn create_container_operation() -> CosmosOperation {
+        let account = AccountReference::with_master_key(
+            Url::parse("https://acct.documents.azure.com/").unwrap(),
+            "k",
+        );
+        CosmosOperation::create_container(DatabaseReference::from_name(account, "db"))
+    }
+
+    fn read_all_containers_operation() -> CosmosOperation {
+        let account = AccountReference::with_master_key(
+            Url::parse("https://acct.documents.azure.com/").unwrap(),
+            "k",
+        );
+        CosmosOperation::read_all_containers(DatabaseReference::from_name(account, "db"))
+    }
+
     fn enabled_strategy() -> HedgingStrategy {
         HedgingStrategy::new(HedgeThreshold::new(Duration::from_millis(500)).unwrap())
     }
@@ -381,10 +409,43 @@ mod tests {
 
     #[test]
     fn should_hedge_non_document() {
-        // Reads against non-Document resource types are excluded in Phase 1.
+        // Reads against non-hedgeable resource types (e.g. Database) are excluded.
         let state = account_state_with_regions(&[Region::EAST_US, Region::WEST_US_2]);
         let op = read_database_operation();
         assert!(!should_hedge(Some(&enabled_strategy()), &op, &state, &[],));
+    }
+
+    /// Regression for issue #4253: a cold container/collection metadata point-read
+    /// is hedged across regions so a slow or unhealthy preferred region cannot stall
+    /// the read (and any operation blocked on warming the container cache) past the
+    /// caller's timeout. This replaces the earlier detached-task approach with the
+    /// crate's structural cross-region mechanism (no detached tasks).
+    #[test]
+    fn should_hedge_container_read() {
+        let state = account_state_with_regions(&[Region::EAST_US, Region::WEST_US_2]);
+        let op = read_container_operation();
+        assert_eq!(op.resource_type(), ResourceType::DocumentCollection);
+        assert!(should_hedge(Some(&enabled_strategy()), &op, &state, &[]));
+    }
+
+    /// Container writes (create/replace/delete) must never hedge — only idempotent
+    /// reads are eligible.
+    #[test]
+    fn should_not_hedge_container_write() {
+        let state = account_state_with_regions(&[Region::EAST_US, Region::WEST_US_2]);
+        let op = create_container_operation();
+        assert_eq!(op.resource_type(), ResourceType::DocumentCollection);
+        assert!(!should_hedge(Some(&enabled_strategy()), &op, &state, &[]));
+    }
+
+    /// Feed-style container reads (`ReadFeed`, e.g. list containers) are not hedged
+    /// in this phase — only point reads of a container's metadata.
+    #[test]
+    fn should_not_hedge_container_feed_read() {
+        let state = account_state_with_regions(&[Region::EAST_US, Region::WEST_US_2]);
+        let op = read_all_containers_operation();
+        assert_eq!(op.resource_type(), ResourceType::DocumentCollection);
+        assert!(!should_hedge(Some(&enabled_strategy()), &op, &state, &[]));
     }
 
     #[test]

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/hedging_eligibility.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/hedging_eligibility.rs
@@ -36,8 +36,7 @@ const DEFAULT_THRESHOLD_CAP: Duration = Duration::from_millis(1000);
 /// control-plane container/collection metadata read that warms a cold
 /// container cache — hedging it across regions keeps a slow or unhealthy
 /// preferred region from stalling the read (and any operation blocked on it)
-/// past the caller's timeout, which is the cross-region-failover-preemption
-/// scenario in issue #4253. Both are idempotent reads.
+/// past the caller's timeout. Both are idempotent reads.
 ///
 /// Subsequent phases may widen this single constant further — no other change
 /// to [`should_hedge`] is required.


### PR DESCRIPTION
## Summary

Reworks the fix for #4253 to use the driver's **structural cross-region hedging** instead of a detached background task (the prior approach, in #4607, conflicted with the crate's stated "no detached tasks" model). Closing #4607 in favor of this.

A cold container/collection metadata read (`DocumentCollection` point read) that warms the container cache could be routed to a slow or unhealthy preferred region and **stall the read — and any operation blocked on warming the cache — past the caller's timeout**. If the caller's future is dropped (Rust cancellation) during the control-plane timeout escalation, the inline cross-region failover is preempted and the next region is never tried.

## Fix

Widen `HEDGEABLE_RESOURCE_TYPES` from `[Document]` to `[Document, DocumentCollection]` in `hedging_eligibility.rs`. Container point reads (`OperationType::Read` + `ResourceType::DocumentCollection`) become hedge-eligible, so once the hedge threshold elapses the read is **speculatively dispatched to a second preferred region in parallel** and a healthy region returns within the caller's deadline — structurally removing the single-region-stall / cancellation-preemption window, with **no detached tasks**. This is exactly the metadata-read phase the eligibility comment already anticipated; the rest of the hedging machinery (`evaluate_hedge_eligibility` -> `should_hedge` -> `execute_hedged`) already handles `PipelineType::Metadata`, so no other change is required.

## Scope (matches the origin issue)

- ✅ Container/collection cache read — covered.
- ❌ Partition-key-range reads — intentionally excluded; the .NET origin issue (#5805) explicitly notes the pk-range cache is **not** affected. (`ReadFeed` is also not hedge-eligible.)
- ❌ Container writes (create/replace/delete) — excluded; only idempotent point reads hedge.
- Account-metadata bootstrap is off-pipeline (not the #4253 scenario).

## Safety

Hedging a container read issues at most one extra **idempotent GET** to another region, and only after the threshold (default `min(1000ms, request_timeout/2)`) — so there's no duplicate-side-effect risk and no cost on the fast path. All existing hedge invariants (result classification, session tokens, PPCB/PPAF feedback, diagnostics) apply unchanged; the data-plane-only hub-region latch correctly stays off for metadata ops.

## Tests

Adds: container read **is** hedged; container write is **not**; container `ReadFeed` is **not**. `cargo clippy --all-targets` clean, `cargo fmt --check` clean, full driver lib suite **1811 passed / 0 failed** (37 hedging-eligibility tests including the 3 new).

Fixes #4253