### PR TITLE
Force-disable cargo deny to unblock pipelines

### DIFF
--- a/eng/scripts/Analyze-Code.ps1
+++ b/eng/scripts/Analyze-Code.ps1
@@ -19,6 +19,11 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 
+# BUGBUG: Force-disable cargo deny to unblock pipelines while an issue outside this
+# repo is breaking all runs. Override whatever value is passed for -Deny.
+# See https://github.com/Azure/azure-sdk-for-rust/issues/4689
+$Deny = $false
+
 . ([System.IO.Path]::Combine($PSScriptRoot, '..', 'common', 'scripts', 'common.ps1'))
 . ([System.IO.Path]::Combine($PSScriptRoot, 'shared', 'Cargo.ps1'))
 


### PR DESCRIPTION
## Why

An issue outside this repo is breaking every pipeline that runs `cargo deny`, blocking PRs across the board. Rather than have each PR disable it individually, this does it once centrally.

## What

In `eng/scripts/Analyze-Code.ps1`, `$Deny` is explicitly overridden to `$false` right after the script's setup, so it wins regardless of whatever `-Deny` value is passed. This skips both the `cargo install cargo-deny` step and the `cargo deny --all-features check` run.

The override is marked with a `BUGBUG` comment linking to Azure/azure-sdk-for-rust#4689 so we remember to reevaluate if and when to run `cargo deny` again.

## Notes

This is intended as a temporary unblock. Revert once the upstream issue is resolved and #4689 is addressed.