### PR TITLE
Add new API generation tool

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "azure-pipelines.1ESPipelineTemplatesSchemaFile": true,
+  "cmake.ignoreCMakeListsMissing": true,
   "cSpell.enabled": true,
   "editor.formatOnSave": true,
   "files.associations": {
@@ -17,9 +18,16 @@
   ],
   "rust-analyzer.cargo.features": "all",
   "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.linkedProjects": [
+    "Cargo.toml",
+    "eng/tools/Cargo.toml",
+    "eng/scripts/update-cratenames.rs",
+    "eng/scripts/update-pathversions.rs",
+    "eng/scripts/verify-dependencies.rs",
+    "eng/scripts/verify-keywords.rs",
+  ],
   "yaml.format.printWidth": 240,
   "[powershell]": {
     "editor.defaultFormatter": "ms-vscode.powershell",
   },
-  "cmake.ignoreCMakeListsMissing": true,
 }

--- a/eng/tools/Cargo.toml
+++ b/eng/tools/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
   "check_api_superset",
+  "generate_api",
   "generate_api_report",
 ]
 
@@ -13,6 +14,7 @@ repository = "https://github.com/Azure/azure-sdk-for-rust"
 rust-version = "1.85"
 
 [workspace.dependencies]
+clap = { version = "4.5.58", features = ["derive"] }
 rustdoc-types = "0.41.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/eng/tools/generate_api/Cargo.toml
+++ b/eng/tools/generate_api/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "generate_api"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[build-dependencies]
+serde = { workspace = true }
+toml = { workspace = true }
+
+[dependencies]
+clap = { workspace = true }
+rustdoc-types = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/eng/tools/generate_api/PLAN.md
+++ b/eng/tools/generate_api/PLAN.md
@@ -161,6 +161,14 @@ Documentation handling:
 - review output renders them as `///` comment lines
 - APIView output renders them as comment/documentation tokens
 
+Signature normalization:
+
+- receiver parameters are rendered in source-like Rust forms when rustdoc JSON spells them as
+  `self: Self`, `self: &Self`, or `self: &mut Self`; those become `self`, `&self`, and
+  `&mut self`
+- `Self` remains rendered normally when it appears as a non-receiver type, such as `Pin<Self>`, a
+  return type, or an associated type
+
 ## Async-trait rendering
 
 Traits whose rustdoc-expanded methods carry synthetic async-trait lifetimes are normalized to better match source intent.

--- a/eng/tools/generate_api/PLAN.md
+++ b/eng/tools/generate_api/PLAN.md
@@ -18,13 +18,15 @@
 The tool exposes:
 
 - `--manifest-path <path/to/Cargo.toml>`
-- `--format <review|apiview>`
+- `--format <review|apiview>` (optional; defaults to `review`)
+- `--no-docs` (optional; suppresses doc comments in `apiview` output only)
 - `--output <directory>`
 
 Behavior:
 
-- `--format review` writes `API.md`
+- default `review` output writes `API.md`
 - `--format apiview` writes `apiview.json`
+- `--no-docs` applies only to `apiview` and suppresses emitted doc comment tokens
 - progress messages go to stdout
 - fatal errors go to stderr and exit with code `1`
 
@@ -46,6 +48,9 @@ The current extraction pipeline is:
 5. render either Markdown or APIView from that shared model
 
 This is intentionally structured so renderer code does not depend directly on unstable upstream `rustdoc-types` details.
+Renderer-specific configuration should use forward-compatible options structs instead of threading
+individual booleans through the call stack, so future rendering controls can be added without
+reworking every render helper signature.
 
 ## Shared intermediate model
 

--- a/eng/tools/generate_api/PLAN.md
+++ b/eng/tools/generate_api/PLAN.md
@@ -1,0 +1,220 @@
+# Generate API final design
+
+## Goal
+
+`eng/tools/generate_api` is a Rust CLI that generates two public API artifacts for a target crate:
+
+1. `API.md` — a Markdown file containing exactly one fenced `rust` code block.
+2. `apiview.json` — an APIView token file matching the tree-style `CodeFile` schema.
+
+## Scope
+
+- This tool lives entirely under `eng/tools/generate_api`.
+- `eng/tools/generate_api_report` is reference-only prior art and is not part of this design.
+- The CLI is intended to be run from the repository root.
+
+## CLI
+
+The tool exposes:
+
+- `--manifest-path <path/to/Cargo.toml>`
+- `--format <review|apiview>`
+- `--output <directory>`
+
+Behavior:
+
+- `--format review` writes `API.md`
+- `--format apiview` writes `apiview.json`
+- progress messages go to stdout
+- fatal errors go to stderr and exit with code `1`
+
+## Toolchain and workspace
+
+- The crate is a standalone bin crate in the `eng/tools` workspace.
+- It uses the pinned `eng/tools/rust-toolchain.toml` toolchain: `nightly-2025-05-09`.
+- The implementation currently depends on `rustdoc-types`, `serde`, `serde_json`, and `clap`.
+- `rustc-dev` is included in the toolchain because the long-term direction remains closer alignment with librustdoc/HIR behavior.
+
+## Extraction design
+
+The current extraction pipeline is:
+
+1. run `cargo metadata` for package and workspace context
+2. run `cargo rustdoc -Z unstable-options --output-format json`
+3. load rustdoc JSON
+4. normalize rustdoc output into a stable, tool-owned intermediate model
+5. render either Markdown or APIView from that shared model
+
+This is intentionally structured so renderer code does not depend directly on unstable upstream `rustdoc-types` details.
+
+## Shared intermediate model
+
+The shared model is the compatibility boundary between extraction and rendering.
+
+It currently models:
+
+- package metadata
+- modules
+- item doc comments
+- item attributes
+- public items
+- associated members (including trait methods, associated types, and associated consts)
+
+Workspace crate models are cached via `Arc<T>` to avoid deep-cloning on repeated lookups during workspace-dep expansion.
+
+Supported item kinds include:
+
+- re-exports
+- macros / proc macros
+- functions
+- structs
+- enums
+- traits
+- trait aliases
+- unions
+- type aliases
+- constants
+- statics
+
+## Ordering rules
+
+Ordering is deterministic and shared by both output formats.
+
+- crate root is rendered first and is not wrapped in a module declaration
+- child modules are rendered recursively in lexical order
+- within each module:
+  - re-exports first
+  - macros / proc macros
+  - free functions
+  - types and other item kinds by stable item-kind order
+  - ties break alphabetically by item name
+- associated members are sorted alphabetically
+
+## Module rendering
+
+- Review output renders child modules as actual nested `pub mod name { ... }` blocks.
+- APIView output uses the same logical module tree with root unwrapped.
+- Module doc comments and attributes are emitted above the module declaration.
+- Trait members (methods, associated types, associated consts) are extracted into `ApiItem.members`
+  rather than embedded in the declaration string.  Both renderers handle the opening `{` in the
+  declaration and the implied closing `}` separately, which makes each trait member navigable with
+  its own `LineId` in APIView output.
+
+## Re-export rules
+
+Re-export handling is driven by public reachability and workspace membership.
+
+### Same-crate re-exports
+
+- If a same-crate re-export points at a source path that is already publicly reachable, keep it as `pub use ...`.
+- If a same-crate re-export exposes an item from a non-public or stripped module path, lift the declaration to the public re-export site.
+- This allows private implementation modules to stay hidden while public exported API appears at the correct visible surface.
+
+### Workspace-crate re-exports
+
+- Re-exports from crates that are also defined in this repository workspace are expanded into declarations at the re-export site.
+- This applies both at crate root and inside public modules.
+- Example consequence: if `azure_core::tracing` re-exports a type from `typespec_client_core::tracing`, the type is declared under `azure_core::tracing`.
+
+### External-crate re-exports
+
+- Re-exports from crates outside this workspace remain `pub use ...`.
+- When rustdoc supplies a more canonical external path, that canonical path is preferred.
+
+## Attribute and doc normalization
+
+Attributes are normalized once in the shared extraction layer before either renderer consumes them.
+
+Current normalization rules include:
+
+- fix rustdoc pretty-printed `cfg` / `cfg_attr` forms
+- rewrite `pin(__private(...))` forms to `pin_project(...)` / `pin_project`
+- remove spaces around `clippy::` lint paths in `allow`, `deny`, and `expect` attrs
+
+Documentation handling:
+
+- rustdoc item docs are stored separately from attrs in the shared model
+- review output renders them as `///` comment lines
+- APIView output renders them as comment/documentation tokens
+
+## Async-trait rendering
+
+Traits whose rustdoc-expanded methods carry synthetic async-trait lifetimes are normalized to better match source intent.
+
+- the trait gets a synthesized `#[async_trait]` attribute
+- synthetic `'lifeN` and `'async_trait` lifetimes are elided from method signatures
+- empty generic parameter lists are removed after elision
+
+## APIView output design
+
+The APIView output targets:
+
+- TypeSpec source: <https://github.com/Azure/azure-sdk-tools/blob/main/tools/apiview/parsers/apiview-treestyle-parser-schema/codeFile.tsp>
+- JSON schema: <https://github.com/Azure/azure-sdk-tools/blob/main/tools/apiview/parsers/apiview-treestyle-parser-schema/CodeFile.json>
+
+Concise schema summary to keep with the design:
+
+- top-level `CodeFile` fields used by this tool:
+  - `PackageName`
+  - `PackageVersion`
+  - `ParserVersion`
+  - `Language`
+  - `ReviewLines`
+- important nested structures:
+  - `ReviewLine`
+    - `LineId?`
+    - `Tokens`
+    - `Children?`
+    - `IsContextEndLine?`
+    - `RelatedToLine?`
+  - `ReviewToken`
+    - `Kind`
+    - `Value`
+    - `HasPrefixSpace?`
+    - `HasSuffixSpace?`
+    - `IsDocumentation?`
+    - `NavigationDisplayName?`
+    - `RenderClasses?`
+- important token kinds used by the current implementation:
+  - `Text = 0`
+  - `Punctuation = 1`
+  - `Keyword = 2`
+  - `TypeName = 3`
+  - `MemberName = 4`
+  - `Comment = 7`
+
+Required top-level fields:
+
+- `PackageName`
+- `PackageVersion`
+- `ParserVersion`
+- `Language`
+- `ReviewLines`
+
+Current APIView decisions:
+
+- `Language` is `Rust`
+- review lines use stable `LineId` generation
+  - module LineIds: `module.{sanitized_path}`
+  - item LineIds: `{module_line_id}.{item_name}_{index}`
+  - member LineIds: `{item_line_id}.{member_name}_{index}`
+- duplicate `LineId`s are rejected at validation time
+- tokens include `HasPrefixSpace` and `HasSuffixSpace`
+- doc comments use token kind `Comment` with `IsDocumentation = true`
+- nested module structure is represented through `ReviewLine.Children`
+- all declaration tokens are typed: keywords use `Keyword`, the item's own name uses `TypeName`
+  (structs, enums, traits, etc.) or `MemberName` (functions), other identifiers default to
+  `TypeName`, and punctuation uses `Punctuation`
+- trait members are rendered as children with individual `LineId` values, enabling navigation
+
+## Rustdoc / librustdoc alignment
+
+The design target remains librustdoc-like behavior rather than HTML scraping.
+
+Important preserved assumptions:
+
+- rustdoc operates on compiler data after HIR is available
+- body type-checking is not required for this task
+- public API signatures, attrs, docs, macros, and module structure are the important outputs
+
+The current implementation still uses rustdoc JSON as the acquisition mechanism, but the architecture is intentionally set up so extraction can move closer to direct librustdoc/HIR integration later without rewriting either renderer.

--- a/eng/tools/generate_api/PLAN.md
+++ b/eng/tools/generate_api/PLAN.md
@@ -58,6 +58,7 @@ It currently models:
 - item doc comments
 - item attributes
 - public items
+- explicit trait impl blocks
 - associated members (including trait methods, associated types, and associated consts)
 
 Workspace crate models are cached via `Arc<T>` to avoid deep-cloning on repeated lookups during workspace-dep expansion.
@@ -71,6 +72,7 @@ Supported item kinds include:
 - enums
 - traits
 - trait aliases
+- explicit trait impls
 - unions
 - type aliases
 - constants
@@ -99,6 +101,9 @@ Ordering is deterministic and shared by both output formats.
   rather than embedded in the declaration string.  Both renderers handle the opening `{` in the
   declaration and the implied closing `}` separately, which makes each trait member navigable with
   its own `LineId` in APIView output.
+- Non-derived trait impls are also extracted as items with `ApiItem.members`, so both renderers can
+  emit source-shaped `impl Trait for Type { ... }` blocks and make each implemented member
+  navigable in APIView.
 
 ## Re-export rules
 
@@ -115,6 +120,10 @@ Re-export handling is driven by public reachability and workspace membership.
 - Re-exports from crates that are also defined in this repository workspace are expanded into declarations at the re-export site.
 - This applies both at crate root and inside public modules.
 - Example consequence: if `azure_core::tracing` re-exports a type from `typespec_client_core::tracing`, the type is declared under `azure_core::tracing`.
+- When a workspace re-export lifts a concrete type declaration, sibling explicit trait impl blocks for
+  that type are lifted alongside it so public surfaces such as `azure_core::Error` still show
+  `impl fmt::Debug for Error { ... }`, `impl fmt::Display for Error { ... }`, and similar
+  declarations.
 
 ### External-crate re-exports
 
@@ -130,6 +139,21 @@ Current normalization rules include:
 - fix rustdoc pretty-printed `cfg` / `cfg_attr` forms
 - rewrite `pin(__private(...))` forms to `pin_project(...)` / `pin_project`
 - remove spaces around `clippy::` lint paths in `allow`, `deny`, and `expect` attrs
+- synthesize `#[derive(...)]` for known non-workspace derive traits discovered via impl blocks on
+  structs, enums, and unions when the impl item carries `#[automatically_derived]`. Current
+  recognized derives are `Clone`, `Copy`, `Debug`, `Default`, `Eq`, `Hash`, `Ord`, `PartialEq`,
+  `PartialOrd`, `serde::Serialize`, and `serde::Deserialize`. `Debug` is recognized from `Debug`,
+  `fmt::Debug`, `core::fmt::Debug`, and `std::fmt::Debug`. `Serialize` and `Deserialize` are
+  recognized from either qualified or unqualified rustdoc paths and are normalized to their
+  `serde::...` spellings. Workspace-defined derives such as `SafeDebug` are not synthesized.
+- synthesized derive attributes follow lifted type declarations across same-crate and workspace-crate
+  re-export expansion, so the visible public API keeps `#[derive(...)]` on the same declaration
+  surface where the type itself is emitted
+- non-derived trait impls are rendered as explicit `impl` blocks instead of being folded into
+  synthesized `#[derive(...)]` attributes
+- explicit trait impl blocks follow lifted type declarations across same-crate and workspace-crate
+  re-export expansion, so the visible public API keeps source-shaped impl declarations even when the
+  type itself is surfaced through `pub use`
 
 Documentation handling:
 
@@ -205,7 +229,14 @@ Current APIView decisions:
 - all declaration tokens are typed: keywords use `Keyword`, the item's own name uses `TypeName`
   (structs, enums, traits, etc.) or `MemberName` (functions), other identifiers default to
   `TypeName`, and punctuation uses `Punctuation`
+- synthesized derive attributes are tokenized the same way as other attributes: `derive` is a
+  `Keyword`, the derived trait names are `TypeName`, and `#`, `[`, `]`, `(`, `)`, `,`, and `::`
+  use `Punctuation`
 - trait members are rendered as children with individual `LineId` values, enabling navigation
+- explicit trait impl blocks use the same typed tokens as source-shaped item declarations: `impl`,
+  `for`, and `fn` are `Keyword`, trait and type identifiers are `TypeName`, implemented method
+  names are `MemberName`, and punctuation such as `#`, `[`, `]`, `(`, `)`, `,`, `:`, `;`, `->`,
+  `&`, `{`, `}`, and `::` uses `Punctuation`
 
 ## Rustdoc / librustdoc alignment
 

--- a/eng/tools/generate_api/PLAN.md
+++ b/eng/tools/generate_api/PLAN.md
@@ -138,6 +138,11 @@ Current normalization rules include:
 
 - fix rustdoc pretty-printed `cfg` / `cfg_attr` forms
 - rewrite `pin(__private(...))` forms to `pin_project(...)` / `pin_project`
+- flatten rustdoc-introduced newlines and repeated whitespace inside attributes while preserving
+  string literal contents, so review output stays source-like for cases such as multiline
+  `#[allow(..., reason = "...")]` and `#[pin_project(...)]`
+- remove whitespace around path separators inside attributes, so paths like `clippy :: shadow_same`
+  normalize to `clippy::shadow_same`
 - remove spaces around `clippy::` lint paths in `allow`, `deny`, and `expect` attrs
 - synthesize `#[derive(...)]` for known non-workspace derive traits discovered via impl blocks on
   structs, enums, and unions when the impl item carries `#[automatically_derived]`. Current

--- a/eng/tools/generate_api/PLAN.md
+++ b/eng/tools/generate_api/PLAN.md
@@ -173,6 +173,8 @@ Signature normalization:
   `&mut self`
 - `Self` remains rendered normally when it appears as a non-receiver type, such as `Pin<Self>`, a
   return type, or an associated type
+- inherent associated members on structs, enums, and unions render in a synthetic source-shaped
+  `impl TypeName { ... }` block after the type declaration, rather than as indented loose members
 
 ## Async-trait rendering
 

--- a/eng/tools/generate_api/README.md
+++ b/eng/tools/generate_api/README.md
@@ -1,0 +1,42 @@
+# generate_api
+
+`generate_api` is a CLI for generating public API artifacts for Rust crates in this repository.
+
+## Usage
+
+Run from the repository root:
+
+```sh
+cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- \
+  --manifest-path sdk/core/azure_core/Cargo.toml \
+  --format review \
+  --output /tmp/generate_api
+```
+
+### Arguments
+
+- `--manifest-path <path>`: path to the target crate's `Cargo.toml`
+- `--format <review|apiview>`: output format to generate
+- `--output <dir>`: directory where generated files are written
+
+### Outputs
+
+- `--format review` writes `API.md`
+- `--format apiview` writes `apiview.json`
+
+## Toolchain
+
+The tool reads `eng/tools/rust-toolchain.toml` and invokes:
+
+```sh
+cargo +nightly-2025-05-09 rustdoc -Z unstable-options --output-format json
+```
+
+`rustc-dev` is included in that toolchain so the implementation can continue moving toward a more direct compiler/HIR-backed pipeline.
+
+## Current state
+
+- The CLI is implemented and validates its APIView output shape.
+- A shared intermediate model is used by both output formats.
+- The current extraction path adapts rustdoc JSON into the shared model.
+- The implementation is intentionally structured so extraction can later move closer to direct librustdoc/HIR usage without rewriting both renderers.

--- a/eng/tools/generate_api/README.md
+++ b/eng/tools/generate_api/README.md
@@ -9,20 +9,21 @@ Run from the repository root:
 ```sh
 cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- \
   --manifest-path sdk/core/azure_core/Cargo.toml \
-  --format review \
   --output /tmp/generate_api
 ```
 
 ### Arguments
 
 - `--manifest-path <path>`: path to the target crate's `Cargo.toml`
-- `--format <review|apiview>`: output format to generate
+- `--format <review|apiview>`: optional output format to generate; defaults to `review`
+- `--no-docs`: when generating `apiview`, omit documentation comment tokens
 - `--output <dir>`: directory where generated files are written
 
 ### Outputs
 
-- `--format review` writes `API.md`
+- default `review` output writes `API.md`
 - `--format apiview` writes `apiview.json`
+- `--format apiview --no-docs` writes `apiview.json` without doc comment tokens
 
 ## Toolchain
 

--- a/eng/tools/generate_api/build.rs
+++ b/eng/tools/generate_api/build.rs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use serde::Deserialize;
+use std::{fs, path::Path};
+
+fn main() {
+    let toolchain_file = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("rust-toolchain.toml");
+    let toolchain_content =
+        fs::read_to_string(toolchain_file).expect("read rust-toolchain.toml from crate root");
+    let manifest: Manifest =
+        toml::from_str(&toolchain_content).expect("deserialize rust-toolchain.toml");
+    println!(
+        "cargo::rustc-env=TOOLCHAIN_CHANNEL={}",
+        manifest.toolchain.channel
+    );
+    println!("cargo::rerun-if-changed=../rust-toolchain.toml");
+}
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    toolchain: Toolchain,
+}
+
+#[derive(Debug, Deserialize)]
+struct Toolchain {
+    channel: String,
+}

--- a/eng/tools/generate_api/src/cli.rs
+++ b/eng/tools/generate_api/src/cli.rs
@@ -15,9 +15,13 @@ struct Args {
     #[arg(long, value_name = "PATH")]
     manifest_path: PathBuf,
 
-    /// Output format to generate.
-    #[arg(long, value_enum)]
+    /// Output format to generate. Defaults to review.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Review)]
     format: OutputFormat,
+
+    /// Do not emit documentation comments in APIView output.
+    #[arg(long)]
+    no_docs: bool,
 
     /// Directory where generated files will be written.
     #[arg(long, value_name = "DIR")]
@@ -28,6 +32,7 @@ struct Args {
 pub(crate) struct Request {
     pub(crate) manifest_path: PathBuf,
     pub(crate) format: OutputFormat,
+    pub(crate) no_docs: bool,
     pub(crate) output_dir: PathBuf,
 }
 
@@ -51,6 +56,57 @@ pub(crate) fn parse() -> Request {
     Request {
         manifest_path: args.manifest_path,
         format: args.format,
+        no_docs: args.no_docs,
         output_dir: args.output,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_review_format() {
+        let args = Args::parse_from([
+            "generate_api",
+            "--manifest-path",
+            "sdk/core/azure_core/Cargo.toml",
+            "--output",
+            "/tmp/generate_api",
+        ]);
+
+        assert_eq!(args.format, OutputFormat::Review);
+        assert!(!args.no_docs);
+    }
+
+    #[test]
+    fn accepts_explicit_apiview_format() {
+        let args = Args::parse_from([
+            "generate_api",
+            "--manifest-path",
+            "sdk/core/azure_core/Cargo.toml",
+            "--format",
+            "apiview",
+            "--output",
+            "/tmp/generate_api",
+        ]);
+
+        assert_eq!(args.format, OutputFormat::Apiview);
+    }
+
+    #[test]
+    fn accepts_no_docs_switch() {
+        let args = Args::parse_from([
+            "generate_api",
+            "--manifest-path",
+            "sdk/core/azure_core/Cargo.toml",
+            "--format",
+            "apiview",
+            "--no-docs",
+            "--output",
+            "/tmp/generate_api",
+        ]);
+
+        assert!(args.no_docs);
     }
 }

--- a/eng/tools/generate_api/src/cli.rs
+++ b/eng/tools/generate_api/src/cli.rs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use clap::{Parser, ValueEnum};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Parser)]
+#[command(
+    author,
+    version,
+    about = "Generate public API artifacts for a Rust crate"
+)]
+struct Args {
+    /// Path to the Cargo.toml for the target package.
+    #[arg(long, value_name = "PATH")]
+    manifest_path: PathBuf,
+
+    /// Output format to generate.
+    #[arg(long, value_enum)]
+    format: OutputFormat,
+
+    /// Directory where generated files will be written.
+    #[arg(long, value_name = "DIR")]
+    output: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Request {
+    pub(crate) manifest_path: PathBuf,
+    pub(crate) format: OutputFormat,
+    pub(crate) output_dir: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, ValueEnum)]
+pub(crate) enum OutputFormat {
+    Review,
+    Apiview,
+}
+
+impl OutputFormat {
+    pub(crate) fn default_file_name(self) -> &'static str {
+        match self {
+            Self::Review => "API.md",
+            Self::Apiview => "apiview.json",
+        }
+    }
+}
+
+pub(crate) fn parse() -> Request {
+    let args = Args::parse();
+    Request {
+        manifest_path: args.manifest_path,
+        format: args.format,
+        output_dir: args.output,
+    }
+}

--- a/eng/tools/generate_api/src/diagnostics.rs
+++ b/eng/tools/generate_api/src/diagnostics.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+pub(crate) fn info(message: impl AsRef<str>) {
+    println!("{}", message.as_ref());
+}
+
+pub(crate) fn fatal(message: impl AsRef<str>) {
+    eprintln!("{}", message.as_ref());
+}

