### PR TITLE
Honor pipeline Rust toolchain overrides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -435,15 +435,22 @@ The incremented version will be a "beta" of an incrementally higher release. Thi
 
 ### Toolchains
 
-The stable and nightly Rust toolchain versions used throughout the repository are pinned to specific versions. The stable channel is pinned in `rust-toolchain.toml`; the nightly channel is pinned in `eng/scripts/Language-Settings.ps1` and in the shebang lines of the `eng/scripts/*.rs` utility scripts.
+Rust toolchain versions are pinned in a few places. In most cases, running `cargo build` or `cargo test` from the repository root or a crate directory will prompt rustup to install the required toolchain and components automatically.
 
-Project maintainers can update both channels by running:
+Current pin locations:
+
+- Stable/default toolchain: root `rust-toolchain.toml` -> `channel` e.g., `"1.95"`
+- MSRV: root `Cargo.toml` -> `rust-version` e.g., `"1.88"`
+- Nightly for `eng/scripts` and `cargo +nightly` utility scripts: `eng/scripts/Language-Settings.ps1` e.g., `"nightly-2026-04-14"`
+- Nightly for tooling under `eng/tools` such as doc and APIView generation: `eng/tools/rust-toolchain.toml` -> `channel` e.g., `"nightly-2025-05-09"`
+
+Project maintainers can update the root stable toolchain, the `eng/scripts` nightly pin, and the `eng/scripts/**/*.rs` nightly shebangs by running:
 
 ```powershell
 eng/scripts/Update-Rust.ps1
 ```
 
