### PR TITLE
cosmos: CHANGELOG updates for June 19 release

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.36.0 (Unreleased)
+## 0.36.0 (2026-06-19)
 
 ### Features Added
 

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.5.0 (Unreleased)
+## 0.5.0 (2026-06-19)
 
 ### Features Added
 
@@ -47,8 +47,6 @@
 - Fixed duplicate items being returned on cross-partition query resume after a physical partition split. When a cross-partition query was paused, serialized to a continuation token, and resumed after the underlying partition had split, the resumed iterator could re-emit items the caller had already consumed on a prior page. The continuation token now records per-range sibling state and is correctly propagated to every surviving leaf after a split. ([#4550](https://github.com/Azure/azure-sdk-for-rust/pull/4550))
 - Fixed per-attempt `activity_id` in diagnostics serializing as `null` on transport failures; it is now seeded from the operation-level activity ID. ([#4602](https://github.com/Azure/azure-sdk-for-rust/pull/4602))
 - Fixed `system_usage.cpu` in diagnostics emitting the literal string `"empty"`; it now serializes as a structured `{ samples, status }` object when no CPU samples are available. ([#4602](https://github.com/Azure/azure-sdk-for-rust/pull/4602))
-
-### Other Changes
 
 ## 0.4.0 (2026-06-09)
 

--- a/sdk/cosmos/azure_data_cosmos_macros/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_macros/CHANGELOG.md
@@ -1,18 +1,12 @@
 # Release History
 
-## 0.2.0 (Unreleased)
+## 0.2.0 (2026-06-19)
 
 ### Features Added
 
 - Added an `overridable` field-level flag (`#[option(env = "...", overridable)]`) that recognizes a `{ENV}_OVERRIDE` kill-switch environment variable, generates `from_env_override()`/`from_env_override_vars()` parsing, and adds a top-priority `env_override` layer to the generated View (constructed via `new_with_override`). ([#4562](https://github.com/Azure/azure-sdk-for-rust/pull/4562))
 - Added an `#[options(env_only)]` struct-level mode to `CosmosOptions` that generates only the `from_env()`/`from_env_vars()` constructors (no View, Builder, or `Default`), allowing an existing builder-style type to double as its own environment-variable source. ([#4562](https://github.com/Azure/azure-sdk-for-rust/pull/4562))
 - Added a `parser` field-level attribute (`#[option(env = "...", parser = path::to::fn)]`) to `CosmosOptions` that parses an environment variable with a custom `fn(&str) -> Option<T>` instead of `FromStr`, supporting field types without a suitable `FromStr` (such as a `Duration` read from a millisecond count). A `None` result is logged and ignored, matching the lenient built-in parsers. ([#4562](https://github.com/Azure/azure-sdk-for-rust/pull/4562))
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 0.1.0 (2026-04-09)
 


### PR DESCRIPTION
CHANGELOG updates for the following releases:

* `azure_data_cosmos` - `0.36.0`
* `azure_data_cosmos_driver` - `0.5.0`
* `azure_data_cosmos_macros` - `0.2.0`