--- a/eng/tools/generate_api/src/driver.rs
+++ b/eng/tools/generate_api/src/driver.rs
@@ -1,0 +1,265 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use crate::{cli::Request, diagnostics, extract, model::ApiModel};
+use rustdoc_types::Crate;
+use serde::Deserialize;
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    ffi::OsStr,
+    fs,
+    path::PathBuf,
+    process::Command,
+    sync::Arc,
+};
+
+pub(crate) fn load_model(request: &Request) -> Result<ApiModel, String> {
+    let metadata = load_workspace_metadata(request)?;
+    let mut loader = ModelLoader::new(metadata.packages);
+    Ok((*loader.load_model_for_workspace(&metadata.current_package)?).clone())
+}
+
+fn generate_rustdoc_json(package: &PackageMetadata) -> Result<PathBuf, String> {
+    let channel = env!("TOOLCHAIN_CHANNEL");
+    let mut command = Command::new("cargo");
+    command
+        .arg(format!("+{channel}"))
+        .arg("rustdoc")
+        .arg("-Z")
+        .arg("unstable-options")
+        .arg("--output-format")
+        .arg("json")
+        .arg("--manifest-path")
+        .arg(&package.manifest_path)
+        .arg("--all-features");
+
+    diagnostics::info(format!(
+        "Running command: {} {}",
+        command.get_program().to_string_lossy(),
+        command
+            .get_args()
+            .collect::<Vec<&OsStr>>()
+            .join(OsStr::new(" "))
+            .to_string_lossy(),
+    ));
+
+    let output = command
+        .output()
+        .map_err(|error| format!("Failed to run cargo rustdoc: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "Failed to generate rustdoc JSON: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(PathBuf::from("target")
+        .join("doc")
+        .join(format!("{}.json", package.name)))
+}
+
+#[derive(Deserialize)]
+struct CargoMetadata {
+    workspace_members: Vec<String>,
+    packages: Vec<CargoPackage>,
+}
+
+#[derive(Deserialize)]
+struct CargoPackage {
+    id: String,
+    manifest_path: String,
+    version: String,
+    name: String,
+    targets: Vec<CargoTarget>,
+}
+
+#[derive(Deserialize)]
+struct CargoTarget {
+    name: String,
+    kind: Vec<String>,
+}
+
+fn load_workspace_metadata(request: &Request) -> Result<WorkspaceMetadata, String> {
+    let mut command = Command::new("cargo");
+    command
+        .arg("metadata")
+        .arg("--format-version")
+        .arg("1")
+        .arg("--no-deps")
+        .arg("--manifest-path")
+        .arg(&request.manifest_path);
+
+    diagnostics::info(format!(
+        "Running command: {} {}",
+        command.get_program().to_string_lossy(),
+        command
+            .get_args()
+            .collect::<Vec<&OsStr>>()
+            .join(OsStr::new(" "))
+            .to_string_lossy(),
+    ));
+
+    let output = command
+        .output()
+        .map_err(|error| format!("Failed to run cargo metadata: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "Failed to run cargo metadata: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let metadata: CargoMetadata = serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("Failed to parse cargo metadata JSON: {error}"))?;
+    let requested_manifest = std::fs::canonicalize(&request.manifest_path).map_err(|error| {
+        format!(
+            "Failed to canonicalize manifest path '{}': {error}",
+            request.manifest_path.display()
+        )
+    })?;
+    let workspace_members: HashSet<String> = metadata.workspace_members.into_iter().collect();
+
+    let mut workspace_packages = BTreeMap::new();
+    let mut current_package = None;
+    for package in metadata.packages {
+        if !workspace_members.contains(&package.id) {
+            continue;
+        }
+
+        let manifest_path = std::fs::canonicalize(&package.manifest_path).map_err(|error| {
+            format!(
+                "Failed to canonicalize manifest path '{}': {error}",
+                package.manifest_path
+            )
+        })?;
+        let name = package
+            .targets
+            .iter()
+            .find(|target| target.kind.iter().any(|k| k == "lib"))
+            .map(|target| target.name.clone())
+            .unwrap_or_else(|| package.name.replace('-', "_"));
+
+        if manifest_path == requested_manifest {
+            current_package = Some(name.clone());
+        }
+
+        workspace_packages.insert(
+            name.clone(),
+            PackageMetadata {
+                name,
+                version: package.version,
+                manifest_path,
+            },
+        );
+    }
+
+    let current_package = current_package.ok_or_else(|| {
+        format!(
+            "cargo metadata did not return a package for manifest '{}'",
+            request.manifest_path.display()
+        )
+    })?;
+
+    Ok(WorkspaceMetadata {
+        current_package,
+        packages: workspace_packages,
+    })
+}
+
+struct WorkspaceMetadata {
+    current_package: String,
+    packages: BTreeMap<String, PackageMetadata>,
+}
+
+struct ModelLoader {
+    packages: BTreeMap<String, PackageMetadata>,
+    crates: HashMap<String, Arc<Crate>>,
+    models: HashMap<String, Arc<ApiModel>>,
+}
+
+impl ModelLoader {
+    fn new(packages: BTreeMap<String, PackageMetadata>) -> Self {
+        Self {
+            packages,
+            crates: HashMap::new(),
+            models: HashMap::new(),
+        }
+    }
+
+    fn load_crate_for_workspace(&mut self, crate_name: &str) -> Result<Arc<Crate>, String> {
+        if let Some(krate) = self.crates.get(crate_name) {
+            return Ok(Arc::clone(krate));
+        }
+
+        let package = self
+            .packages
+            .get(crate_name)
+            .cloned()
+            .ok_or_else(|| format!("Unknown workspace crate '{crate_name}'"))?;
+        let rustdoc_json_path = generate_rustdoc_json(&package)?;
+        diagnostics::info(format!("Reading file: {}", rustdoc_json_path.display()));
+
+        let contents = fs::read_to_string(&rustdoc_json_path).map_err(|error| {
+            format!(
+                "Failed to read rustdoc JSON '{}': {error}",
+                rustdoc_json_path.display()
+            )
+        })?;
+        let krate: Crate = serde_json::from_str(&contents).map_err(|error| {
+            format!(
+                "Failed to parse rustdoc JSON '{}': {error}",
+                rustdoc_json_path.display()
+            )
+        })?;
+        let krate = Arc::new(krate);
+        self.crates
+            .insert(crate_name.to_string(), Arc::clone(&krate));
+        Ok(krate)
+    }
+
+    fn load_model_for_workspace(&mut self, crate_name: &str) -> Result<Arc<ApiModel>, String> {
+        if let Some(model) = self.models.get(crate_name) {
+            return Ok(Arc::clone(model));
+        }
+
+        let package = self
+            .packages
+            .get(crate_name)
+            .cloned()
+            .ok_or_else(|| format!("Unknown workspace crate '{crate_name}'"))?;
+        let krate = self.load_crate_for_workspace(crate_name)?;
+
+        let model = extract::extract_model(&package, &krate, self)?;
+        let model = Arc::new(model);
+        self.models
+            .insert(crate_name.to_string(), Arc::clone(&model));
+        Ok(model)
+    }
+}
+
+impl extract::WorkspaceResolver for ModelLoader {
+    fn is_workspace_crate(&self, crate_name: &str) -> bool {
+        self.packages.contains_key(crate_name)
+    }
+
+    fn load_workspace_model(&mut self, crate_name: &str) -> Result<Option<Arc<ApiModel>>, String> {
+        if !self.is_workspace_crate(crate_name) {
+            return Ok(None);
+        }
+        self.load_model_for_workspace(crate_name).map(Some)
+    }
+
+    fn load_workspace_crate(&mut self, crate_name: &str) -> Result<Option<Arc<Crate>>, String> {
+        if !self.is_workspace_crate(crate_name) {
+            return Ok(None);
+        }
+        self.load_crate_for_workspace(crate_name).map(Some)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PackageMetadata {
+    pub(crate) name: String,
+    pub(crate) version: String,
+    pub(crate) manifest_path: PathBuf,
+}

--- a/eng/tools/generate_api/src/driver.rs
+++ b/eng/tools/generate_api/src/driver.rs
@@ -19,6 +19,30 @@ pub(crate) fn load_model(request: &Request) -> Result<ApiModel, String> {
     Ok((*loader.load_model_for_workspace(&metadata.current_package)?).clone())
 }
 
+fn run_command(mut command: Command, error_prefix: &str) -> Result<std::process::Output, String> {
+    diagnostics::info(format!(
+        "Running command: {} {}",
+        command.get_program().to_string_lossy(),
+        command
+            .get_args()
+            .collect::<Vec<&OsStr>>()
+            .join(OsStr::new(" "))
+            .to_string_lossy(),
+    ));
+
+    let output = command
+        .output()
+        .map_err(|error| format!("{error_prefix}: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "{error_prefix}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(output)
+}
+
 fn generate_rustdoc_json(package: &PackageMetadata) -> Result<PathBuf, String> {
     let channel = env!("TOOLCHAIN_CHANNEL");
     let mut command = Command::new("cargo");
@@ -33,25 +57,7 @@ fn generate_rustdoc_json(package: &PackageMetadata) -> Result<PathBuf, String> {
         .arg(&package.manifest_path)
         .arg("--all-features");
 
-    diagnostics::info(format!(
-        "Running command: {} {}",
-        command.get_program().to_string_lossy(),
-        command
-            .get_args()
-            .collect::<Vec<&OsStr>>()
-            .join(OsStr::new(" "))
-            .to_string_lossy(),
-    ));
-
-    let output = command
-        .output()
-        .map_err(|error| format!("Failed to run cargo rustdoc: {error}"))?;
-    if !output.status.success() {
-        return Err(format!(
-            "Failed to generate rustdoc JSON: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
-    }
+    run_command(command, "Failed to generate rustdoc JSON")?;
 
     Ok(PathBuf::from("target")
         .join("doc")
@@ -89,25 +95,7 @@ fn load_workspace_metadata(request: &Request) -> Result<WorkspaceMetadata, Strin
         .arg("--manifest-path")
         .arg(&request.manifest_path);
 
-    diagnostics::info(format!(
-        "Running command: {} {}",
-        command.get_program().to_string_lossy(),
-        command
-            .get_args()
-            .collect::<Vec<&OsStr>>()
-            .join(OsStr::new(" "))
-            .to_string_lossy(),
-    ));
-
-    let output = command
-        .output()
-        .map_err(|error| format!("Failed to run cargo metadata: {error}"))?;
-    if !output.status.success() {
-        return Err(format!(
-            "Failed to run cargo metadata: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
-    }
+    let output = run_command(command, "Failed to run cargo metadata")?;
 
     let metadata: CargoMetadata = serde_json::from_slice(&output.stdout)
         .map_err(|error| format!("Failed to parse cargo metadata JSON: {error}"))?;

--- a/eng/tools/generate_api/src/extract.rs
+++ b/eng/tools/generate_api/src/extract.rs
@@ -206,10 +206,7 @@ fn expand_local_reexport(
         }
         if let Some(target_id) = &other_import.id {
             if let Some(raw_target) = krate.index.get(target_id) {
-                merge_expanded(
-                    &mut expanded,
-                    expand_item_with_impls(krate, raw_target, current_module_path),
-                );
+                merge_expanded(&mut expanded, expand_item_with_impls(krate, raw_target));
             }
         }
         if expanded.items.is_empty() && expanded.modules.is_empty() {
@@ -235,7 +232,7 @@ fn expand_local_reexport(
                 }
             }
         }
-        _ if !import.is_glob => expand_item_with_impls(krate, target, current_module_path),
+        _ if !import.is_glob => expand_item_with_impls(krate, target),
         _ => return Ok(None),
     };
     apply_import_attributes(&mut expanded, import_attributes);
@@ -269,26 +266,26 @@ fn expand_model_reexport(
             )],
         }
     } else {
-        expand_model_item_reexport(&model.root_module, target_segments, current_module_path)?
+        expand_model_item_reexport(&model.root_module, target_segments)?
     };
     apply_import_attributes(&mut expanded, import_attributes);
     Some(expanded)
 }
 
-fn expand_item_with_impls(krate: &Crate, target: &Item, current_module_path: &str) -> ExpandedUse {
+fn expand_item_with_impls(krate: &Crate, target: &Item) -> ExpandedUse {
     let mut expanded = ExpandedUse {
         items: vec![extract_item(krate, target)],
         modules: Vec::new(),
     };
 
-    for sibling in trait_impls_for_item(krate, target, current_module_path) {
+    for sibling in trait_impls_for_item(krate, target) {
         expanded.items.push(sibling);
     }
 
     expanded
 }
 
-fn trait_impls_for_item(krate: &Crate, target: &Item, current_module_path: &str) -> Vec<ApiItem> {
+fn trait_impls_for_item(krate: &Crate, target: &Item) -> Vec<ApiItem> {
     let Some(impl_ids) = item_impl_ids(target) else {
         return Vec::new();
     };
@@ -302,11 +299,11 @@ fn trait_impls_for_item(krate: &Crate, target: &Item, current_module_path: &str)
             }
             _ => None,
         })
-        .map(|item| rebase_trait_impl_item(item, current_module_path))
+        .map(rebase_trait_impl_item)
         .collect()
 }
 
-fn rebase_trait_impl_item(mut item: ApiItem, _current_module_path: &str) -> ApiItem {
+fn rebase_trait_impl_item(mut item: ApiItem) -> ApiItem {
     if let Some((trait_name, _)) = item.declaration.split_once(" for ") {
         let trait_name = trait_name
             .trim_start_matches("unsafe ")
@@ -316,11 +313,7 @@ fn rebase_trait_impl_item(mut item: ApiItem, _current_module_path: &str) -> ApiI
     item
 }
 
-fn expand_model_item_reexport(
-    module: &ApiModule,
-    target_segments: &[&str],
-    current_module_path: &str,
-) -> Option<ExpandedUse> {
+fn expand_model_item_reexport(module: &ApiModule, target_segments: &[&str]) -> Option<ExpandedUse> {
     let target = find_item(module, target_segments)?.clone();
     let local_name = target_segments.last().copied()?;
     let items = module
@@ -334,7 +327,7 @@ fn expand_model_item_reexport(
                         .contains(&format!(" for {local_name}")))
         })
         .cloned()
-        .map(|item| rebase_trait_impl_item(item, current_module_path))
+        .map(rebase_trait_impl_item)
         .collect::<Vec<_>>();
 
     if items.is_empty() {

--- a/eng/tools/generate_api/src/extract.rs
+++ b/eng/tools/generate_api/src/extract.rs
@@ -838,11 +838,11 @@ fn normalize_attribute(text: &str) -> String {
         .replace("#[<cfg>(", "#[cfg(")
         .replace("#![<cfg>(", "#![cfg(")
         .replace("#[<cfg_attr>(", "#[cfg_attr(")
-        .replace("#![<cfg_attr>(", "#![cfg_attr(")
-        .replace("clippy :: ", "clippy::")
-        .replace("clippy ::", "clippy::");
+        .replace("#![<cfg_attr>(", "#![cfg_attr(");
 
     normalized = normalize_pin_attribute(&normalized);
+    normalized = collapse_attribute_whitespace(&normalized);
+    normalized = collapse_path_separator_whitespace(&normalized);
     normalized = collapse_clippy_lint_whitespace(&normalized);
     normalized
 }
@@ -876,6 +876,85 @@ fn collapse_clippy_lint_whitespace(attribute: &str) -> String {
     }
 
     normalized.push_str(remaining);
+    normalized
+}
+
+fn collapse_attribute_whitespace(attribute: &str) -> String {
+    let mut normalized = String::new();
+    let mut chars = attribute.chars().peekable();
+    let mut in_string = false;
+    let mut previous_was_escape = false;
+    let mut pending_space = false;
+
+    while let Some(ch) = chars.next() {
+        if in_string {
+            normalized.push(ch);
+            if previous_was_escape {
+                previous_was_escape = false;
+            } else if ch == '\\' {
+                previous_was_escape = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if ch == '"' {
+            if pending_space && !normalized.is_empty() && !normalized.ends_with(['(', '[', '{']) {
+                normalized.push(' ');
+            }
+            pending_space = false;
+            in_string = true;
+            normalized.push(ch);
+            continue;
+        }
+
+        if ch.is_whitespace() {
+            pending_space = !normalized.is_empty();
+            while chars.next_if(|next| next.is_whitespace()).is_some() {}
+            continue;
+        }
+
+        if pending_space && !normalized.is_empty() && !normalized.ends_with(['(', '[', '{']) {
+            normalized.push(' ');
+        }
+        pending_space = false;
+        normalized.push(ch);
+    }
+
+    normalized
+}
+
+fn collapse_path_separator_whitespace(attribute: &str) -> String {
+    let mut normalized = String::new();
+    let chars = attribute.chars().collect::<Vec<_>>();
+    let mut index = 0;
+
+    while index < chars.len() {
+        if chars[index] == ':' {
+            let mut left = normalized.len();
+            while left > 0 && normalized[..left].ends_with(' ') {
+                normalized.pop();
+                left -= 1;
+            }
+
+            normalized.push(':');
+            index += 1;
+            while index < chars.len() && chars[index].is_whitespace() {
+                index += 1;
+            }
+
+            if index < chars.len() && chars[index] == ':' {
+                normalized.push(':');
+                index += 1;
+            }
+            continue;
+        }
+
+        normalized.push(chars[index]);
+        index += 1;
+    }
+
     normalized
 }
 
@@ -2435,6 +2514,36 @@ mod tests {
                 .map(|attribute| attribute.text.as_str())
                 .collect::<Vec<_>>(),
             vec!["#[derive(Clone, Debug)]"]
+        );
+    }
+
+    #[test]
+    fn normalize_attribute_flattens_multiline_reason_strings() {
+        assert_eq!(
+            normalize_attribute(
+                "#[allow(unknown_lints, clippy::infallible_try_from, reason =\n\"maintain a consistent pattern of `try_into()`\")]"
+            ),
+            "#[allow(unknown_lints, clippy::infallible_try_from, reason = \"maintain a consistent pattern of `try_into()`\")]"
+        );
+    }
+
+    #[test]
+    fn normalize_attribute_flattens_multiline_pin_project_arguments() {
+        assert_eq!(
+            normalize_attribute(
+                "#[pin_project(project = ItemIteratorProjection, project_replace =\nItemIteratorProjectionOwned)]"
+            ),
+            "#[pin_project(project = ItemIteratorProjection, project_replace = ItemIteratorProjectionOwned)]"
+        );
+    }
+
+    #[test]
+    fn normalize_attribute_removes_path_separator_spacing() {
+        assert_eq!(
+            normalize_attribute(
+                "#[allow(elided_named_lifetimes, clippy\n:: shadow_same, clippy :: type_complexity)]"
+            ),
+            "#[allow(elided_named_lifetimes, clippy::shadow_same, clippy::type_complexity)]"
         );
     }
 

--- a/eng/tools/generate_api/src/extract.rs
+++ b/eng/tools/generate_api/src/extract.rs
@@ -73,6 +73,13 @@ fn extract_module(
                 let module = extract_module(krate, child, child_path, resolver)?;
                 insert_module(&mut result.modules, &mut seen_modules, module);
             }
+            ItemEnum::Impl(impl_block) if include_trait_impl_block(impl_block) => {
+                if let Some(extracted) = extract_trait_impl(krate, child, impl_block) {
+                    if seen_declarations.insert(extracted.declaration.clone()) {
+                        result.items.push(extracted);
+                    }
+                }
+            }
             ItemEnum::Impl(_) => {}
             ItemEnum::Use(use_item) if should_include_item(child) => {
                 if let Some(expanded) =
@@ -191,11 +198,23 @@ fn expand_local_reexport(
     resolver: &mut impl WorkspaceResolver,
 ) -> Result<Option<ExpandedUse>, String> {
     if let ItemEnum::Use(other_import) = &target.inner {
-        let Some(mut expanded) =
+        let mut expanded = ExpandedUse::default();
+        if let Some(nested) =
             expand_reexport(krate, target, other_import, current_module_path, resolver)?
-        else {
+        {
+            merge_expanded(&mut expanded, nested);
+        }
+        if let Some(target_id) = &other_import.id {
+            if let Some(raw_target) = krate.index.get(target_id) {
+                merge_expanded(
+                    &mut expanded,
+                    expand_item_with_impls(krate, raw_target, current_module_path),
+                );
+            }
+        }
+        if expanded.items.is_empty() && expanded.modules.is_empty() {
             return Ok(None);
-        };
+        }
         apply_import_attributes(&mut expanded, import_attributes);
         return Ok(Some(expanded));
     }
@@ -216,10 +235,7 @@ fn expand_local_reexport(
                 }
             }
         }
-        _ if !import.is_glob => ExpandedUse {
-            items: vec![extract_item(krate, target)],
-            modules: Vec::new(),
-        },
+        _ if !import.is_glob => expand_item_with_impls(krate, target, current_module_path),
         _ => return Ok(None),
     };
     apply_import_attributes(&mut expanded, import_attributes);
@@ -253,13 +269,96 @@ fn expand_model_reexport(
             )],
         }
     } else {
-        ExpandedUse {
-            items: vec![find_item(&model.root_module, target_segments)?.clone()],
-            modules: Vec::new(),
-        }
+        expand_model_item_reexport(&model.root_module, target_segments, current_module_path)?
     };
     apply_import_attributes(&mut expanded, import_attributes);
     Some(expanded)
+}
+
+fn expand_item_with_impls(krate: &Crate, target: &Item, current_module_path: &str) -> ExpandedUse {
+    let mut expanded = ExpandedUse {
+        items: vec![extract_item(krate, target)],
+        modules: Vec::new(),
+    };
+
+    for sibling in trait_impls_for_item(krate, target, current_module_path) {
+        expanded.items.push(sibling);
+    }
+
+    expanded
+}
+
+fn trait_impls_for_item(krate: &Crate, target: &Item, current_module_path: &str) -> Vec<ApiItem> {
+    let impl_ids = match &target.inner {
+        ItemEnum::Struct(struct_item) => &struct_item.impls,
+        ItemEnum::Enum(enum_item) => &enum_item.impls,
+        ItemEnum::Union(union_item) => &union_item.impls,
+        _ => return Vec::new(),
+    };
+
+    impl_ids
+        .iter()
+        .filter_map(|impl_id| krate.index.get(impl_id))
+        .filter_map(|impl_item| match &impl_item.inner {
+            ItemEnum::Impl(impl_block) if include_trait_impl_block(impl_block) => {
+                extract_trait_impl(krate, impl_item, impl_block)
+            }
+            _ => None,
+        })
+        .map(|item| rebase_trait_impl_item(item, current_module_path))
+        .collect()
+}
+
+fn rebase_trait_impl_item(mut item: ApiItem, current_module_path: &str) -> ApiItem {
+    if let Some((trait_name, _)) = item.declaration.split_once(" for ") {
+        let trait_name = trait_name
+            .trim_start_matches("unsafe ")
+            .trim_start_matches("impl ");
+        item.name = format!("{}_{}", last_path_segment(trait_name), item.name);
+    }
+    if current_module_path.is_empty() {
+        return item;
+    }
+    item
+}
+
+fn expand_model_item_reexport(
+    module: &ApiModule,
+    target_segments: &[&str],
+    current_module_path: &str,
+) -> Option<ExpandedUse> {
+    let target = find_item(module, target_segments)?.clone();
+    let local_name = target_segments.last().copied()?;
+    let items = module
+        .items
+        .iter()
+        .filter(|candidate| {
+            candidate.name == local_name
+                || (candidate.kind == ApiItemKind::TraitImpl
+                    && candidate
+                        .declaration
+                        .contains(&format!(" for {local_name}")))
+        })
+        .cloned()
+        .map(|item| rebase_trait_impl_item(item, current_module_path))
+        .collect::<Vec<_>>();
+
+    if items.is_empty() {
+        Some(ExpandedUse {
+            items: vec![target],
+            modules: Vec::new(),
+        })
+    } else {
+        Some(ExpandedUse {
+            items,
+            modules: Vec::new(),
+        })
+    }
+}
+
+fn merge_expanded(target: &mut ExpandedUse, source: ExpandedUse) {
+    target.items.extend(source.items);
+    target.modules.extend(source.modules);
 }
 
 fn should_expand_local_reexport(
@@ -510,6 +609,9 @@ fn insert_module(
 
 fn extract_item(krate: &Crate, item: &Item) -> ApiItem {
     let mut attributes = extract_attributes(item);
+    if let Some(attribute) = synthesize_derive_attribute(krate, item) {
+        prepend_attributes(&mut attributes, &[attribute]);
+    }
     if matches!(item.inner, ItemEnum::Trait(_)) && trait_uses_async_trait(krate, item) {
         prepend_attributes(
             &mut attributes,
@@ -534,38 +636,124 @@ fn extract_item(krate: &Crate, item: &Item) -> ApiItem {
 
 fn extract_members(krate: &Crate, item: &Item) -> Vec<ApiMember> {
     match &item.inner {
-        ItemEnum::Struct(struct_item) => extract_impl_members(krate, &struct_item.impls),
-        ItemEnum::Enum(enum_item) => extract_impl_members(krate, &enum_item.impls),
-        ItemEnum::Union(union_item) => extract_impl_members(krate, &union_item.impls),
+        ItemEnum::Struct(struct_item) => extract_inherent_impl_members(krate, &struct_item.impls),
+        ItemEnum::Enum(enum_item) => extract_inherent_impl_members(krate, &enum_item.impls),
+        ItemEnum::Union(union_item) => extract_inherent_impl_members(krate, &union_item.impls),
         ItemEnum::Trait(trait_item) => extract_trait_members(krate, trait_item),
         _ => Vec::new(),
     }
 }
 
-fn extract_impl_members(krate: &Crate, impl_ids: &[Id]) -> Vec<ApiMember> {
+fn synthesize_derive_attribute(krate: &Crate, item: &Item) -> Option<ApiAttribute> {
+    let impl_ids = match &item.inner {
+        ItemEnum::Struct(struct_item) => &struct_item.impls,
+        ItemEnum::Enum(enum_item) => &enum_item.impls,
+        ItemEnum::Union(union_item) => &union_item.impls,
+        _ => return None,
+    };
+
+    let mut derived = BTreeSet::new();
+    for impl_id in impl_ids {
+        let Some(impl_item) = krate.index.get(impl_id) else {
+            continue;
+        };
+        let ItemEnum::Impl(impl_block) = &impl_item.inner else {
+            continue;
+        };
+        if impl_block.is_synthetic || impl_block.blanket_impl.is_some() {
+            continue;
+        }
+        if !has_automatically_derived(impl_item) {
+            continue;
+        }
+        let Some(trait_path) = &impl_block.trait_ else {
+            continue;
+        };
+        if let Some(derive_name) = known_derive_trait_name(trait_path) {
+            derived.insert(derive_name);
+        }
+    }
+
+    if derived.is_empty() {
+        None
+    } else {
+        Some(ApiAttribute {
+            text: format!(
+                "#[derive({})]",
+                derived.into_iter().collect::<Vec<_>>().join(", ")
+            ),
+        })
+    }
+}
+
+fn has_automatically_derived(item: &Item) -> bool {
+    item.attrs
+        .iter()
+        .any(|attr| attr.contains("automatically_derived"))
+}
+
+fn known_derive_trait_name(path: &Path) -> Option<&'static str> {
+    match path.path.as_str() {
+        "Clone" | "core::clone::Clone" | "std::clone::Clone" => Some("Clone"),
+        "Copy" | "core::marker::Copy" | "std::marker::Copy" => Some("Copy"),
+        "Debug" | "fmt::Debug" | "core::fmt::Debug" | "std::fmt::Debug" => Some("Debug"),
+        "Default" | "core::default::Default" | "std::default::Default" => Some("Default"),
+        "Eq" | "core::cmp::Eq" | "std::cmp::Eq" => Some("Eq"),
+        "Hash" | "core::hash::Hash" | "std::hash::Hash" => Some("Hash"),
+        "Ord" | "core::cmp::Ord" | "std::cmp::Ord" => Some("Ord"),
+        "PartialEq" | "core::cmp::PartialEq" | "std::cmp::PartialEq" => Some("PartialEq"),
+        "PartialOrd" | "core::cmp::PartialOrd" | "std::cmp::PartialOrd" => Some("PartialOrd"),
+        "Serialize" => Some("serde::Serialize"),
+        _ if path.path == "serde::Serialize" || path.path.ends_with("::Serialize") => {
+            Some("serde::Serialize")
+        }
+        "Deserialize" => Some("serde::Deserialize"),
+        _ if path.path == "serde::Deserialize" || path.path.ends_with("::Deserialize") => {
+            Some("serde::Deserialize")
+        }
+        _ => None,
+    }
+}
+
+fn extract_trait_impl(krate: &Crate, item: &Item, impl_block: &Impl) -> Option<ApiItem> {
+    if has_automatically_derived(item) {
+        return None;
+    }
+
+    let trait_path = impl_block.trait_.as_ref()?;
+    let self_type = render_type(&impl_block.for_);
+    let declaration = render_trait_impl_declaration(impl_block, trait_path, &self_type);
+
+    Some(ApiItem {
+        name: self_type,
+        kind: ApiItemKind::TraitImpl,
+        doc_comments: extract_doc_comments(item),
+        attributes: extract_attributes(item),
+        declaration,
+        members: extract_impl_items(krate, &impl_block.items),
+    })
+}
+
+fn extract_inherent_impl_members(krate: &Crate, impl_ids: &[Id]) -> Vec<ApiMember> {
     impl_ids
         .iter()
         .filter_map(|impl_id| krate.index.get(impl_id))
         .filter_map(|impl_item| match &impl_item.inner {
-            ItemEnum::Impl(impl_block) if include_impl_block(impl_block) => Some(impl_block),
+            ItemEnum::Impl(impl_block) if include_inherent_impl_block(impl_block) => {
+                Some(&impl_block.items)
+            }
             _ => None,
         })
-        .flat_map(|impl_block| impl_block.items.iter())
+        .flat_map(|items| extract_impl_items(krate, items))
+        .collect()
+}
+
+fn extract_impl_items(krate: &Crate, item_ids: &[Id]) -> Vec<ApiMember> {
+    item_ids
+        .iter()
         .filter_map(|item_id| krate.index.get(item_id))
         .filter(|item| is_visible(item))
-        .filter_map(|item| match &item.inner {
-            ItemEnum::Function(function) => Some(ApiMember {
-                name: item.name.clone().unwrap_or_default(),
-                doc_comments: extract_doc_comments(item),
-                attributes: extract_attributes(item),
-                declaration: render_function_declaration(
-                    item.name.as_deref().unwrap_or("unknown_fn"),
-                    function,
-                    false,
-                ),
-            }),
-            _ => None,
-        })
+        .filter_map(extract_associated_member)
         .collect()
 }
 
@@ -574,45 +762,49 @@ fn extract_trait_members(krate: &Crate, trait_item: &Trait) -> Vec<ApiMember> {
         .items
         .iter()
         .filter_map(|item_id| krate.index.get(item_id))
-        .filter_map(|item| match &item.inner {
-            ItemEnum::Function(function) => Some(ApiMember {
-                name: item.name.clone().unwrap_or_default(),
-                doc_comments: extract_doc_comments(item),
-                attributes: extract_attributes(item),
-                declaration: render_function_declaration(
-                    item.name.as_deref().unwrap_or("unknown_fn"),
-                    function,
-                    false,
-                ),
-            }),
-            ItemEnum::AssocConst { type_, value } => Some(ApiMember {
-                name: item.name.clone().unwrap_or_default(),
-                doc_comments: extract_doc_comments(item),
-                attributes: extract_attributes(item),
-                declaration: render_assoc_const(
-                    item.name.as_deref().unwrap_or("UNKNOWN_CONST"),
-                    type_,
-                    value.as_deref(),
-                ),
-            }),
-            ItemEnum::AssocType {
+        .filter_map(extract_associated_member)
+        .collect()
+}
+
+fn extract_associated_member(item: &Item) -> Option<ApiMember> {
+    match &item.inner {
+        ItemEnum::Function(function) => Some(ApiMember {
+            name: item.name.clone().unwrap_or_default(),
+            doc_comments: extract_doc_comments(item),
+            attributes: extract_attributes(item),
+            declaration: render_function_declaration(
+                item.name.as_deref().unwrap_or("unknown_fn"),
+                function,
+                false,
+            ),
+        }),
+        ItemEnum::AssocConst { type_, value } => Some(ApiMember {
+            name: item.name.clone().unwrap_or_default(),
+            doc_comments: extract_doc_comments(item),
+            attributes: extract_attributes(item),
+            declaration: render_assoc_const(
+                item.name.as_deref().unwrap_or("UNKNOWN_CONST"),
+                type_,
+                value.as_deref(),
+            ),
+        }),
+        ItemEnum::AssocType {
+            generics,
+            bounds,
+            type_,
+        } => Some(ApiMember {
+            name: item.name.clone().unwrap_or_default(),
+            doc_comments: extract_doc_comments(item),
+            attributes: extract_attributes(item),
+            declaration: render_assoc_type(
+                item.name.as_deref().unwrap_or("UnknownType"),
                 generics,
                 bounds,
-                type_,
-            } => Some(ApiMember {
-                name: item.name.clone().unwrap_or_default(),
-                doc_comments: extract_doc_comments(item),
-                attributes: extract_attributes(item),
-                declaration: render_assoc_type(
-                    item.name.as_deref().unwrap_or("UnknownType"),
-                    generics,
-                    bounds,
-                    type_.as_ref(),
-                ),
-            }),
-            _ => None,
-        })
-        .collect()
+                type_.as_ref(),
+            ),
+        }),
+        _ => None,
+    }
 }
 
 fn extract_attributes(item: &Item) -> Vec<ApiAttribute> {
@@ -704,8 +896,12 @@ fn is_visible(item: &Item) -> bool {
     matches!(item.visibility, Visibility::Public | Visibility::Default)
 }
 
-fn include_impl_block(impl_block: &Impl) -> bool {
+fn include_inherent_impl_block(impl_block: &Impl) -> bool {
     !impl_block.is_synthetic && impl_block.blanket_impl.is_none() && impl_block.trait_.is_none()
+}
+
+fn include_trait_impl_block(impl_block: &Impl) -> bool {
+    !impl_block.is_synthetic && impl_block.blanket_impl.is_none() && impl_block.trait_.is_some()
 }
 
 fn item_kind(item: &Item) -> ApiItemKind {
@@ -1091,6 +1287,25 @@ fn render_trait_alias_declaration(item: &Item, trait_alias: &TraitAlias) -> Stri
     declaration
 }
 
+fn render_trait_impl_declaration(impl_block: &Impl, trait_path: &Path, self_type: &str) -> String {
+    let mut declaration = String::new();
+    if impl_block.is_unsafe {
+        declaration.push_str("unsafe ");
+    }
+    declaration.push_str("impl");
+    declaration.push_str(&render_generics_declaration(&impl_block.generics));
+    declaration.push(' ');
+    if impl_block.is_negative {
+        declaration.push('!');
+    }
+    declaration.push_str(&render_path(trait_path));
+    declaration.push_str(" for ");
+    declaration.push_str(self_type);
+    declaration.push_str(&render_where_clause(&impl_block.generics.where_predicates));
+    declaration.push_str(" {");
+    declaration
+}
+
 fn render_type_alias_declaration(item: &Item, type_alias: &TypeAlias) -> String {
     let mut declaration = format!(
         "pub type {}{} = {}",
@@ -1415,6 +1630,10 @@ fn render_type(type_: &Type) -> String {
     render_type_with_elision(type_, &HashSet::new())
 }
 
+fn render_path(path: &Path) -> String {
+    render_path_with_elision(path, &HashSet::new())
+}
+
 fn render_type_with_elision(type_: &Type, synthetic_lifetimes: &HashSet<String>) -> String {
     match type_ {
         Type::ResolvedPath(path) => render_path_with_elision(path, synthetic_lifetimes),
@@ -1704,4 +1923,603 @@ fn is_synthetic_async_trait_lifetime(name: &str) -> bool {
 
 fn last_path_segment(path: &str) -> &str {
     path.rsplit("::").next().unwrap_or(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustdoc_types::{
+        Abi, FunctionSignature, Generics, ItemSummary, Module, Struct, Target, Type,
+    };
+    use std::collections::HashMap;
+
+    #[test]
+    fn recognizes_common_derive_trait_paths() {
+        assert_eq!(known_derive_trait_name(&path("Clone", 1)), Some("Clone"));
+        assert_eq!(
+            known_derive_trait_name(&path("fmt::Debug", 1)),
+            Some("Debug")
+        );
+        assert_eq!(
+            known_derive_trait_name(&path("std::fmt::Debug", 1)),
+            Some("Debug")
+        );
+        assert_eq!(
+            known_derive_trait_name(&path("Serialize", 1)),
+            Some("serde::Serialize")
+        );
+        assert_eq!(
+            known_derive_trait_name(&path("serde::de::Deserialize", 1)),
+            Some("serde::Deserialize")
+        );
+        assert_eq!(known_derive_trait_name(&path("SafeDebug", 1)), None);
+    }
+
+    #[test]
+    fn synthesizes_known_derives_and_ignores_workspace_defined_traits() {
+        let struct_id = Id(1);
+        let clone_impl_id = Id(2);
+        let debug_impl_id = Id(3);
+        let serialize_impl_id = Id(4);
+        let safe_debug_impl_id = Id(5);
+        let explicit_default_impl_id = Id(6);
+
+        let krate = crate_with_items(vec![
+            item(
+                struct_id,
+                Some("Model"),
+                ItemEnum::Struct(Struct {
+                    kind: StructKind::Unit,
+                    generics: empty_generics(),
+                    impls: vec![
+                        clone_impl_id,
+                        debug_impl_id,
+                        serialize_impl_id,
+                        safe_debug_impl_id,
+                        explicit_default_impl_id,
+                    ],
+                }),
+            ),
+            impl_item(
+                clone_impl_id,
+                Some(path("Clone", 10)),
+                "Model",
+                struct_id,
+                true,
+            ),
+            impl_item(
+                debug_impl_id,
+                Some(path("fmt::Debug", 11)),
+                "Model",
+                struct_id,
+                true,
+            ),
+            impl_item(
+                serialize_impl_id,
+                Some(path("Serialize", 12)),
+                "Model",
+                struct_id,
+                true,
+            ),
+            impl_item(
+                safe_debug_impl_id,
+                Some(path("SafeDebug", 13)),
+                "Model",
+                struct_id,
+                true,
+            ),
+            impl_item(
+                explicit_default_impl_id,
+                Some(path("Default", 14)),
+                "Model",
+                struct_id,
+                false,
+            ),
+        ]);
+
+        let item = krate.index.get(&struct_id).expect("struct item present");
+        let attribute = synthesize_derive_attribute(&krate, item)
+            .expect("recognized derive attribute should be synthesized");
+
+        assert_eq!(attribute.text, "#[derive(Clone, Debug, serde::Serialize)]");
+    }
+
+    #[test]
+    fn extracts_explicit_trait_impl_blocks_with_members() {
+        let struct_id = Id(1);
+        let impl_id = Id(2);
+        let fmt_id = Id(3);
+
+        let model = extract_model(
+            &package_metadata("demo"),
+            &crate_with_items(vec![
+                item(
+                    struct_id,
+                    Some("MyType"),
+                    ItemEnum::Struct(Struct {
+                        kind: StructKind::Unit,
+                        generics: empty_generics(),
+                        impls: vec![impl_id],
+                    }),
+                ),
+                impl_item_with_items(
+                    impl_id,
+                    Some(path("fmt::Debug", 10)),
+                    "MyType",
+                    struct_id,
+                    false,
+                    vec![fmt_id],
+                ),
+                item(
+                    fmt_id,
+                    Some("fmt"),
+                    ItemEnum::Function(Function {
+                        sig: FunctionSignature {
+                            inputs: vec![
+                                (
+                                    "self".to_string(),
+                                    Type::BorrowedRef {
+                                        lifetime: None,
+                                        is_mutable: false,
+                                        type_: Box::new(Type::Generic("Self".to_string())),
+                                    },
+                                ),
+                                (
+                                    "f".to_string(),
+                                    Type::BorrowedRef {
+                                        lifetime: None,
+                                        is_mutable: true,
+                                        type_: Box::new(Type::ResolvedPath(path(
+                                            "fmt::Formatter",
+                                            11,
+                                        ))),
+                                    },
+                                ),
+                            ],
+                            output: Some(Type::ResolvedPath(path("fmt::Result", 12))),
+                            is_c_variadic: false,
+                        },
+                        generics: empty_generics(),
+                        header: FunctionHeader {
+                            is_const: false,
+                            is_unsafe: false,
+                            is_async: false,
+                            abi: Abi::Rust,
+                        },
+                        has_body: true,
+                    }),
+                ),
+            ]),
+            &mut NoopResolver,
+        )
+        .expect("model extraction should succeed");
+
+        let trait_impl = model
+            .root_module
+            .items
+            .iter()
+            .find(|item| item.kind == ApiItemKind::TraitImpl)
+            .expect("explicit trait impl should be extracted");
+
+        assert_eq!(trait_impl.declaration, "impl fmt::Debug for MyType {");
+        assert_eq!(trait_impl.members.len(), 1);
+        assert_eq!(
+            trait_impl.members[0].declaration,
+            "fn fmt(self: &Self, f: &mut fmt::Formatter) -> fmt::Result;"
+        );
+    }
+
+    #[test]
+    fn extract_item_synthesizes_async_trait_and_elides_synthetic_lifetimes() {
+        let function_id = Id(2);
+        let trait_id = Id(1);
+
+        let krate = crate_with_items(vec![
+            item(
+                trait_id,
+                Some("Polling"),
+                ItemEnum::Trait(Trait {
+                    is_auto: false,
+                    is_unsafe: false,
+                    is_dyn_compatible: true,
+                    items: vec![function_id],
+                    generics: empty_generics(),
+                    bounds: Vec::new(),
+                    implementations: Vec::new(),
+                }),
+            ),
+            item(
+                function_id,
+                Some("poll"),
+                ItemEnum::Function(Function {
+                    sig: FunctionSignature {
+                        inputs: vec![(
+                            "self".to_string(),
+                            Type::BorrowedRef {
+                                lifetime: Some("'life0".to_string()),
+                                is_mutable: false,
+                                type_: Box::new(Type::Generic("Self".to_string())),
+                            },
+                        )],
+                        output: None,
+                        is_c_variadic: false,
+                    },
+                    generics: Generics {
+                        params: vec![lifetime_param("'life0"), lifetime_param("'async_trait")],
+                        where_predicates: Vec::new(),
+                    },
+                    header: FunctionHeader {
+                        is_const: false,
+                        is_unsafe: false,
+                        is_async: false,
+                        abi: Abi::Rust,
+                    },
+                    has_body: false,
+                }),
+            ),
+        ]);
+
+        let item = krate.index.get(&trait_id).expect("trait item present");
+        let extracted = extract_item(&krate, item);
+
+        assert!(
+            extracted
+                .attributes
+                .iter()
+                .any(|attribute| attribute.text == "#[async_trait]"),
+            "trait should synthesize #[async_trait]"
+        );
+        assert_eq!(extracted.members.len(), 1);
+        assert_eq!(extracted.members[0].declaration, "fn poll(self: &Self);");
+    }
+
+    #[test]
+    fn local_reexport_carries_explicit_trait_impls_for_reexported_items() {
+        let hidden_module_id = Id(1);
+        let struct_id = Id(2);
+        let impl_id = Id(3);
+        let fmt_id = Id(4);
+        let reexport_id = Id(5);
+
+        let model = extract_model(
+            &package_metadata("demo"),
+            &crate_with_root_items(
+                vec![hidden_module_id, reexport_id],
+                vec![
+                    module_item(hidden_module_id, "hidden", vec![struct_id, impl_id], true),
+                    item(
+                        struct_id,
+                        Some("Error"),
+                        ItemEnum::Struct(Struct {
+                            kind: StructKind::Unit,
+                            generics: empty_generics(),
+                            impls: vec![impl_id],
+                        }),
+                    ),
+                    impl_item_with_items(
+                        impl_id,
+                        Some(path("fmt::Debug", 10)),
+                        "Error",
+                        struct_id,
+                        false,
+                        vec![fmt_id],
+                    ),
+                    item(
+                        fmt_id,
+                        Some("fmt"),
+                        ItemEnum::Function(Function {
+                            sig: FunctionSignature {
+                                inputs: vec![
+                                    (
+                                        "self".to_string(),
+                                        Type::BorrowedRef {
+                                            lifetime: None,
+                                            is_mutable: false,
+                                            type_: Box::new(Type::Generic("Self".to_string())),
+                                        },
+                                    ),
+                                    (
+                                        "f".to_string(),
+                                        Type::BorrowedRef {
+                                            lifetime: None,
+                                            is_mutable: true,
+                                            type_: Box::new(Type::ResolvedPath(path(
+                                                "fmt::Formatter",
+                                                11,
+                                            ))),
+                                        },
+                                    ),
+                                ],
+                                output: Some(Type::ResolvedPath(path("fmt::Result", 12))),
+                                is_c_variadic: false,
+                            },
+                            generics: empty_generics(),
+                            header: FunctionHeader {
+                                is_const: false,
+                                is_unsafe: false,
+                                is_async: false,
+                                abi: Abi::Rust,
+                            },
+                            has_body: true,
+                        }),
+                    ),
+                    item(
+                        reexport_id,
+                        Some("Error"),
+                        ItemEnum::Use(rustdoc_types::Use {
+                            source: "crate::hidden::Error".to_string(),
+                            name: "Error".to_string(),
+                            id: Some(struct_id),
+                            is_glob: false,
+                        }),
+                    ),
+                ],
+            ),
+            &mut NoopResolver,
+        )
+        .expect("model extraction should succeed");
+
+        assert!(model.root_module.modules.is_empty());
+        assert!(model
+            .root_module
+            .items
+            .iter()
+            .any(|item| item.declaration == "pub struct Error;"));
+        assert!(model.root_module.items.iter().any(|item| {
+            item.kind == ApiItemKind::TraitImpl
+                && item.declaration == "impl fmt::Debug for Error {"
+                && item.members.iter().any(|member| member.name == "fmt")
+        }));
+    }
+
+    #[test]
+    fn local_reexport_preserves_synthesized_derives_for_reexported_items() {
+        let hidden_module_id = Id(1);
+        let struct_id = Id(2);
+        let clone_impl_id = Id(3);
+        let debug_impl_id = Id(4);
+        let reexport_id = Id(5);
+
+        let model = extract_model(
+            &package_metadata("demo"),
+            &crate_with_root_items(
+                vec![hidden_module_id, reexport_id],
+                vec![
+                    module_item(
+                        hidden_module_id,
+                        "hidden",
+                        vec![struct_id, clone_impl_id, debug_impl_id],
+                        true,
+                    ),
+                    item(
+                        struct_id,
+                        Some("ErrorKind"),
+                        ItemEnum::Struct(Struct {
+                            kind: StructKind::Unit,
+                            generics: empty_generics(),
+                            impls: vec![clone_impl_id, debug_impl_id],
+                        }),
+                    ),
+                    impl_item(
+                        clone_impl_id,
+                        Some(path("Clone", 20)),
+                        "ErrorKind",
+                        struct_id,
+                        true,
+                    ),
+                    impl_item(
+                        debug_impl_id,
+                        Some(path("fmt::Debug", 21)),
+                        "ErrorKind",
+                        struct_id,
+                        true,
+                    ),
+                    item(
+                        reexport_id,
+                        Some("ErrorKind"),
+                        ItemEnum::Use(rustdoc_types::Use {
+                            source: "crate::hidden::ErrorKind".to_string(),
+                            name: "ErrorKind".to_string(),
+                            id: Some(struct_id),
+                            is_glob: false,
+                        }),
+                    ),
+                ],
+            ),
+            &mut NoopResolver,
+        )
+        .expect("model extraction should succeed");
+
+        let item = model
+            .root_module
+            .items
+            .iter()
+            .find(|item| item.declaration == "pub struct ErrorKind;")
+            .expect("re-exported struct should be lifted");
+
+        assert!(model.root_module.modules.is_empty());
+        assert_eq!(
+            item.attributes
+                .iter()
+                .map(|attribute| attribute.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["#[derive(Clone, Debug)]"]
+        );
+    }
+
+    fn crate_with_items(items: Vec<Item>) -> Crate {
+        let module_items = items.iter().map(|item| item.id).collect::<Vec<_>>();
+        crate_with_root_items(module_items, items)
+    }
+
+    fn crate_with_root_items(root_items: Vec<Id>, items: Vec<Item>) -> Crate {
+        let root = Id(0);
+        let mut index = HashMap::new();
+        index.insert(
+            root,
+            item(
+                root,
+                Some("crate"),
+                ItemEnum::Module(Module {
+                    is_crate: true,
+                    items: root_items,
+                    is_stripped: false,
+                }),
+            ),
+        );
+        index.extend(items.into_iter().map(|item| (item.id, item)));
+
+        Crate {
+            root,
+            crate_version: None,
+            includes_private: false,
+            index,
+            paths: HashMap::<Id, ItemSummary>::new(),
+            external_crates: HashMap::new(),
+            target: Target {
+                triple: "x86_64-unknown-linux-gnu".to_string(),
+                target_features: Vec::new(),
+            },
+            format_version: 0,
+        }
+    }
+
+    fn item(id: Id, name: Option<&str>, inner: ItemEnum) -> Item {
+        Item {
+            id,
+            crate_id: 0,
+            name: name.map(str::to_string),
+            span: None,
+            visibility: Visibility::Public,
+            docs: None,
+            links: HashMap::new(),
+            attrs: Vec::new(),
+            deprecation: None,
+            inner,
+        }
+    }
+
+    fn impl_item(
+        id: Id,
+        trait_path: Option<Path>,
+        self_type_name: &str,
+        struct_id: Id,
+        automatically_derived: bool,
+    ) -> Item {
+        impl_item_with_items(
+            id,
+            trait_path,
+            self_type_name,
+            struct_id,
+            automatically_derived,
+            Vec::new(),
+        )
+    }
+
+    fn impl_item_with_items(
+        id: Id,
+        trait_path: Option<Path>,
+        self_type_name: &str,
+        struct_id: Id,
+        automatically_derived: bool,
+        items: Vec<Id>,
+    ) -> Item {
+        item(
+            id,
+            None,
+            ItemEnum::Impl(Impl {
+                is_unsafe: false,
+                generics: empty_generics(),
+                provided_trait_methods: Vec::new(),
+                trait_: trait_path,
+                for_: Type::ResolvedPath(path(self_type_name, struct_id.0)),
+                items,
+                is_negative: false,
+                is_synthetic: false,
+                blanket_impl: None,
+            }),
+        )
+        .with_attrs(if automatically_derived {
+            vec!["#[automatically_derived]".to_string()]
+        } else {
+            Vec::new()
+        })
+    }
+
+    fn module_item(id: Id, name: &str, items: Vec<Id>, is_stripped: bool) -> Item {
+        item(
+            id,
+            Some(name),
+            ItemEnum::Module(Module {
+                is_crate: false,
+                items,
+                is_stripped,
+            }),
+        )
+    }
+
+    fn path(path: &str, id: u32) -> Path {
+        Path {
+            path: path.to_string(),
+            id: Id(id),
+            args: None,
+        }
+    }
+
+    fn lifetime_param(name: &str) -> GenericParamDef {
+        GenericParamDef {
+            name: name.to_string(),
+            kind: GenericParamDefKind::Lifetime {
+                outlives: Vec::new(),
+            },
+        }
+    }
+
+    fn empty_generics() -> Generics {
+        Generics {
+            params: Vec::new(),
+            where_predicates: Vec::new(),
+        }
+    }
+
+    fn package_metadata(name: &str) -> PackageMetadata {
+        PackageMetadata {
+            name: name.to_string(),
+            version: "1.0.0".to_string(),
+            manifest_path: std::path::PathBuf::from("Cargo.toml"),
+        }
+    }
+
+    struct NoopResolver;
+
+    impl WorkspaceResolver for NoopResolver {
+        fn is_workspace_crate(&self, _crate_name: &str) -> bool {
+            false
+        }
+
+        fn load_workspace_model(
+            &mut self,
+            _crate_name: &str,
+        ) -> Result<Option<Arc<ApiModel>>, String> {
+            Ok(None)
+        }
+
+        fn load_workspace_crate(
+            &mut self,
+            _crate_name: &str,
+        ) -> Result<Option<Arc<Crate>>, String> {
+            Ok(None)
+        }
+    }
+
+    trait ItemTestExt {
+        fn with_attrs(self, attrs: Vec<String>) -> Self;
+    }
+
+    impl ItemTestExt for Item {
+        fn with_attrs(mut self, attrs: Vec<String>) -> Self {
+            self.attrs = attrs;
+            self
+        }
+    }
 }

--- a/eng/tools/generate_api/src/extract.rs
+++ b/eng/tools/generate_api/src/extract.rs
@@ -289,11 +289,8 @@ fn expand_item_with_impls(krate: &Crate, target: &Item, current_module_path: &st
 }
 
 fn trait_impls_for_item(krate: &Crate, target: &Item, current_module_path: &str) -> Vec<ApiItem> {
-    let impl_ids = match &target.inner {
-        ItemEnum::Struct(struct_item) => &struct_item.impls,
-        ItemEnum::Enum(enum_item) => &enum_item.impls,
-        ItemEnum::Union(union_item) => &union_item.impls,
-        _ => return Vec::new(),
+    let Some(impl_ids) = item_impl_ids(target) else {
+        return Vec::new();
     };
 
     impl_ids
@@ -309,15 +306,12 @@ fn trait_impls_for_item(krate: &Crate, target: &Item, current_module_path: &str)
         .collect()
 }
 
-fn rebase_trait_impl_item(mut item: ApiItem, current_module_path: &str) -> ApiItem {
+fn rebase_trait_impl_item(mut item: ApiItem, _current_module_path: &str) -> ApiItem {
     if let Some((trait_name, _)) = item.declaration.split_once(" for ") {
         let trait_name = trait_name
             .trim_start_matches("unsafe ")
             .trim_start_matches("impl ");
         item.name = format!("{}_{}", last_path_segment(trait_name), item.name);
-    }
-    if current_module_path.is_empty() {
-        return item;
     }
     item
 }
@@ -635,22 +629,17 @@ fn extract_item(krate: &Crate, item: &Item) -> ApiItem {
 }
 
 fn extract_members(krate: &Crate, item: &Item) -> Vec<ApiMember> {
+    if let Some(impl_ids) = item_impl_ids(item) {
+        return extract_inherent_impl_members(krate, impl_ids);
+    }
     match &item.inner {
-        ItemEnum::Struct(struct_item) => extract_inherent_impl_members(krate, &struct_item.impls),
-        ItemEnum::Enum(enum_item) => extract_inherent_impl_members(krate, &enum_item.impls),
-        ItemEnum::Union(union_item) => extract_inherent_impl_members(krate, &union_item.impls),
         ItemEnum::Trait(trait_item) => extract_trait_members(krate, trait_item),
         _ => Vec::new(),
     }
 }
 
 fn synthesize_derive_attribute(krate: &Crate, item: &Item) -> Option<ApiAttribute> {
-    let impl_ids = match &item.inner {
-        ItemEnum::Struct(struct_item) => &struct_item.impls,
-        ItemEnum::Enum(enum_item) => &enum_item.impls,
-        ItemEnum::Union(union_item) => &union_item.impls,
-        _ => return None,
-    };
+    let impl_ids = item_impl_ids(item)?;
 
     let mut derived = BTreeSet::new();
     for impl_id in impl_ids {
@@ -766,43 +755,46 @@ fn extract_trait_members(krate: &Crate, trait_item: &Trait) -> Vec<ApiMember> {
         .collect()
 }
 
+fn api_member(item: &Item, declaration: String) -> ApiMember {
+    ApiMember {
+        name: item.name.clone().unwrap_or_default(),
+        doc_comments: extract_doc_comments(item),
+        attributes: extract_attributes(item),
+        declaration,
+    }
+}
+
 fn extract_associated_member(item: &Item) -> Option<ApiMember> {
     match &item.inner {
-        ItemEnum::Function(function) => Some(ApiMember {
-            name: item.name.clone().unwrap_or_default(),
-            doc_comments: extract_doc_comments(item),
-            attributes: extract_attributes(item),
-            declaration: render_function_declaration(
+        ItemEnum::Function(function) => Some(api_member(
+            item,
+            render_function_declaration(
                 item.name.as_deref().unwrap_or("unknown_fn"),
                 function,
                 false,
             ),
-        }),
-        ItemEnum::AssocConst { type_, value } => Some(ApiMember {
-            name: item.name.clone().unwrap_or_default(),
-            doc_comments: extract_doc_comments(item),
-            attributes: extract_attributes(item),
-            declaration: render_assoc_const(
+        )),
+        ItemEnum::AssocConst { type_, value } => Some(api_member(
+            item,
+            render_assoc_const(
                 item.name.as_deref().unwrap_or("UNKNOWN_CONST"),
                 type_,
                 value.as_deref(),
             ),
-        }),
+        )),
         ItemEnum::AssocType {
             generics,
             bounds,
             type_,
-        } => Some(ApiMember {
-            name: item.name.clone().unwrap_or_default(),
-            doc_comments: extract_doc_comments(item),
-            attributes: extract_attributes(item),
-            declaration: render_assoc_type(
+        } => Some(api_member(
+            item,
+            render_assoc_type(
                 item.name.as_deref().unwrap_or("UnknownType"),
                 generics,
                 bounds,
                 type_.as_ref(),
             ),
-        }),
+        )),
         _ => None,
     }
 }
@@ -814,6 +806,15 @@ fn extract_attributes(item: &Item) -> Vec<ApiAttribute> {
             text: normalize_attribute(text),
         })
         .collect()
+}
+
+fn item_impl_ids(item: &Item) -> Option<&[Id]> {
+    match &item.inner {
+        ItemEnum::Struct(struct_item) => Some(&struct_item.impls),
+        ItemEnum::Enum(enum_item) => Some(&enum_item.impls),
+        ItemEnum::Union(union_item) => Some(&union_item.impls),
+        _ => None,
+    }
 }
 
 fn extract_doc_comments(item: &Item) -> Vec<String> {
@@ -927,32 +928,30 @@ fn collapse_attribute_whitespace(attribute: &str) -> String {
 
 fn collapse_path_separator_whitespace(attribute: &str) -> String {
     let mut normalized = String::new();
-    let chars = attribute.chars().collect::<Vec<_>>();
-    let mut index = 0;
+    let mut chars = attribute.chars().peekable();
 
-    while index < chars.len() {
-        if chars[index] == ':' {
-            let mut left = normalized.len();
-            while left > 0 && normalized[..left].ends_with(' ') {
+    while let Some(ch) = chars.next() {
+        if ch == ':' {
+            // Strip any trailing space we just wrote before the first colon.
+            while normalized.ends_with(' ') {
                 normalized.pop();
-                left -= 1;
             }
-
             normalized.push(':');
-            index += 1;
-            while index < chars.len() && chars[index].is_whitespace() {
-                index += 1;
+
+            // Skip whitespace between the two colons.
+            while chars.peek().is_some_and(|c| c.is_whitespace()) {
+                chars.next();
             }
 
-            if index < chars.len() && chars[index] == ':' {
+            // Consume the second colon if present.
+            if chars.peek() == Some(&':') {
+                chars.next();
                 normalized.push(':');
-                index += 1;
             }
             continue;
         }
 
-        normalized.push(chars[index]);
-        index += 1;
+        normalized.push(ch);
     }
 
     normalized
@@ -2036,7 +2035,8 @@ fn last_path_segment(path: &str) -> &str {
 mod tests {
     use super::*;
     use rustdoc_types::{
-        Abi, FunctionSignature, Generics, ItemSummary, Module, Struct, Target, Type,
+        Abi, Enum as RustdocEnum, FunctionSignature, Generics, ItemSummary, Module, Struct, Target,
+        Type,
     };
     use std::collections::HashMap;
 
@@ -2545,6 +2545,189 @@ mod tests {
             ),
             "#[allow(elided_named_lifetimes, clippy::shadow_same, clippy::type_complexity)]"
         );
+    }
+
+    #[test]
+    fn extract_members_for_enum_includes_inherent_impl_methods() {
+        let enum_id = Id(1);
+        let impl_id = Id(2);
+        let func_id = Id(3);
+
+        let krate = crate_with_items(vec![
+            item(
+                enum_id,
+                Some("Status"),
+                ItemEnum::Enum(RustdocEnum {
+                    generics: empty_generics(),
+                    has_stripped_variants: false,
+                    variants: Vec::new(),
+                    impls: vec![impl_id],
+                }),
+            ),
+            item(
+                impl_id,
+                None,
+                ItemEnum::Impl(Impl {
+                    is_unsafe: false,
+                    generics: empty_generics(),
+                    provided_trait_methods: Vec::new(),
+                    trait_: None,
+                    for_: Type::ResolvedPath(path("Status", enum_id.0)),
+                    items: vec![func_id],
+                    is_negative: false,
+                    is_synthetic: false,
+                    blanket_impl: None,
+                }),
+            ),
+            item(
+                func_id,
+                Some("is_ready"),
+                ItemEnum::Function(Function {
+                    sig: FunctionSignature {
+                        inputs: vec![(
+                            "self".to_string(),
+                            Type::BorrowedRef {
+                                lifetime: None,
+                                is_mutable: false,
+                                type_: Box::new(Type::Generic("Self".to_string())),
+                            },
+                        )],
+                        output: Some(Type::Primitive("bool".to_string())),
+                        is_c_variadic: false,
+                    },
+                    generics: empty_generics(),
+                    header: FunctionHeader {
+                        is_const: false,
+                        is_unsafe: false,
+                        is_async: false,
+                        abi: Abi::Rust,
+                    },
+                    has_body: true,
+                }),
+            ),
+        ]);
+
+        let enum_item = krate.index.get(&enum_id).expect("enum item present");
+        let extracted = extract_item(&krate, enum_item);
+
+        assert_eq!(extracted.members.len(), 1);
+        assert_eq!(
+            extracted.members[0].declaration,
+            "fn is_ready(&self) -> bool;"
+        );
+    }
+
+    #[test]
+    fn synthesize_derive_attribute_for_enum() {
+        let enum_id = Id(1);
+        let clone_impl_id = Id(2);
+        let debug_impl_id = Id(3);
+
+        let krate = crate_with_items(vec![
+            item(
+                enum_id,
+                Some("Kind"),
+                ItemEnum::Enum(RustdocEnum {
+                    generics: empty_generics(),
+                    has_stripped_variants: false,
+                    variants: Vec::new(),
+                    impls: vec![clone_impl_id, debug_impl_id],
+                }),
+            ),
+            impl_item(
+                clone_impl_id,
+                Some(path("Clone", 10)),
+                "Kind",
+                enum_id,
+                true,
+            ),
+            impl_item(
+                debug_impl_id,
+                Some(path("Debug", 11)),
+                "Kind",
+                enum_id,
+                true,
+            ),
+        ]);
+
+        let enum_item = krate.index.get(&enum_id).expect("enum item present");
+        let attribute = synthesize_derive_attribute(&krate, enum_item)
+            .expect("derive attribute should be synthesized for enum");
+
+        assert_eq!(attribute.text, "#[derive(Clone, Debug)]");
+    }
+
+    #[test]
+    fn extracts_assoc_const_member_from_trait() {
+        let trait_id = Id(1);
+        let const_id = Id(2);
+
+        let krate = crate_with_items(vec![
+            item(
+                trait_id,
+                Some("Configurable"),
+                ItemEnum::Trait(Trait {
+                    is_auto: false,
+                    is_unsafe: false,
+                    is_dyn_compatible: true,
+                    items: vec![const_id],
+                    generics: empty_generics(),
+                    bounds: Vec::new(),
+                    implementations: Vec::new(),
+                }),
+            ),
+            item(
+                const_id,
+                Some("MAX"),
+                ItemEnum::AssocConst {
+                    type_: Type::Primitive("u32".to_string()),
+                    value: None,
+                },
+            ),
+        ]);
+
+        let trait_item = krate.index.get(&trait_id).expect("trait item present");
+        let extracted = extract_item(&krate, trait_item);
+
+        assert_eq!(extracted.members.len(), 1);
+        assert_eq!(extracted.members[0].declaration, "const MAX: u32;");
+    }
+
+    #[test]
+    fn extracts_assoc_type_member_from_trait() {
+        let trait_id = Id(1);
+        let type_id = Id(2);
+
+        let krate = crate_with_items(vec![
+            item(
+                trait_id,
+                Some("IntoIter"),
+                ItemEnum::Trait(Trait {
+                    is_auto: false,
+                    is_unsafe: false,
+                    is_dyn_compatible: true,
+                    items: vec![type_id],
+                    generics: empty_generics(),
+                    bounds: Vec::new(),
+                    implementations: Vec::new(),
+                }),
+            ),
+            item(
+                type_id,
+                Some("Item"),
+                ItemEnum::AssocType {
+                    generics: empty_generics(),
+                    bounds: Vec::new(),
+                    type_: None,
+                },
+            ),
+        ]);
+
+        let trait_item = krate.index.get(&trait_id).expect("trait item present");
+        let extracted = extract_item(&krate, trait_item);
+
+        assert_eq!(extracted.members.len(), 1);
+        assert_eq!(extracted.members[0].declaration, "type Item;");
     }
 
     fn crate_with_items(items: Vec<Item>) -> Crate {

--- a/eng/tools/generate_api/src/extract.rs
+++ b/eng/tools/generate_api/src/extract.rs
@@ -1033,14 +1033,7 @@ fn render_function_declaration(name: &str, function: &Function, is_public: bool)
             .inputs
             .iter()
             .map(|(argument_name, argument_type)| {
-                if argument_name.is_empty() {
-                    render_type_with_elision(argument_type, &synthetic_lifetimes)
-                } else {
-                    format!(
-                        "{argument_name}: {}",
-                        render_type_with_elision(argument_type, &synthetic_lifetimes)
-                    )
-                }
+                render_function_parameter(argument_name, argument_type, &synthetic_lifetimes)
             })
             .collect::<Vec<String>>()
             .join(", "),
@@ -1065,6 +1058,41 @@ fn render_function_declaration(name: &str, function: &Function, is_public: bool)
     ));
     declaration.push(';');
     declaration
+}
+
+fn render_function_parameter(
+    argument_name: &str,
+    argument_type: &Type,
+    synthetic_lifetimes: &HashSet<String>,
+) -> String {
+    if let Some(receiver) = render_self_parameter(argument_name, argument_type) {
+        return receiver;
+    }
+
+    if argument_name.is_empty() {
+        render_type_with_elision(argument_type, synthetic_lifetimes)
+    } else {
+        format!(
+            "{argument_name}: {}",
+            render_type_with_elision(argument_type, synthetic_lifetimes)
+        )
+    }
+}
+
+fn render_self_parameter(argument_name: &str, argument_type: &Type) -> Option<String> {
+    if argument_name != "self" {
+        return None;
+    }
+
+    match argument_type {
+        Type::Generic(name) if name == "Self" => Some("self".to_string()),
+        Type::BorrowedRef {
+            is_mutable, type_, ..
+        } if matches!(type_.as_ref(), Type::Generic(name) if name == "Self") => {
+            Some(if *is_mutable { "&mut self" } else { "&self" }.to_string())
+        }
+        _ => None,
+    }
 }
 
 fn render_function_header(header: &FunctionHeader) -> String {
@@ -2105,7 +2133,7 @@ mod tests {
         assert_eq!(trait_impl.members.len(), 1);
         assert_eq!(
             trait_impl.members[0].declaration,
-            "fn fmt(self: &Self, f: &mut fmt::Formatter) -> fmt::Result;"
+            "fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result;"
         );
     }
 
@@ -2170,7 +2198,70 @@ mod tests {
             "trait should synthesize #[async_trait]"
         );
         assert_eq!(extracted.members.len(), 1);
-        assert_eq!(extracted.members[0].declaration, "fn poll(self: &Self);");
+        assert_eq!(extracted.members[0].declaration, "fn poll(&self);");
+    }
+
+    #[test]
+    fn renders_self_receivers_in_source_like_forms() {
+        let function = Function {
+            sig: FunctionSignature {
+                inputs: vec![
+                    ("self".to_string(), Type::Generic("Self".to_string())),
+                    (
+                        "other".to_string(),
+                        Type::ResolvedPath(path("Pin", 30).with_args(
+                            GenericArgs::AngleBracketed {
+                                args: vec![GenericArg::Type(Type::Generic("Self".to_string()))],
+                                constraints: Vec::new(),
+                            },
+                        )),
+                    ),
+                ],
+                output: Some(Type::Generic("Self".to_string())),
+                is_c_variadic: false,
+            },
+            generics: empty_generics(),
+            header: FunctionHeader {
+                is_const: false,
+                is_unsafe: false,
+                is_async: false,
+                abi: Abi::Rust,
+            },
+            has_body: false,
+        };
+
+        assert_eq!(
+            render_function_declaration("into_self", &function, false),
+            "fn into_self(self, other: Pin<Self>) -> Self;"
+        );
+
+        let mut_ref_function = Function {
+            sig: FunctionSignature {
+                inputs: vec![(
+                    "self".to_string(),
+                    Type::BorrowedRef {
+                        lifetime: None,
+                        is_mutable: true,
+                        type_: Box::new(Type::Generic("Self".to_string())),
+                    },
+                )],
+                output: None,
+                is_c_variadic: false,
+            },
+            generics: empty_generics(),
+            header: FunctionHeader {
+                is_const: false,
+                is_unsafe: false,
+                is_async: false,
+                abi: Abi::Rust,
+            },
+            has_body: false,
+        };
+
+        assert_eq!(
+            render_function_declaration("touch", &mut_ref_function, false),
+            "fn touch(&mut self);"
+        );
     }
 
     #[test]
@@ -2463,6 +2554,17 @@ mod tests {
             path: path.to_string(),
             id: Id(id),
             args: None,
+        }
+    }
+
+    trait PathTestExt {
+        fn with_args(self, args: GenericArgs) -> Self;
+    }
+
+    impl PathTestExt for Path {
+        fn with_args(mut self, args: GenericArgs) -> Self {
+            self.args = Some(Box::new(args));
+            self
         }
     }
 

--- a/eng/tools/generate_api/src/extract.rs
+++ b/eng/tools/generate_api/src/extract.rs
@@ -1,0 +1,1707 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use crate::{
+    driver::PackageMetadata,
+    model::{ApiAttribute, ApiItem, ApiItemKind, ApiMember, ApiModel, ApiModule},
+};
+use rustdoc_types::{
+    Constant, Crate, Function, FunctionHeader, GenericArg, GenericArgs, GenericBound,
+    GenericParamDef, GenericParamDefKind, Id, Impl, Item, ItemEnum, MacroKind, Path, Static,
+    StructKind, Term, Trait, TraitAlias, Type, TypeAlias, Union, Variant, VariantKind, Visibility,
+    WherePredicate,
+};
+use std::collections::{BTreeSet, HashSet};
+use std::sync::Arc;
+
+pub(crate) trait WorkspaceResolver {
+    fn is_workspace_crate(&self, crate_name: &str) -> bool;
+    fn load_workspace_model(&mut self, crate_name: &str) -> Result<Option<Arc<ApiModel>>, String>;
+    fn load_workspace_crate(&mut self, crate_name: &str) -> Result<Option<Arc<Crate>>, String>;
+}
+
+pub(crate) fn extract_model(
+    package: &PackageMetadata,
+    krate: &Crate,
+    resolver: &mut impl WorkspaceResolver,
+) -> Result<ApiModel, String> {
+    let root = krate
+        .index
+        .get(&krate.root)
+        .ok_or_else(|| "rustdoc JSON root module was missing from the index".to_string())?;
+    let ItemEnum::Module(_) = &root.inner else {
+        return Err("rustdoc JSON root item was not a module".to_string());
+    };
+
+    let mut model = ApiModel::new(package.name.clone(), package.version.clone());
+    model.root_module = extract_module(krate, root, package.name.clone(), resolver)?;
+    Ok(model)
+}
+
+fn extract_module(
+    krate: &Crate,
+    item: &Item,
+    path: String,
+    resolver: &mut impl WorkspaceResolver,
+) -> Result<ApiModule, String> {
+    let ItemEnum::Module(module) = &item.inner else {
+        unreachable!("extract_module only accepts module items");
+    };
+
+    let mut result = ApiModule {
+        path,
+        doc_comments: extract_doc_comments(item),
+        attributes: extract_attributes(item),
+        items: Vec::new(),
+        modules: Vec::new(),
+    };
+    let mut seen_declarations = BTreeSet::new();
+    let mut seen_modules = BTreeSet::new();
+
+    for child_id in &module.items {
+        let Some(child) = krate.index.get(child_id) else {
+            continue;
+        };
+
+        match &child.inner {
+            ItemEnum::Module(inner) if !inner.is_stripped && is_visible(child) => {
+                let child_path = format!(
+                    "{}::{}",
+                    result.path,
+                    child.name.as_deref().unwrap_or("unknown_module")
+                );
+                let module = extract_module(krate, child, child_path, resolver)?;
+                insert_module(&mut result.modules, &mut seen_modules, module);
+            }
+            ItemEnum::Impl(_) => {}
+            ItemEnum::Use(use_item) if should_include_item(child) => {
+                if let Some(expanded) =
+                    expand_reexport(krate, child, use_item, &result.path, resolver)?
+                {
+                    insert_expanded(
+                        &mut result,
+                        &mut seen_declarations,
+                        &mut seen_modules,
+                        expanded,
+                    );
+                } else {
+                    let extracted = extract_item(krate, child);
+                    if seen_declarations.insert(extracted.declaration.clone()) {
+                        result.items.push(extracted);
+                    }
+                }
+            }
+            _ if should_include_item(child) => {
+                let extracted = extract_item(krate, child);
+                if seen_declarations.insert(extracted.declaration.clone()) {
+                    result.items.push(extracted);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(result)
+}
+
+#[derive(Default)]
+struct ExpandedUse {
+    items: Vec<ApiItem>,
+    modules: Vec<ApiModule>,
+}
+
+fn expand_reexport(
+    krate: &Crate,
+    use_item: &Item,
+    import: &rustdoc_types::Use,
+    current_module_path: &str,
+    resolver: &mut impl WorkspaceResolver,
+) -> Result<Option<ExpandedUse>, String> {
+    let import_attributes = extract_attributes(use_item);
+    if !import.is_glob && import.name != last_path_segment(&import.source) {
+        return Ok(None);
+    }
+
+    let Some(target_id) = &import.id else {
+        return Ok(None);
+    };
+
+    if let Some(target) = krate.index.get(target_id) {
+        if should_expand_local_reexport(krate, import, current_module_path) {
+            return expand_local_reexport(
+                krate,
+                target,
+                import,
+                current_module_path,
+                &import_attributes,
+                resolver,
+            );
+        }
+
+        return Ok(None);
+    }
+
+    let Some(summary) = krate.paths.get(target_id) else {
+        return Ok(None);
+    };
+    let Some(crate_name) = summary.path.first() else {
+        return Ok(None);
+    };
+    if !resolver.is_workspace_crate(crate_name) {
+        return Ok(None);
+    }
+
+    if let Some(krate) = resolver.load_workspace_crate(crate_name)? {
+        if let Some(target) = find_raw_item_by_path(&krate, &summary.path[1..]) {
+            return expand_local_reexport(
+                &krate,
+                target,
+                import,
+                current_module_path,
+                &import_attributes,
+                resolver,
+            );
+        }
+    }
+
+    let Some(model) = resolver.load_workspace_model(crate_name)? else {
+        return Ok(None);
+    };
+    let target_segments = summary
+        .path
+        .iter()
+        .skip(1)
+        .map(String::as_str)
+        .collect::<Vec<&str>>();
+    Ok(expand_model_reexport(
+        &model,
+        import,
+        current_module_path,
+        &import_attributes,
+        &target_segments,
+    ))
+}
+
+fn expand_local_reexport(
+    krate: &Crate,
+    target: &Item,
+    import: &rustdoc_types::Use,
+    current_module_path: &str,
+    import_attributes: &[ApiAttribute],
+    resolver: &mut impl WorkspaceResolver,
+) -> Result<Option<ExpandedUse>, String> {
+    if let ItemEnum::Use(other_import) = &target.inner {
+        let Some(mut expanded) =
+            expand_reexport(krate, target, other_import, current_module_path, resolver)?
+        else {
+            return Ok(None);
+        };
+        apply_import_attributes(&mut expanded, import_attributes);
+        return Ok(Some(expanded));
+    }
+
+    let mut expanded = match &target.inner {
+        ItemEnum::Module(_) => {
+            let rebased_path = format!("{}::{}", current_module_path, import.name);
+            let module = extract_module(krate, target, rebased_path, resolver)?;
+            if import.is_glob {
+                ExpandedUse {
+                    items: module.items,
+                    modules: module.modules,
+                }
+            } else {
+                ExpandedUse {
+                    items: Vec::new(),
+                    modules: vec![module],
+                }
+            }
+        }
+        _ if !import.is_glob => ExpandedUse {
+            items: vec![extract_item(krate, target)],
+            modules: Vec::new(),
+        },
+        _ => return Ok(None),
+    };
+    apply_import_attributes(&mut expanded, import_attributes);
+    Ok(Some(expanded))
+}
+
+fn expand_model_reexport(
+    model: &ApiModel,
+    import: &rustdoc_types::Use,
+    current_module_path: &str,
+    import_attributes: &[ApiAttribute],
+    target_segments: &[&str],
+) -> Option<ExpandedUse> {
+    let mut expanded = if import.is_glob {
+        let module = if target_segments.is_empty() {
+            model.root_module.clone()
+        } else {
+            find_module(&model.root_module, target_segments)?.clone()
+        };
+        let mut module = rebase_module(module, current_module_path.to_string());
+        ExpandedUse {
+            items: module.items.drain(..).collect(),
+            modules: module.modules.drain(..).collect(),
+        }
+    } else if let Some(module) = find_module(&model.root_module, target_segments) {
+        ExpandedUse {
+            items: Vec::new(),
+            modules: vec![rebase_module(
+                module.clone(),
+                format!("{}::{}", current_module_path, import.name),
+            )],
+        }
+    } else {
+        ExpandedUse {
+            items: vec![find_item(&model.root_module, target_segments)?.clone()],
+            modules: Vec::new(),
+        }
+    };
+    apply_import_attributes(&mut expanded, import_attributes);
+    Some(expanded)
+}
+
+fn should_expand_local_reexport(
+    krate: &Crate,
+    import: &rustdoc_types::Use,
+    current_module_path: &str,
+) -> bool {
+    !is_local_source_publicly_reachable(krate, &import.source, import.is_glob, current_module_path)
+}
+
+fn is_local_source_publicly_reachable(
+    krate: &Crate,
+    source: &str,
+    is_glob: bool,
+    current_module_path: &str,
+) -> bool {
+    let absolute_segments = resolve_local_source_segments(source, current_module_path);
+    if absolute_segments.is_empty() {
+        return false;
+    }
+
+    let mut module = match krate.index.get(&krate.root) {
+        Some(module) => module,
+        None => return false,
+    };
+
+    let module_segments = if is_glob {
+        absolute_segments.as_slice()
+    } else {
+        &absolute_segments[..absolute_segments.len().saturating_sub(1)]
+    };
+
+    for segment in module_segments {
+        let ItemEnum::Module(module_data) = &module.inner else {
+            return false;
+        };
+
+        let Some(child_module) = module_data
+            .items
+            .iter()
+            .filter_map(|child_id| krate.index.get(child_id))
+            .find(|child| {
+                item_lookup_name(child) == Some(segment.as_str())
+                    && matches!(child.inner, ItemEnum::Module(_))
+            })
+        else {
+            return false;
+        };
+
+        if !is_visible(child_module) {
+            return false;
+        }
+
+        let ItemEnum::Module(child_data) = &child_module.inner else {
+            return false;
+        };
+        if child_data.is_stripped {
+            return false;
+        }
+
+        module = child_module;
+    }
+
+    true
+}
+
+fn resolve_local_source_segments(source: &str, current_module_path: &str) -> Vec<String> {
+    let mut base_segments = current_module_path
+        .split("::")
+        .skip(1)
+        .map(str::to_string)
+        .collect::<Vec<String>>();
+    let mut remaining = source;
+
+    if let Some(rest) = remaining.strip_prefix("crate::") {
+        return rest.split("::").map(str::to_string).collect();
+    }
+    if remaining == "crate" {
+        return Vec::new();
+    }
+
+    while let Some(rest) = remaining.strip_prefix("self::") {
+        remaining = rest;
+    }
+
+    while let Some(rest) = remaining.strip_prefix("super::") {
+        base_segments.pop();
+        remaining = rest;
+    }
+
+    if remaining.is_empty() {
+        base_segments
+    } else {
+        base_segments.extend(remaining.split("::").map(str::to_string));
+        base_segments
+    }
+}
+
+fn find_raw_item_by_path<'a>(krate: &'a Crate, path: &[String]) -> Option<&'a Item> {
+    let mut module = krate.index.get(&krate.root)?;
+    if path.is_empty() {
+        return Some(module);
+    }
+
+    for (index, segment) in path.iter().enumerate() {
+        let ItemEnum::Module(module_data) = &module.inner else {
+            return None;
+        };
+        let child = module_data
+            .items
+            .iter()
+            .filter_map(|child_id| krate.index.get(child_id))
+            .find(|child| item_lookup_name(child) == Some(segment.as_str()))?;
+        if index + 1 == path.len() {
+            return Some(child);
+        }
+        module = child;
+    }
+
+    None
+}
+
+fn item_lookup_name(item: &Item) -> Option<&str> {
+    item.name.as_deref().or(match &item.inner {
+        ItemEnum::Use(use_item) => Some(use_item.name.as_str()),
+        _ => None,
+    })
+}
+
+fn find_module<'a>(module: &'a ApiModule, segments: &[&str]) -> Option<&'a ApiModule> {
+    if segments.is_empty() {
+        return Some(module);
+    }
+
+    let (head, tail) = segments.split_first()?;
+    if let Some(child) = module
+        .modules
+        .iter()
+        .find(|candidate| candidate.local_name() == *head)
+    {
+        if tail.is_empty() {
+            return Some(child);
+        }
+        if let Some(found) = find_module(child, tail) {
+            return Some(found);
+        }
+    }
+
+    if tail.is_empty() {
+        None
+    } else {
+        find_module(module, tail)
+    }
+}
+
+fn find_item<'a>(module: &'a ApiModule, segments: &[&str]) -> Option<&'a ApiItem> {
+    let (head, tail) = segments.split_first()?;
+    if tail.is_empty() {
+        module
+            .items
+            .iter()
+            .find(|candidate| candidate.name == *head)
+    } else {
+        if let Some(child) = module
+            .modules
+            .iter()
+            .find(|candidate| candidate.local_name() == *head)
+        {
+            if let Some(found) = find_item(child, tail) {
+                return Some(found);
+            }
+        }
+
+        find_item(module, tail)
+    }
+}
+
+fn rebase_module(mut module: ApiModule, new_path: String) -> ApiModule {
+    let parent_path = new_path.clone();
+    module.path = new_path;
+    module.modules = module
+        .modules
+        .into_iter()
+        .map(|child| {
+            let child_name = child.local_name().to_string();
+            rebase_module(child, format!("{parent_path}::{child_name}"))
+        })
+        .collect();
+    module
+}
+
+fn apply_import_attributes(expanded: &mut ExpandedUse, import_attributes: &[ApiAttribute]) {
+    if import_attributes.is_empty() {
+        return;
+    }
+
+    for item in &mut expanded.items {
+        prepend_attributes(&mut item.attributes, import_attributes);
+    }
+    for module in &mut expanded.modules {
+        prepend_attributes(&mut module.attributes, import_attributes);
+    }
+}
+
+fn prepend_attributes(attributes: &mut Vec<ApiAttribute>, prefix: &[ApiAttribute]) {
+    if prefix.is_empty() {
+        return;
+    }
+
+    let mut combined = prefix.to_vec();
+    for attribute in attributes.drain(..) {
+        if !combined
+            .iter()
+            .any(|candidate| candidate.text == attribute.text)
+        {
+            combined.push(attribute);
+        }
+    }
+    *attributes = combined;
+}
+
+fn insert_expanded(
+    module: &mut ApiModule,
+    seen_declarations: &mut BTreeSet<String>,
+    seen_modules: &mut BTreeSet<String>,
+    expanded: ExpandedUse,
+) {
+    for item in expanded.items {
+        if seen_declarations.insert(item.declaration.clone()) {
+            module.items.push(item);
+        }
+    }
+
+    for child_module in expanded.modules {
+        insert_module(&mut module.modules, seen_modules, child_module);
+    }
+}
+
+fn insert_module(
+    modules: &mut Vec<ApiModule>,
+    seen_modules: &mut BTreeSet<String>,
+    module: ApiModule,
+) {
+    if seen_modules.insert(module.path.clone()) {
+        modules.push(module);
+    }
+}
+
+fn extract_item(krate: &Crate, item: &Item) -> ApiItem {
+    let mut attributes = extract_attributes(item);
+    if matches!(item.inner, ItemEnum::Trait(_)) && trait_uses_async_trait(krate, item) {
+        prepend_attributes(
+            &mut attributes,
+            &[ApiAttribute {
+                text: "#[async_trait]".to_string(),
+            }],
+        );
+    }
+
+    ApiItem {
+        name: item
+            .name
+            .clone()
+            .unwrap_or_else(|| fallback_item_name(item).to_string()),
+        kind: item_kind(item),
+        doc_comments: extract_doc_comments(item),
+        attributes,
+        declaration: render_item_declaration(krate, item),
+        members: extract_members(krate, item),
+    }
+}
+
+fn extract_members(krate: &Crate, item: &Item) -> Vec<ApiMember> {
+    match &item.inner {
+        ItemEnum::Struct(struct_item) => extract_impl_members(krate, &struct_item.impls),
+        ItemEnum::Enum(enum_item) => extract_impl_members(krate, &enum_item.impls),
+        ItemEnum::Union(union_item) => extract_impl_members(krate, &union_item.impls),
+        ItemEnum::Trait(trait_item) => extract_trait_members(krate, trait_item),
+        _ => Vec::new(),
+    }
+}
+
+fn extract_impl_members(krate: &Crate, impl_ids: &[Id]) -> Vec<ApiMember> {
+    impl_ids
+        .iter()
+        .filter_map(|impl_id| krate.index.get(impl_id))
+        .filter_map(|impl_item| match &impl_item.inner {
+            ItemEnum::Impl(impl_block) if include_impl_block(impl_block) => Some(impl_block),
+            _ => None,
+        })
+        .flat_map(|impl_block| impl_block.items.iter())
+        .filter_map(|item_id| krate.index.get(item_id))
+        .filter(|item| is_visible(item))
+        .filter_map(|item| match &item.inner {
+            ItemEnum::Function(function) => Some(ApiMember {
+                name: item.name.clone().unwrap_or_default(),
+                doc_comments: extract_doc_comments(item),
+                attributes: extract_attributes(item),
+                declaration: render_function_declaration(
+                    item.name.as_deref().unwrap_or("unknown_fn"),
+                    function,
+                    false,
+                ),
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+fn extract_trait_members(krate: &Crate, trait_item: &Trait) -> Vec<ApiMember> {
+    trait_item
+        .items
+        .iter()
+        .filter_map(|item_id| krate.index.get(item_id))
+        .filter_map(|item| match &item.inner {
+            ItemEnum::Function(function) => Some(ApiMember {
+                name: item.name.clone().unwrap_or_default(),
+                doc_comments: extract_doc_comments(item),
+                attributes: extract_attributes(item),
+                declaration: render_function_declaration(
+                    item.name.as_deref().unwrap_or("unknown_fn"),
+                    function,
+                    false,
+                ),
+            }),
+            ItemEnum::AssocConst { type_, value } => Some(ApiMember {
+                name: item.name.clone().unwrap_or_default(),
+                doc_comments: extract_doc_comments(item),
+                attributes: extract_attributes(item),
+                declaration: render_assoc_const(
+                    item.name.as_deref().unwrap_or("UNKNOWN_CONST"),
+                    type_,
+                    value.as_deref(),
+                ),
+            }),
+            ItemEnum::AssocType {
+                generics,
+                bounds,
+                type_,
+            } => Some(ApiMember {
+                name: item.name.clone().unwrap_or_default(),
+                doc_comments: extract_doc_comments(item),
+                attributes: extract_attributes(item),
+                declaration: render_assoc_type(
+                    item.name.as_deref().unwrap_or("UnknownType"),
+                    generics,
+                    bounds,
+                    type_.as_ref(),
+                ),
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+fn extract_attributes(item: &Item) -> Vec<ApiAttribute> {
+    item.attrs
+        .iter()
+        .map(|text| ApiAttribute {
+            text: normalize_attribute(text),
+        })
+        .collect()
+}
+
+fn extract_doc_comments(item: &Item) -> Vec<String> {
+    item.docs
+        .as_deref()
+        .map(|docs| {
+            docs.lines()
+                .map(|line| {
+                    if line.is_empty() {
+                        "///".to_string()
+                    } else {
+                        format!("/// {line}")
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn normalize_attribute(text: &str) -> String {
+    let mut normalized = text
+        .replace("#[<cfg>(", "#[cfg(")
+        .replace("#![<cfg>(", "#![cfg(")
+        .replace("#[<cfg_attr>(", "#[cfg_attr(")
+        .replace("#![<cfg_attr>(", "#![cfg_attr(")
+        .replace("clippy :: ", "clippy::")
+        .replace("clippy ::", "clippy::");
+
+    normalized = normalize_pin_attribute(&normalized);
+    normalized = collapse_clippy_lint_whitespace(&normalized);
+    normalized
+}
+
+fn normalize_pin_attribute(attribute: &str) -> String {
+    normalize_pin_attribute_with_prefix(attribute, "#[")
+        .or_else(|| normalize_pin_attribute_with_prefix(attribute, "#!["))
+        .unwrap_or_else(|| attribute.to_string())
+}
+
+fn normalize_pin_attribute_with_prefix(attribute: &str, prefix: &str) -> Option<String> {
+    let body = attribute.strip_prefix(prefix)?;
+    let body = body.strip_suffix(']')?;
+    let inner = body.strip_prefix("pin(__private(")?;
+    let inner = inner.strip_suffix("))")?;
+    if inner.is_empty() {
+        Some(format!("{prefix}pin_project]"))
+    } else {
+        Some(format!("{prefix}pin_project({inner})]"))
+    }
+}
+
+fn collapse_clippy_lint_whitespace(attribute: &str) -> String {
+    let mut remaining = attribute;
+    let mut normalized = String::new();
+
+    while let Some(index) = remaining.find("clippy::") {
+        normalized.push_str(&remaining[..index + "clippy::".len()]);
+        remaining = &remaining[index + "clippy::".len()..];
+        remaining = remaining.trim_start_matches(char::is_whitespace);
+    }
+
+    normalized.push_str(remaining);
+    normalized
+}
+
+fn should_include_item(item: &Item) -> bool {
+    is_visible(item)
+        && !matches!(
+            item.inner,
+            ItemEnum::Variant(_)
+                | ItemEnum::StructField(_)
+                | ItemEnum::AssocConst { .. }
+                | ItemEnum::AssocType { .. }
+                | ItemEnum::ExternCrate { .. }
+                | ItemEnum::Primitive(_)
+        )
+}
+
+fn is_visible(item: &Item) -> bool {
+    matches!(item.visibility, Visibility::Public | Visibility::Default)
+}
+
+fn include_impl_block(impl_block: &Impl) -> bool {
+    !impl_block.is_synthetic && impl_block.blanket_impl.is_none() && impl_block.trait_.is_none()
+}
+
+fn item_kind(item: &Item) -> ApiItemKind {
+    match &item.inner {
+        ItemEnum::Use(_) => ApiItemKind::Use,
+        ItemEnum::Macro(_) => ApiItemKind::Macro,
+        ItemEnum::ProcMacro(_) => ApiItemKind::ProcMacro,
+        ItemEnum::Function(_) => ApiItemKind::Function,
+        ItemEnum::Struct(_) => ApiItemKind::Struct,
+        ItemEnum::Enum(_) => ApiItemKind::Enum,
+        ItemEnum::Trait(_) => ApiItemKind::Trait,
+        ItemEnum::TraitAlias(_) => ApiItemKind::TraitAlias,
+        ItemEnum::Union(_) => ApiItemKind::Union,
+        ItemEnum::TypeAlias(_) => ApiItemKind::TypeAlias,
+        ItemEnum::Constant { .. } => ApiItemKind::Const,
+        ItemEnum::Static(_) => ApiItemKind::Static,
+        _ => ApiItemKind::TypeAlias,
+    }
+}
+
+fn fallback_item_name(item: &Item) -> &'static str {
+    match &item.inner {
+        ItemEnum::Use(_) => "use",
+        ItemEnum::Macro(_) => "macro",
+        ItemEnum::ProcMacro(_) => "proc_macro",
+        ItemEnum::Function(_) => "function",
+        ItemEnum::Struct(_) => "struct",
+        ItemEnum::Enum(_) => "enum",
+        ItemEnum::Trait(_) => "trait",
+        ItemEnum::TraitAlias(_) => "trait_alias",
+        ItemEnum::Union(_) => "union",
+        ItemEnum::TypeAlias(_) => "type_alias",
+        ItemEnum::Constant { .. } => "const",
+        ItemEnum::Static(_) => "static",
+        _ => "item",
+    }
+}
+
+fn render_item_declaration(krate: &Crate, item: &Item) -> String {
+    match &item.inner {
+        ItemEnum::Use(use_item) => render_use_declaration(krate, use_item),
+        ItemEnum::Macro(source) => source.clone(),
+        ItemEnum::ProcMacro(proc_macro) => render_proc_macro_declaration(
+            item.name.as_deref().unwrap_or("unknown_macro"),
+            proc_macro,
+        ),
+        ItemEnum::Function(function) => render_function_declaration(
+            item.name.as_deref().unwrap_or("unknown_fn"),
+            function,
+            true,
+        ),
+        ItemEnum::Struct(struct_item) => render_struct_declaration(krate, item, struct_item),
+        ItemEnum::Enum(enum_item) => render_enum_declaration(krate, item, enum_item),
+        ItemEnum::Trait(trait_item) => render_trait_declaration(krate, item, trait_item),
+        ItemEnum::TraitAlias(trait_alias) => render_trait_alias_declaration(item, trait_alias),
+        ItemEnum::Union(union_item) => render_union_declaration(krate, item, union_item),
+        ItemEnum::TypeAlias(type_alias) => render_type_alias_declaration(item, type_alias),
+        ItemEnum::Constant { type_, const_ } => render_const_declaration(item, type_, const_),
+        ItemEnum::Static(static_item) => render_static_declaration(item, static_item),
+        _ => format!("// Unsupported item: {}", fallback_item_name(item)),
+    }
+}
+
+fn render_use_declaration(krate: &Crate, use_item: &rustdoc_types::Use) -> String {
+    let source = use_item
+        .id
+        .as_ref()
+        .and_then(|id| krate.paths.get(id))
+        .map(|summary| normalize_use_path(&summary.path))
+        .unwrap_or_else(|| use_item.source.clone());
+
+    if use_item.is_glob {
+        format!("pub use {source}::*;")
+    } else if use_item.name == last_path_segment(&source) {
+        format!("pub use {source};")
+    } else {
+        format!("pub use {} as {};", source, use_item.name)
+    }
+}
+
+fn normalize_use_path(path: &[String]) -> String {
+    if path.len() >= 2 && path[0] == path[1] {
+        path[1..].join("::")
+    } else {
+        path.join("::")
+    }
+}
+
+fn render_proc_macro_declaration(name: &str, proc_macro: &rustdoc_types::ProcMacro) -> String {
+    match proc_macro.kind {
+        MacroKind::Bang => format!("{name}!() {{ /* proc-macro */ }}"),
+        MacroKind::Attr => format!("#[{name}]"),
+        MacroKind::Derive => {
+            if proc_macro.helpers.is_empty() {
+                format!("#[derive({name})]")
+            } else {
+                let mut declaration = format!("#[derive({name})]\n{{\n");
+                declaration.push_str("    // Attributes available to this derive:\n");
+                for helper in &proc_macro.helpers {
+                    declaration.push_str("    #[");
+                    declaration.push_str(helper);
+                    declaration.push_str("]\n");
+                }
+                declaration.push('}');
+                declaration
+            }
+        }
+    }
+}
+
+fn render_function_declaration(name: &str, function: &Function, is_public: bool) -> String {
+    let synthetic_lifetimes = synthetic_async_trait_lifetimes(function);
+    let mut declaration = String::new();
+    if is_public {
+        declaration.push_str("pub ");
+    }
+
+    declaration.push_str(&render_function_header(&function.header));
+    declaration.push_str("fn ");
+    declaration.push_str(name);
+    declaration.push_str(&render_generics_declaration_with_elision(
+        &function.generics,
+        &synthetic_lifetimes,
+    ));
+    declaration.push('(');
+    declaration.push_str(
+        &function
+            .sig
+            .inputs
+            .iter()
+            .map(|(argument_name, argument_type)| {
+                if argument_name.is_empty() {
+                    render_type_with_elision(argument_type, &synthetic_lifetimes)
+                } else {
+                    format!(
+                        "{argument_name}: {}",
+                        render_type_with_elision(argument_type, &synthetic_lifetimes)
+                    )
+                }
+            })
+            .collect::<Vec<String>>()
+            .join(", "),
+    );
+    if function.sig.is_c_variadic {
+        if !function.sig.inputs.is_empty() {
+            declaration.push_str(", ...");
+        } else {
+            declaration.push_str("...");
+        }
+    }
+    declaration.push(')');
+
+    if let Some(output) = &function.sig.output {
+        declaration.push_str(" -> ");
+        declaration.push_str(&render_type_with_elision(output, &synthetic_lifetimes));
+    }
+
+    declaration.push_str(&render_where_clause_with_elision(
+        &function.generics.where_predicates,
+        &synthetic_lifetimes,
+    ));
+    declaration.push(';');
+    declaration
+}
+
+fn render_function_header(header: &FunctionHeader) -> String {
+    let mut parts = Vec::new();
+    if header.is_const {
+        parts.push("const".to_string());
+    }
+    if header.is_async {
+        parts.push("async".to_string());
+    }
+    if header.is_unsafe {
+        parts.push("unsafe".to_string());
+    }
+
+    match &header.abi {
+        rustdoc_types::Abi::Rust => {}
+        rustdoc_types::Abi::C { unwind } => parts.push(render_abi("C", *unwind)),
+        rustdoc_types::Abi::Cdecl { unwind } => parts.push(render_abi("cdecl", *unwind)),
+        rustdoc_types::Abi::Stdcall { unwind } => parts.push(render_abi("stdcall", *unwind)),
+        rustdoc_types::Abi::Fastcall { unwind } => parts.push(render_abi("fastcall", *unwind)),
+        rustdoc_types::Abi::Aapcs { unwind } => parts.push(render_abi("aapcs", *unwind)),
+        rustdoc_types::Abi::Win64 { unwind } => parts.push(render_abi("win64", *unwind)),
+        rustdoc_types::Abi::SysV64 { unwind } => parts.push(render_abi("sysv64", *unwind)),
+        rustdoc_types::Abi::System { unwind } => parts.push(render_abi("system", *unwind)),
+        rustdoc_types::Abi::Other(abi) => parts.push(format!("extern {abi:?}")),
+    }
+
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!("{} ", parts.join(" "))
+    }
+}
+
+fn render_abi(abi: &str, unwind: bool) -> String {
+    if unwind {
+        format!("extern \"{abi}-unwind\"")
+    } else {
+        format!("extern \"{abi}\"")
+    }
+}
+
+fn render_struct_declaration(
+    krate: &Crate,
+    item: &Item,
+    struct_item: &rustdoc_types::Struct,
+) -> String {
+    let mut declaration = format!(
+        "pub struct {}{}",
+        item.name.as_deref().unwrap_or("UnknownStruct"),
+        render_generics_declaration(&struct_item.generics)
+    );
+    declaration.push_str(&render_where_clause(&struct_item.generics.where_predicates));
+
+    match &struct_item.kind {
+        StructKind::Unit => declaration.push(';'),
+        StructKind::Tuple(fields) => {
+            let rendered_fields = fields
+                .iter()
+                .filter_map(|field_id| field_id.as_ref())
+                .filter_map(|field_id| krate.index.get(field_id))
+                .filter_map(render_tuple_field)
+                .collect::<Vec<String>>()
+                .join(", ");
+            declaration.push('(');
+            declaration.push_str(&rendered_fields);
+            declaration.push_str(");");
+        }
+        StructKind::Plain { fields, .. } => {
+            declaration.push_str(" {\n");
+            for field in fields
+                .iter()
+                .filter_map(|field_id| krate.index.get(field_id))
+            {
+                if let Some(field_line) = render_named_field(field) {
+                    declaration.push_str("    ");
+                    declaration.push_str(&field_line);
+                    declaration.push('\n');
+                }
+            }
+            declaration.push('}');
+        }
+    }
+
+    declaration
+}
+
+fn render_union_declaration(krate: &Crate, item: &Item, union_item: &Union) -> String {
+    let mut declaration = format!(
+        "pub union {}{}",
+        item.name.as_deref().unwrap_or("UnknownUnion"),
+        render_generics_declaration(&union_item.generics)
+    );
+    declaration.push_str(&render_where_clause(&union_item.generics.where_predicates));
+    declaration.push_str(" {\n");
+    for field in union_item
+        .fields
+        .iter()
+        .filter_map(|field_id| krate.index.get(field_id))
+    {
+        if let Some(field_line) = render_named_field(field) {
+            declaration.push_str("    ");
+            declaration.push_str(&field_line);
+            declaration.push('\n');
+        }
+    }
+    declaration.push('}');
+    declaration
+}
+
+fn render_enum_declaration(krate: &Crate, item: &Item, enum_item: &rustdoc_types::Enum) -> String {
+    let mut declaration = format!(
+        "pub enum {}{}",
+        item.name.as_deref().unwrap_or("UnknownEnum"),
+        render_generics_declaration(&enum_item.generics)
+    );
+    declaration.push_str(&render_where_clause(&enum_item.generics.where_predicates));
+    declaration.push_str(" {\n");
+    for variant_id in &enum_item.variants {
+        if let Some(variant_item) = krate.index.get(variant_id) {
+            declaration.push_str("    ");
+            declaration.push_str(&render_variant(krate, variant_item));
+            declaration.push('\n');
+        }
+    }
+    declaration.push('}');
+    declaration
+}
+
+fn render_variant(krate: &Crate, variant_item: &Item) -> String {
+    let name = variant_item.name.as_deref().unwrap_or("UnknownVariant");
+    let ItemEnum::Variant(Variant { kind, discriminant }) = &variant_item.inner else {
+        return name.to_string();
+    };
+
+    let mut declaration = String::from(name);
+    match kind {
+        VariantKind::Plain => {}
+        VariantKind::Tuple(fields) => {
+            declaration.push('(');
+            declaration.push_str(
+                &fields
+                    .iter()
+                    .filter_map(|field_id| field_id.as_ref())
+                    .filter_map(|field_id| krate.index.get(field_id))
+                    .filter_map(render_tuple_field)
+                    .collect::<Vec<String>>()
+                    .join(", "),
+            );
+            declaration.push(')');
+        }
+        VariantKind::Struct { fields, .. } => {
+            declaration.push_str(" { ");
+            declaration.push_str(
+                &fields
+                    .iter()
+                    .filter_map(|field_id| krate.index.get(field_id))
+                    .filter_map(render_named_field)
+                    .collect::<Vec<String>>()
+                    .join(", "),
+            );
+            declaration.push_str(" }");
+        }
+    }
+
+    if let Some(discriminant) = discriminant {
+        declaration.push_str(" = ");
+        declaration.push_str(&discriminant.expr);
+    }
+
+    declaration.push(',');
+    declaration
+}
+
+fn render_trait_declaration(_krate: &Crate, item: &Item, trait_item: &Trait) -> String {
+    let mut declaration = String::from("pub ");
+    if trait_item.is_unsafe {
+        declaration.push_str("unsafe ");
+    }
+    if trait_item.is_auto {
+        declaration.push_str("auto ");
+    }
+    declaration.push_str("trait ");
+    declaration.push_str(item.name.as_deref().unwrap_or("UnknownTrait"));
+    declaration.push_str(&render_generics_declaration(&trait_item.generics));
+
+    if !trait_item.bounds.is_empty() {
+        declaration.push_str(": ");
+        declaration.push_str(
+            &trait_item
+                .bounds
+                .iter()
+                .map(render_generic_bound)
+                .collect::<Vec<String>>()
+                .join(" + "),
+        );
+    }
+
+    declaration.push_str(&render_where_clause(&trait_item.generics.where_predicates));
+    declaration.push_str(" {");
+    declaration
+}
+
+fn render_trait_alias_declaration(item: &Item, trait_alias: &TraitAlias) -> String {
+    let mut declaration = format!(
+        "pub trait {}{} = ",
+        item.name.as_deref().unwrap_or("UnknownTraitAlias"),
+        render_generics_declaration(&trait_alias.generics)
+    );
+    declaration.push_str(
+        &trait_alias
+            .params
+            .iter()
+            .map(render_generic_bound)
+            .collect::<Vec<String>>()
+            .join(" + "),
+    );
+    declaration.push_str(&render_where_clause(&trait_alias.generics.where_predicates));
+    declaration.push(';');
+    declaration
+}
+
+fn render_type_alias_declaration(item: &Item, type_alias: &TypeAlias) -> String {
+    let mut declaration = format!(
+        "pub type {}{} = {}",
+        item.name.as_deref().unwrap_or("UnknownTypeAlias"),
+        render_generics_declaration(&type_alias.generics),
+        render_type(&type_alias.type_)
+    );
+    declaration.push_str(&render_where_clause(&type_alias.generics.where_predicates));
+    declaration.push(';');
+    declaration
+}
+
+fn render_const_declaration(item: &Item, type_: &Type, const_: &Constant) -> String {
+    format!(
+        "pub const {}: {} = {};",
+        item.name.as_deref().unwrap_or("UNKNOWN_CONST"),
+        render_type(type_),
+        const_.expr
+    )
+}
+
+fn render_static_declaration(item: &Item, static_item: &Static) -> String {
+    format!(
+        "pub {}static {}{}: {} = {};",
+        if static_item.is_unsafe { "unsafe " } else { "" },
+        if static_item.is_mutable { "mut " } else { "" },
+        item.name.as_deref().unwrap_or("UNKNOWN_STATIC"),
+        render_type(&static_item.type_),
+        static_item.expr
+    )
+}
+
+fn render_assoc_const(name: &str, type_: &Type, value: Option<&str>) -> String {
+    match value {
+        Some(value) => format!("const {name}: {} = {value};", render_type(type_)),
+        None => format!("const {name}: {};", render_type(type_)),
+    }
+}
+
+fn render_assoc_type(
+    name: &str,
+    generics: &rustdoc_types::Generics,
+    bounds: &[GenericBound],
+    type_: Option<&Type>,
+) -> String {
+    let mut declaration = format!("type {name}{}", render_generics_declaration(generics));
+    if !bounds.is_empty() {
+        declaration.push_str(": ");
+        declaration.push_str(
+            &bounds
+                .iter()
+                .map(render_generic_bound)
+                .collect::<Vec<String>>()
+                .join(" + "),
+        );
+    }
+    if let Some(type_) = type_ {
+        declaration.push_str(" = ");
+        declaration.push_str(&render_type(type_));
+    }
+    declaration.push_str(&render_where_clause(&generics.where_predicates));
+    declaration.push(';');
+    declaration
+}
+
+fn render_tuple_field(field_item: &Item) -> Option<String> {
+    let ItemEnum::StructField(type_) = &field_item.inner else {
+        return None;
+    };
+
+    let mut field = String::new();
+    if matches!(field_item.visibility, Visibility::Public) {
+        field.push_str("pub ");
+    }
+    field.push_str(&render_type(type_));
+    Some(field)
+}
+
+fn render_named_field(field_item: &Item) -> Option<String> {
+    let ItemEnum::StructField(type_) = &field_item.inner else {
+        return None;
+    };
+
+    let mut field = String::new();
+    if matches!(field_item.visibility, Visibility::Public) {
+        field.push_str("pub ");
+    }
+    field.push_str(field_item.name.as_deref().unwrap_or("unknown_field"));
+    field.push_str(": ");
+    field.push_str(&render_type(type_));
+    field.push(',');
+    Some(field)
+}
+
+fn render_generics_declaration(generics: &rustdoc_types::Generics) -> String {
+    render_generics_declaration_with_elision(generics, &HashSet::new())
+}
+
+fn render_generics_declaration_with_elision(
+    generics: &rustdoc_types::Generics,
+    synthetic_lifetimes: &HashSet<String>,
+) -> String {
+    let rendered_params = generics
+        .params
+        .iter()
+        .filter(|param| !synthetic_lifetimes.contains(&param.name))
+        .map(|param| render_generic_param_with_elision(param, synthetic_lifetimes))
+        .filter(|param| !param.is_empty())
+        .collect::<Vec<String>>();
+    if rendered_params.is_empty() {
+        String::new()
+    } else {
+        format!("<{}>", rendered_params.join(", "))
+    }
+}
+
+fn render_generic_param_with_elision(
+    param: &GenericParamDef,
+    synthetic_lifetimes: &HashSet<String>,
+) -> String {
+    if synthetic_lifetimes.contains(&param.name) {
+        return String::new();
+    }
+
+    match &param.kind {
+        GenericParamDefKind::Lifetime { outlives } => {
+            let filtered = outlives
+                .iter()
+                .filter(|lifetime| !synthetic_lifetimes.contains(*lifetime))
+                .cloned()
+                .collect::<Vec<String>>();
+            if filtered.is_empty() {
+                param.name.clone()
+            } else {
+                format!("{}: {}", param.name, filtered.join(" + "))
+            }
+        }
+        GenericParamDefKind::Type {
+            bounds,
+            default,
+            is_synthetic: _,
+        } => {
+            let mut rendered = param.name.clone();
+            let rendered_bounds = bounds
+                .iter()
+                .map(|bound| render_generic_bound_with_elision(bound, synthetic_lifetimes))
+                .filter(|bound| !bound.is_empty())
+                .collect::<Vec<String>>();
+            if !rendered_bounds.is_empty() {
+                rendered.push_str(": ");
+                rendered.push_str(&rendered_bounds.join(" + "));
+            }
+            if let Some(default) = default {
+                rendered.push_str(" = ");
+                rendered.push_str(&render_type_with_elision(default, synthetic_lifetimes));
+            }
+            rendered
+        }
+        GenericParamDefKind::Const { type_, default } => {
+            let mut rendered = format!(
+                "const {}: {}",
+                param.name,
+                render_type_with_elision(type_, synthetic_lifetimes)
+            );
+            if let Some(default) = default {
+                rendered.push_str(" = ");
+                rendered.push_str(default);
+            }
+            rendered
+        }
+    }
+}
+
+fn render_where_clause(predicates: &[WherePredicate]) -> String {
+    render_where_clause_with_elision(predicates, &HashSet::new())
+}
+
+fn render_where_clause_with_elision(
+    predicates: &[WherePredicate],
+    synthetic_lifetimes: &HashSet<String>,
+) -> String {
+    let rendered_predicates = predicates
+        .iter()
+        .filter_map(|predicate| render_where_predicate_with_elision(predicate, synthetic_lifetimes))
+        .collect::<Vec<String>>();
+    if rendered_predicates.is_empty() {
+        String::new()
+    } else {
+        format!(" where {}", rendered_predicates.join(", "))
+    }
+}
+
+fn render_where_predicate_with_elision(
+    predicate: &WherePredicate,
+    synthetic_lifetimes: &HashSet<String>,
+) -> Option<String> {
+    match predicate {
+        WherePredicate::BoundPredicate {
+            type_,
+            bounds,
+            generic_params,
+        } => {
+            let rendered_generic_params = generic_params
+                .iter()
+                .filter(|param| !synthetic_lifetimes.contains(&param.name))
+                .map(|param| render_generic_param_with_elision(param, synthetic_lifetimes))
+                .filter(|param| !param.is_empty())
+                .collect::<Vec<String>>();
+            let prefix = if rendered_generic_params.is_empty() {
+                String::new()
+            } else {
+                format!("for<{}> ", rendered_generic_params.join(", "))
+            };
+            let rendered_bounds = bounds
+                .iter()
+                .map(|bound| render_generic_bound_with_elision(bound, synthetic_lifetimes))
+                .filter(|bound| !bound.is_empty())
+                .collect::<Vec<String>>();
+            if rendered_bounds.is_empty() {
+                None
+            } else {
+                Some(format!(
+                    "{prefix}{}: {}",
+                    render_type_with_elision(type_, synthetic_lifetimes),
+                    rendered_bounds.join(" + ")
+                ))
+            }
+        }
+        WherePredicate::LifetimePredicate { lifetime, outlives } => {
+            if synthetic_lifetimes.contains(lifetime) {
+                return None;
+            }
+            let filtered = outlives
+                .iter()
+                .filter(|outlives| !synthetic_lifetimes.contains(*outlives))
+                .cloned()
+                .collect::<Vec<String>>();
+            if filtered.is_empty() {
+                None
+            } else {
+                Some(format!("{lifetime}: {}", filtered.join(" + ")))
+            }
+        }
+        WherePredicate::EqPredicate { lhs, rhs } => Some(format!(
+            "{} = {}",
+            render_type_with_elision(lhs, synthetic_lifetimes),
+            render_term_with_elision(rhs, synthetic_lifetimes)
+        )),
+    }
+}
+
+fn render_generic_bound(bound: &GenericBound) -> String {
+    render_generic_bound_with_elision(bound, &HashSet::new())
+}
+
+fn render_generic_bound_with_elision(
+    bound: &GenericBound,
+    synthetic_lifetimes: &HashSet<String>,
+) -> String {
+    match bound {
+        GenericBound::TraitBound {
+            trait_,
+            generic_params,
+            modifier,
+        } => {
+            let rendered_generic_params = generic_params
+                .iter()
+                .filter(|param| !synthetic_lifetimes.contains(&param.name))
+                .map(|param| render_generic_param_with_elision(param, synthetic_lifetimes))
+                .filter(|param| !param.is_empty())
+                .collect::<Vec<String>>();
+            let prefix = if rendered_generic_params.is_empty() {
+                String::new()
+            } else {
+                format!("for<{}> ", rendered_generic_params.join(", "))
+            };
+            let modifier = match modifier {
+                rustdoc_types::TraitBoundModifier::None => "",
+                rustdoc_types::TraitBoundModifier::Maybe => "?",
+                rustdoc_types::TraitBoundModifier::MaybeConst => "const ",
+            };
+            format!(
+                "{prefix}{modifier}{}",
+                render_path_with_elision(trait_, synthetic_lifetimes)
+            )
+        }
+        GenericBound::Outlives(lifetime) => {
+            if synthetic_lifetimes.contains(lifetime) {
+                String::new()
+            } else {
+                lifetime.clone()
+            }
+        }
+        GenericBound::Use(args) => {
+            let rendered = args
+                .iter()
+                .map(|arg| match arg {
+                    rustdoc_types::PreciseCapturingArg::Lifetime(lifetime) => {
+                        if synthetic_lifetimes.contains(lifetime) {
+                            "'_".to_string()
+                        } else {
+                            lifetime.clone()
+                        }
+                    }
+                    rustdoc_types::PreciseCapturingArg::Param(param) => param.clone(),
+                })
+                .collect::<Vec<String>>()
+                .join(", ");
+            format!("use<{rendered}>")
+        }
+    }
+}
+
+fn render_term_with_elision(term: &Term, synthetic_lifetimes: &HashSet<String>) -> String {
+    match term {
+        Term::Type(type_) => render_type_with_elision(type_, synthetic_lifetimes),
+        Term::Constant(constant) => constant.expr.clone(),
+    }
+}
+
+fn render_type(type_: &Type) -> String {
+    render_type_with_elision(type_, &HashSet::new())
+}
+
+fn render_type_with_elision(type_: &Type, synthetic_lifetimes: &HashSet<String>) -> String {
+    match type_ {
+        Type::ResolvedPath(path) => render_path_with_elision(path, synthetic_lifetimes),
+        Type::DynTrait(dyn_trait) => {
+            let mut rendered = String::from("dyn ");
+            rendered.push_str(
+                &dyn_trait
+                    .traits
+                    .iter()
+                    .map(|trait_| {
+                        let rendered_generic_params = trait_
+                            .generic_params
+                            .iter()
+                            .filter(|param| !synthetic_lifetimes.contains(&param.name))
+                            .map(|param| {
+                                render_generic_param_with_elision(param, synthetic_lifetimes)
+                            })
+                            .filter(|param| !param.is_empty())
+                            .collect::<Vec<String>>();
+                        let prefix = if rendered_generic_params.is_empty() {
+                            String::new()
+                        } else {
+                            format!("for<{}> ", rendered_generic_params.join(", "))
+                        };
+                        format!(
+                            "{prefix}{}",
+                            render_path_with_elision(&trait_.trait_, synthetic_lifetimes)
+                        )
+                    })
+                    .collect::<Vec<String>>()
+                    .join(" + "),
+            );
+            if let Some(lifetime) = &dyn_trait.lifetime {
+                if !synthetic_lifetimes.contains(lifetime) {
+                    rendered.push_str(" + ");
+                    rendered.push_str(lifetime);
+                }
+            }
+            rendered
+        }
+        Type::Generic(name) => name.clone(),
+        Type::Primitive(name) => name.clone(),
+        Type::FunctionPointer(pointer) => {
+            let mut rendered = render_function_header(&pointer.header);
+            rendered.push_str("fn");
+            let rendered_generic_params = pointer
+                .generic_params
+                .iter()
+                .filter(|param| !synthetic_lifetimes.contains(&param.name))
+                .map(|param| render_generic_param_with_elision(param, synthetic_lifetimes))
+                .filter(|param| !param.is_empty())
+                .collect::<Vec<String>>();
+            if !rendered_generic_params.is_empty() {
+                rendered.push_str(&format!("<{}>", rendered_generic_params.join(", ")));
+            }
+            rendered.push('(');
+            rendered.push_str(
+                &pointer
+                    .sig
+                    .inputs
+                    .iter()
+                    .map(|(_, type_)| render_type_with_elision(type_, synthetic_lifetimes))
+                    .collect::<Vec<String>>()
+                    .join(", "),
+            );
+            if pointer.sig.is_c_variadic {
+                if !pointer.sig.inputs.is_empty() {
+                    rendered.push_str(", ...");
+                } else {
+                    rendered.push_str("...");
+                }
+            }
+            rendered.push(')');
+            if let Some(output) = &pointer.sig.output {
+                rendered.push_str(" -> ");
+                rendered.push_str(&render_type_with_elision(output, synthetic_lifetimes));
+            }
+            rendered
+        }
+        Type::Tuple(types) => format!(
+            "({})",
+            types
+                .iter()
+                .map(|type_| render_type_with_elision(type_, synthetic_lifetimes))
+                .collect::<Vec<String>>()
+                .join(", ")
+        ),
+        Type::Slice(type_) => format!("[{}]", render_type_with_elision(type_, synthetic_lifetimes)),
+        Type::Array { type_, len } => {
+            format!(
+                "[{}; {len}]",
+                render_type_with_elision(type_, synthetic_lifetimes)
+            )
+        }
+        Type::Pat { type_, .. } => render_type_with_elision(type_, synthetic_lifetimes),
+        Type::ImplTrait(bounds) => format!(
+            "impl {}",
+            bounds
+                .iter()
+                .map(|bound| render_generic_bound_with_elision(bound, synthetic_lifetimes))
+                .filter(|bound| !bound.is_empty())
+                .collect::<Vec<String>>()
+                .join(" + ")
+        ),
+        Type::Infer => "_".to_string(),
+        Type::RawPointer { is_mutable, type_ } => {
+            format!(
+                "*{} {}",
+                if *is_mutable { "mut" } else { "const" },
+                render_type_with_elision(type_, synthetic_lifetimes)
+            )
+        }
+        Type::BorrowedRef {
+            lifetime,
+            is_mutable,
+            type_,
+        } => {
+            let mut rendered = String::from("&");
+            if let Some(lifetime) = lifetime {
+                if !synthetic_lifetimes.contains(lifetime) {
+                    rendered.push_str(lifetime);
+                    rendered.push(' ');
+                }
+            }
+            if *is_mutable {
+                rendered.push_str("mut ");
+            }
+            rendered.push_str(&render_type_with_elision(type_, synthetic_lifetimes));
+            rendered
+        }
+        Type::QualifiedPath {
+            name,
+            args,
+            self_type,
+            trait_,
+        } => {
+            let mut rendered = format!(
+                "<{}",
+                render_type_with_elision(self_type, synthetic_lifetimes)
+            );
+            if let Some(trait_) = trait_ {
+                rendered.push_str(" as ");
+                rendered.push_str(&render_path_with_elision(trait_, synthetic_lifetimes));
+            }
+            rendered.push_str(">::");
+            rendered.push_str(name);
+            rendered.push_str(&render_generic_args_with_elision(args, synthetic_lifetimes));
+            rendered
+        }
+    }
+}
+
+fn render_path_with_elision(path: &Path, synthetic_lifetimes: &HashSet<String>) -> String {
+    let mut rendered = path.path.clone();
+    if let Some(args) = &path.args {
+        rendered.push_str(&render_generic_args_with_elision(args, synthetic_lifetimes));
+    }
+    rendered
+}
+
+fn render_generic_args_with_elision(
+    args: &GenericArgs,
+    synthetic_lifetimes: &HashSet<String>,
+) -> String {
+    match args {
+        GenericArgs::AngleBracketed { args, constraints } => {
+            let mut rendered_args = args
+                .iter()
+                .map(|arg| render_generic_arg_with_elision(arg, synthetic_lifetimes))
+                .collect::<Vec<String>>();
+            rendered_args.extend(constraints.iter().map(|constraint| {
+                render_assoc_constraint_with_elision(constraint, synthetic_lifetimes)
+            }));
+            if rendered_args.is_empty() {
+                String::new()
+            } else {
+                format!("<{}>", rendered_args.join(", "))
+            }
+        }
+        GenericArgs::Parenthesized { inputs, output } => {
+            let mut rendered = format!(
+                "({})",
+                inputs
+                    .iter()
+                    .map(|type_| render_type_with_elision(type_, synthetic_lifetimes))
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            );
+            if let Some(output) = output {
+                rendered.push_str(" -> ");
+                rendered.push_str(&render_type_with_elision(output, synthetic_lifetimes));
+            }
+            rendered
+        }
+        GenericArgs::ReturnTypeNotation => "(..)".to_string(),
+    }
+}
+
+fn render_generic_arg_with_elision(
+    arg: &GenericArg,
+    synthetic_lifetimes: &HashSet<String>,
+) -> String {
+    match arg {
+        GenericArg::Lifetime(lifetime) => {
+            if synthetic_lifetimes.contains(lifetime) {
+                "'_".to_string()
+            } else {
+                lifetime.clone()
+            }
+        }
+        GenericArg::Type(type_) => render_type_with_elision(type_, synthetic_lifetimes),
+        GenericArg::Const(constant) => constant.expr.clone(),
+        GenericArg::Infer => "_".to_string(),
+    }
+}
+
+fn render_assoc_constraint_with_elision(
+    constraint: &rustdoc_types::AssocItemConstraint,
+    synthetic_lifetimes: &HashSet<String>,
+) -> String {
+    let mut rendered = constraint.name.clone();
+    rendered.push_str(&render_generic_args_with_elision(
+        &constraint.args,
+        synthetic_lifetimes,
+    ));
+    match &constraint.binding {
+        rustdoc_types::AssocItemConstraintKind::Equality(term) => {
+            rendered.push_str(" = ");
+            rendered.push_str(&render_term_with_elision(term, synthetic_lifetimes));
+        }
+        rustdoc_types::AssocItemConstraintKind::Constraint(bounds) => {
+            rendered.push_str(": ");
+            rendered.push_str(
+                &bounds
+                    .iter()
+                    .map(|bound| render_generic_bound_with_elision(bound, synthetic_lifetimes))
+                    .filter(|bound| !bound.is_empty())
+                    .collect::<Vec<String>>()
+                    .join(" + "),
+            );
+        }
+    }
+    rendered
+}
+
+fn trait_uses_async_trait(krate: &Crate, item: &Item) -> bool {
+    let ItemEnum::Trait(trait_item) = &item.inner else {
+        return false;
+    };
+
+    trait_item
+        .items
+        .iter()
+        .filter_map(|item_id| krate.index.get(item_id))
+        .filter_map(|item| match &item.inner {
+            ItemEnum::Function(function) => Some(function),
+            _ => None,
+        })
+        .any(function_uses_async_trait)
+}
+
+fn synthetic_async_trait_lifetimes(function: &Function) -> HashSet<String> {
+    function
+        .generics
+        .params
+        .iter()
+        .filter_map(|param| {
+            if is_synthetic_async_trait_lifetime(&param.name) {
+                Some(param.name.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn function_uses_async_trait(function: &Function) -> bool {
+    !synthetic_async_trait_lifetimes(function).is_empty()
+}
+
+fn is_synthetic_async_trait_lifetime(name: &str) -> bool {
+    name == "'async_trait"
+        || name.strip_prefix("'life").is_some_and(|suffix| {
+            !suffix.is_empty() && suffix.chars().all(|ch| ch.is_ascii_digit())
+        })
+}
+
+fn last_path_segment(path: &str) -> &str {
+    path.rsplit("::").next().unwrap_or(path)
+}

--- a/eng/tools/generate_api/src/main.rs
+++ b/eng/tools/generate_api/src/main.rs
@@ -37,7 +37,10 @@ fn run() -> Result<(), String> {
 
     let rendered = match request.format {
         cli::OutputFormat::Review => render::markdown::render(&model),
-        cli::OutputFormat::Apiview => render::apiview::render(&model)?,
+        cli::OutputFormat::Apiview => {
+            let options = render::apiview::RenderOptions::new(!request.no_docs);
+            render::apiview::render(&model, &options)?
+        }
     };
 
     output::write_file(&output_path, &rendered)?;

--- a/eng/tools/generate_api/src/main.rs
+++ b/eng/tools/generate_api/src/main.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+mod cli;
+mod diagnostics;
+mod driver;
+mod extract;
+mod model;
+mod output;
+mod render;
+
+use std::path::Path;
+
+fn main() {
+    if let Err(error) = run() {
+        diagnostics::fatal(&error);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    verify_repository_root()?;
+
+    let request = cli::parse();
+    diagnostics::info(format!(
+        "Using toolchain channel: {}",
+        env!("TOOLCHAIN_CHANNEL")
+    ));
+    diagnostics::info(format!(
+        "Loading manifest: {}",
+        request.manifest_path.display()
+    ));
+
+    let model = driver::load_model(&request)?;
+    let output_path = output::output_path(&request)?;
+    diagnostics::info(format!("Generating file: {}", output_path.display()));
+
+    let rendered = match request.format {
+        cli::OutputFormat::Review => render::markdown::render(&model),
+        cli::OutputFormat::Apiview => render::apiview::render(&model)?,
+    };
+
+    output::write_file(&output_path, &rendered)?;
+    diagnostics::info(format!("Wrote file: {}", output_path.display()));
+    Ok(())
+}
+
+fn verify_repository_root() -> Result<(), String> {
+    if Path::new("eng/tools/generate_api").exists() {
+        Ok(())
+    } else {
+        Err("This tool must be run from the root of the azure-sdk-for-rust repository.".to_string())
+    }
+}

--- a/eng/tools/generate_api/src/model.rs
+++ b/eng/tools/generate_api/src/model.rs
@@ -43,6 +43,17 @@ impl ApiModule {
             .rsplit_once("::")
             .map_or(self.path.as_str(), |(_, name)| name)
     }
+
+    pub(crate) fn sorted_items(&self) -> Vec<&ApiItem> {
+        let mut items: Vec<&ApiItem> = self.items.iter().collect();
+        items.sort_by(|left, right| {
+            left.kind
+                .sort_rank()
+                .cmp(&right.kind.sort_rank())
+                .then_with(|| left.name.cmp(&right.name))
+        });
+        items
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -86,26 +97,21 @@ pub(crate) enum ApiItemKind {
 }
 
 impl ApiItemKind {
-    pub(crate) const ORDER: [Self; 13] = [
-        Self::Use,
-        Self::Macro,
-        Self::ProcMacro,
-        Self::Function,
-        Self::Struct,
-        Self::Enum,
-        Self::Trait,
-        Self::TraitAlias,
-        Self::TraitImpl,
-        Self::Union,
-        Self::TypeAlias,
-        Self::Const,
-        Self::Static,
-    ];
-
     pub(crate) fn sort_rank(self) -> usize {
-        Self::ORDER
-            .iter()
-            .position(|candidate| *candidate == self)
-            .expect("all item kinds are present in the stable ordering")
+        match self {
+            Self::Use => 0,
+            Self::Macro => 1,
+            Self::ProcMacro => 2,
+            Self::Function => 3,
+            Self::Struct => 4,
+            Self::Enum => 5,
+            Self::Trait => 6,
+            Self::TraitAlias => 7,
+            Self::TraitImpl => 8,
+            Self::Union => 9,
+            Self::TypeAlias => 10,
+            Self::Const => 11,
+            Self::Static => 12,
+        }
     }
 }

--- a/eng/tools/generate_api/src/model.rs
+++ b/eng/tools/generate_api/src/model.rs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#[derive(Debug, Clone)]
+pub(crate) struct ApiModel {
+    pub(crate) package_name: String,
+    pub(crate) package_version: String,
+    pub(crate) parser_version: String,
+    pub(crate) root_module: ApiModule,
+}
+
+impl ApiModel {
+    pub(crate) fn new(package_name: String, package_version: String) -> Self {
+        let root_module = ApiModule {
+            path: package_name.clone(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: Vec::new(),
+            modules: Vec::new(),
+        };
+
+        Self {
+            package_name,
+            package_version,
+            parser_version: env!("CARGO_PKG_VERSION").to_string(),
+            root_module,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ApiModule {
+    pub(crate) path: String,
+    pub(crate) doc_comments: Vec<String>,
+    pub(crate) attributes: Vec<ApiAttribute>,
+    pub(crate) items: Vec<ApiItem>,
+    pub(crate) modules: Vec<ApiModule>,
+}
+
+impl ApiModule {
+    pub(crate) fn local_name(&self) -> &str {
+        self.path
+            .rsplit_once("::")
+            .map_or(self.path.as_str(), |(_, name)| name)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ApiItem {
+    pub(crate) name: String,
+    pub(crate) kind: ApiItemKind,
+    pub(crate) doc_comments: Vec<String>,
+    pub(crate) attributes: Vec<ApiAttribute>,
+    pub(crate) declaration: String,
+    pub(crate) members: Vec<ApiMember>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ApiAttribute {
+    pub(crate) text: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ApiMember {
+    pub(crate) name: String,
+    pub(crate) doc_comments: Vec<String>,
+    pub(crate) attributes: Vec<ApiAttribute>,
+    pub(crate) declaration: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum ApiItemKind {
+    Use,
+    Macro,
+    ProcMacro,
+    Function,
+    Struct,
+    Enum,
+    Trait,
+    TraitAlias,
+    Union,
+    TypeAlias,
+    Const,
+    Static,
+}
+
+impl ApiItemKind {
+    pub(crate) const ORDER: [Self; 12] = [
+        Self::Use,
+        Self::Macro,
+        Self::ProcMacro,
+        Self::Function,
+        Self::Struct,
+        Self::Enum,
+        Self::Trait,
+        Self::TraitAlias,
+        Self::Union,
+        Self::TypeAlias,
+        Self::Const,
+        Self::Static,
+    ];
+
+    pub(crate) fn sort_rank(self) -> usize {
+        Self::ORDER
+            .iter()
+            .position(|candidate| *candidate == self)
+            .expect("all item kinds are present in the stable ordering")
+    }
+}

--- a/eng/tools/generate_api/src/model.rs
+++ b/eng/tools/generate_api/src/model.rs
@@ -78,6 +78,7 @@ pub(crate) enum ApiItemKind {
     Enum,
     Trait,
     TraitAlias,
+    TraitImpl,
     Union,
     TypeAlias,
     Const,
@@ -85,7 +86,7 @@ pub(crate) enum ApiItemKind {
 }
 
 impl ApiItemKind {
-    pub(crate) const ORDER: [Self; 12] = [
+    pub(crate) const ORDER: [Self; 13] = [
         Self::Use,
         Self::Macro,
         Self::ProcMacro,
@@ -94,6 +95,7 @@ impl ApiItemKind {
         Self::Enum,
         Self::Trait,
         Self::TraitAlias,
+        Self::TraitImpl,
         Self::Union,
         Self::TypeAlias,
         Self::Const,

--- a/eng/tools/generate_api/src/output.rs
+++ b/eng/tools/generate_api/src/output.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use crate::cli::Request;
+use std::{fs, path::PathBuf};
+
+pub(crate) fn output_path(request: &Request) -> Result<PathBuf, String> {
+    fs::create_dir_all(&request.output_dir).map_err(|error| {
+        format!(
+            "Failed to create output directory '{}': {error}",
+            request.output_dir.display()
+        )
+    })?;
+
+    Ok(request.output_dir.join(request.format.default_file_name()))
+}
+
+pub(crate) fn write_file(path: &PathBuf, contents: &str) -> Result<(), String> {
+    fs::write(path, contents)
+        .map_err(|error| format!("Failed to write output file '{}': {error}", path.display()))
+}

--- a/eng/tools/generate_api/src/output.rs
+++ b/eng/tools/generate_api/src/output.rs
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 
 use crate::cli::Request;
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 pub(crate) fn output_path(request: &Request) -> Result<PathBuf, String> {
     fs::create_dir_all(&request.output_dir).map_err(|error| {
@@ -15,7 +18,7 @@ pub(crate) fn output_path(request: &Request) -> Result<PathBuf, String> {
     Ok(request.output_dir.join(request.format.default_file_name()))
 }
 
-pub(crate) fn write_file(path: &PathBuf, contents: &str) -> Result<(), String> {
+pub(crate) fn write_file(path: &Path, contents: &str) -> Result<(), String> {
     fs::write(path, contents)
         .map_err(|error| format!("Failed to write output file '{}': {error}", path.display()))
 }

--- a/eng/tools/generate_api/src/render/apiview.rs
+++ b/eng/tools/generate_api/src/render/apiview.rs
@@ -469,7 +469,7 @@ mod tests {
                     name: "fmt".to_string(),
                     doc_comments: Vec::new(),
                     attributes: Vec::new(),
-                    declaration: "fn fmt(self: &Self, f: &mut fmt::Formatter) -> fmt::Result;"
+                    declaration: "fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result;"
                         .to_string(),
                 }],
             }],
@@ -506,10 +506,8 @@ mod tests {
                 (token_kind::KEYWORD, "fn"),
                 (token_kind::MEMBER_NAME, "fmt"),
                 (token_kind::PUNCTUATION, "("),
-                (token_kind::KEYWORD, "self"),
-                (token_kind::PUNCTUATION, ":"),
                 (token_kind::PUNCTUATION, "&"),
-                (token_kind::KEYWORD, "Self"),
+                (token_kind::KEYWORD, "self"),
                 (token_kind::PUNCTUATION, ","),
                 (token_kind::TYPE_NAME, "f"),
                 (token_kind::PUNCTUATION, ":"),

--- a/eng/tools/generate_api/src/render/apiview.rs
+++ b/eng/tools/generate_api/src/render/apiview.rs
@@ -60,7 +60,7 @@ pub(crate) fn render(model: &ApiModel) -> Result<String, String> {
         package_version: &model.package_version,
         parser_version: &model.parser_version,
         language: "Rust",
-        review_lines: render_root_module(&model.root_module),
+        review_lines: render_module_contents(&model.root_module),
     };
     validate_code_file(&document)?;
 
@@ -103,10 +103,6 @@ fn validate_review_lines(
     }
 
     Ok(())
-}
-
-fn render_root_module(module: &ApiModule) -> Vec<ReviewLine> {
-    render_module_contents(module)
 }
 
 fn render_module_contents(module: &ApiModule) -> Vec<ReviewLine> {
@@ -160,16 +156,9 @@ fn render_module(module: &ApiModule) -> Vec<ReviewLine> {
 }
 
 fn render_items(module: &ApiModule) -> Vec<ReviewLine> {
-    let mut items = module.items.clone();
-    items.sort_by(|left, right| {
-        left.kind
-            .sort_rank()
-            .cmp(&right.kind.sort_rank())
-            .then_with(|| left.name.cmp(&right.name))
-    });
-
+    let items = module.sorted_items();
     let mut lines = Vec::new();
-    for (index, item) in items.iter().enumerate() {
+    for (index, item) in items.into_iter().enumerate() {
         lines.extend(render_item(module, item, index));
     }
     lines
@@ -476,7 +465,7 @@ mod tests {
             modules: Vec::new(),
         };
 
-        let lines = render_root_module(&module);
+        let lines = render_module_contents(&module);
 
         assert_eq!(lines.len(), 3);
         assert_eq!(

--- a/eng/tools/generate_api/src/render/apiview.rs
+++ b/eng/tools/generate_api/src/render/apiview.rs
@@ -5,6 +5,23 @@ use crate::model::{ApiItem, ApiItemKind, ApiModel, ApiModule};
 use serde::Serialize;
 use std::collections::BTreeSet;
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RenderOptions {
+    pub(crate) include_docs: bool,
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self { include_docs: true }
+    }
+}
+
+impl RenderOptions {
+    pub(crate) fn new(include_docs: bool) -> Self {
+        Self { include_docs }
+    }
+}
+
 #[derive(Debug, Serialize)]
 struct CodeFile<'a> {
     #[serde(rename = "PackageName")]
@@ -54,13 +71,13 @@ struct ReviewToken {
     render_classes: Option<Vec<String>>,
 }
 
-pub(crate) fn render(model: &ApiModel) -> Result<String, String> {
+pub(crate) fn render(model: &ApiModel, options: &RenderOptions) -> Result<String, String> {
     let document = CodeFile {
         package_name: &model.package_name,
         package_version: &model.package_version,
         parser_version: &model.parser_version,
         language: "Rust",
-        review_lines: render_module_contents(&model.root_module),
+        review_lines: render_module_contents(&model.root_module, options),
     };
     validate_code_file(&document)?;
 
@@ -105,24 +122,26 @@ fn validate_review_lines(
     Ok(())
 }
 
-fn render_module_contents(module: &ApiModule) -> Vec<ReviewLine> {
-    let mut lines = render_items(module);
+fn render_module_contents(module: &ApiModule, options: &RenderOptions) -> Vec<ReviewLine> {
+    let mut lines = render_items(module, options);
     let mut child_modules = module.modules.clone();
     child_modules.sort_by(|left, right| left.path.cmp(&right.path));
     for child in &child_modules {
-        lines.extend(render_module(child));
+        lines.extend(render_module(child, options));
     }
     lines
 }
 
-fn render_module(module: &ApiModule) -> Vec<ReviewLine> {
+fn render_module(module: &ApiModule, options: &RenderOptions) -> Vec<ReviewLine> {
     let line_id = module_line_id(&module.path);
     let mut lines = Vec::new();
 
-    lines.extend(render_doc_comment_lines(
-        &module.doc_comments,
-        Some(line_id.clone()),
-    ));
+    if options.include_docs {
+        lines.extend(render_doc_comment_lines(
+            &module.doc_comments,
+            Some(line_id.clone()),
+        ));
+    }
 
     for attribute in &module.attributes {
         lines.push(ReviewLine {
@@ -141,7 +160,7 @@ fn render_module(module: &ApiModule) -> Vec<ReviewLine> {
             module.local_name(),
             token_kind::TYPE_NAME,
         ),
-        children: render_module_contents(module),
+        children: render_module_contents(module, options),
         is_context_end_line: None,
         related_to_line: None,
     });
@@ -155,24 +174,31 @@ fn render_module(module: &ApiModule) -> Vec<ReviewLine> {
     lines
 }
 
-fn render_items(module: &ApiModule) -> Vec<ReviewLine> {
+fn render_items(module: &ApiModule, options: &RenderOptions) -> Vec<ReviewLine> {
     let items = module.sorted_items();
     let mut lines = Vec::new();
     for (index, item) in items.into_iter().enumerate() {
-        lines.extend(render_item(module, item, index));
+        lines.extend(render_item(module, item, index, options));
     }
     lines
 }
 
-fn render_item(module: &ApiModule, item: &ApiItem, index: usize) -> Vec<ReviewLine> {
+fn render_item(
+    module: &ApiModule,
+    item: &ApiItem,
+    index: usize,
+    options: &RenderOptions,
+) -> Vec<ReviewLine> {
     let line_id = format!("{}.{}_{index}", module_line_id(&module.path), item.name);
     let name_token_kind = item_name_token_kind(item.kind);
     let mut lines = Vec::new();
 
-    lines.extend(render_doc_comment_lines(
-        &item.doc_comments,
-        Some(line_id.clone()),
-    ));
+    if options.include_docs {
+        lines.extend(render_doc_comment_lines(
+            &item.doc_comments,
+            Some(line_id.clone()),
+        ));
+    }
 
     for attribute in &item.attributes {
         lines.push(ReviewLine {
@@ -192,7 +218,7 @@ fn render_item(module: &ApiModule, item: &ApiItem, index: usize) -> Vec<ReviewLi
     } else {
         format!("{line_id}.impl")
     };
-    let member_lines = render_member_lines(&members, &member_related_line);
+    let member_lines = render_member_lines(&members, &member_related_line, options);
 
     for (declaration_index, declaration_line) in item.declaration.lines().enumerate() {
         if declaration_line.trim().is_empty() {
@@ -255,13 +281,16 @@ fn render_item(module: &ApiModule, item: &ApiItem, index: usize) -> Vec<ReviewLi
 fn render_member_lines(
     members: &[crate::model::ApiMember],
     related_to_line: &str,
+    options: &RenderOptions,
 ) -> Vec<ReviewLine> {
     let mut lines = Vec::new();
     for (member_index, member) in members.iter().enumerate() {
-        lines.extend(render_doc_comment_lines(
-            &member.doc_comments,
-            Some(related_to_line.to_string()),
-        ));
+        if options.include_docs {
+            lines.extend(render_doc_comment_lines(
+                &member.doc_comments,
+                Some(related_to_line.to_string()),
+            ));
+        }
 
         for attribute in &member.attributes {
             lines.push(ReviewLine {
@@ -498,7 +527,7 @@ mod tests {
             modules: Vec::new(),
         };
 
-        let lines = render_module_contents(&module);
+        let lines = render_module_contents(&module, &RenderOptions::default());
 
         assert_eq!(lines.len(), 3);
         assert_eq!(
@@ -570,7 +599,7 @@ mod tests {
             modules: Vec::new(),
         };
 
-        let lines = render_module_contents(&module);
+        let lines = render_module_contents(&module, &RenderOptions::default());
 
         assert_eq!(lines.len(), 3);
         assert_eq!(
@@ -602,5 +631,40 @@ mod tests {
             lines[2].related_to_line.as_deref(),
             Some("module.demo.Foo_0.impl")
         );
+    }
+
+    #[test]
+    fn omits_doc_comment_lines_when_docs_are_disabled() {
+        let module = ApiModule {
+            path: "demo".to_string(),
+            doc_comments: vec!["/// module docs".to_string()],
+            attributes: Vec::new(),
+            items: vec![ApiItem {
+                name: "Foo".to_string(),
+                kind: ApiItemKind::Struct,
+                doc_comments: vec!["/// item docs".to_string()],
+                attributes: Vec::new(),
+                declaration: "pub struct Foo;".to_string(),
+                members: vec![ApiMember {
+                    name: "method".to_string(),
+                    doc_comments: vec!["/// member docs".to_string()],
+                    attributes: Vec::new(),
+                    declaration: "pub fn method(&self);".to_string(),
+                }],
+            }],
+            modules: Vec::new(),
+        };
+
+        let with_docs = render_module(&module, &RenderOptions::default());
+        let without_docs = render_module(&module, &RenderOptions::new(false));
+
+        assert!(with_docs.iter().any(|line| {
+            line.tokens
+                .iter()
+                .any(|token| token.is_documentation && token.value == "/// module docs")
+        }));
+        assert!(!without_docs
+            .iter()
+            .any(|line| { line.tokens.iter().any(|token| token.is_documentation) }));
     }
 }

--- a/eng/tools/generate_api/src/render/apiview.rs
+++ b/eng/tools/generate_api/src/render/apiview.rs
@@ -1,0 +1,447 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use crate::model::{ApiItem, ApiItemKind, ApiModel, ApiModule};
+use serde::Serialize;
+use std::collections::BTreeSet;
+
+#[derive(Debug, Serialize)]
+struct CodeFile<'a> {
+    #[serde(rename = "PackageName")]
+    package_name: &'a str,
+    #[serde(rename = "PackageVersion")]
+    package_version: &'a str,
+    #[serde(rename = "ParserVersion")]
+    parser_version: &'a str,
+    #[serde(rename = "Language")]
+    language: &'static str,
+    #[serde(rename = "ReviewLines")]
+    review_lines: Vec<ReviewLine>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ReviewLine {
+    #[serde(rename = "LineId", skip_serializing_if = "Option::is_none")]
+    line_id: Option<String>,
+    #[serde(rename = "Tokens")]
+    tokens: Vec<ReviewToken>,
+    #[serde(rename = "Children", skip_serializing_if = "Vec::is_empty")]
+    children: Vec<ReviewLine>,
+    #[serde(rename = "IsContextEndLine", skip_serializing_if = "Option::is_none")]
+    is_context_end_line: Option<bool>,
+    #[serde(rename = "RelatedToLine", skip_serializing_if = "Option::is_none")]
+    related_to_line: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ReviewToken {
+    #[serde(rename = "Kind")]
+    kind: u8,
+    #[serde(rename = "Value")]
+    value: String,
+    #[serde(rename = "HasPrefixSpace")]
+    has_prefix_space: bool,
+    #[serde(rename = "HasSuffixSpace")]
+    has_suffix_space: bool,
+    #[serde(rename = "IsDocumentation", skip_serializing_if = "std::ops::Not::not")]
+    is_documentation: bool,
+    #[serde(
+        rename = "NavigationDisplayName",
+        skip_serializing_if = "Option::is_none"
+    )]
+    navigation_display_name: Option<String>,
+    #[serde(rename = "RenderClasses", skip_serializing_if = "Option::is_none")]
+    render_classes: Option<Vec<String>>,
+}
+
+pub(crate) fn render(model: &ApiModel) -> Result<String, String> {
+    let document = CodeFile {
+        package_name: &model.package_name,
+        package_version: &model.package_version,
+        parser_version: &model.parser_version,
+        language: "Rust",
+        review_lines: render_root_module(&model.root_module),
+    };
+    validate_code_file(&document)?;
+
+    serde_json::to_string_pretty(&document)
+        .map_err(|error| format!("Failed to serialize APIView JSON: {error}"))
+}
+
+fn validate_code_file(document: &CodeFile<'_>) -> Result<(), String> {
+    if document.package_name.is_empty() {
+        return Err("APIView output is missing PackageName".to_string());
+    }
+    if document.package_version.is_empty() {
+        return Err("APIView output is missing PackageVersion".to_string());
+    }
+    if document.parser_version.is_empty() {
+        return Err("APIView output is missing ParserVersion".to_string());
+    }
+
+    let mut line_ids = BTreeSet::new();
+    validate_review_lines(&document.review_lines, &mut line_ids)
+}
+
+fn validate_review_lines(
+    lines: &[ReviewLine],
+    line_ids: &mut BTreeSet<String>,
+) -> Result<(), String> {
+    for line in lines {
+        if line.tokens.is_empty() {
+            return Err("APIView output contained a review line with no tokens".to_string());
+        }
+        if let Some(line_id) = &line.line_id {
+            if !line_ids.insert(line_id.clone()) {
+                return Err(format!(
+                    "APIView output contained a duplicate LineId: {line_id}"
+                ));
+            }
+        }
+
+        validate_review_lines(&line.children, line_ids)?;
+    }
+
+    Ok(())
+}
+
+fn render_root_module(module: &ApiModule) -> Vec<ReviewLine> {
+    render_module_contents(module)
+}
+
+fn render_module_contents(module: &ApiModule) -> Vec<ReviewLine> {
+    let mut lines = render_items(module);
+    let mut child_modules = module.modules.clone();
+    child_modules.sort_by(|left, right| left.path.cmp(&right.path));
+    for child in &child_modules {
+        lines.extend(render_module(child));
+    }
+    lines
+}
+
+fn render_module(module: &ApiModule) -> Vec<ReviewLine> {
+    let line_id = module_line_id(&module.path);
+    let mut lines = Vec::new();
+
+    lines.extend(render_doc_comment_lines(
+        &module.doc_comments,
+        Some(line_id.clone()),
+    ));
+
+    for attribute in &module.attributes {
+        lines.push(ReviewLine {
+            line_id: None,
+            tokens: tokenize_line(&attribute.text, "", token_kind::TYPE_NAME),
+            children: Vec::new(),
+            is_context_end_line: None,
+            related_to_line: Some(line_id.clone()),
+        });
+    }
+
+    lines.push(ReviewLine {
+        line_id: Some(line_id.clone()),
+        tokens: tokenize_line(
+            &format!("pub mod {} {{", module.local_name()),
+            module.local_name(),
+            token_kind::TYPE_NAME,
+        ),
+        children: render_module_contents(module),
+        is_context_end_line: None,
+        related_to_line: None,
+    });
+    lines.push(ReviewLine {
+        line_id: None,
+        tokens: tokenize_line("}", "", token_kind::TYPE_NAME),
+        children: Vec::new(),
+        is_context_end_line: Some(true),
+        related_to_line: Some(line_id),
+    });
+    lines
+}
+
+fn render_items(module: &ApiModule) -> Vec<ReviewLine> {
+    let mut items = module.items.clone();
+    items.sort_by(|left, right| {
+        left.kind
+            .sort_rank()
+            .cmp(&right.kind.sort_rank())
+            .then_with(|| left.name.cmp(&right.name))
+    });
+
+    let mut lines = Vec::new();
+    for (index, item) in items.iter().enumerate() {
+        lines.extend(render_item(module, item, index));
+    }
+    lines
+}
+
+fn render_item(module: &ApiModule, item: &ApiItem, index: usize) -> Vec<ReviewLine> {
+    let line_id = format!("{}.{}_{index}", module_line_id(&module.path), item.name);
+    let name_token_kind = item_name_token_kind(item.kind);
+    let mut lines = Vec::new();
+
+    lines.extend(render_doc_comment_lines(
+        &item.doc_comments,
+        Some(line_id.clone()),
+    ));
+
+    for attribute in &item.attributes {
+        lines.push(ReviewLine {
+            line_id: None,
+            tokens: tokenize_line(&attribute.text, "", token_kind::TYPE_NAME),
+            children: Vec::new(),
+            is_context_end_line: None,
+            related_to_line: Some(line_id.clone()),
+        });
+    }
+
+    let mut children = Vec::new();
+    let mut members = item.members.clone();
+    members.sort_by(|left, right| left.name.cmp(&right.name));
+    for (member_index, member) in members.iter().enumerate() {
+        children.extend(render_doc_comment_lines(
+            &member.doc_comments,
+            Some(line_id.clone()),
+        ));
+
+        for attribute in &member.attributes {
+            children.push(ReviewLine {
+                line_id: None,
+                tokens: tokenize_line(&attribute.text, "", token_kind::TYPE_NAME),
+                children: Vec::new(),
+                is_context_end_line: None,
+                related_to_line: Some(line_id.clone()),
+            });
+        }
+
+        children.push(ReviewLine {
+            line_id: Some(format!("{line_id}.{}_{member_index}", member.name)),
+            tokens: tokenize_line(&member.declaration, &member.name, token_kind::MEMBER_NAME),
+            children: Vec::new(),
+            is_context_end_line: None,
+            related_to_line: Some(line_id.clone()),
+        });
+    }
+
+    for (declaration_index, declaration_line) in item.declaration.lines().enumerate() {
+        if declaration_line.trim().is_empty() {
+            continue;
+        }
+
+        lines.push(ReviewLine {
+            line_id: if declaration_index == 0 {
+                Some(line_id.clone())
+            } else {
+                None
+            },
+            tokens: tokenize_line(declaration_line, &item.name, name_token_kind),
+            children: if declaration_index == 0 {
+                children.clone()
+            } else {
+                Vec::new()
+            },
+            is_context_end_line: None,
+            related_to_line: if declaration_index == 0 {
+                None
+            } else {
+                Some(line_id.clone())
+            },
+        });
+    }
+
+    if item.declaration.trim_end().ends_with('{') {
+        lines.push(ReviewLine {
+            line_id: None,
+            tokens: tokenize_line("}", "", token_kind::TYPE_NAME),
+            children: Vec::new(),
+            is_context_end_line: Some(true),
+            related_to_line: Some(line_id),
+        });
+    }
+
+    lines
+}
+
+fn render_doc_comment_lines(
+    doc_comments: &[String],
+    related_to_line: Option<String>,
+) -> Vec<ReviewLine> {
+    doc_comments
+        .iter()
+        .map(|comment| ReviewLine {
+            line_id: None,
+            tokens: vec![doc_token(comment)],
+            children: Vec::new(),
+            is_context_end_line: None,
+            related_to_line: related_to_line.clone(),
+        })
+        .collect()
+}
+
+fn module_line_id(path: &str) -> String {
+    format!("module.{}", sanitize(path))
+}
+
+fn sanitize(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| match character {
+            'a'..='z' | 'A'..='Z' | '0'..='9' => character,
+            _ => '_',
+        })
+        .collect()
+}
+
+mod token_kind {
+    pub const TEXT: u8 = 0;
+    pub const PUNCTUATION: u8 = 1;
+    pub const KEYWORD: u8 = 2;
+    pub const TYPE_NAME: u8 = 3;
+    pub const MEMBER_NAME: u8 = 4;
+    pub const COMMENT: u8 = 7;
+}
+
+const RUST_KEYWORDS: &[&str] = &[
+    "as", "async", "auto", "const", "crate", "dyn", "enum", "extern", "false", "fn", "for", "impl",
+    "in", "mod", "move", "mut", "pub", "ref", "self", "Self", "static", "struct", "super", "trait",
+    "true", "type", "union", "unsafe", "use", "where",
+];
+
+fn is_rust_keyword(s: &str) -> bool {
+    RUST_KEYWORDS.contains(&s)
+}
+
+fn item_name_token_kind(kind: ApiItemKind) -> u8 {
+    match kind {
+        ApiItemKind::Function => token_kind::MEMBER_NAME,
+        _ => token_kind::TYPE_NAME,
+    }
+}
+
+fn tokenize_line(line: &str, item_name: &str, name_token_kind: u8) -> Vec<ReviewToken> {
+    let mut tokens: Vec<ReviewToken> = Vec::new();
+    let mut s = line.trim_start();
+    let mut name_emitted = false;
+
+    while !s.is_empty() {
+        let trimmed = s.trim_start();
+        let has_prefix_space = trimmed.len() < s.len() && !tokens.is_empty();
+        s = trimmed;
+
+        if s.is_empty() {
+            break;
+        }
+
+        let (kind, len) = next_token_kind(s, item_name, name_token_kind, &mut name_emitted);
+        tokens.push(ReviewToken {
+            kind,
+            value: s[..len].to_string(),
+            has_prefix_space,
+            has_suffix_space: false,
+            is_documentation: false,
+            navigation_display_name: None,
+            render_classes: None,
+        });
+        s = &s[len..];
+    }
+
+    tokens
+}
+
+fn next_token_kind(
+    s: &str,
+    item_name: &str,
+    name_token_kind: u8,
+    name_emitted: &mut bool,
+) -> (u8, usize) {
+    // Multi-character punctuation sequences
+    if s.starts_with("::") {
+        return (token_kind::PUNCTUATION, 2);
+    }
+    if s.starts_with("->") {
+        return (token_kind::PUNCTUATION, 2);
+    }
+    if s.starts_with("=>") {
+        return (token_kind::PUNCTUATION, 2);
+    }
+    if s.starts_with("..=") {
+        return (token_kind::PUNCTUATION, 3);
+    }
+    if s.starts_with("..") {
+        return (token_kind::PUNCTUATION, 2);
+    }
+
+    let ch = s.chars().next().expect("non-empty string");
+
+    // Identifier or keyword
+    if ch.is_alphabetic() || ch == '_' {
+        let end = s
+            .find(|c: char| !c.is_alphanumeric() && c != '_')
+            .unwrap_or(s.len());
+        let word = &s[..end];
+        let kind = if is_rust_keyword(word) {
+            token_kind::KEYWORD
+        } else if word == item_name && !*name_emitted {
+            *name_emitted = true;
+            name_token_kind
+        } else {
+            token_kind::TYPE_NAME
+        };
+        return (kind, end);
+    }
+
+    // Lifetime: 'a, 'static, 'async_trait, '_
+    if ch == '\'' {
+        let rest = &s[1..];
+        if rest.starts_with(|c: char| c.is_alphabetic() || c == '_') {
+            let inner_end = rest
+                .find(|c: char| !c.is_alphanumeric() && c != '_')
+                .unwrap_or(rest.len());
+            return (token_kind::TYPE_NAME, 1 + inner_end);
+        }
+        return (token_kind::PUNCTUATION, 1);
+    }
+
+    // String literal (ABI strings, default values)
+    if ch == '"' {
+        let mut end = 1;
+        let mut chars = s[1..].char_indices();
+        while let Some((i, c)) = chars.next() {
+            if c == '\\' {
+                chars.next(); // skip escaped char
+            } else if c == '"' {
+                end = 1 + i + c.len_utf8();
+                break;
+            }
+        }
+        return (token_kind::TEXT, end);
+    }
+
+    // Numeric literals (in discriminants, array lengths, const values)
+    if ch.is_ascii_digit() {
+        let end = s
+            .find(|c: char| !c.is_alphanumeric() && c != '_' && c != '.')
+            .unwrap_or(s.len());
+        return (token_kind::TEXT, end.max(1));
+    }
+
+    // Punctuation characters
+    if "{}()<>[],;=+*&|!?@#:./-\\^%~".contains(ch) {
+        return (token_kind::PUNCTUATION, ch.len_utf8());
+    }
+
+    // Anything else: single character as text
+    (token_kind::TEXT, ch.len_utf8())
+}
+
+fn doc_token(value: &str) -> ReviewToken {
+    ReviewToken {
+        kind: token_kind::COMMENT,
+        value: value.to_string(),
+        has_prefix_space: false,
+        has_suffix_space: false,
+        is_documentation: true,
+        navigation_display_name: None,
+        render_classes: None,
+    }
+}

--- a/eng/tools/generate_api/src/render/apiview.rs
+++ b/eng/tools/generate_api/src/render/apiview.rs
@@ -184,33 +184,15 @@ fn render_item(module: &ApiModule, item: &ApiItem, index: usize) -> Vec<ReviewLi
         });
     }
 
-    let mut children = Vec::new();
     let mut members = item.members.clone();
     members.sort_by(|left, right| left.name.cmp(&right.name));
-    for (member_index, member) in members.iter().enumerate() {
-        children.extend(render_doc_comment_lines(
-            &member.doc_comments,
-            Some(line_id.clone()),
-        ));
-
-        for attribute in &member.attributes {
-            children.push(ReviewLine {
-                line_id: None,
-                tokens: tokenize_line(&attribute.text, "", token_kind::TYPE_NAME),
-                children: Vec::new(),
-                is_context_end_line: None,
-                related_to_line: Some(line_id.clone()),
-            });
-        }
-
-        children.push(ReviewLine {
-            line_id: Some(format!("{line_id}.{}_{member_index}", member.name)),
-            tokens: tokenize_line(&member.declaration, &member.name, token_kind::MEMBER_NAME),
-            children: Vec::new(),
-            is_context_end_line: None,
-            related_to_line: Some(line_id.clone()),
-        });
-    }
+    let declaration_owns_members = item.declaration.trim_end().ends_with('{');
+    let member_related_line = if declaration_owns_members {
+        line_id.clone()
+    } else {
+        format!("{line_id}.impl")
+    };
+    let member_lines = render_member_lines(&members, &member_related_line);
 
     for (declaration_index, declaration_line) in item.declaration.lines().enumerate() {
         if declaration_line.trim().is_empty() {
@@ -224,8 +206,8 @@ fn render_item(module: &ApiModule, item: &ApiItem, index: usize) -> Vec<ReviewLi
                 None
             },
             tokens: tokenize_line(declaration_line, &item.name, name_token_kind),
-            children: if declaration_index == 0 {
-                children.clone()
+            children: if declaration_index == 0 && declaration_owns_members {
+                member_lines.clone()
             } else {
                 Vec::new()
             },
@@ -238,7 +220,7 @@ fn render_item(module: &ApiModule, item: &ApiItem, index: usize) -> Vec<ReviewLi
         });
     }
 
-    if item.declaration.trim_end().ends_with('{') {
+    if declaration_owns_members {
         lines.push(ReviewLine {
             line_id: None,
             tokens: tokenize_line("}", "", token_kind::TYPE_NAME),
@@ -246,8 +228,59 @@ fn render_item(module: &ApiModule, item: &ApiItem, index: usize) -> Vec<ReviewLi
             is_context_end_line: Some(true),
             related_to_line: Some(line_id),
         });
+    } else if !member_lines.is_empty() {
+        lines.push(ReviewLine {
+            line_id: Some(member_related_line.clone()),
+            tokens: tokenize_line(
+                &format!("impl {} {{", item.name),
+                &item.name,
+                token_kind::TYPE_NAME,
+            ),
+            children: member_lines,
+            is_context_end_line: None,
+            related_to_line: Some(line_id.clone()),
+        });
+        lines.push(ReviewLine {
+            line_id: None,
+            tokens: tokenize_line("}", "", token_kind::TYPE_NAME),
+            children: Vec::new(),
+            is_context_end_line: Some(true),
+            related_to_line: Some(member_related_line),
+        });
     }
 
+    lines
+}
+
+fn render_member_lines(
+    members: &[crate::model::ApiMember],
+    related_to_line: &str,
+) -> Vec<ReviewLine> {
+    let mut lines = Vec::new();
+    for (member_index, member) in members.iter().enumerate() {
+        lines.extend(render_doc_comment_lines(
+            &member.doc_comments,
+            Some(related_to_line.to_string()),
+        ));
+
+        for attribute in &member.attributes {
+            lines.push(ReviewLine {
+                line_id: None,
+                tokens: tokenize_line(&attribute.text, "", token_kind::TYPE_NAME),
+                children: Vec::new(),
+                is_context_end_line: None,
+                related_to_line: Some(related_to_line.to_string()),
+            });
+        }
+
+        lines.push(ReviewLine {
+            line_id: Some(format!("{related_to_line}.{}_{member_index}", member.name)),
+            tokens: tokenize_line(&member.declaration, &member.name, token_kind::MEMBER_NAME),
+            children: Vec::new(),
+            is_context_end_line: None,
+            related_to_line: Some(related_to_line.to_string()),
+        });
+    }
     lines
 }
 
@@ -512,6 +545,62 @@ mod tests {
                 (token_kind::TYPE_NAME, "Result"),
                 (token_kind::PUNCTUATION, ";"),
             ]
+        );
+    }
+
+    #[test]
+    fn renders_inherent_members_inside_impl_blocks() {
+        let module = ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![ApiItem {
+                name: "Foo".to_string(),
+                kind: ApiItemKind::Struct,
+                doc_comments: Vec::new(),
+                attributes: Vec::new(),
+                declaration: "pub struct Foo;".to_string(),
+                members: vec![ApiMember {
+                    name: "method".to_string(),
+                    doc_comments: Vec::new(),
+                    attributes: Vec::new(),
+                    declaration: "pub fn method(&self);".to_string(),
+                }],
+            }],
+            modules: Vec::new(),
+        };
+
+        let lines = render_module_contents(&module);
+
+        assert_eq!(lines.len(), 3);
+        assert_eq!(
+            lines[0]
+                .tokens
+                .iter()
+                .map(|token| token.value.as_str())
+                .collect::<Vec<_>>(),
+            vec!["pub", "struct", "Foo", ";"]
+        );
+        assert_eq!(
+            lines[1]
+                .tokens
+                .iter()
+                .map(|token| token.value.as_str())
+                .collect::<Vec<_>>(),
+            vec!["impl", "Foo", "{"]
+        );
+        assert_eq!(lines[1].children.len(), 1);
+        assert_eq!(
+            lines[1].children[0]
+                .tokens
+                .iter()
+                .map(|token| token.value.as_str())
+                .collect::<Vec<_>>(),
+            vec!["pub", "fn", "method", "(", "&", "self", ")", ";"]
+        );
+        assert_eq!(
+            lines[2].related_to_line.as_deref(),
+            Some("module.demo.Foo_0.impl")
         );
     }
 }

--- a/eng/tools/generate_api/src/render/apiview.rs
+++ b/eng/tools/generate_api/src/render/apiview.rs
@@ -302,9 +302,9 @@ mod token_kind {
 }
 
 const RUST_KEYWORDS: &[&str] = &[
-    "as", "async", "auto", "const", "crate", "dyn", "enum", "extern", "false", "fn", "for", "impl",
-    "in", "mod", "move", "mut", "pub", "ref", "self", "Self", "static", "struct", "super", "trait",
-    "true", "type", "union", "unsafe", "use", "where",
+    "as", "async", "auto", "const", "crate", "derive", "dyn", "enum", "extern", "false", "fn",
+    "for", "impl", "in", "mod", "move", "mut", "pub", "ref", "self", "Self", "static", "struct",
+    "super", "trait", "true", "type", "union", "unsafe", "use", "where",
 ];
 
 fn is_rust_keyword(s: &str) -> bool {
@@ -443,5 +443,88 @@ fn doc_token(value: &str) -> ReviewToken {
         is_documentation: true,
         navigation_display_name: None,
         render_classes: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ApiAttribute, ApiMember};
+
+    #[test]
+    fn renders_trait_impl_tokens_with_typed_members() {
+        let module = ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![ApiItem {
+                name: "MyType".to_string(),
+                kind: ApiItemKind::TraitImpl,
+                doc_comments: Vec::new(),
+                attributes: vec![ApiAttribute {
+                    text: "#[cfg(feature = \"std\")]".to_string(),
+                }],
+                declaration: "impl fmt::Debug for MyType {".to_string(),
+                members: vec![ApiMember {
+                    name: "fmt".to_string(),
+                    doc_comments: Vec::new(),
+                    attributes: Vec::new(),
+                    declaration: "fn fmt(self: &Self, f: &mut fmt::Formatter) -> fmt::Result;"
+                        .to_string(),
+                }],
+            }],
+            modules: Vec::new(),
+        };
+
+        let lines = render_root_module(&module);
+
+        assert_eq!(lines.len(), 3);
+        assert_eq!(
+            lines[1]
+                .tokens
+                .iter()
+                .map(|token| (token.kind, token.value.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                (token_kind::KEYWORD, "impl"),
+                (token_kind::TYPE_NAME, "fmt"),
+                (token_kind::PUNCTUATION, "::"),
+                (token_kind::TYPE_NAME, "Debug"),
+                (token_kind::KEYWORD, "for"),
+                (token_kind::TYPE_NAME, "MyType"),
+                (token_kind::PUNCTUATION, "{"),
+            ]
+        );
+        assert_eq!(lines[1].children.len(), 1);
+        assert_eq!(
+            lines[1].children[0]
+                .tokens
+                .iter()
+                .map(|token| (token.kind, token.value.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                (token_kind::KEYWORD, "fn"),
+                (token_kind::MEMBER_NAME, "fmt"),
+                (token_kind::PUNCTUATION, "("),
+                (token_kind::KEYWORD, "self"),
+                (token_kind::PUNCTUATION, ":"),
+                (token_kind::PUNCTUATION, "&"),
+                (token_kind::KEYWORD, "Self"),
+                (token_kind::PUNCTUATION, ","),
+                (token_kind::TYPE_NAME, "f"),
+                (token_kind::PUNCTUATION, ":"),
+                (token_kind::PUNCTUATION, "&"),
+                (token_kind::KEYWORD, "mut"),
+                (token_kind::TYPE_NAME, "fmt"),
+                (token_kind::PUNCTUATION, "::"),
+                (token_kind::TYPE_NAME, "Formatter"),
+                (token_kind::PUNCTUATION, ")"),
+                (token_kind::PUNCTUATION, "->"),
+                (token_kind::TYPE_NAME, "fmt"),
+                (token_kind::PUNCTUATION, "::"),
+                (token_kind::TYPE_NAME, "Result"),
+                (token_kind::PUNCTUATION, ";"),
+            ]
+        );
     }
 }

--- a/eng/tools/generate_api/src/render/markdown.rs
+++ b/eng/tools/generate_api/src/render/markdown.rs
@@ -11,13 +11,7 @@ pub(crate) fn render(model: &ApiModel) -> String {
 }
 
 fn render_module(output: &mut String, module: &ApiModule, is_root: bool, indent: usize) {
-    let mut items = module.items.clone();
-    items.sort_by(|left, right| {
-        left.kind
-            .sort_rank()
-            .cmp(&right.kind.sort_rank())
-            .then_with(|| left.name.cmp(&right.name))
-    });
+    let items = module.sorted_items();
 
     let mut modules = module.modules.clone();
     modules.sort_by(|left, right| left.path.cmp(&right.path));
@@ -34,7 +28,7 @@ fn render_module(output: &mut String, module: &ApiModule, is_root: bool, indent:
         );
     }
 
-    for item in &items {
+    for item in items {
         render_item(output, item, body_indent);
     }
 

--- a/eng/tools/generate_api/src/render/markdown.rs
+++ b/eng/tools/generate_api/src/render/markdown.rs
@@ -51,11 +51,16 @@ fn render_item(output: &mut String, item: &ApiItem, indent: usize) {
     let mut members = item.members.clone();
     members.sort_by(|left, right| left.name.cmp(&right.name));
 
-    for member in &members {
-        render_member(output, member, indent + 1);
-    }
-
     if item.declaration.trim_end().ends_with('{') {
+        for member in &members {
+            render_member(output, member, indent + 1);
+        }
+        push_line(output, indent, "}");
+    } else if !members.is_empty() {
+        push_line(output, indent, &format!("impl {} {{", item.name));
+        for member in &members {
+            render_member(output, member, indent + 1);
+        }
         push_line(output, indent, "}");
     }
 }
@@ -121,5 +126,39 @@ mod tests {
         assert!(rendered.contains("impl fmt::Debug for MyType {"));
         assert!(rendered.contains("    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result;"));
         assert!(rendered.contains("}\n```\n"));
+    }
+
+    #[test]
+    fn renders_inherent_members_inside_impl_blocks() {
+        let model = ApiModel {
+            package_name: "demo".to_string(),
+            package_version: "1.0.0".to_string(),
+            parser_version: "0.0.0".to_string(),
+            root_module: ApiModule {
+                path: "demo".to_string(),
+                doc_comments: Vec::new(),
+                attributes: Vec::new(),
+                items: vec![ApiItem {
+                    name: "Foo".to_string(),
+                    kind: ApiItemKind::Struct,
+                    doc_comments: Vec::new(),
+                    attributes: Vec::new(),
+                    declaration: "pub struct Foo;".to_string(),
+                    members: vec![ApiMember {
+                        name: "method".to_string(),
+                        doc_comments: Vec::new(),
+                        attributes: Vec::new(),
+                        declaration: "pub fn method(&self);".to_string(),
+                    }],
+                }],
+                modules: Vec::new(),
+            },
+        };
+
+        let rendered = render(&model);
+
+        assert!(rendered.contains("pub struct Foo;"));
+        assert!(rendered.contains("impl Foo {\n    pub fn method(&self);\n}"));
+        assert!(!rendered.contains("pub struct Foo;\n    pub fn method(&self);"));
     }
 }

--- a/eng/tools/generate_api/src/render/markdown.rs
+++ b/eng/tools/generate_api/src/render/markdown.rs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use crate::model::{ApiItem, ApiMember, ApiModel, ApiModule};
+
+pub(crate) fn render(model: &ApiModel) -> String {
+    let mut output = String::from("```rust\n");
+    render_module(&mut output, &model.root_module, true, 0);
+    output.push_str("```\n");
+    output
+}
+
+fn render_module(output: &mut String, module: &ApiModule, is_root: bool, indent: usize) {
+    let mut items = module.items.clone();
+    items.sort_by(|left, right| {
+        left.kind
+            .sort_rank()
+            .cmp(&right.kind.sort_rank())
+            .then_with(|| left.name.cmp(&right.name))
+    });
+
+    let mut modules = module.modules.clone();
+    modules.sort_by(|left, right| left.path.cmp(&right.path));
+
+    let body_indent = if is_root { indent } else { indent + 1 };
+    if !is_root {
+        for attribute in &module.attributes {
+            push_line(output, indent, &attribute.text);
+        }
+        push_line(
+            output,
+            indent,
+            &format!("pub mod {} {{", module.local_name()),
+        );
+    }
+
+    for item in &items {
+        render_item(output, item, body_indent);
+    }
+
+    for child in &modules {
+        render_module(output, child, false, body_indent);
+    }
+
+    if !is_root {
+        push_line(output, indent, "}");
+    }
+}
+
+fn render_item(output: &mut String, item: &ApiItem, indent: usize) {
+    for attribute in &item.attributes {
+        push_line(output, indent, &attribute.text);
+    }
+
+    push_multiline(output, indent, &item.declaration);
+
+    let mut members = item.members.clone();
+    members.sort_by(|left, right| left.name.cmp(&right.name));
+
+    for member in &members {
+        render_member(output, member, indent + 1);
+    }
+
+    if item.declaration.trim_end().ends_with('{') {
+        push_line(output, indent, "}");
+    }
+}
+
+fn render_member(output: &mut String, function: &ApiMember, indent: usize) {
+    for attribute in &function.attributes {
+        push_line(output, indent, &attribute.text);
+    }
+
+    push_multiline(output, indent, &function.declaration);
+}
+
+fn push_multiline(output: &mut String, indent: usize, text: &str) {
+    for line in text.lines() {
+        push_line(output, indent, line);
+    }
+}
+
+fn push_line(output: &mut String, indent: usize, text: &str) {
+    output.push_str(&"    ".repeat(indent));
+    output.push_str(text);
+    output.push('\n');
+}

--- a/eng/tools/generate_api/src/render/markdown.rs
+++ b/eng/tools/generate_api/src/render/markdown.rs
@@ -85,3 +85,49 @@ fn push_line(output: &mut String, indent: usize, text: &str) {
     output.push_str(text);
     output.push('\n');
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ApiAttribute, ApiItemKind};
+
+    #[test]
+    fn renders_explicit_trait_impl_blocks() {
+        let model = ApiModel {
+            package_name: "demo".to_string(),
+            package_version: "1.0.0".to_string(),
+            parser_version: "0.0.0".to_string(),
+            root_module: ApiModule {
+                path: "demo".to_string(),
+                doc_comments: Vec::new(),
+                attributes: Vec::new(),
+                items: vec![ApiItem {
+                    name: "MyType".to_string(),
+                    kind: ApiItemKind::TraitImpl,
+                    doc_comments: Vec::new(),
+                    attributes: vec![ApiAttribute {
+                        text: "#[cfg(feature = \"std\")]".to_string(),
+                    }],
+                    declaration: "impl fmt::Debug for MyType {".to_string(),
+                    members: vec![ApiMember {
+                        name: "fmt".to_string(),
+                        doc_comments: Vec::new(),
+                        attributes: Vec::new(),
+                        declaration: "fn fmt(self: &Self, f: &mut fmt::Formatter) -> fmt::Result;"
+                            .to_string(),
+                    }],
+                }],
+                modules: Vec::new(),
+            },
+        };
+
+        let rendered = render(&model);
+
+        assert!(rendered.contains("#[cfg(feature = \"std\")]"));
+        assert!(rendered.contains("impl fmt::Debug for MyType {"));
+        assert!(
+            rendered.contains("    fn fmt(self: &Self, f: &mut fmt::Formatter) -> fmt::Result;")
+        );
+        assert!(rendered.contains("}\n```\n"));
+    }
+}

--- a/eng/tools/generate_api/src/render/markdown.rs
+++ b/eng/tools/generate_api/src/render/markdown.rs
@@ -113,7 +113,7 @@ mod tests {
                         name: "fmt".to_string(),
                         doc_comments: Vec::new(),
                         attributes: Vec::new(),
-                        declaration: "fn fmt(self: &Self, f: &mut fmt::Formatter) -> fmt::Result;"
+                        declaration: "fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result;"
                             .to_string(),
                     }],
                 }],
@@ -125,9 +125,7 @@ mod tests {
 
         assert!(rendered.contains("#[cfg(feature = \"std\")]"));
         assert!(rendered.contains("impl fmt::Debug for MyType {"));
-        assert!(
-            rendered.contains("    fn fmt(self: &Self, f: &mut fmt::Formatter) -> fmt::Result;")
-        );
+        assert!(rendered.contains("    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result;"));
         assert!(rendered.contains("}\n```\n"));
     }
 }

--- a/eng/tools/generate_api/src/render/mod.rs
+++ b/eng/tools/generate_api/src/render/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+pub(crate) mod apiview;
+pub(crate) mod markdown;

--- a/eng/tools/rust-toolchain.toml
+++ b/eng/tools/rust-toolchain.toml
@@ -5,4 +5,5 @@ components = [
   "cargo",
   "rust-docs",
   "rust-std",
+  "rustc-dev",
 ]


### PR DESCRIPTION
Introduce a new command-line tool for generating API documentation in the azure-sdk-for-rust repository. This tool includes diagnostics, a model for API structure, and supports output in both APIView and Markdown formats.

Enhancements include the extraction and rendering of explicit trait implementations, ensuring accurate representation in the documentation. The Rust toolchain configuration has been updated to include the `rustc-dev` component for development purposes.

Tests have been added to verify the correct rendering of trait implementations.

This will replace generate_api_report in a subsequent PR.

Fixes Azure/azure-sdk-tools#12698
Fixes Azure/azure-sdk-tools#15383
Fixes Azure/azure-sdk-tools#15384
Fixes Azure/azure-sdk-tools#15385
Fixes Azure/azure-sdk-tools#15445