-This script automatically detects the latest stable release from GitHub and finds a working nightly toolchain. You can also specify either or both versions explicitly:
+This script automatically detects the latest stable release from GitHub and finds a working nightly toolchain for `eng/scripts`. You can also specify either or both versions explicitly:
 
 ```powershell
 eng/scripts/Update-Rust.ps1 -Version 1.96.0 -NightlyVersion 2026-05-01
@@ -452,6 +459,8 @@ eng/scripts/Update-Rust.ps1 -Version 1.96.0 -NightlyVersion 2026-05-01
 Outside contributors who need a newer toolchain should [open an issue](https://github.com/Azure/azure-sdk-for-rust/issues) describing specifically why the update is needed.
 
 The minimum supported Rust version (MSRV) is pinned to an older version in the root `Cargo.toml` and is updated less frequently because raising it is a breaking change. To request an MSRV bump, [open an issue](https://github.com/Azure/azure-sdk-for-rust/issues) with a clear justification for why the increase is necessary.
+
+The `eng/tools/rust-toolchain.toml` file is maintained independently because it pins the JSON output format required by tooling under `eng/tools`; `eng/scripts/Update-Rust.ps1` does not modify it.
 
 ## Samples
 

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -91,7 +91,7 @@ jobs:
 
   - task: PublishTestResults@2
     displayName: Publish Test Results
-    condition: and(succeededOrFailed(), ne(variables['NoPackagesChanged'],'true'))
+    condition: and(succeededOrFailed(), ne(variables['NoPackagesChanged'],'true'), eq(variables['HasJUnitTestResults'], 'true'))
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: '**/test-results/junit/*.xml'

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -159,7 +159,7 @@ jobs:
 
   - task: PublishTestResults@2
     displayName: Publish Test Results
-    condition: and(succeededOrFailed(), eq(variables['CI_HAS_DEPLOYED_RESOURCES'], 'true'))
+    condition: and(succeededOrFailed(), eq(variables['CI_HAS_DEPLOYED_RESOURCES'], 'true'), eq(variables['HasJUnitTestResults'], 'true'))
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: '**/test-results/junit/*.xml'

--- a/eng/pipelines/templates/steps/use-rust.yml
+++ b/eng/pipelines/templates/steps/use-rust.yml
@@ -4,8 +4,8 @@ parameters:
     default: active
     # Expected values: 'stable', 'nightly', 'msrv', 'active' or a specific toolchain version
     # 'msrv' will read the MSRV from azure_core
-    # 'active' will use the active toolchain for the working directory, which will be from rust-toolchain.toml, from a
-    #   folder override or the rustup default toolchain
+    # 'active' will use the active toolchain for the working directory, which may come from
+    #   a rustup directory override, rust-toolchain.toml, or the rustup default toolchain
   - name: MaxAttempts
     type: number
     default: 3
@@ -15,6 +15,7 @@ parameters:
   - name: SetDefault
     type: boolean
     default: true
+    # When true, Use-Rust.ps1 sets a rustup directory override for WorkingDirectory.
 
 steps:
 - task: PowerShell@2

--- a/eng/pipelines/templates/steps/use-rust.yml
+++ b/eng/pipelines/templates/steps/use-rust.yml
@@ -1,11 +1,11 @@
 parameters:
   - name: Toolchain
     type: string
-    default: active
     # Expected values: 'stable', 'nightly', 'msrv', 'active' or a specific toolchain version
     # 'msrv' will read the MSRV from azure_core
     # 'active' will use the active toolchain for the working directory, which may come from
     #   a rustup directory override, rust-toolchain.toml, or the rustup default toolchain
+    default: active
   - name: MaxAttempts
     type: number
     default: 3
@@ -14,8 +14,8 @@ parameters:
     default: $(System.DefaultWorkingDirectory)
   - name: SetDefault
     type: boolean
-    default: true
     # When true, Use-Rust.ps1 sets a rustup directory override for WorkingDirectory.
+    default: true
 
 steps:
 - task: PowerShell@2

--- a/eng/scripts/Analyze-Code.ps1
+++ b/eng/scripts/Analyze-Code.ps1
@@ -22,7 +22,8 @@ Set-StrictMode -Version 2.0
 . ([System.IO.Path]::Combine($PSScriptRoot, '..', 'common', 'scripts', 'common.ps1'))
 . ([System.IO.Path]::Combine($PSScriptRoot, 'shared', 'Cargo.ps1'))
 
-$resolvedToolchain = [Channels]::Resolve($Toolchain)
+$resolvedToolchain = Get-ResolvedRustToolchain -Toolchain $Toolchain
+$isNightlyToolchain = Test-IsNightlyRustToolchain -Toolchain $Toolchain
 
 Write-Host @"
 Analyzing code with
@@ -85,7 +86,7 @@ if (!$SkipPackageAnalysis) {
   }
 
   # Ideally would want to install this with the others, but not replicate the conditions in which the tool is run.
-  if ($Toolchain -eq 'nightly') {
+  if ($isNightlyToolchain) {
     $cargoDocsRsVersionParams = Get-VersionParamsFromCgManifest cargo-docs-rs
     Invoke-LoggedCommand "cargo install cargo-docs-rs --locked $($cargoDocsRsVersionParams -join ' ')" -GroupOutput
   }
@@ -148,7 +149,7 @@ if (!$SkipPackageAnalysis) {
     Invoke-LoggedCommand "&$verifyDependenciesScript $packageManifestPath" -GroupOutput
     Invoke-LoggedCommand "&$verifyKeywordsScript $packageManifestPath" -GroupOutput
 
-    if ($Toolchain -eq 'nightly') {
+    if ($isNightlyToolchain) {
       Invoke-LoggedCommand "cargo +$resolvedToolchain docs-rs --manifest-path $packageManifestPath" -GroupOutput
     }
 

--- a/eng/scripts/Convert-TestResultsToJUnit.ps1
+++ b/eng/scripts/Convert-TestResultsToJUnit.ps1
@@ -1,5 +1,8 @@
 #!/usr/bin/env pwsh
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 #Requires -Version 7.0
 <#
 .SYNOPSIS
@@ -23,8 +26,8 @@ The directory where JUnit XML files should be written. Defaults to test-results/
 #>
 
 param(
-  [string]$TestResultsDirectory = "$PSScriptRoot/../../test-results",
-  [string]$OutputDirectory = "$PSScriptRoot/../../test-results/junit"
+  [string]$TestResultsDirectory = ([System.IO.Path]::Combine($PSScriptRoot, '..', '..', 'test-results')),
+  [string]$OutputDirectory = ([System.IO.Path]::Combine($PSScriptRoot, '..', '..', 'test-results', 'junit'))
 )
 
 $ErrorActionPreference = 'Stop'
@@ -32,22 +35,29 @@ Set-StrictMode -Version 2.0
 . ([System.IO.Path]::Combine($PSScriptRoot, '..', 'common', 'scripts', 'common.ps1'))
 . ([System.IO.Path]::Combine($PSScriptRoot, 'shared', 'Cargo.ps1'))
 
+Write-Host "##vso[task.setvariable variable=HasJUnitTestResults]false"
 Write-Host "Converting test results from JSON to JUnit XML using cargo2junit"
 Write-Host "  Input directory:  $TestResultsDirectory"
 Write-Host "  Output directory: $OutputDirectory"
 
 if (!(Test-Path $TestResultsDirectory)) {
-  LogWarning "Test results directory not found: $TestResultsDirectory"
-  Write-Host "No test results to convert."
+  Write-Host "Skipping JUnit conversion because the test results directory does not exist."
   exit 0
 }
 
-$jsonFiles = @(Get-ChildItem -Path $TestResultsDirectory -Filter "*.json" -File)
-if ($jsonFiles.Count -eq 0) {
-  LogWarning "No JSON files found in $TestResultsDirectory"
-  Write-Host "No test results to convert."
+$allJsonFiles = @(Get-ChildItem -Path $TestResultsDirectory -Filter "*.json" -File)
+if ($allJsonFiles.Count -eq 0) {
+  Write-Host "Skipping JUnit conversion because no JSON test result files were produced."
   exit 0
 }
+
+$jsonFiles = @($allJsonFiles | Where-Object { $_.Length -gt 0 })
+if ($jsonFiles.Count -eq 0) {
+  Write-Host "Skipping JUnit conversion because all JSON test result files are empty."
+  exit 0
+}
+
+Write-Host "##vso[task.setvariable variable=HasJUnitTestResults]true"
 
 if (!(Test-Path $OutputDirectory)) {
   New-Item -ItemType Directory -Path $OutputDirectory | Out-Null

--- a/eng/scripts/Format-Code.ps1
+++ b/eng/scripts/Format-Code.ps1
@@ -25,7 +25,7 @@ Set-StrictMode -Version 2.0
 . ([System.IO.Path]::Combine($PSScriptRoot, '..', 'common', 'scripts', 'common.ps1'))
 . ([System.IO.Path]::Combine($PSScriptRoot, 'shared', 'Cargo.ps1'))
 
-$resolvedToolchain = [Channels]::Resolve($Toolchain)
+$resolvedToolchain = Get-ResolvedRustToolchain -Toolchain $Toolchain
 
 $taploCliVersionParams = Get-VersionParamsFromCgManifest taplo-cli
 Invoke-LoggedCommand "cargo install taplo-cli --locked $($taploCliVersionParams -join ' ')" -GroupOutput

--- a/eng/scripts/Test-Packages.ps1
+++ b/eng/scripts/Test-Packages.ps1
@@ -1,5 +1,8 @@
 #!/usr/bin/env pwsh
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 #Requires -Version 7.0
 param(
   [string]$PackageInfoDirectory
@@ -7,32 +10,42 @@ param(
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
-. "$PSScriptRoot/../common/scripts/common.ps1"
+. ([System.IO.Path]::Combine($PSScriptRoot, '..', 'common', 'scripts', 'common.ps1'))
 
-$resolvedToolchain = [Channels]::Nightly()
+$activeToolchain = (Invoke-LoggedCommand "rustup show active-toolchain" | Select-Object -First 1).Trim()
+$usesJsonTestOutput = $activeToolchain -match '^nightly(?:$|[-\s])'
 
-# Helper function to run cargo test with JSON output
-function Invoke-CargoTestWithJsonOutput (
+# Helper function to run cargo test, capturing JSON output only when the active
+# toolchain supports `--format json -Z unstable-options`.
+function Invoke-CargoTest (
   [string]$TestParams,
   [string]$PackageName,
   [string]$ManifestPath,
   [string]$OutputFile
 ) {
   Write-Host "Running tests for $PackageName"
-  # Use nightly toolchain to enable JSON output format which can be converted
-  # and uploaded to DevOps for display in the Tests tab
-  # (requires -Z unstable-options)
-  $result = Invoke-LoggedCommand `
-    "cargo +$resolvedToolchain test $TestParams --manifest-path $ManifestPath --all-features --no-fail-fast -- --format json -Z unstable-options" `
-    -GroupOutput `
-    -DoNotExitOnFailedExitCode
+  $command = "cargo test $TestParams --manifest-path $ManifestPath --all-features --no-fail-fast"
 
