### PR TITLE
Cosmos: Honor `AZURE_COSMOS_PPCB_*` env vars when partition-failover options are omitted

### DIFF
--- a/sdk/cosmos/.cspell.json
+++ b/sdk/cosmos/.cspell.json
@@ -32,6 +32,7 @@
     "changefeed",
     "chinaeast",
     "chinanorth",
+    "chokepoint",
     "cloneable",
     "codepoint",
     "codepoints",

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed the `AZURE_COSMOS_PPCB_*` environment variables (including `AZURE_COSMOS_PPCB_ENABLED` and the `AZURE_COSMOS_PPCB_ENABLED_OVERRIDE` kill switch) being ignored when a `CosmosClient` was built without calling `CosmosClientBuilder::with_partition_failover_options`. The per-partition circuit breaker (PPCB) stayed enabled even with `AZURE_COSMOS_PPCB_ENABLED=false`. The client's driver now resolves these options from the environment when they are not supplied explicitly.
+
 ### Other Changes
 
 ## 0.36.0 (2026-06-19)

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client_builder.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client_builder.rs
@@ -140,9 +140,16 @@ impl CosmosClientBuilder {
     /// circuit breaker and partition-level failover for the lifetime of the
     /// client. They are independent of per-request [`OperationOptions`].
     ///
-    /// When this setter is not called, the driver falls back to
-    /// [`PartitionFailoverOptions::default`], which honors the
-    /// `AZURE_COSMOS_PPCB_*` environment variables.
+    /// When this setter is **not** called, the driver resolves these options
+    /// from the `AZURE_COSMOS_PPCB_*` environment variables — including the
+    /// `AZURE_COSMOS_PPCB_ENABLED` master switch and the
+    /// `AZURE_COSMOS_PPCB_ENABLED_OVERRIDE` kill switch — falling back to
+    /// compile-time defaults for anything unset. Passing an explicit value
+    /// here takes precedence over those variables (except the
+    /// `AZURE_COSMOS_PPCB_ENABLED_OVERRIDE` kill switch, which is read from the
+    /// environment when you build the [`PartitionFailoverOptions`] and remains
+    /// authoritative). To disable PPCB regardless of the account property, set
+    /// `AZURE_COSMOS_PPCB_ENABLED_OVERRIDE=false`.
     pub fn with_partition_failover_options(mut self, options: PartitionFailoverOptions) -> Self {
         self.partition_failover_options = Some(options);
         self
@@ -541,10 +548,14 @@ mod tests {
         );
     }
 
-    /// Omitting the partition-failover options on the builder must produce
-    /// driver options that carry the type's `Default` value (i.e. PPCB off).
+    /// Omitting the partition-failover options on the builder must resolve
+    /// them from the `AZURE_COSMOS_PPCB_*` environment. With none of those
+    /// variables set (the CI default), resolution falls back to the type's
+    /// compile-time defaults — i.e. PPCB enabled. This guards the wiring that
+    /// routes an omitted value through the driver's env-backed builder rather
+    /// than a bare `Default` that bypasses the environment entirely.
     #[test]
-    fn missing_partition_failover_options_uses_default() {
+    fn missing_partition_failover_options_resolves_from_env_then_default() {
         let opts = build_driver_options(
             test_account(),
             RoutingStrategy::PreferredRegions(Vec::new()),

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed `AZURE_COSMOS_PPCB_*` environment variables (including the `AZURE_COSMOS_PPCB_ENABLED` master switch and the `AZURE_COSMOS_PPCB_ENABLED_OVERRIDE` kill switch) being silently ignored when a caller built `DriverOptions` without calling `DriverOptionsBuilder::with_partition_failover_options`. The environment is read only by `PartitionFailoverOptionsBuilder::build`, but the omitted-options path used a bare `PartitionFailoverOptions::default()` (which hard-codes PPCB enabled and reads no environment), so PPCB stayed on even with `AZURE_COSMOS_PPCB_ENABLED=false`. `DriverOptionsBuilder::build` now resolves the partition-failover options from the environment when the caller does not supply them (falling back to defaults, fail-soft, if an environment value is out of bounds). An explicitly supplied `PartitionFailoverOptions` continues to take precedence.
+
 ### Other Changes
 
 ## 0.5.0 (2026-06-19)

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/routing/partition_endpoint_state.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/routing/partition_endpoint_state.rs
@@ -154,9 +154,12 @@ mod tests {
 
     #[test]
     fn new_propagates_circuit_breaker_enabled_to_state_flag() {
+        // Resolve against an empty environment so unrelated `AZURE_COSMOS_PPCB_*`
+        // values from a concurrently-running env-mutating test can't fail the
+        // build's bounds validation.
         let opts = PartitionFailoverOptions::builder()
             .with_circuit_breaker_enabled(true)
-            .build()
+            .build_from_env(&|_| None)
             .unwrap();
         let state = PartitionEndpointState::new(opts);
         assert!(state.per_partition_circuit_breaker_enabled);
@@ -171,7 +174,7 @@ mod tests {
         let opts = PartitionFailoverOptions::builder()
             .with_circuit_breaker_enabled(true)
             .with_circuit_breaker_enabled_override(false)
-            .build()
+            .build_from_env(&|_| None)
             .unwrap();
         let state = PartitionEndpointState::new(opts);
         assert!(!state.per_partition_circuit_breaker_enabled);
@@ -184,7 +187,7 @@ mod tests {
         let opts = PartitionFailoverOptions::builder()
             .with_circuit_breaker_enabled(false)
             .with_circuit_breaker_enabled_override(true)
-            .build()
+            .build_from_env(&|_| None)
             .unwrap();
         let state = PartitionEndpointState::new(opts);
         assert!(state.per_partition_circuit_breaker_enabled);

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/runtime.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/runtime.rs
@@ -596,6 +596,7 @@ impl CosmosDriverRuntimeBuilder {
             5_000,
             1_000,
             60_000,
+            &|k| std::env::var(k).ok(),
         )?;
         let cpu_monitor = CpuMemoryMonitor::get_or_init(refresh_interval);
         let vm_metadata = VmMetadataService::get_or_init().await;

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/driver_options.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/driver_options.rs
@@ -549,3 +549,140 @@ mod tests {
         assert!(pfo.circuit_breaker_enabled());
     }
 }
+
+/// Real-process-environment tests for the bug chokepoint:
+/// [`DriverOptionsBuilder::build`] resolving omitted partition-failover options
+/// from the actual `AZURE_COSMOS_PPCB_*` variables.
+///
+/// These complement the injected-closure tests above by exercising the public,
+/// production `build()` (which reads `std::env::var`) end to end — the exact
+/// path a customer hits when they set the env and never call
+/// `with_partition_failover_options`. Every case runs inside [`with_scoped_env`]
+/// (shared lock + clear/restore) so it is hermetic and parallel-safe.
+#[cfg(test)]
+mod real_env_tests {
+    use super::*;
+    use crate::options::env_parsing::test_env::{with_scoped_env, PPCB_ENV_VARS};
+    use url::Url;
+
+    fn test_account() -> AccountReference {
+        AccountReference::with_master_key(
+            Url::parse("https://test.documents.azure.com:443/").unwrap(),
+            "test-key",
+        )
+    }
+
+    #[test]
+    fn real_env_omitted_options_honor_disable() {
+        // The exact customer scenario, end to end: env disables PPCB and the
+        // caller never supplies options, so the driver must observe `false`.
+        with_scoped_env(
+            PPCB_ENV_VARS,
+            &[("AZURE_COSMOS_PPCB_ENABLED", "false")],
+            || {
+                let options = DriverOptionsBuilder::new(test_account()).build();
+                assert!(!options
+                    .partition_failover_options()
+                    .circuit_breaker_enabled());
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_omitted_options_default_enabled_when_unset() {
+        with_scoped_env(PPCB_ENV_VARS, &[], || {
+            let options = DriverOptionsBuilder::new(test_account()).build();
+            assert!(options
+                .partition_failover_options()
+                .circuit_breaker_enabled());
+        });
+    }
+
+    #[test]
+    fn real_env_omitted_options_honor_kill_switch() {
+        with_scoped_env(
+            PPCB_ENV_VARS,
+            &[("AZURE_COSMOS_PPCB_ENABLED_OVERRIDE", "false")],
+            || {
+                let options = DriverOptionsBuilder::new(test_account()).build();
+                assert_eq!(
+                    options
+                        .partition_failover_options()
+                        .circuit_breaker_enabled_override(),
+                    Some(false)
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_omitted_options_honor_tuning_combination() {
+        with_scoped_env(
+            PPCB_ENV_VARS,
+            &[
+                ("AZURE_COSMOS_PPCB_READ_FAILURE_THRESHOLD", "21"),
+                ("AZURE_COSMOS_PPCB_WRITE_FAILURE_THRESHOLD", "6"),
+                ("AZURE_COSMOS_PPCB_COUNTER_RESET_WINDOW_MS", "60000"),
+                ("AZURE_COSMOS_PPCB_FAILBACK_SWEEP_INTERVAL_MS", "90000"),
+            ],
+            || {
+                let options = DriverOptionsBuilder::new(test_account()).build();
+                let pfo = options.partition_failover_options();
+                assert_eq!(pfo.read_failure_threshold(), 21);
+                assert_eq!(pfo.write_failure_threshold(), 6);
+                assert_eq!(
+                    pfo.counter_reset_window(),
+                    std::time::Duration::from_millis(60_000)
+                );
+                assert_eq!(
+                    pfo.failback_sweep_interval(),
+                    std::time::Duration::from_millis(90_000)
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_explicit_options_beat_env() {
+        // With explicit options supplied, the env is ignored entirely.
+        with_scoped_env(
+            PPCB_ENV_VARS,
+            &[
+                ("AZURE_COSMOS_PPCB_ENABLED", "false"),
+                ("AZURE_COSMOS_PPCB_READ_FAILURE_THRESHOLD", "99"),
+            ],
+            || {
+                let explicit = PartitionFailoverOptions::builder()
+                    .with_circuit_breaker_enabled(true)
+                    .with_read_failure_threshold(7)
+                    .build_from_env(&|_| None)
+                    .expect("valid options");
+                let options = DriverOptionsBuilder::new(test_account())
+                    .with_partition_failover_options(explicit)
+                    .build();
+                let pfo = options.partition_failover_options();
+                assert!(pfo.circuit_breaker_enabled());
+                assert_eq!(pfo.read_failure_threshold(), 7);
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_out_of_bounds_falls_back_infallibly() {
+        // `build()` is infallible; an out-of-bounds env value is logged and the
+        // group falls back to defaults rather than panicking.
+        with_scoped_env(
+            PPCB_ENV_VARS,
+            &[("AZURE_COSMOS_PPCB_READ_FAILURE_THRESHOLD", "0")],
+            || {
+                let options = DriverOptionsBuilder::new(test_account()).build();
+                let pfo = options.partition_failover_options();
+                assert_eq!(
+                    pfo.read_failure_threshold(),
+                    PartitionFailoverOptions::default().read_failure_threshold()
+                );
+                assert!(pfo.circuit_breaker_enabled());
+            },
+        );
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/driver_options.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/driver_options.rs
@@ -294,7 +294,53 @@ impl DriverOptionsBuilder {
     }
 
     /// Builds the [`DriverOptions`].
+    ///
+    /// When [`with_partition_failover_options`](Self::with_partition_failover_options)
+    /// was **not** called, the partition-failover / PPCB options are resolved
+    /// from the `AZURE_COSMOS_PPCB_*` environment variables (including the
+    /// `AZURE_COSMOS_PPCB_ENABLED` master switch and the
+    /// `AZURE_COSMOS_PPCB_ENABLED_OVERRIDE` kill switch). This is the single
+    /// place those variables are honored when the caller does not supply
+    /// explicit options, so omitting them no longer silently forces PPCB on.
+    /// If the environment carries an out-of-bounds value the error is logged
+    /// and the options fall back to [`PartitionFailoverOptions::default`]
+    /// (so `build` stays infallible); callers that want strict validation
+    /// should build [`PartitionFailoverOptions`] themselves and pass them via
+    /// [`with_partition_failover_options`](Self::with_partition_failover_options).
     pub fn build(self) -> DriverOptions {
+        self.build_from_env(&|k| std::env::var(k).ok())
+    }
+
+    /// Builds the [`DriverOptions`], resolving any omitted environment-backed
+    /// option groups through the supplied `get_env` accessor instead of the
+    /// process environment directly.
+    ///
+    /// [`build`](Self::build) delegates here with `|k| std::env::var(k).ok()`.
+    /// The seam lets tests exercise the "caller omitted the options, so they
+    /// come from the environment" path for every override combination
+    /// deterministically, without mutating process-wide environment.
+    pub(crate) fn build_from_env(self, get_env: &dyn Fn(&str) -> Option<String>) -> DriverOptions {
+        // When the caller supplied explicit partition-failover options, honor
+        // them verbatim. Otherwise resolve them from the environment — this is
+        // the fix for "PPCB stays enabled even though AZURE_COSMOS_PPCB_ENABLED
+        // (or the kill switch) is set to false": the env is only consulted by
+        // the builder's `build`, which a caller that omits the options would
+        // never reach, so the bare `unwrap_or_default()` used to bypass every
+        // AZURE_COSMOS_PPCB_* variable.
+        let partition_failover_options = match self.partition_failover_options {
+            Some(options) => options,
+            None => PartitionFailoverOptions::builder()
+                .build_from_env(get_env)
+                .unwrap_or_else(|e| {
+                    tracing::warn!(
+                        error = %e,
+                        "failed to resolve PartitionFailoverOptions from the environment \
+                         (AZURE_COSMOS_PPCB_*); falling back to defaults",
+                    );
+                    PartitionFailoverOptions::default()
+                }),
+        };
+
         DriverOptions {
             account: self.account,
             operation_options: Arc::new(self.operation_options.unwrap_or_default()),
@@ -303,7 +349,7 @@ impl DriverOptionsBuilder {
             #[cfg(feature = "fault_injection")]
             fault_injection_rules: self.fault_injection_rules.filter(|r| !r.is_empty()),
             throughput_control_groups: self.throughput_control_groups,
-            partition_failover_options: self.partition_failover_options.unwrap_or_default(),
+            partition_failover_options,
         }
     }
 }
@@ -391,5 +437,115 @@ mod tests {
             .build();
 
         assert_eq!(options.preferred_regions(), &regions);
+    }
+
+    // ── Partition-failover / PPCB end-to-end env resolution ─────────────────
+    //
+    // These guard the customer-reported bug: when the caller omits
+    // `with_partition_failover_options`, `DriverOptionsBuilder::build` must
+    // resolve PPCB from `AZURE_COSMOS_PPCB_*` (rather than a bare `Default`
+    // that bypasses the environment). They drive `build_from_env` with an
+    // injected map so they don't race on process-wide `std::env`.
+
+    use std::collections::HashMap;
+
+    fn env_of(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |k: &str| map.get(k).cloned()
+    }
+
+    #[test]
+    fn omitted_pfo_defaults_ppcb_on_with_empty_env() {
+        let options = DriverOptionsBuilder::new(test_account()).build_from_env(&|_| None);
+        assert!(options
+            .partition_failover_options()
+            .circuit_breaker_enabled());
+        assert_eq!(
+            options
+                .partition_failover_options()
+                .circuit_breaker_enabled_override(),
+            None
+        );
+    }
+
+    #[test]
+    fn omitted_pfo_honors_env_disable() {
+        // The exact customer scenario: no explicit options, env disables PPCB.
+        // Before the fix this silently stayed enabled.
+        let options = DriverOptionsBuilder::new(test_account())
+            .build_from_env(&env_of(&[("AZURE_COSMOS_PPCB_ENABLED", "false")]));
+        assert!(!options
+            .partition_failover_options()
+            .circuit_breaker_enabled());
+    }
+
+    #[test]
+    fn omitted_pfo_honors_kill_switch_from_env() {
+        // The authoritative kill switch must be picked up on the omitted path
+        // too, so an operator can force PPCB off fleet-wide without code.
+        let options = DriverOptionsBuilder::new(test_account())
+            .build_from_env(&env_of(&[("AZURE_COSMOS_PPCB_ENABLED_OVERRIDE", "false")]));
+        assert_eq!(
+            options
+                .partition_failover_options()
+                .circuit_breaker_enabled_override(),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn omitted_pfo_honors_env_thresholds_and_durations() {
+        let options = DriverOptionsBuilder::new(test_account()).build_from_env(&env_of(&[
+            ("AZURE_COSMOS_PPCB_READ_FAILURE_THRESHOLD", "21"),
+            ("AZURE_COSMOS_PPCB_COUNTER_RESET_WINDOW_MS", "60000"),
+        ]));
+        let pfo = options.partition_failover_options();
+        assert_eq!(pfo.read_failure_threshold(), 21);
+        assert_eq!(
+            pfo.counter_reset_window(),
+            std::time::Duration::from_millis(60_000)
+        );
+    }
+
+    #[test]
+    fn explicit_pfo_takes_precedence_over_env() {
+        // An explicitly-supplied options value is honored verbatim and the
+        // environment is *not* consulted for that group.
+        let explicit = PartitionFailoverOptions::builder()
+            .with_circuit_breaker_enabled(true)
+            .with_read_failure_threshold(7)
+            .build()
+            .expect("valid options");
+
+        let options = DriverOptionsBuilder::new(test_account())
+            .with_partition_failover_options(explicit)
+            // Env would say "disabled / threshold 99" but must be ignored.
+            .build_from_env(&env_of(&[
+                ("AZURE_COSMOS_PPCB_ENABLED", "false"),
+                ("AZURE_COSMOS_PPCB_READ_FAILURE_THRESHOLD", "99"),
+            ]));
+        let pfo = options.partition_failover_options();
+        assert!(pfo.circuit_breaker_enabled());
+        assert_eq!(pfo.read_failure_threshold(), 7);
+    }
+
+    #[test]
+    fn omitted_pfo_out_of_bounds_env_falls_back_to_default_infallibly() {
+        // `build` is infallible: an out-of-bounds env value on the omitted
+        // path is logged and the whole group falls back to defaults rather
+        // than panicking or losing the builder's other (non-PPCB) settings.
+        let options = DriverOptionsBuilder::new(test_account()).build_from_env(&env_of(&[(
+            "AZURE_COSMOS_PPCB_READ_FAILURE_THRESHOLD",
+            "0",
+        )]));
+        let pfo = options.partition_failover_options();
+        assert_eq!(
+            pfo.read_failure_threshold(),
+            PartitionFailoverOptions::default().read_failure_threshold()
+        );
+        assert!(pfo.circuit_breaker_enabled());
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/env_parsing.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/env_parsing.rs
@@ -358,6 +358,20 @@ pub(crate) mod test_env {
         "AZURE_COSMOS_PPCB_CONSECUTIVE_HEDGE_WIN_THRESHOLD",
     ];
 
+    /// Every environment variable read by `OperationOptions::from_env` /
+    /// `from_env_override` (including the nested `ThrottlingRetryOptions`).
+    /// Tests clear all of these so an ambient value can't leak into an
+    /// assertion about a single field.
+    pub(crate) const OPERATION_ENV_VARS: &[&str] = &[
+        "AZURE_COSMOS_READ_CONSISTENCY_STRATEGY",
+        "AZURE_COSMOS_CONTENT_RESPONSE_ON_WRITE",
+        "AZURE_COSMOS_MAX_FAILOVER_RETRY_COUNT",
+        "AZURE_COSMOS_MAX_SESSION_RETRY_COUNT",
+        "AZURE_COSMOS_MAX_THROTTLE_RETRY_COUNT",
+        "AZURE_COSMOS_HEDGING_ENABLED",
+        "AZURE_COSMOS_HEDGING_ENABLED_OVERRIDE",
+    ];
+
     /// Runs `body` with a hermetic view of the named environment variables.
     ///
     /// Holds the shared [`ENV_TEST_LOCK`] for the whole call (so parallel tests

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/env_parsing.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/env_parsing.rs
@@ -8,9 +8,13 @@
 //! helpers here only resolve a final value from
 //! `builder override → pre-read env value → default` and validate it against
 //! bounds. A few driver-level helpers (`parse_duration_millis_from_env`,
-//! `parse_from_env`, `parse_optional_bool_from_env`) additionally read
-//! `std::env::var` directly for option builders that are not macro-generated;
-//! like the macro, they log and ignore a present-but-unparseable value
+//! `parse_from_env`, `parse_optional_bool_from_env`) additionally look up
+//! environment variables for option builders that are not macro-generated.
+//! Rather than calling `std::env::var` directly, they take a
+//! `get_env: &dyn Fn(&str) -> Option<String>` accessor (production passes
+//! `|k| std::env::var(k).ok()`; tests inject a deterministic map so option
+//! resolution can be exercised without racing on process-wide environment).
+//! Like the macro, they log and ignore a present-but-unparseable value
 //! (fail-soft) rather than erroring.
 
 use std::time::Duration;
@@ -161,10 +165,13 @@ pub(crate) fn resolve_duration_ms(
 /// Reads, resolves, and validates a millisecond-duration environment variable
 /// in a single call.
 ///
-/// Reads `env_var_name` itself (parsing it as `u64` milliseconds), then applies
-/// the shared `builder → env → default` resolution and bounds validation. This
-/// is the single duration env-reading path shared by the driver-level option
-/// builders (e.g. [`PartitionFailoverOptions`](crate::options::PartitionFailoverOptions))
+/// Looks up `env_var_name` through the supplied `get_env` accessor (parsing it
+/// as `u64` milliseconds), then applies the shared `builder → env → default`
+/// resolution and bounds validation. `get_env` is normally
+/// `|k| std::env::var(k).ok()`; tests inject a deterministic map so they don't
+/// race on process-wide environment. This is the single duration env-reading
+/// path shared by the driver-level option builders (e.g.
+/// [`PartitionFailoverOptions`](crate::options::PartitionFailoverOptions))
 /// and the runtime CPU-refresh interval.
 pub(crate) fn parse_duration_millis_from_env(
     builder_value: Option<Duration>,
@@ -172,8 +179,9 @@ pub(crate) fn parse_duration_millis_from_env(
     default_millis: u64,
     min_millis: u64,
     max_millis: u64,
+    get_env: &dyn Fn(&str) -> Option<String>,
 ) -> crate::error::Result<Duration> {
-    let env_millis = std::env::var(env_var_name).ok().and_then(|raw| {
+    let env_millis = get_env(env_var_name).and_then(|raw| {
         raw.parse::<u64>().ok().or_else(|| {
             // Fail-soft: a present-but-unparseable value is logged and ignored
             // (falls back to the default), matching the macro's lenient
@@ -203,11 +211,12 @@ pub(super) fn parse_from_env<T>(
     env_var_name: &str,
     default: T,
     bounds: ValidationBounds<T>,
+    get_env: &dyn Fn(&str) -> Option<String>,
 ) -> crate::error::Result<T>
 where
     T: PartialOrd + std::fmt::Debug + std::str::FromStr,
 {
-    let env_value = std::env::var(env_var_name).ok().and_then(|raw| {
+    let env_value = get_env(env_var_name).and_then(|raw| {
         raw.parse::<T>().ok().or_else(|| {
             // Fail-soft: a present-but-unparseable value is logged and ignored
             // (falls back to the default), matching the macro's lenient
@@ -235,12 +244,13 @@ where
 pub(super) fn parse_optional_bool_from_env(
     builder_value: Option<bool>,
     env_var_name: &str,
+    get_env: &dyn Fn(&str) -> Option<String>,
 ) -> Option<bool> {
     if let Some(value) = builder_value {
         return Some(value);
     }
 
-    let raw = std::env::var(env_var_name).ok()?;
+    let raw = get_env(env_var_name)?;
     match raw.trim().to_ascii_lowercase().as_str() {
         "true" | "1" | "yes" | "on" => Some(true),
         "false" | "0" | "no" | "off" => Some(false),

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/env_parsing.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/env_parsing.rs
@@ -326,6 +326,92 @@ pub(super) fn resolve_optional_duration_ms(
     }
 }
 
+/// Shared helpers for tests that exercise the *real* process environment.
+///
+/// Mutating `std::env` is process-global, so every test that does so — in any
+/// module — must serialize on one lock and restore what it changed, otherwise
+/// tests racing in parallel corrupt each other's view of the environment. This
+/// module provides that single lock plus a scoping helper, so the partition-
+/// failover and driver-options test modules can validate that the production
+/// `build()` path (which reads `std::env::var`) honors the `AZURE_COSMOS_PPCB_*`
+/// variables.
+#[cfg(test)]
+pub(crate) mod test_env {
+    use std::sync::Mutex;
+
+    /// Process-wide lock serializing every test that mutates real environment
+    /// variables through [`with_scoped_env`].
+    static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Every `AZURE_COSMOS_PPCB_*` environment variable read by
+    /// [`PartitionFailoverOptionsBuilder::build`](crate::options::PartitionFailoverOptionsBuilder::build).
+    /// Tests clear all of these before applying their own subset so a value left
+    /// in the ambient / CI environment cannot leak into an assertion.
+    pub(crate) const PPCB_ENV_VARS: &[&str] = &[
+        "AZURE_COSMOS_PPCB_ENABLED",
+        "AZURE_COSMOS_PPCB_ENABLED_OVERRIDE",
+        "AZURE_COSMOS_PPCB_READ_FAILURE_THRESHOLD",
+        "AZURE_COSMOS_PPCB_WRITE_FAILURE_THRESHOLD",
+        "AZURE_COSMOS_PPCB_COUNTER_RESET_WINDOW_MS",
+        "AZURE_COSMOS_PPCB_PARTITION_UNAVAILABILITY_DURATION_MS",
+        "AZURE_COSMOS_PPCB_FAILBACK_SWEEP_INTERVAL_MS",
+        "AZURE_COSMOS_PPCB_CONSECUTIVE_HEDGE_WIN_THRESHOLD",
+    ];
+
+    /// Runs `body` with a hermetic view of the named environment variables.
+    ///
+    /// Holds the shared [`ENV_TEST_LOCK`] for the whole call (so parallel tests
+    /// don't race), snapshots and **removes** every key in `clear` (so the test
+    /// starts from a known-empty state regardless of ambient environment), then
+    /// applies each `(key, value)` in `set`. The original values of all `clear`
+    /// keys are restored when the call returns — including on panic, via a
+    /// `Drop` guard — and the restore happens before the lock is released.
+    ///
+    /// `std::env::set_var` / `remove_var` are safe to call here on the crate's
+    /// edition; the serialization above is what makes that sound under parallel
+    /// test execution.
+    pub(crate) fn with_scoped_env<R>(
+        clear: &[&str],
+        set: &[(&str, &str)],
+        body: impl FnOnce() -> R,
+    ) -> R {
+        // Recover a poisoned lock: a prior test panicking while holding it left
+        // no shared state behind (the env is restored by the `Drop` guard), so
+        // the lock is still usable.
+        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let saved: Vec<(String, Option<String>)> = clear
+            .iter()
+            .map(|&k| (k.to_string(), std::env::var(k).ok()))
+            .collect();
+
+        // Restore-on-drop runs before `_guard` drops (reverse declaration
+        // order), so the environment is repaired while the lock is still held,
+        // even if `body` panics.
+        struct Restore(Vec<(String, Option<String>)>);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                for (k, original) in &self.0 {
+                    match original {
+                        Some(v) => std::env::set_var(k, v),
+                        None => std::env::remove_var(k),
+                    }
+                }
+            }
+        }
+        let _restore = Restore(saved);
+
+        for &k in clear {
+            std::env::remove_var(k);
+        }
+        for &(k, v) in set {
+            std::env::set_var(k, v);
+        }
+
+        body()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/operation_options.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/operation_options.rs
@@ -692,3 +692,181 @@ mod tests {
         assert!(throughput.priority_level().is_none());
     }
 }
+
+/// Real-process-environment tests for `OperationOptions::from_env` /
+/// `from_env_override` (and the nested `ThrottlingRetryOptions::from_env`).
+///
+/// The tests above inject a closure; these set actual `AZURE_COSMOS_*`
+/// variables via `std::env` and call the real production constructors the
+/// runtime uses, proving each env field is wired to its option. Every case
+/// runs inside [`with_scoped_env`] (shared lock + clear/restore) so it is
+/// hermetic and safe under parallel execution.
+#[cfg(test)]
+mod real_env_tests {
+    use super::*;
+    use crate::options::env_parsing::test_env::{with_scoped_env, OPERATION_ENV_VARS};
+
+    #[test]
+    fn real_env_empty_yields_all_none() {
+        with_scoped_env(OPERATION_ENV_VARS, &[], || {
+            let o = OperationOptions::from_env();
+            assert!(o.read_consistency_strategy.is_none());
+            assert!(o.content_response_on_write.is_none());
+            assert!(o.max_failover_retry_count.is_none());
+            assert!(o.max_session_retry_count.is_none());
+            assert!(o.hedging_enabled.is_none());
+        });
+    }
+
+    #[test]
+    fn real_env_read_consistency_strategy() {
+        with_scoped_env(
+            OPERATION_ENV_VARS,
+            &[("AZURE_COSMOS_READ_CONSISTENCY_STRATEGY", "Session")],
+            || {
+                let o = OperationOptions::from_env();
+                assert_eq!(
+                    o.read_consistency_strategy,
+                    Some(ReadConsistencyStrategy::Session)
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_content_response_on_write_toggles() {
+        with_scoped_env(
+            OPERATION_ENV_VARS,
+            &[("AZURE_COSMOS_CONTENT_RESPONSE_ON_WRITE", "true")],
+            || {
+                let o = OperationOptions::from_env();
+                assert_eq!(
+                    o.content_response_on_write,
+                    Some(ContentResponseOnWrite::Enabled)
+                );
+            },
+        );
+        with_scoped_env(
+            OPERATION_ENV_VARS,
+            &[("AZURE_COSMOS_CONTENT_RESPONSE_ON_WRITE", "false")],
+            || {
+                let o = OperationOptions::from_env();
+                assert_eq!(
+                    o.content_response_on_write,
+                    Some(ContentResponseOnWrite::Disabled)
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_retry_counts() {
+        with_scoped_env(
+            OPERATION_ENV_VARS,
+            &[
+                ("AZURE_COSMOS_MAX_FAILOVER_RETRY_COUNT", "7"),
+                ("AZURE_COSMOS_MAX_SESSION_RETRY_COUNT", "3"),
+            ],
+            || {
+                let o = OperationOptions::from_env();
+                assert_eq!(o.max_failover_retry_count, Some(7));
+                assert_eq!(o.max_session_retry_count, Some(3));
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_hedging_enabled_toggles() {
+        for (raw, expected) in [("false", false), ("true", true)] {
+            with_scoped_env(
+                OPERATION_ENV_VARS,
+                &[("AZURE_COSMOS_HEDGING_ENABLED", raw)],
+                || {
+                    let o = OperationOptions::from_env();
+                    assert_eq!(o.hedging_enabled, Some(expected), "hedging {raw:?}");
+                },
+            );
+        }
+    }
+
+    #[test]
+    fn real_env_hedging_override_only_on_override_path() {
+        with_scoped_env(
+            OPERATION_ENV_VARS,
+            &[
+                // The base var must NOT leak into the override layer...
+                ("AZURE_COSMOS_HEDGING_ENABLED", "true"),
+                ("AZURE_COSMOS_HEDGING_ENABLED_OVERRIDE", "false"),
+            ],
+            || {
+                // `from_env_override` reads only the `_OVERRIDE` variants.
+                let over = OperationOptions::from_env_override();
+                assert_eq!(over.hedging_enabled, Some(false));
+
+                // The base `from_env` reads the non-override var.
+                let base = OperationOptions::from_env();
+                assert_eq!(base.hedging_enabled, Some(true));
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_throttle_retry_count_nested_group() {
+        // `OperationOptions::from_env` does not recurse into nested groups;
+        // the runtime loads `ThrottlingRetryOptions::from_env` separately, so
+        // that's what this exercises.
+        with_scoped_env(
+            OPERATION_ENV_VARS,
+            &[("AZURE_COSMOS_MAX_THROTTLE_RETRY_COUNT", "4")],
+            || {
+                let t = ThrottlingRetryOptions::from_env();
+                assert_eq!(t.max_retry_count, Some(4));
+                assert!(t.max_retry_wait_time.is_none());
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_all_base_fields_at_once() {
+        with_scoped_env(
+            OPERATION_ENV_VARS,
+            &[
+                ("AZURE_COSMOS_READ_CONSISTENCY_STRATEGY", "Session"),
+                ("AZURE_COSMOS_CONTENT_RESPONSE_ON_WRITE", "true"),
+                ("AZURE_COSMOS_MAX_FAILOVER_RETRY_COUNT", "9"),
+                ("AZURE_COSMOS_MAX_SESSION_RETRY_COUNT", "2"),
+                ("AZURE_COSMOS_HEDGING_ENABLED", "false"),
+            ],
+            || {
+                let o = OperationOptions::from_env();
+                assert_eq!(
+                    o.read_consistency_strategy,
+                    Some(ReadConsistencyStrategy::Session)
+                );
+                assert_eq!(
+                    o.content_response_on_write,
+                    Some(ContentResponseOnWrite::Enabled)
+                );
+                assert_eq!(o.max_failover_retry_count, Some(9));
+                assert_eq!(o.max_session_retry_count, Some(2));
+                assert_eq!(o.hedging_enabled, Some(false));
+                // A field with no env annotation stays None.
+                assert!(o.excluded_regions.is_none());
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_unparseable_numeric_is_ignored() {
+        // The derive macro is lenient: a non-numeric value is logged and
+        // ignored, leaving the field `None` (inherits a lower layer).
+        with_scoped_env(
+            OPERATION_ENV_VARS,
+            &[("AZURE_COSMOS_MAX_FAILOVER_RETRY_COUNT", "not-a-number")],
+            || {
+                let o = OperationOptions::from_env();
+                assert!(o.max_failover_retry_count.is_none());
+            },
+        );
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/partition_failover.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/partition_failover.rs
@@ -402,7 +402,13 @@ mod tests {
 
     #[test]
     fn builder_defaults_match_documented_values() {
-        let options = PartitionFailoverOptionsBuilder::new().build().unwrap();
+        // Resolve against an explicitly empty environment so the documented
+        // compile-time defaults are asserted deterministically, regardless of
+        // any ambient `AZURE_COSMOS_PPCB_*` value. (Real-environment resolution
+        // is covered by the `real_env_tests` module below.)
+        let options = PartitionFailoverOptionsBuilder::new()
+            .build_from_env(&|_| None)
+            .unwrap();
 
         assert!(options.circuit_breaker_enabled());
         assert_eq!(options.read_failure_threshold(), 10);
@@ -443,7 +449,11 @@ mod tests {
 
     #[test]
     fn circuit_breaker_override_unset_by_default() {
-        let options = PartitionFailoverOptionsBuilder::new().build().unwrap();
+        // Empty environment → the kill switch is unset. (Real-environment
+        // resolution of the override is covered by `real_env_tests`.)
+        let options = PartitionFailoverOptionsBuilder::new()
+            .build_from_env(&|_| None)
+            .unwrap();
         assert_eq!(options.circuit_breaker_enabled_override(), None);
     }
 
@@ -849,5 +859,214 @@ mod env_matrix_tests {
             Duration::from_secs(5)
         ); // env garbage -> default
         assert_eq!(o.failback_sweep_interval(), Duration::from_secs(300)); // default
+    }
+}
+
+/// Real-process-environment tests for the production
+/// [`PartitionFailoverOptionsBuilder::build`] path.
+///
+/// Unlike `env_matrix_tests` (which inject a closure), these set actual
+/// `AZURE_COSMOS_PPCB_*` variables via `std::env` and call the public `build()`
+/// — proving the production accessor (`|k| std::env::var(k).ok()`) is wired
+/// correctly and that the variables genuinely enable / disable / tune PPCB.
+/// Every case runs inside [`with_scoped_env`], which serializes on a shared
+/// lock and clears + restores the PPCB variables, so the cases are hermetic and
+/// safe under parallel test execution.
+#[cfg(test)]
+mod real_env_tests {
+    use super::*;
+    use crate::options::env_parsing::test_env::{with_scoped_env, PPCB_ENV_VARS};
+    use std::time::Duration;
+
+    #[test]
+    fn real_env_enable_false_disables_ppcb() {
+        with_scoped_env(
+            PPCB_ENV_VARS,
+            &[("AZURE_COSMOS_PPCB_ENABLED", "false")],
+            || {
+                let o = PartitionFailoverOptionsBuilder::new().build().unwrap();
+                assert!(!o.circuit_breaker_enabled());
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_enable_true_keeps_ppcb_on() {
+        with_scoped_env(
+            PPCB_ENV_VARS,
+            &[("AZURE_COSMOS_PPCB_ENABLED", "true")],
+            || {
+                let o = PartitionFailoverOptionsBuilder::new().build().unwrap();
+                assert!(o.circuit_breaker_enabled());
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_empty_uses_default_enabled() {
+        with_scoped_env(PPCB_ENV_VARS, &[], || {
+            let o = PartitionFailoverOptionsBuilder::new().build().unwrap();
+            assert!(o.circuit_breaker_enabled());
+            assert_eq!(o.circuit_breaker_enabled_override(), None);
+            assert_eq!(o.read_failure_threshold(), 10);
+        });
+    }
+
+    #[test]
+    fn real_env_kill_switch_false() {
+        with_scoped_env(
+            PPCB_ENV_VARS,
+            &[("AZURE_COSMOS_PPCB_ENABLED_OVERRIDE", "false")],
+            || {
+                let o = PartitionFailoverOptionsBuilder::new().build().unwrap();
+                assert_eq!(o.circuit_breaker_enabled_override(), Some(false));
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_kill_switch_true() {
+        with_scoped_env(
+            PPCB_ENV_VARS,
+            &[("AZURE_COSMOS_PPCB_ENABLED_OVERRIDE", "true")],
+            || {
+                let o = PartitionFailoverOptionsBuilder::new().build().unwrap();
+                assert_eq!(o.circuit_breaker_enabled_override(), Some(true));
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_kill_switch_lenient_spellings() {
+        for raw in ["1", "yes", "ON", " no ", "Off"] {
+            with_scoped_env(
+                PPCB_ENV_VARS,
+                &[("AZURE_COSMOS_PPCB_ENABLED_OVERRIDE", raw)],
+                || {
+                    let expected =
+                        matches!(raw.trim().to_ascii_lowercase().as_str(), "1" | "yes" | "on");
+                    let o = PartitionFailoverOptionsBuilder::new().build().unwrap();
+                    assert_eq!(
+                        o.circuit_breaker_enabled_override(),
+                        Some(expected),
+                        "override spelling {raw:?}",
+                    );
+                },
+            );
+        }
+    }
+
+    #[test]
+    fn real_env_thresholds_applied() {
+        with_scoped_env(
+            PPCB_ENV_VARS,
+            &[
+                ("AZURE_COSMOS_PPCB_READ_FAILURE_THRESHOLD", "20"),
+                ("AZURE_COSMOS_PPCB_WRITE_FAILURE_THRESHOLD", "8"),
+                ("AZURE_COSMOS_PPCB_CONSECUTIVE_HEDGE_WIN_THRESHOLD", "3"),
+            ],
+            || {
+                let o = PartitionFailoverOptionsBuilder::new().build().unwrap();
+                assert_eq!(o.read_failure_threshold(), 20);
+                assert_eq!(o.write_failure_threshold(), 8);
+                assert_eq!(o.consecutive_hedge_win_threshold(), 3);
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_durations_applied() {
+        with_scoped_env(
+            PPCB_ENV_VARS,
+            &[
+                ("AZURE_COSMOS_PPCB_COUNTER_RESET_WINDOW_MS", "60000"),
+                (
+                    "AZURE_COSMOS_PPCB_PARTITION_UNAVAILABILITY_DURATION_MS",
+                    "30000",
+                ),
+                ("AZURE_COSMOS_PPCB_FAILBACK_SWEEP_INTERVAL_MS", "120000"),
+            ],
+            || {
+                let o = PartitionFailoverOptionsBuilder::new().build().unwrap();
+                assert_eq!(o.counter_reset_window(), Duration::from_millis(60_000));
+                assert_eq!(
+                    o.partition_unavailability_duration(),
+                    Duration::from_millis(30_000)
+                );
+                assert_eq!(o.failback_sweep_interval(), Duration::from_millis(120_000));
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_combination_disable_with_override_and_tuning() {
+        // The weird-but-valid mix: base disabled, kill switch forces it on,
+        // and a couple of tuning knobs are set — all from real env at once.
+        with_scoped_env(
+            PPCB_ENV_VARS,
+            &[
+                ("AZURE_COSMOS_PPCB_ENABLED", "false"),
+                ("AZURE_COSMOS_PPCB_ENABLED_OVERRIDE", "true"),
+                ("AZURE_COSMOS_PPCB_READ_FAILURE_THRESHOLD", "15"),
+                ("AZURE_COSMOS_PPCB_COUNTER_RESET_WINDOW_MS", "45000"),
+            ],
+            || {
+                let o = PartitionFailoverOptionsBuilder::new().build().unwrap();
+                // Base option observes the env `false`...
+                assert!(!o.circuit_breaker_enabled());
+                // ...while the kill switch is independently `Some(true)` (the
+                // routing layer applies `override ?? base`, so PPCB is on).
+                assert_eq!(o.circuit_breaker_enabled_override(), Some(true));
+                assert_eq!(o.read_failure_threshold(), 15);
+                assert_eq!(o.counter_reset_window(), Duration::from_millis(45_000));
+                // Untouched knobs keep their defaults.
+                assert_eq!(o.write_failure_threshold(), 5);
+                assert_eq!(o.failback_sweep_interval(), Duration::from_secs(300));
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_builder_value_beats_env() {
+        with_scoped_env(
+            PPCB_ENV_VARS,
+            &[("AZURE_COSMOS_PPCB_ENABLED", "false")],
+            || {
+                // Explicit builder value wins over the env `false`.
+                let o = PartitionFailoverOptionsBuilder::new()
+                    .with_circuit_breaker_enabled(true)
+                    .build()
+                    .unwrap();
+                assert!(o.circuit_breaker_enabled());
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_out_of_bounds_threshold_errors() {
+        with_scoped_env(
+            PPCB_ENV_VARS,
+            &[("AZURE_COSMOS_PPCB_READ_FAILURE_THRESHOLD", "0")],
+            || {
+                let err = PartitionFailoverOptionsBuilder::new()
+                    .build()
+                    .unwrap_err()
+                    .to_string();
+                assert!(
+                    err.contains("read_failure_threshold must be at least 1"),
+                    "unexpected error: {err}",
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn real_env_garbage_enable_falls_back_to_default() {
+        // `AZURE_COSMOS_PPCB_ENABLED` is strict-parsed; a non-`true`/`false`
+        // value is ignored and the default (enabled) applies.
+        with_scoped_env(PPCB_ENV_VARS, &[("AZURE_COSMOS_PPCB_ENABLED", "1")], || {
+            let o = PartitionFailoverOptionsBuilder::new().build().unwrap();
+            assert!(o.circuit_breaker_enabled());
+        });
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/partition_failover.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/partition_failover.rs
@@ -424,6 +424,9 @@ mod tests {
 
     #[test]
     fn builder_round_trips_custom_values() {
+        // Resolve against an empty environment so the builder values are the
+        // only inputs (and the test can't race the env-mutating
+        // `real_env_tests`).
         let options = PartitionFailoverOptionsBuilder::new()
             .with_circuit_breaker_enabled(true)
             .with_read_failure_threshold(20)
@@ -432,7 +435,7 @@ mod tests {
             .with_partition_unavailability_duration(Duration::from_secs(30))
             .with_failback_sweep_interval(Duration::from_secs(120))
             .with_consecutive_hedge_win_threshold(3)
-            .build()
+            .build_from_env(&|_| None)
             .unwrap();
 
         assert!(options.circuit_breaker_enabled());
@@ -459,15 +462,17 @@ mod tests {
 
     #[test]
     fn circuit_breaker_override_builder_value_round_trips() {
+        // Empty env so the *other* (unset) PPCB vars can't leak in from a
+        // concurrently-running env-mutating test and fail bounds validation.
         let off = PartitionFailoverOptionsBuilder::new()
             .with_circuit_breaker_enabled_override(false)
-            .build()
+            .build_from_env(&|_| None)
             .unwrap();
         assert_eq!(off.circuit_breaker_enabled_override(), Some(false));
 
         let on = PartitionFailoverOptionsBuilder::new()
             .with_circuit_breaker_enabled_override(true)
-            .build()
+            .build_from_env(&|_| None)
             .unwrap();
         assert_eq!(on.circuit_breaker_enabled_override(), Some(true));
     }
@@ -476,7 +481,7 @@ mod tests {
     fn read_failure_threshold_zero_rejected() {
         let err = PartitionFailoverOptionsBuilder::new()
             .with_read_failure_threshold(0)
-            .build()
+            .build_from_env(&|_| None)
             .unwrap_err()
             .to_string();
         assert!(
@@ -489,7 +494,7 @@ mod tests {
     fn counter_reset_window_below_min_rejected() {
         let err = PartitionFailoverOptionsBuilder::new()
             .with_counter_reset_window(Duration::from_millis(500))
-            .build()
+            .build_from_env(&|_| None)
             .unwrap_err()
             .to_string();
         assert!(
@@ -502,7 +507,7 @@ mod tests {
     fn partition_unavailability_duration_below_min_rejected() {
         let err = PartitionFailoverOptionsBuilder::new()
             .with_partition_unavailability_duration(Duration::from_millis(50))
-            .build()
+            .build_from_env(&|_| None)
             .unwrap_err()
             .to_string();
         assert!(
@@ -515,7 +520,7 @@ mod tests {
     fn failback_sweep_interval_below_min_rejected() {
         let err = PartitionFailoverOptionsBuilder::new()
             .with_failback_sweep_interval(Duration::from_millis(100))
-            .build()
+            .build_from_env(&|_| None)
             .unwrap_err()
             .to_string();
         assert!(

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/partition_failover.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/partition_failover.rs
@@ -297,6 +297,21 @@ impl PartitionFailoverOptionsBuilder {
     /// Returns an error if any environment variable cannot be parsed or any
     /// supplied value falls outside its validation bounds.
     pub fn build(self) -> crate::error::Result<PartitionFailoverOptions> {
+        self.build_from_env(&|k| std::env::var(k).ok())
+    }
+
+    /// Builds the options, resolving unset fields through the supplied
+    /// environment accessor instead of the process environment directly.
+    ///
+    /// `build()` delegates here with `|k| std::env::var(k).ok()`. The seam
+    /// exists so the driver-options layer can share one env lookup across all
+    /// option groups, and so tests can exercise every `builder × env` override
+    /// combination deterministically without mutating process-wide environment
+    /// (which would race across parallel tests).
+    pub(crate) fn build_from_env(
+        self,
+        get_env: &dyn Fn(&str) -> Option<String>,
+    ) -> crate::error::Result<PartitionFailoverOptions> {
         let defaults = PartitionFailoverOptions::default();
 
         let circuit_breaker_enabled = parse_from_env(
@@ -304,6 +319,7 @@ impl PartitionFailoverOptionsBuilder {
             "AZURE_COSMOS_PPCB_ENABLED",
             defaults.circuit_breaker_enabled,
             ValidationBounds::none(),
+            get_env,
         )?;
 
         // Incident kill switch — lenient bool, builder wins over env, and an
@@ -313,6 +329,7 @@ impl PartitionFailoverOptionsBuilder {
         let circuit_breaker_enabled_override = parse_optional_bool_from_env(
             self.circuit_breaker_enabled_override,
             "AZURE_COSMOS_PPCB_ENABLED_OVERRIDE",
+            get_env,
         );
 
         let read_failure_threshold = parse_from_env(
@@ -320,6 +337,7 @@ impl PartitionFailoverOptionsBuilder {
             "AZURE_COSMOS_PPCB_READ_FAILURE_THRESHOLD",
             defaults.read_failure_threshold,
             ValidationBounds::min(1),
+            get_env,
         )?;
 
         let write_failure_threshold = parse_from_env(
@@ -327,6 +345,7 @@ impl PartitionFailoverOptionsBuilder {
             "AZURE_COSMOS_PPCB_WRITE_FAILURE_THRESHOLD",
             defaults.write_failure_threshold,
             ValidationBounds::min(1),
+            get_env,
         )?;
 
         let counter_reset_window = parse_duration_millis_from_env(
@@ -335,6 +354,7 @@ impl PartitionFailoverOptionsBuilder {
             defaults.counter_reset_window.as_millis() as u64,
             1_000,
             u64::MAX,
+            get_env,
         )?;
 
         let partition_unavailability_duration = parse_duration_millis_from_env(
@@ -343,6 +363,7 @@ impl PartitionFailoverOptionsBuilder {
             defaults.partition_unavailability_duration.as_millis() as u64,
             1_000,
             u64::MAX,
+            get_env,
         )?;
 
         let failback_sweep_interval = parse_duration_millis_from_env(
@@ -351,6 +372,7 @@ impl PartitionFailoverOptionsBuilder {
             defaults.failback_sweep_interval.as_millis() as u64,
             1_000,
             u64::MAX,
+            get_env,
         )?;
 
         let consecutive_hedge_win_threshold = parse_from_env(
@@ -358,6 +380,7 @@ impl PartitionFailoverOptionsBuilder {
             "AZURE_COSMOS_PPCB_CONSECUTIVE_HEDGE_WIN_THRESHOLD",
             defaults.consecutive_hedge_win_threshold,
             ValidationBounds::min(1),
+            get_env,
         )?;
 
         Ok(PartitionFailoverOptions {
@@ -489,5 +512,342 @@ mod tests {
             err.contains("failback_sweep_interval_ms must be at least 1000ms"),
             "unexpected error: {err}",
         );
+    }
+}
+
+/// Exhaustive `builder × environment` resolution matrix for
+/// [`PartitionFailoverOptionsBuilder::build_from_env`].
+///
+/// Each case drives the builder through a deterministic, injected environment
+/// map (no process-wide `std::env` mutation, so the cases are parallel-safe)
+/// and asserts the resolved value for every field. The goal is to pin down the
+/// precedence contract — **builder value > environment value > compile-time
+/// default** — and the parsing quirks (strict vs. lenient booleans, bounds
+/// validation, fail-soft on garbage) in all the "weird" combinations a fuzzing
+/// consumer might throw at it.
+#[cfg(test)]
+mod env_matrix_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Builds an env accessor from a slice of `(name, value)` pairs.
+    fn env_of(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |k: &str| map.get(k).cloned()
+    }
+
+    /// An env accessor that always returns `None` (nothing set).
+    fn empty_env() -> impl Fn(&str) -> Option<String> {
+        |_: &str| None
+    }
+
+    // ── Master switch: AZURE_COSMOS_PPCB_ENABLED ────────────────────────────
+
+    #[test]
+    fn enabled_defaults_true_when_nothing_set() {
+        let o = PartitionFailoverOptionsBuilder::new()
+            .build_from_env(&empty_env())
+            .unwrap();
+        assert!(o.circuit_breaker_enabled());
+    }
+
+    #[test]
+    fn enabled_env_false_honored_when_builder_unset() {
+        // The customer's exact scenario: env says false, caller never set it.
+        let o = PartitionFailoverOptionsBuilder::new()
+            .build_from_env(&env_of(&[("AZURE_COSMOS_PPCB_ENABLED", "false")]))
+            .unwrap();
+        assert!(!o.circuit_breaker_enabled());
+    }
+
+    #[test]
+    fn enabled_builder_true_wins_over_env_false() {
+        let o = PartitionFailoverOptionsBuilder::new()
+            .with_circuit_breaker_enabled(true)
+            .build_from_env(&env_of(&[("AZURE_COSMOS_PPCB_ENABLED", "false")]))
+            .unwrap();
+        assert!(o.circuit_breaker_enabled());
+    }
+
+    #[test]
+    fn enabled_builder_false_wins_over_env_true() {
+        let o = PartitionFailoverOptionsBuilder::new()
+            .with_circuit_breaker_enabled(false)
+            .build_from_env(&env_of(&[("AZURE_COSMOS_PPCB_ENABLED", "true")]))
+            .unwrap();
+        assert!(!o.circuit_breaker_enabled());
+    }
+
+    #[test]
+    fn enabled_env_uses_strict_bool_parsing() {
+        // `AZURE_COSMOS_PPCB_ENABLED` parses via `bool::from_str`, which only
+        // accepts exactly "true"/"false" (case-sensitive, no trimming). Every
+        // other spelling is fail-soft ignored and falls back to the default
+        // (true). The *kill switch* is the lenient one — verified separately.
+        for garbage in ["1", "yes", "on", "TRUE", "False", " false ", "enabled", ""] {
+            let o = PartitionFailoverOptionsBuilder::new()
+                .build_from_env(&env_of(&[("AZURE_COSMOS_PPCB_ENABLED", garbage)]))
+                .unwrap();
+            assert!(
+                o.circuit_breaker_enabled(),
+                "{garbage:?} should be ignored and fall back to default true",
+            );
+        }
+    }
+
+    // ── Kill switch: AZURE_COSMOS_PPCB_ENABLED_OVERRIDE ─────────────────────
+
+    #[test]
+    fn override_unset_by_default() {
+        let o = PartitionFailoverOptionsBuilder::new()
+            .build_from_env(&empty_env())
+            .unwrap();
+        assert_eq!(o.circuit_breaker_enabled_override(), None);
+    }
+
+    #[test]
+    fn override_env_lenient_true_spellings() {
+        for raw in ["true", "1", "yes", "on", "TRUE", "On", "  yes  "] {
+            let o = PartitionFailoverOptionsBuilder::new()
+                .build_from_env(&env_of(&[("AZURE_COSMOS_PPCB_ENABLED_OVERRIDE", raw)]))
+                .unwrap();
+            assert_eq!(
+                o.circuit_breaker_enabled_override(),
+                Some(true),
+                "{raw:?} should parse as Some(true)",
+            );
+        }
+    }
+
+    #[test]
+    fn override_env_lenient_false_spellings() {
+        for raw in ["false", "0", "no", "off", "FALSE", "Off", "  no  "] {
+            let o = PartitionFailoverOptionsBuilder::new()
+                .build_from_env(&env_of(&[("AZURE_COSMOS_PPCB_ENABLED_OVERRIDE", raw)]))
+                .unwrap();
+            assert_eq!(
+                o.circuit_breaker_enabled_override(),
+                Some(false),
+                "{raw:?} should parse as Some(false)",
+            );
+        }
+    }
+
+    #[test]
+    fn override_env_garbage_ignored() {
+        // An unrecognized override value is treated as unset so an operator
+        // typo can't silently flip the incident kill switch the wrong way.
+        for raw in ["maybe", "2", "", "tru", "noo"] {
+            let o = PartitionFailoverOptionsBuilder::new()
+                .build_from_env(&env_of(&[("AZURE_COSMOS_PPCB_ENABLED_OVERRIDE", raw)]))
+                .unwrap();
+            assert_eq!(
+                o.circuit_breaker_enabled_override(),
+                None,
+                "{raw:?} should be ignored (treated as unset)",
+            );
+        }
+    }
+
+    #[test]
+    fn override_is_independent_of_base_enable() {
+        // The base flag and the override resolve from independent variables;
+        // setting one must not perturb the other. Here base=false (env) while
+        // override=true (env) — both observed verbatim. The *effective* PPCB
+        // value (override wins) is resolved later in the routing layer, which
+        // is covered by `partition_endpoint_state` tests.
+        let o = PartitionFailoverOptionsBuilder::new()
+            .build_from_env(&env_of(&[
+                ("AZURE_COSMOS_PPCB_ENABLED", "false"),
+                ("AZURE_COSMOS_PPCB_ENABLED_OVERRIDE", "true"),
+            ]))
+            .unwrap();
+        assert!(!o.circuit_breaker_enabled());
+        assert_eq!(o.circuit_breaker_enabled_override(), Some(true));
+    }
+
+    #[test]
+    fn override_builder_wins_over_env() {
+        let o = PartitionFailoverOptionsBuilder::new()
+            .with_circuit_breaker_enabled_override(false)
+            .build_from_env(&env_of(&[("AZURE_COSMOS_PPCB_ENABLED_OVERRIDE", "true")]))
+            .unwrap();
+        assert_eq!(o.circuit_breaker_enabled_override(), Some(false));
+    }
+
+    // ── Numeric thresholds: builder > env > default, with bounds ────────────
+
+    #[test]
+    fn thresholds_env_values_honored() {
+        let o = PartitionFailoverOptionsBuilder::new()
+            .build_from_env(&env_of(&[
+                ("AZURE_COSMOS_PPCB_READ_FAILURE_THRESHOLD", "20"),
+                ("AZURE_COSMOS_PPCB_WRITE_FAILURE_THRESHOLD", "8"),
+                ("AZURE_COSMOS_PPCB_CONSECUTIVE_HEDGE_WIN_THRESHOLD", "3"),
+            ]))
+            .unwrap();
+        assert_eq!(o.read_failure_threshold(), 20);
+        assert_eq!(o.write_failure_threshold(), 8);
+        assert_eq!(o.consecutive_hedge_win_threshold(), 3);
+    }
+
+    #[test]
+    fn thresholds_builder_wins_over_env() {
+        let o = PartitionFailoverOptionsBuilder::new()
+            .with_read_failure_threshold(99)
+            .build_from_env(&env_of(&[(
+                "AZURE_COSMOS_PPCB_READ_FAILURE_THRESHOLD",
+                "20",
+            )]))
+            .unwrap();
+        assert_eq!(o.read_failure_threshold(), 99);
+    }
+
+    #[test]
+    fn thresholds_default_when_env_unparseable() {
+        // Garbage numeric env is fail-soft: logged and ignored, falls back to
+        // the compile-time default rather than erroring.
+        let o = PartitionFailoverOptionsBuilder::new()
+            .build_from_env(&env_of(&[(
+                "AZURE_COSMOS_PPCB_READ_FAILURE_THRESHOLD",
+                "not-a-number",
+            )]))
+            .unwrap();
+        assert_eq!(o.read_failure_threshold(), 10);
+    }
+
+    #[test]
+    fn threshold_env_zero_is_out_of_bounds_error() {
+        // A *parseable* but out-of-bounds env value is a hard error (unlike
+        // unparseable garbage, which is ignored).
+        let err = PartitionFailoverOptionsBuilder::new()
+            .build_from_env(&env_of(&[(
+                "AZURE_COSMOS_PPCB_READ_FAILURE_THRESHOLD",
+                "0",
+            )]))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("read_failure_threshold must be at least 1"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn threshold_builder_zero_is_out_of_bounds_even_with_valid_env() {
+        // The builder value bypasses the env but is still bounds-validated.
+        let err = PartitionFailoverOptionsBuilder::new()
+            .with_write_failure_threshold(0)
+            .build_from_env(&env_of(&[(
+                "AZURE_COSMOS_PPCB_WRITE_FAILURE_THRESHOLD",
+                "5",
+            )]))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("write_failure_threshold must be at least 1"),
+            "unexpected error: {err}",
+        );
+    }
+
+    // ── Duration knobs (millis): builder > env > default, with min bound ────
+
+    #[test]
+    fn durations_env_values_honored() {
+        let o = PartitionFailoverOptionsBuilder::new()
+            .build_from_env(&env_of(&[
+                ("AZURE_COSMOS_PPCB_COUNTER_RESET_WINDOW_MS", "60000"),
+                (
+                    "AZURE_COSMOS_PPCB_PARTITION_UNAVAILABILITY_DURATION_MS",
+                    "30000",
+                ),
+                ("AZURE_COSMOS_PPCB_FAILBACK_SWEEP_INTERVAL_MS", "120000"),
+            ]))
+            .unwrap();
+        assert_eq!(o.counter_reset_window(), Duration::from_millis(60_000));
+        assert_eq!(
+            o.partition_unavailability_duration(),
+            Duration::from_millis(30_000)
+        );
+        assert_eq!(o.failback_sweep_interval(), Duration::from_millis(120_000));
+    }
+
+    #[test]
+    fn duration_builder_wins_over_env() {
+        let o = PartitionFailoverOptionsBuilder::new()
+            .with_counter_reset_window(Duration::from_secs(90))
+            .build_from_env(&env_of(&[(
+                "AZURE_COSMOS_PPCB_COUNTER_RESET_WINDOW_MS",
+                "60000",
+            )]))
+            .unwrap();
+        assert_eq!(o.counter_reset_window(), Duration::from_secs(90));
+    }
+
+    #[test]
+    fn duration_env_below_min_is_error() {
+        let err = PartitionFailoverOptionsBuilder::new()
+            .build_from_env(&env_of(&[(
+                "AZURE_COSMOS_PPCB_COUNTER_RESET_WINDOW_MS",
+                "500",
+            )]))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("counter_reset_window_ms must be at least 1000ms"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn duration_env_unparseable_falls_back_to_default() {
+        let o = PartitionFailoverOptionsBuilder::new()
+            .build_from_env(&env_of(&[(
+                "AZURE_COSMOS_PPCB_FAILBACK_SWEEP_INTERVAL_MS",
+                "soon",
+            )]))
+            .unwrap();
+        assert_eq!(o.failback_sweep_interval(), Duration::from_millis(300_000));
+    }
+
+    // ── Everything at once, in the weirdest mixed combination ───────────────
+
+    #[test]
+    fn kitchen_sink_mixed_builder_env_and_defaults() {
+        // builder: read threshold + override(false)
+        // env:     enabled=false, write threshold, garbage hedge-win (ignored),
+        //          counter-reset duration, unparseable unavailability (ignored)
+        // default: failback sweep, consecutive hedge wins, unavailability dur.
+        let o = PartitionFailoverOptionsBuilder::new()
+            .with_read_failure_threshold(33)
+            .with_circuit_breaker_enabled_override(false)
+            .build_from_env(&env_of(&[
+                ("AZURE_COSMOS_PPCB_ENABLED", "false"),
+                ("AZURE_COSMOS_PPCB_ENABLED_OVERRIDE", "true"), // builder wins
+                ("AZURE_COSMOS_PPCB_READ_FAILURE_THRESHOLD", "11"), // builder wins
+                ("AZURE_COSMOS_PPCB_WRITE_FAILURE_THRESHOLD", "9"),
+                ("AZURE_COSMOS_PPCB_CONSECUTIVE_HEDGE_WIN_THRESHOLD", "xx"), // ignored
+                ("AZURE_COSMOS_PPCB_COUNTER_RESET_WINDOW_MS", "45000"),
+                (
+                    "AZURE_COSMOS_PPCB_PARTITION_UNAVAILABILITY_DURATION_MS",
+                    "later",
+                ), // ignored
+            ]))
+            .unwrap();
+
+        assert!(!o.circuit_breaker_enabled()); // env false, builder unset
+        assert_eq!(o.circuit_breaker_enabled_override(), Some(false)); // builder wins
+        assert_eq!(o.read_failure_threshold(), 33); // builder wins over env 11
+        assert_eq!(o.write_failure_threshold(), 9); // env
+        assert_eq!(o.consecutive_hedge_win_threshold(), 5); // env garbage -> default
+        assert_eq!(o.counter_reset_window(), Duration::from_millis(45_000)); // env
+        assert_eq!(
+            o.partition_unavailability_duration(),
+            Duration::from_secs(5)
+        ); // env garbage -> default
+        assert_eq!(o.failback_sweep_interval(), Duration::from_secs(300)); // default
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/multi_region_tests/driver_partition_failover.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/multi_region_tests/driver_partition_failover.rs
@@ -300,7 +300,8 @@ pub async fn ppcb_enabled_503_on_read_fails_over_after_threshold() -> Result<(),
 /// - `partition_unavailability_duration` = 5s (default) — entry must be at least
 ///   this old before the sweep transitions it to `ProbeCandidate`.
 /// - `failback_sweep_interval` is overridden to 5s for this test (default 300s)
-///   via `AZURE_COSMOS_PPCB_STALE_PARTITION_UNAVAILABILITY_REFRESH_INTERVAL_IN_SECONDS`.
+///   via `with_failback_sweep_interval` (equivalently the
+///   `AZURE_COSMOS_PPCB_FAILBACK_SWEEP_INTERVAL_MS` environment variable).
 /// - After the rule is disabled we wait `partition_unavailability_duration +
 ///   failback_sweep_interval + buffer` to guarantee the sweep has had a chance to
 ///   run after the entry's age threshold has been met.

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/multi_write_tests/driver_partition_failover.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/multi_write_tests/driver_partition_failover.rs
@@ -163,7 +163,8 @@ pub async fn ppcb_enabled_503_on_create_fails_over_after_threshold() -> Result<(
 /// - `partition_unavailability_duration` = 5s (default) — entry must be at least
 ///   this old before the sweep transitions it to `ProbeCandidate`.
 /// - `failback_sweep_interval` is overridden to 5s for this test (default 300s)
-///   via `with_ppcb_stale_partition_unavailability_refresh_interval_in_seconds`.
+///   via `with_failback_sweep_interval` (equivalently the
+///   `AZURE_COSMOS_PPCB_FAILBACK_SWEEP_INTERVAL_MS` environment variable).
 /// - After the rule is disabled we wait `partition_unavailability_duration +
 ///   failback_sweep_interval + buffer` to guarantee the sweep has had a chance
 ///   to run after the entry's age threshold has been met.

--- a/sdk/cosmos/azure_data_cosmos_perf/src/main.rs
+++ b/sdk/cosmos/azure_data_cosmos_perf/src/main.rs
@@ -320,7 +320,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         application_region: config.application_region.clone(),
         excluded_regions: config.excluded_regions.join(", "),
         tokio_threads: tokio::runtime::Handle::current().metrics().num_workers() as u64,
-        ppcb_enabled: std::env::var("AZURE_COSMOS_PER_PARTITION_CIRCUIT_BREAKER_ENABLED")
+        ppcb_enabled: std::env::var("AZURE_COSMOS_PPCB_ENABLED")
             .ok()
             .and_then(|v| v.parse::<bool>().ok())
             .unwrap_or(true),


### PR DESCRIPTION
## Summary

Fixes a bug where the per-partition circuit breaker (PPCB) stayed **enabled**
even when a caller disabled it through the `AZURE_COSMOS_PPCB_ENABLED=false`
environment variable (or the `AZURE_COSMOS_PPCB_ENABLED_OVERRIDE=false` incident
kill switch), as long as the caller did **not** explicitly pass
`PartitionFailoverOptions`.

The `AZURE_COSMOS_PPCB_*` variables are only read by
`PartitionFailoverOptionsBuilder::build()`. The omitted-options path in
`DriverOptionsBuilder::build()` used a bare `unwrap_or_default()`, and
`PartitionFailoverOptions::default()` hard-codes `circuit_breaker_enabled: true`
and reads **no** environment — so every PPCB env var (master switch, kill
switch, and tuning knobs) was silently ignored on the common
"don't-pass-options" construction path.

This was reported by a customer running the SDK in production: with PPCB
unexpectedly left on, the per-partition tracking state added **~1 GB to RSS**
(and was still climbing).

The fix resolves the partition-failover options from the environment at the
`DriverOptionsBuilder::build()` chokepoint when the caller omits them, so the
SDK (`azure_data_cosmos`), direct driver consumers, and the native FFI crate all
inherit the correct behavior.

Resolves #4654.

## The bug

```rust
// Environment: AZURE_COSMOS_PPCB_ENABLED=false
let opts = DriverOptions::builder(account).build(); // no with_partition_failover_options(..)

// EXPECTED: false (env disabled it)
// ACTUAL (before this PR): true
assert!(!opts.partition_failover_options().circuit_breaker_enabled());
```

Root cause, all in `azure_data_cosmos_driver`:

1. `PartitionFailoverOptions::default()` hard-codes `circuit_breaker_enabled:
   true` and reads no environment. The env is only consulted in
   `PartitionFailoverOptionsBuilder::build()`.
2. `DriverOptionsBuilder::build()` filled the field with
   `self.partition_failover_options.unwrap_or_default()`, so when the caller
   never called `with_partition_failover_options`, the env-reading builder was
   never invoked.
3. The SDK `CosmosClientBuilder` forwards an
   `Option<PartitionFailoverOptions>` and only calls
   `with_partition_failover_options` when the user supplied one — so a
   `CosmosClient` built without it hit the same `unwrap_or_default()`. (Its doc
   comment even claimed the default path "honors the `AZURE_COSMOS_PPCB_*`
   environment variables", which was incorrect.)

## The fix

- **`DriverOptionsBuilder::build()` now resolves PPCB options from the
  environment when they are omitted**, instead of using a bare `Default`. When
  `with_partition_failover_options` was not called, it builds the options via
  `PartitionFailoverOptionsBuilder` (which reads `AZURE_COSMOS_PPCB_*`). An
  explicitly supplied `PartitionFailoverOptions` still takes precedence.
- **`build()` stays infallible** (no signature change — avoids a breaking change
  for the SDK and native crate): if the environment carries an out-of-bounds
  value, it is logged and the group falls back to defaults (fail-soft).
- **Injectable env accessor.** The three direct-env helpers
  (`parse_from_env`, `parse_optional_bool_from_env`,
  `parse_duration_millis_from_env`) and the new
  `PartitionFailoverOptionsBuilder::build_from_env` /
  `DriverOptionsBuilder::build_from_env` take a
  `get_env: &dyn Fn(&str) -> Option<String>` accessor. Production passes
  `|k| std::env::var(k).ok()`; tests inject a deterministic map. This mirrors the
  existing `from_env_vars(|key| ...)` convention and lets every
  builder × env combination be tested without mutating process-wide
  environment (so the tests are parallel-safe).
- **SDK doc fix.** Corrected the
  `CosmosClientBuilder::with_partition_failover_options` doc comment that wrongly
  claimed the default path honors the environment.

### Resolution precedence (unchanged at runtime)

The effective in-driver value is still
`override ?? (account_property || base_enabled)`, where `override` is the
`AZURE_COSMOS_PPCB_ENABLED_OVERRIDE` kill switch (authoritative over both the
base option and the account property `enable_per_partition_failover_behavior`).
This PR only fixes how the *base* options are sourced when the caller omits
them; it does not change how the value is resolved once it reaches the routing
layer.

## Design alignment

The crate has two conventions for env-backed option groups:

- **`Default` reads the env** (`ConnectionPoolOptions`): `Default` delegates to
  `Builder::build()`. Env-aware, but `Default` is no longer pure and the current
  implementation panics on an out-of-bounds value.
- **`Default` is pure; env is a construction-time layer** (`OperationOptions`):
  the derived `Default` is all-`None` and the runtime composes a separate
  `from_env()` layer.

This fix follows the **second** convention: `PartitionFailoverOptions::default()`
stays pure and the env is resolved at the `DriverOptionsBuilder::build()`
chokepoint. This keeps `Default` deterministic for the ~20 in-crate tests that
construct it, and is fail-soft rather than panicking during client construction.

The live path was verified to consume the env-resolved value
(`CosmosDriver` → `DriverOptions::partition_failover_options()` →
`LocationStateStore::new` → `PartitionEndpointState::new`); every
`PartitionFailoverOptions::default()` / `PartitionEndpointState::default()` site
that bypasses the env is `#[cfg(test)]` only, and `DriverOptions` has no
constructor other than `build()`, so the chokepoint is airtight.

## Scope: other environment variables audited

The bug class is "an option group whose `Default` doesn't read the environment,
consumed via `unwrap_or_default()`." Every env-backed option group in the driver
was audited; **PPCB is the only one affected** — the rest already read the env
unconditionally on their live construction path:

| Option group | Env vars | Status |
| --- | --- | --- |
| `PartitionFailoverOptions` | `AZURE_COSMOS_PPCB_*` | **Fixed here** |
| `ConnectionPoolOptions` | `AZURE_COSMOS_CONNECTION_POOL_*` | OK (`Default` → env-reading builder) |
| `OperationOptions` (hedging, throttling, retries, consistency) | `AZURE_COSMOS_HEDGING_ENABLED[_OVERRIDE]`, `AZURE_COSMOS_MAX_FAILOVER_RETRY_COUNT`, `AZURE_COSMOS_MAX_SESSION_RETRY_COUNT`, `AZURE_COSMOS_READ_CONSISTENCY_STRATEGY`, `AZURE_COSMOS_CONTENT_RESPONSE_ON_WRITE`, `AZURE_COSMOS_MAX_THROTTLE_RETRY_COUNT` | OK (always-on `from_env()` layer) |
| CPU monitor | `AZURE_COSMOS_CPU_REFRESH_INTERVAL_MS` | OK (read every runtime build) |
| Backtrace capture | `AZURE_COSMOS_BACKTRACE_CAPTURES_PER_SECOND`, `AZURE_COSMOS_BACKTRACE_RESOLUTIONS_PER_SECOND` | OK (global once-init) |
| Endpoint cooldown | `AZURE_COSMOS_ENDPOINT_UNAVAILABLE_TTL_MS` | OK (direct read on driver build) |

The legacy `AZURE_COSMOS_PER_PARTITION_CIRCUIT_BREAKER_ENABLED` /
`AZURE_COSMOS_CIRCUIT_BREAKER_*` names were renamed under the
`AZURE_COSMOS_PPCB_*` prefix in #4588 and are read by no code, so they are
unaffected.

## Tests

- **Exhaustive `builder × env × default` matrix** in
  `partition_failover.rs` (new `env_matrix_tests` module): precedence for every
  field; strict-vs-lenient boolean parsing (`AZURE_COSMOS_PPCB_ENABLED` is strict
  `true`/`false` only; the kill switch accepts `true/false`, `1/0`, `yes/no`,
  `on/off`, case-insensitive and trimmed); parseable-but-out-of-bounds → error
  vs. unparseable garbage → fail-soft default; a kitchen-sink case mixing
  builder, env, and defaults.
- **End-to-end at `DriverOptionsBuilder`** in `driver_options.rs`: omitted
  options honor `AZURE_COSMOS_PPCB_ENABLED=false`, the kill switch, and the
  tuning knobs; an explicit options value beats the env; out-of-bounds env falls
  back infallibly.
- **SDK-level** test (`cosmos_client_builder.rs`): renamed and updated to assert
  the omitted-options path resolves from the env (then defaults).

All tests inject a deterministic env accessor (closure) rather than mutating
process-wide `std::env`, so they stay parallel-safe.

### Validation

- `azure_data_cosmos_driver` lib: **1904 passed** (150 in `options::`)
- `azure_data_cosmos` builder tests: **9 passed**
- `cargo clippy -p azure_data_cosmos_driver --all-features --all-targets`: clean
- `cargo fmt` (both crates): clean

## Changed files

| File | Change |
| --- | --- |
| `azure_data_cosmos_driver/src/options/driver_options.rs` | Core fix: `build()` → `build_from_env()`; resolve PPCB from env when omitted (fail-soft); end-to-end tests. |
| `azure_data_cosmos_driver/src/options/partition_failover.rs` | `build()` → `build_from_env(get_env)`; exhaustive env-matrix tests. |
| `azure_data_cosmos_driver/src/options/env_parsing.rs` | Add injectable `get_env` accessor to the three direct-env helpers. |
| `azure_data_cosmos_driver/src/driver/runtime.rs` | Pass `std::env::var` accessor to the CPU-refresh helper (behavior unchanged). |
| `azure_data_cosmos/src/clients/cosmos_client_builder.rs` | Fix misleading doc comment; update/rename the env-resolution test. |
| `azure_data_cosmos_driver/CHANGELOG.md` | Bugs Fixed entry (0.6.0). |
| `azure_data_cosmos/CHANGELOG.md` | Bugs Fixed entry (0.37.0). |

## Compatibility

- **No breaking changes.** `build()` signatures are unchanged and remain
  infallible. An explicitly supplied `PartitionFailoverOptions` behaves exactly
  as before.
- **Behavior change (the fix):** callers that set `AZURE_COSMOS_PPCB_*` and omit
  `with_partition_failover_options` will now have those variables honored. This
  is the intended correction; callers relying on the previous (buggy) "always
  default" behavior should pass an explicit `PartitionFailoverOptions` if they
  need PPCB on regardless of the environment.

## Related

- Bug: #4654
- Introduced by #4588 (options restructure + `AZURE_COSMOS_PPCB_*` consolidation).
- Kill switch added in #4562.
