### PR TITLE
Support no-op for PR pipeline

### DIFF
--- a/eng/pipelines/pullrequest.yml
+++ b/eng/pipelines/pullrequest.yml
@@ -12,6 +12,9 @@ pr:
       - feature/*
       - hotfix/*
       - release/*
+  paths:
+    exclude:
+      - .github/skills/azsdk-common-*/**
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/eng/pipelines/pullrequest.yml
+++ b/eng/pipelines/pullrequest.yml
@@ -1,3 +1,8 @@
+parameters:
+- name: SkipPrValidation
+  type: boolean
+  default: false
+
 trigger: none
 
 pr:
@@ -14,6 +19,7 @@ extends:
     ServiceDirectory: auto
     IncludeRelease: false
     RunLiveTests: false
+    SkipPrValidation: ${{ parameters.SkipPrValidation }}
     MatrixConfigs:
       - Name: rust_pr_test_base
         Path: eng/pipelines/templates/stages/pr-platform-matrix.json

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -7,6 +7,9 @@ parameters:
 - name: IncludeRelease
   type: boolean
   default: true
+- name: SkipPrValidation
+  type: boolean
+  default: false
 - name: RunLiveTests
   type: boolean
   default: false
@@ -82,7 +85,25 @@ extends:
   parameters:
     AutoBaseline: ${{ and(eq(variables['Build.DefinitionName'], 'rust - core'), eq(replace(variables['Build.SourceBranchName'], 'refs/heads/', ''), 'main'), eq(variables['System.TeamProject'], 'internal')) }}
     stages:
+    - ${{ if and(eq(parameters.SkipPrValidation, true), eq(variables['Build.Reason'], 'Manual')) }}:
+      - stage: NoOp
+        displayName: No-op
+        variables:
+        - template: /eng/pipelines/templates/variables/image.yml
+        jobs:
+        - job: NoOp
+          displayName: No-op
+          pool:
+            name: $(LINUXPOOL)
+            image: $(LINUXVMIMAGE)
+            os: linux
+          steps:
+          - checkout: none
+          - pwsh: Write-Host "PR validation skipped because SkipPrValidation was set to true for a manual run."
+            displayName: Skip PR validation
+
     - stage: Build
+      condition: not(and(eq(${{ parameters.SkipPrValidation }}, true), eq(variables['Build.Reason'], 'Manual')))
       variables:
       - template: /eng/pipelines/templates/variables/image.yml
       - template: /eng/pipelines/templates/variables/rust.yml
@@ -102,7 +123,7 @@ extends:
           MatrixReplace: ${{ parameters.MatrixReplace }}
 
     # Run live tests for internal only, not public CI builds. This can be triggered manually via an `/azp run` comment.
-    - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.RunLiveTests, 'true')) }}:
+    - ${{ if and(not(and(eq(parameters.SkipPrValidation, true), eq(variables['Build.Reason'], 'Manual'))), eq(variables['System.TeamProject'], 'internal'), eq(parameters.RunLiveTests, 'true')) }}:
       - ${{ each cloud in parameters.CloudConfig }}:
         # Run all clouds by default for weekly test pipeline, except for clouds specifically unsupported by the calling pipeline
         - ${{ if or(contains(parameters.Clouds, cloud.key), and(contains(variables['Build.DefinitionName'], 'weekly'), contains(parameters.SupportedClouds, cloud.key))) }}:
@@ -149,7 +170,7 @@ extends:
     # 1. Internal trigger, not Pull Request trigger
     # 2. Not weekly build
     # 3. Manual trigger or force IncludeRelease
-    - ${{ if and(not(startsWith(variables['Build.SourceBranchName'], 'refs/pull/')), eq(variables['System.TeamProject'], 'internal')) }}:
+    - ${{ if and(not(and(eq(parameters.SkipPrValidation, true), eq(variables['Build.Reason'], 'Manual'))), not(startsWith(variables['Build.SourceBranchName'], 'refs/pull/')), eq(variables['System.TeamProject'], 'internal')) }}:
       - ${{ if not(contains(variables['Build.DefinitionName'], 'weekly')) }}:
         - ${{ if or(in(variables['Build.Reason'], 'Manual', ''), eq(parameters.IncludeRelease, true)) }}:
           - template: archetype-rust-release.yml


### PR DESCRIPTION
This mirrors Azure SDK for Java PR #49558 for the Rust PR validation pipeline.

- Adds `SkipPrValidation` to `eng/pipelines/pullrequest.yml` and passes it to the SDK client archetype template.
- Adds a manual-run-only `NoOp` stage that checks out nothing and logs that PR validation was skipped.
- Keeps build, live test, and release validation unchanged unless `SkipPrValidation` is enabled for a manual run.

Validation:
- Parsed `eng/pipelines/pullrequest.yml` with PyYAML.
- Parsed `eng/pipelines/templates/stages/archetype-sdk-client.yml` with PyYAML.
- Verified the no-op parameter wiring and manual-run condition with assertions.