-  LogGroupStart 'Test result JSON'
-  $result | Tee-Object -FilePath $OutputFile
-  LogGroupEnd
+  if ($usesJsonTestOutput) {
+    $result = Invoke-LoggedCommand `
+      "$command -- --format json -Z unstable-options" `
+      -GroupOutput `
+      -DoNotExitOnFailedExitCode
+
+    LogGroupStart 'Test result JSON'
+    $result | Tee-Object -FilePath $OutputFile
+    LogGroupEnd
+  }
+  else {
+    Invoke-LoggedCommand $command -GroupOutput -DoNotExitOnFailedExitCode | Out-Null
+  }
 
   if ($LASTEXITCODE) {
-    LogError "Tests failed for $PackageName. For more information see the pipeline Tests tab."
+    $message = "Tests failed for $PackageName."
+    if ($usesJsonTestOutput) {
+      $message += " For more information see the pipeline Tests tab."
+    }
+    LogError $message
     exit $LASTEXITCODE
   }
 }
@@ -46,13 +59,19 @@ Testing packages with
     AZURE_TEST_MODE: '$env:AZURE_TEST_MODE'
     SYSTEM_ACCESSTOKEN: $($env:SYSTEM_ACCESSTOKEN ? 'present' : 'not present')
     ARM_OIDC_TOKEN: $($env:ARM_OIDC_TOKEN ? 'present' : 'not present')
+    Active Rust toolchain: '$activeToolchain'
 "@
 
 $testResultsDir = ([System.IO.Path]::Combine($RepoRoot, 'test-results'))
-if (!(Test-Path $testResultsDir)) {
-  New-Item -ItemType Directory -Path $testResultsDir | Out-Null
+if ($usesJsonTestOutput) {
+  if (!(Test-Path $testResultsDir)) {
+    New-Item -ItemType Directory -Path $testResultsDir | Out-Null
+  }
+  Write-Host "JSON test results will be saved to: $testResultsDir"
 }
-Write-Host "Test results will be saved to: $testResultsDir"
+else {
+  Write-Host "Skipping JSON test result capture because the active Rust toolchain is not nightly."
+}
 
 if ($PackageInfoDirectory) {
   if (!(Test-Path $PackageInfoDirectory)) {
@@ -95,14 +114,14 @@ foreach ($package in $packagesToTest) {
   $timestamp = Get-Date -Format "yyyyMMdd-HHmmss-fff"
 
   $docTestOutput = ([System.IO.Path]::Combine($testResultsDir, "$($package.Name)-doctest-$timestamp.json"))
-  Invoke-CargoTestWithJsonOutput `
+  Invoke-CargoTest `
     -TestParams "--doc" `
     -PackageName $package.Name `
     -ManifestPath $manifestPath `
     -OutputFile $docTestOutput
 
   $allTargetsOutput = ([System.IO.Path]::Combine($testResultsDir, "$($package.Name)-alltargets-$timestamp.json"))
-  Invoke-CargoTestWithJsonOutput `
+  Invoke-CargoTest `
     -TestParams "--lib --bins --tests --examples" `
     -PackageName $package.Name `
     -ManifestPath $manifestPath `

--- a/eng/scripts/Test-Packages.ps1
+++ b/eng/scripts/Test-Packages.ps1
@@ -11,9 +11,10 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 . ([System.IO.Path]::Combine($PSScriptRoot, '..', 'common', 'scripts', 'common.ps1'))
+. ([System.IO.Path]::Combine($PSScriptRoot, 'shared', 'Cargo.ps1'))
 
-$activeToolchain = (Invoke-LoggedCommand "rustup show active-toolchain" | Select-Object -First 1).Trim()
-$usesJsonTestOutput = $activeToolchain -match '^nightly(?:$|[-\s])'
+$activeToolchain = Get-ResolvedRustToolchain
+$usesJsonTestOutput = Test-IsNightlyRustToolchain
 
 # Helper function to run cargo test, capturing JSON output only when the active
 # toolchain supports `--format json -Z unstable-options`.

--- a/eng/scripts/Test-Packages.ps1
+++ b/eng/scripts/Test-Packages.ps1
@@ -37,7 +37,7 @@ function Invoke-CargoTest (
     LogGroupEnd
   }
   else {
-    Invoke-LoggedCommand $command -GroupOutput -DoNotExitOnFailedExitCode | Out-Null
+    Invoke-LoggedCommand $command -GroupOutput -DoNotExitOnFailedExitCode
   }
 
   if ($LASTEXITCODE) {

--- a/eng/scripts/Test-Semver.ps1
+++ b/eng/scripts/Test-Semver.ps1
@@ -17,7 +17,7 @@ exit 0
 . ([System.IO.Path]::Combine($PSScriptRoot, '..', 'common', 'scripts', 'common.ps1'))
 . ([System.IO.Path]::Combine($PSScriptRoot, 'shared', 'Cargo.ps1'))
 
-$resolvedToolchain = [Channels]::Resolve($Toolchain)
+$resolvedToolchain = Get-ResolvedRustToolchain -Toolchain $Toolchain
 
 function Get-OutputPackages($workspacePackages) {
   $packages = @()

--- a/eng/scripts/Update-PackageVersion.ps1
+++ b/eng/scripts/Update-PackageVersion.ps1
@@ -41,9 +41,10 @@ Param (
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
-. "$PSScriptRoot/../common/scripts/common.ps1"
+. ([System.IO.Path]::Combine($PSScriptRoot, '..', 'common', 'scripts', 'common.ps1'))
+. ([System.IO.Path]::Combine($PSScriptRoot, 'shared', 'Cargo.ps1'))
 
-$resolvedToolchain = [Channels]::Nightly()
+$resolvedToolchain = Get-ResolvedRustToolchain -Toolchain 'nightly'
 
 Write-Host "Getting package properties for $PackageName in $ServiceDirectory."
 $pkgProperties = Get-PkgProperties -PackageName $PackageName -ServiceDirectory $ServiceDirectory
@@ -77,7 +78,7 @@ if ($pkgProperties.ChangeLogPath) {
     -ReplaceLatestEntryTitle $ReplaceLatestEntryTitle -ReleaseDate $ReleaseDate
 }
 
-$tomlPath = Join-Path $pkgProperties.DirectoryPath "Cargo.toml"
+$tomlPath = ([System.IO.Path]::Combine($pkgProperties.DirectoryPath, 'Cargo.toml'))
 $content = Get-Content -Path $tomlPath -Raw
 $updated = $content -replace '(\[package\](.|\n)+?version\s*=\s*)"(.+?)"', "`$1`"$packageSemVer`""
 

--- a/eng/scripts/Use-Rust.ps1
+++ b/eng/scripts/Use-Rust.ps1
@@ -42,12 +42,22 @@ $toolchainArg = if ($Toolchain -eq 'active') {
 } else {
   Get-ResolvedRustToolchain -Toolchain $Toolchain
 }
+$installToolchainArg = if ($toolchainArg) { $toolchainArg } else { Get-ResolvedRustToolchain -Toolchain $Toolchain }
 
 $attempts = 0
 while ($true) {
   $attempts++
 
-  Invoke-LoggedCommand "rustup install --no-self-update $toolchainArg" -GroupOutput -DoNotExitOnFailedExitCode
+  $installArgs = @('--no-self-update')
+  if ($SetDefault) {
+    # Use a directory override because it takes precedence over rust-toolchain.toml:
+    # https://rust-lang.github.io/rustup/overrides.html#directory-overrides
+    # This is easier to carry through pipelines than relying on an environment
+    # variable that would need to be propagated across subsequent jobs.
+    $installArgs += '--override'
+  }
+  $installArgs += $installToolchainArg
+  Invoke-LoggedCommand "rustup install $($installArgs -join ' ')" -GroupOutput -DoNotExitOnFailedExitCode
 
   if ($LASTEXITCODE -eq 0) { break }
 
@@ -61,18 +71,6 @@ while ($true) {
   # Failures to update are usually caused by file locks on Windows.
   # Sleep for a few seconds to give the blocking process a chance to release the lock.
   Start-Sleep -Seconds 3
-}
-
-if ($SetDefault) {
-  if ($Toolchain -eq 'active') {
-    $toolchainArg = Get-ResolvedRustToolchain -Toolchain $Toolchain
-  }
-
-  # Use a directory override because it takes precedence over rust-toolchain.toml:
-  # https://rust-lang.github.io/rustup/overrides.html#directory-overrides
-  # This is easier to carry through pipelines than relying on an environment
-  # variable that would need to be propagated across subsequent jobs.
-  Invoke-LoggedCommand "rustup override set $toolchainArg" -GroupOutput
 }
 
 Invoke-LoggedCommand "rustup show" -GroupOutput

--- a/eng/scripts/Use-Rust.ps1
+++ b/eng/scripts/Use-Rust.ps1
@@ -6,7 +6,8 @@
 #Requires -Version 7.0
 param(
   # Toolchain to install: 'stable', 'nightly', 'msrv' resolve to pinned versions via [Channels];
-  # 'active' uses the toolchain from rust-toolchain.toml in the working directory;
+  # 'active' uses the current toolchain for the working directory, whether that comes
+  # from a rustup directory override, rust-toolchain.toml, or the rustup default.
   # any other value is passed through as a literal toolchain string.
   [string] $Toolchain = 'active',
   [int] $MaxAttempts = 3,
@@ -20,6 +21,7 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 
 . ([System.IO.Path]::Combine($PSScriptRoot, '..', 'common', 'scripts', 'common.ps1'))
+. ([System.IO.Path]::Combine($PSScriptRoot, 'shared', 'Cargo.ps1'))
 
 $toolchainArg = if ($Toolchain -eq 'active') {
   # Depending on the version of rustup currently installed, simply calling `rustup --version` will
@@ -38,7 +40,7 @@ $toolchainArg = if ($Toolchain -eq 'active') {
 
   ''
 } else {
-  [Channels]::Resolve($Toolchain)
+  Get-ResolvedRustToolchain -Toolchain $Toolchain
 }
 
 $attempts = 0
@@ -63,10 +65,14 @@ while ($true) {
 
 if ($SetDefault) {
   if ($Toolchain -eq 'active') {
-    $toolchainArg = rustup show active-toolchain -v | Select-Object -First 1
+    $toolchainArg = Get-ResolvedRustToolchain -Toolchain $Toolchain
   }
 
-  Invoke-LoggedCommand "rustup default $toolchainArg" -GroupOutput
+  # Use a directory override because it takes precedence over rust-toolchain.toml:
+  # https://rust-lang.github.io/rustup/overrides.html#directory-overrides
+  # This is easier to carry through pipelines than relying on an environment
+  # variable that would need to be propagated across subsequent jobs.
+  Invoke-LoggedCommand "rustup override set $toolchainArg" -GroupOutput
 }
 
 Invoke-LoggedCommand "rustup show" -GroupOutput

--- a/eng/scripts/Use-Rust.ps1
+++ b/eng/scripts/Use-Rust.ps1
@@ -48,7 +48,7 @@ $attempts = 0
 while ($true) {
   $attempts++
 
-  $installArgs = @('--no-self-update')
+  $installArgs = @('--no-self-update', '--profile', 'default')
   if ($SetDefault) {
     # Use a directory override because it takes precedence over rust-toolchain.toml:
     # https://rust-lang.github.io/rustup/overrides.html#directory-overrides

--- a/eng/scripts/shared/Cargo.ps1
+++ b/eng/scripts/shared/Cargo.ps1
@@ -1,4 +1,36 @@
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+function Get-ActiveRustToolchain(
+  [string]$ExecutePath
+) {
+  $activeToolchain = (Invoke-LoggedCommand "rustup show active-toolchain" -ExecutePath $ExecutePath | Select-Object -First 1).Trim()
+  if (!$activeToolchain) {
+    throw "Failed to determine the active Rust toolchain."
+  }
+
+  return ($activeToolchain -split '\s+')[0]
+}
+
+function Get-ResolvedRustToolchain(
+  [string]$Toolchain = 'active',
+  [string]$ExecutePath
+) {
+  if ($Toolchain -eq 'active') {
+    return Get-ActiveRustToolchain -ExecutePath $ExecutePath
+  }
+
+  return [Channels]::Resolve($Toolchain)
+}
+
+function Test-IsNightlyRustToolchain(
+  [string]$Toolchain = 'active',
+  [string]$ExecutePath
+) {
+  return (Get-ResolvedRustToolchain -Toolchain $Toolchain -ExecutePath $ExecutePath) -match '^nightly(?:$|[-])'
+}
+
 function Get-CargoMetadata() {
   cargo metadata --no-deps --format-version 1 --manifest-path "$RepoRoot/Cargo.toml" | ConvertFrom-Json -Depth 100 -AsHashtable
 }

--- a/eng/tools/rust-toolchain.toml
+++ b/eng/tools/rust-toolchain.toml
@@ -6,4 +6,5 @@ components = [
   "rust-docs",
   "rust-std",
   "rustc-dev",
+  "rustfmt",
 ]


### PR DESCRIPTION
Make pipeline-selected Rust toolchains take effect consistently across eng scripts and test jobs.

- `eng/scripts/Use-Rust.ps1`, `eng/pipelines/templates/steps/use-rust.yml`, `eng/scripts/shared/Cargo.ps1`: set a rustup directory override, document why it takes precedence over `rust-toolchain.toml`, and share helper functions for resolving the active or pinned toolchain.
- `eng/scripts/Test-Packages.ps1`, `eng/scripts/Convert-TestResultsToJUnit.ps1`, `eng/pipelines/templates/jobs/ci.tests.yml`, `eng/pipelines/templates/jobs/live.tests.yml`: only emit JSON test output on nightly toolchains and only publish JUnit results when result files were actually produced.
- `eng/scripts/Analyze-Code.ps1`, `eng/pipelines/templates/jobs/analyze.yml`, `eng/scripts/Format-Code.ps1`, `eng/scripts/Test-Semver.ps1`, `eng/scripts/Update-PackageVersion.ps1`: use the shared toolchain helpers consistently and skip `cargo-deny` on pull request analyze runs, matching the existing `cargo-audit` behavior.