### PR TITLE
Add opt-in metadata hedging to Cosmos SDK

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Added `tokio` feature to `default` features.
 - Changed `default_ttl` and `analytical_storage_ttl` fields on `ContainerProperties` from `Option<Duration>` to `TimeToLive`, a new enum with variants `Forever`, `NoDefault`, and `Seconds(u32)`, to correctly handle the `-1` wire value (TTL enabled with no default expiration).
 
+### Bugs Fixed
+
+- Fixed `410 Gone` responses carrying a partition-key-range routing sub-status (`1000` NameCacheIsStale, `1002` PartitionKeyRangeGone, `1007` CompletingSplit) escaping the retry pipeline as a raw, unclassifiable `410` (returned directly to the caller on writes, or after non-curative cross-region failover on reads). These are now retried within a small bound — flagging a routing-cache refresh so SDK-routing paths re-resolve stale routing information — and, on exhaustion, surfaced as `503 Service Unavailable` with the original sub-status preserved. This aligns the surfaced status with the rest of the Gone family so application-layer retry/circuit-breaker logic (wired for `503`, not `410`) can classify it.
+
 ## 0.31.0 (2026-02-25)
 
 ### Features Added

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.32.0 (Unreleased)
 
+### Features Added
+
+- Added opt-in cross-region hedging for the two hot-path metadata reads (Collection Read and the first `PartitionKeyRange` ReadFeed page). When enabled and the account has at least two applicable regions, a slow or regionally-failing primary metadata read triggers a single hedged request to another region after a ~1.5s threshold; the primary always remains authoritative (a hedge can only make the read faster, never change its outcome). Enable via `CosmosClientBuilder::with_metadata_hedging_enabled` or the `AZURE_COSMOS_METADATA_HEDGING_ENABLED` environment variable (`true` force-enables, `false` is a hard kill-switch). Disabled by default. Ported from the .NET SDK ([Azure/azure-cosmos-dotnet-v3#5999](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5999)).
+
 ### Breaking Changes
 
 - Added `tokio` feature to `default` features.

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -19,6 +19,7 @@ use crate::operation_context::OperationType;
 use crate::routing::container_cache::ContainerCache;
 use crate::routing::global_endpoint_manager::GlobalEndpointManager;
 use crate::routing::global_partition_endpoint_manager::GlobalPartitionEndpointManager;
+use crate::routing::metadata_hedging::MetadataHedgingStrategy;
 use crate::routing::partition_key_range_cache::PartitionKeyRangeCache;
 use azure_core::http::headers::AsHeaders;
 use azure_core::http::Context;
@@ -49,16 +50,26 @@ impl ContainerClient {
             .item(container_id);
         let items_link = link.feed(ResourceType::Documents);
 
-        let container_cache = Arc::from(ContainerCache::new(
+        // A single hedging strategy is shared by both metadata caches for this client.
+        // Constructed only when the client-wide opt-in (with env override) is enabled.
+        let hedging = if pipeline.metadata_hedging_enabled() {
+            Some(Arc::new(MetadataHedgingStrategy::new()))
+        } else {
+            None
+        };
+
+        let container_cache = Arc::from(ContainerCache::new_with_hedging(
             pipeline.clone(),
             link.clone(),
             global_endpoint_manager.clone(),
+            hedging.clone(),
         ));
-        let partition_key_range_cache = Arc::from(PartitionKeyRangeCache::new(
+        let partition_key_range_cache = Arc::from(PartitionKeyRangeCache::new_with_hedging(
             pipeline.clone(),
             database_link.clone(),
             container_cache.clone(),
             global_endpoint_manager.clone(),
+            hedging.clone(),
         ));
         let container_connection = Arc::from(ContainerConnection::new(
             pipeline.clone(),

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client_builder.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client_builder.rs
@@ -115,6 +115,22 @@ impl CosmosClientBuilder {
         self
     }
 
+    /// Enables cross-region hedging for metadata reads (Collection Read and the first
+    /// PartitionKeyRange ReadFeed page).
+    ///
+    /// When enabled and the account has at least two applicable regions, a slow or
+    /// regionally-failing primary metadata read triggers a single hedged request to
+    /// another region after a fixed latency threshold (~1.5s). The primary always
+    /// remains authoritative — a hedge can only make the read faster, never change its
+    /// outcome.
+    ///
+    /// The `AZURE_COSMOS_METADATA_HEDGING_ENABLED` environment variable overrides this
+    /// value at client construction (`true` force-enables, `false` is a hard kill-switch).
+    pub fn with_metadata_hedging_enabled(mut self, enabled: bool) -> Self {
+        self.options.metadata_hedging_enabled = enabled;
+        self
+    }
+
     /// Configures fault injection for testing.
     ///
     /// Pass a [`FaultInjectionClientBuilder`](crate::fault_injection::FaultInjectionClientBuilder)
@@ -164,11 +180,21 @@ impl CosmosClientBuilder {
     ///
     /// Returns an error if the client cannot be constructed.
     pub async fn build(
-        self,
+        mut self,
         account: impl Into<CosmosAccountReference>,
     ) -> azure_core::Result<CosmosClient> {
         let (account_endpoint, credential) = account.into().into_parts();
         let endpoint = account_endpoint.into_url();
+
+        // Resolve the metadata-hedging opt-in: the AZURE_COSMOS_METADATA_HEDGING_ENABLED
+        // environment variable overrides the builder value (`true` force-enables, any
+        // other set value is a hard kill-switch).
+        if let Ok(raw) = std::env::var("AZURE_COSMOS_METADATA_HEDGING_ENABLED") {
+            self.options.metadata_hedging_enabled = matches!(
+                raw.trim().to_ascii_lowercase().as_str(),
+                "true" | "1" | "yes" | "on"
+            );
+        }
 
         // Derive fault_injection_enabled from builder state
         #[cfg(feature = "fault_injection")]

--- a/sdk/cosmos/azure_data_cosmos/src/handler/retry_handler.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/handler/retry_handler.rs
@@ -4,7 +4,7 @@
 use crate::cosmos_request::CosmosRequest;
 use crate::retry_policies::client_retry_policy::ClientRetryPolicy;
 use crate::retry_policies::metadata_request_retry_policy::MetadataRequestRetryPolicy;
-use crate::retry_policies::{RetryPolicy, RetryResult};
+use crate::retry_policies::{convert_gone_to_service_unavailable, RetryPolicy, RetryResult};
 use crate::routing::global_endpoint_manager::GlobalEndpointManager;
 use crate::routing::global_partition_endpoint_manager::GlobalPartitionEndpointManager;
 use async_trait::async_trait;
@@ -139,7 +139,15 @@ impl RetryHandler for BackOffRetryHandler {
             let retry_result = retry_policy.should_retry(&result).await;
 
             match retry_result {
-                RetryResult::DoNotRetry => return result,
+                RetryResult::DoNotRetry => {
+                    // If the data-plane policy exhausted its partition-key-range Gone
+                    // budget, surface the terminal failure as 503 (preserving the
+                    // original sub-status) instead of letting a raw 410 escape.
+                    if let Some(sub_status) = retry_policy.terminal_gone_substatus() {
+                        return convert_gone_to_service_unavailable(result, sub_status);
+                    }
+                    return result;
+                }
                 RetryResult::Retry { after } => get_async_runtime().sleep(after).await,
             }
         }

--- a/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
@@ -38,6 +38,10 @@ pub struct CosmosClientOptions {
     pub(crate) user_agent_suffix: Option<String>,
     pub(crate) application_region: Option<RegionName>,
     pub(crate) custom_headers: HashMap<HeaderName, HeaderValue>,
+    /// Whether cross-region hedging is enabled for metadata reads (Collection Read and
+    /// the first PartitionKeyRange ReadFeed page). Resolved during client construction:
+    /// the `AZURE_COSMOS_METADATA_HEDGING_ENABLED` environment variable overrides this.
+    pub(crate) metadata_hedging_enabled: bool,
 }
 
 impl CosmosClientOptions {
@@ -55,6 +59,20 @@ impl CosmosClientOptions {
         self.custom_headers = custom_headers;
         self
     }
+
+    /// Enables cross-region hedging for metadata reads (Collection Read and the first
+    /// PartitionKeyRange ReadFeed page).
+    ///
+    /// When enabled and the account has at least two applicable regions, a slow or
+    /// regionally-failing primary metadata read triggers a single hedged request to
+    /// another region after a fixed latency threshold. The primary always remains
+    /// authoritative. Overridden by the `AZURE_COSMOS_METADATA_HEDGING_ENABLED`
+    /// environment variable (`true` force-enables, `false` is a hard kill-switch).
+    pub fn with_metadata_hedging_enabled(mut self, enabled: bool) -> Self {
+        self.metadata_hedging_enabled = enabled;
+        self
+    }
+
     pub(crate) fn apply_headers(&self, headers: &mut Headers) {
         for (header_name, header_value) in &self.custom_headers {
             // Only insert if not already set — request-level headers take priority.

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
@@ -72,6 +72,12 @@ impl GatewayPipeline {
         link.url(&self.endpoint)
     }
 
+    /// Whether cross-region metadata hedging is enabled for this client (after
+    /// environment-variable resolution during client construction).
+    pub(crate) fn metadata_hedging_enabled(&self) -> bool {
+        self.options.metadata_hedging_enabled
+    }
+
     pub async fn send<T>(
         &self,
         mut cosmos_request: CosmosRequest,

--- a/sdk/cosmos/azure_data_cosmos/src/retry_policies/client_retry_policy.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/retry_policies/client_retry_policy.rs
@@ -29,6 +29,13 @@ const MAX_RETRY_COUNT_ON_ENDPOINT_FAILURE: usize = 120;
 /// the endpoint unavailable.
 const MAX_RETRY_COUNT_ON_CONNECTION_FAILURE: usize = 3;
 
+/// Maximum number of in-line retries for the partition-key-range Gone family
+/// (410 with sub-status 1000/1002/1007) before the terminal outcome is surfaced
+/// as 503 Service Unavailable. A small fixed bound (one routing-cache refresh +
+/// one retry) mirrors the dedicated PartitionKeyRangeGone retry policy used by
+/// the other Cosmos SDKs and avoids retry amplification on writes.
+const MAX_RETRY_COUNT_ON_PARTITION_KEY_RANGE_GONE: usize = 1;
+
 /// Context information for routing retry attempts to specific endpoints.
 #[derive(Clone, Debug)]
 struct RetryContext {
@@ -66,6 +73,20 @@ pub(crate) struct ClientRetryPolicy {
     /// Counter tracking the number of consecutive connection failure retry attempts
     /// on the current endpoint before marking it unavailable.
     connection_retry_count: usize,
+
+    /// Counter tracking the number of partition-key-range Gone (410.1000/1002/1007)
+    /// retry attempts for the current request.
+    partition_key_range_gone_retry_count: usize,
+
+    /// When set, the next `before_send_request` flags the request for a routing-cache
+    /// refresh (name cache, partition-key-range and collection routing map) so that
+    /// SDK-routing paths re-resolve a stale routing map instead of replaying it.
+    refresh_routing_on_next_attempt: bool,
+
+    /// Set when the partition-key-range Gone family has exhausted its in-line retry
+    /// budget. Signals the retry handler to surface the terminal failure as
+    /// 503 Service Unavailable while preserving this original Cosmos sub-status.
+    terminal_gone_substatus: Option<SubStatusCode>,
 
     /// Whether the current request is a read operation (true) or write operation (false)
     operation_type: Option<OperationType>,
@@ -117,6 +138,9 @@ impl ClientRetryPolicy {
             session_token_retry_count: 0,
             service_unavailable_retry_count: 0,
             connection_retry_count: 0,
+            partition_key_range_gone_retry_count: 0,
+            refresh_routing_on_next_attempt: false,
+            terminal_gone_substatus: None,
             operation_type: None,
             request: None,
             can_use_multiple_write_locations: false,
@@ -214,6 +238,16 @@ impl ClientRetryPolicy {
         {
             self.partition_key_range_location_cache
                 .try_add_partition_level_location_override(request);
+        }
+
+        // If a prior attempt hit the partition-key-range Gone family, flag the
+        // request so SDK-routing paths refresh the (now demonstrably stale)
+        // routing caches before this attempt instead of replaying the stale map.
+        if self.refresh_routing_on_next_attempt {
+            request.force_name_cache_refresh = true;
+            request.force_partition_key_range_refresh = true;
+            request.force_collection_routing_map_refresh = true;
+            self.refresh_routing_on_next_attempt = false;
         }
 
         self.request = Some(request.clone());
@@ -497,6 +531,45 @@ impl ClientRetryPolicy {
         }
     }
 
+    /// Handles the partition-key-range Gone family (410.1000/1002/1007).
+    ///
+    /// A 410 carrying one of these sub-statuses means the routing information the
+    /// request was resolved against is stale (a split/merge/migration moved the
+    /// range). We retry a small, fixed number of times, flagging a routing-cache
+    /// refresh for the next attempt so SDK-routing paths re-resolve instead of
+    /// replaying the stale map. Once the bound is exhausted we stop retrying and
+    /// record the sub-status so the retry handler can surface the terminal failure
+    /// as 503 Service Unavailable (preserving the sub-status) rather than letting a
+    /// raw, unclassifiable 410 escape to the caller.
+    ///
+    /// Applies to reads and writes alike: a 410 from routing resolution means the
+    /// operation was not applied, so retrying a write is safe.
+    fn should_retry_on_partition_key_range_gone(
+        &mut self,
+        sub_status: SubStatusCode,
+    ) -> RetryResult {
+        self.partition_key_range_gone_retry_count += 1;
+
+        if self.partition_key_range_gone_retry_count <= MAX_RETRY_COUNT_ON_PARTITION_KEY_RANGE_GONE
+        {
+            self.refresh_routing_on_next_attempt = true;
+            return RetryResult::Retry {
+                after: Duration::ZERO,
+            };
+        }
+
+        // Bound exhausted: surface as 503 with the original sub-status preserved.
+        self.terminal_gone_substatus = Some(sub_status);
+        RetryResult::DoNotRetry
+    }
+
+    /// Returns the sub-status to preserve when a terminal partition-key-range Gone
+    /// must be surfaced as 503 Service Unavailable, or `None` if no such conversion
+    /// is pending. Consulted by the retry handler after a `DoNotRetry` decision.
+    pub(crate) fn terminal_gone_substatus(&self) -> Option<SubStatusCode> {
+        self.terminal_gone_substatus
+    }
+
     /// Routes HTTP status codes to appropriate retry handling logic.
     ///
     /// # Summary
@@ -587,6 +660,26 @@ impl ClientRetryPolicy {
             && sub_status_code == Some(SubStatusCode::LEASE_NOT_FOUND)
         {
             return Some(self.should_retry_on_unavailable_endpoint_status_codes());
+        }
+
+        // Gone - partition-key-range staleness family (410.1000 NameCacheIsStale,
+        // 410.1002 PartitionKeyRangeGone, 410.1007 CompletingSplit). This must be
+        // matched on the (Gone, sub-status) tuple: sub-status 1002 is also used by
+        // 404 ReadSessionNotAvailable (handled above), so keying on sub-status
+        // alone would conflate the two. Without this branch a 410.1002 escapes the
+        // pipeline as a raw, unclassifiable 410 (writes) or burns non-curative
+        // cross-region failover (reads). Instead we drive a bounded routing-cache
+        // refresh + retry and, on exhaustion, surface 503 (see the retry handler).
+        if status_code == StatusCode::Gone
+            && matches!(
+                sub_status_code,
+                Some(SubStatusCode::NAME_CACHE_IS_STALE)
+                    | Some(SubStatusCode::PARTITION_KEY_RANGE_GONE)
+                    | Some(SubStatusCode::COMPLETING_SPLIT)
+            )
+        {
+            // sub_status_code is Some in every arm of the match above.
+            return Some(self.should_retry_on_partition_key_range_gone(sub_status_code.unwrap()));
         }
 
         // For read operations, retry on any status code that is not explicitly non-retryable.
@@ -1011,6 +1104,101 @@ mod tests {
             }
             _ => panic!("Expected retry for Gone with LeaseNotFound on write"),
         }
+    }
+
+    #[tokio::test]
+    async fn gone_partition_key_range_retries_then_converts_to_503_read() {
+        let mut policy = create_test_policy_with_preferred_locations();
+        policy.operation_type = Some(OperationType::Read);
+        let error = create_error_with_substatus(
+            StatusCode::Gone,
+            SubStatusCode::PARTITION_KEY_RANGE_GONE.value() as u32,
+        );
+
+        // First 410/1002: bounded retry, routing refresh flagged, no terminal conversion yet.
+        let first = policy.should_retry_error(&error).await;
+        assert!(first.is_retry(), "first 410/1002 should retry");
+        assert_eq!(policy.partition_key_range_gone_retry_count, 1);
+        assert!(policy.refresh_routing_on_next_attempt);
+        assert!(policy.terminal_gone_substatus().is_none());
+
+        // Second 410/1002: bound exhausted -> stop retrying, terminal 503 conversion pending.
+        let second = policy.should_retry_error(&error).await;
+        assert!(!second.is_retry(), "second 410/1002 should stop retrying");
+        assert_eq!(
+            policy.terminal_gone_substatus(),
+            Some(SubStatusCode::PARTITION_KEY_RANGE_GONE),
+            "terminal Gone must surface as 503 preserving sub-status 1002"
+        );
+    }
+
+    #[tokio::test]
+    async fn gone_partition_key_range_retries_then_converts_to_503_write() {
+        // Writes must also recover: a 410 from routing resolution means the
+        // operation was not applied, so a bounded retry is safe (Q4=B).
+        let mut policy = create_test_policy_with_preferred_locations();
+        policy.operation_type = Some(OperationType::Create);
+        let error = create_error_with_substatus(
+            StatusCode::Gone,
+            SubStatusCode::PARTITION_KEY_RANGE_GONE.value() as u32,
+        );
+
+        assert!(
+            policy.should_retry_error(&error).await.is_retry(),
+            "writes must also retry a 410/1002"
+        );
+        assert!(
+            !policy.should_retry_error(&error).await.is_retry(),
+            "writes must stop after the bound and convert"
+        );
+        assert_eq!(
+            policy.terminal_gone_substatus(),
+            Some(SubStatusCode::PARTITION_KEY_RANGE_GONE)
+        );
+    }
+
+    #[tokio::test]
+    async fn gone_name_cache_stale_and_completing_split_take_gone_branch() {
+        for ss in [
+            SubStatusCode::NAME_CACHE_IS_STALE,
+            SubStatusCode::COMPLETING_SPLIT,
+        ] {
+            let mut policy = create_test_policy_with_preferred_locations();
+            policy.operation_type = Some(OperationType::Read);
+            let error = create_error_with_substatus(StatusCode::Gone, ss.value() as u32);
+
+            assert!(
+                policy.should_retry_error(&error).await.is_retry(),
+                "410/{} should take the Gone-family retry branch",
+                ss.value()
+            );
+            assert_eq!(policy.partition_key_range_gone_retry_count, 1);
+            assert!(policy.refresh_routing_on_next_attempt);
+        }
+    }
+
+    #[tokio::test]
+    async fn not_found_session_not_available_not_treated_as_gone() {
+        // 404/1002 ReadSessionNotAvailable shares sub-status 1002 with 410/1002
+        // PartitionKeyRangeGone. It must keep the session-retry path, untouched by
+        // the new Gone-family branch (regression guard for the overloaded 1002).
+        let mut policy = create_test_policy();
+        policy.operation_type = Some(OperationType::Read);
+        let error = create_error_with_substatus(
+            StatusCode::NotFound,
+            SubStatusCode::READ_SESSION_NOT_AVAILABLE.value() as u32,
+        );
+
+        let _ = policy.should_retry_error(&error).await;
+        assert_eq!(
+            policy.session_token_retry_count, 1,
+            "404/1002 must use the session-not-available path"
+        );
+        assert_eq!(
+            policy.partition_key_range_gone_retry_count, 0,
+            "404/1002 must NOT use the Gone-family path"
+        );
+        assert!(policy.terminal_gone_substatus().is_none());
     }
 
     #[tokio::test]

--- a/sdk/cosmos/azure_data_cosmos/src/retry_policies/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/retry_policies/mod.rs
@@ -11,6 +11,7 @@ use crate::retry_policies::client_retry_policy::ClientRetryPolicy;
 use crate::retry_policies::metadata_request_retry_policy::MetadataRequestRetryPolicy;
 use crate::retry_policies::resource_throttle_retry_policy::ResourceThrottleRetryPolicy;
 use azure_core::error::ErrorKind;
+use azure_core::http::headers::Headers;
 use azure_core::http::{RawResponse, StatusCode};
 use azure_core::time::Duration;
 
@@ -124,6 +125,61 @@ impl RetryPolicy {
             RetryPolicy::ResourceThrottle(p) => p.should_retry(response).await,
             RetryPolicy::Metadata(p) => p.should_retry(response).await,
         }
+    }
+
+    /// Returns the Cosmos sub-status to preserve when a terminal partition-key-range
+    /// Gone (410.1000/1002/1007) must be surfaced as 503 Service Unavailable instead
+    /// of a raw 410, or `None` when no such conversion is pending. Only the data-plane
+    /// [`ClientRetryPolicy`] produces this signal.
+    pub fn terminal_gone_substatus(&self) -> Option<SubStatusCode> {
+        match self {
+            RetryPolicy::Client(p) => p.terminal_gone_substatus(),
+            RetryPolicy::ResourceThrottle(_) | RetryPolicy::Metadata(_) => None,
+        }
+    }
+}
+
+/// Rewrites a terminal partition-key-range Gone result (410 with sub-status
+/// 1000/1002/1007) into a 503 Service Unavailable while preserving the original
+/// Cosmos sub-status, so application-layer resilience logic (which is wired for
+/// 503, not 410) can classify and react to it.
+///
+/// Cosmos gateway responses for non-success status codes arrive here as an
+/// `Err(HttpResponse { status: Gone, .. })`; the rare `Ok(RawResponse)` form with a
+/// Gone status is handled too. Any other result is returned unchanged.
+pub(crate) fn convert_gone_to_service_unavailable(
+    result: azure_core::Result<RawResponse>,
+    sub_status: SubStatusCode,
+) -> azure_core::Result<RawResponse> {
+    let mut headers = match &result {
+        Ok(response) if response.status() == StatusCode::Gone => response.headers().clone(),
+        Err(err) if err.http_status() == Some(StatusCode::Gone) => Headers::new(),
+        // Not a Gone result: leave it untouched.
+        _ => return result,
+    };
+    headers.insert(SUB_STATUS, sub_status.to_string());
+
+    match result {
+        Ok(_) => Ok(RawResponse::from_bytes(
+            StatusCode::ServiceUnavailable,
+            headers,
+            Vec::new(),
+        )),
+        Err(_) => Err(azure_core::Error::with_message(
+            ErrorKind::HttpResponse {
+                status: StatusCode::ServiceUnavailable,
+                error_code: Some("ServiceUnavailable".to_string()),
+                raw_response: Some(Box::new(RawResponse::from_bytes(
+                    StatusCode::ServiceUnavailable,
+                    headers,
+                    Vec::new(),
+                ))),
+            },
+            format!(
+                "partition key range is gone (sub-status {sub_status}); routing information was stale \
+                 and could not be refreshed within the retry budget, surfaced as 503 Service Unavailable"
+            ),
+        )),
     }
 }
 
@@ -282,5 +338,67 @@ mod tests {
     fn credential_is_not_sent() {
         let err = azure_core::Error::with_message(ErrorKind::Credential, "auth failed");
         assert_eq!(err.request_sent_status(), RequestSentStatus::NotSent);
+    }
+
+    fn gone_error_with_substatus(value: &str) -> azure_core::Error {
+        let mut headers = azure_core::http::headers::Headers::new();
+        headers.insert(SUB_STATUS, value.to_string());
+        let raw = RawResponse::from_bytes(StatusCode::Gone, headers, Vec::new());
+        azure_core::Error::new(
+            ErrorKind::HttpResponse {
+                status: StatusCode::Gone,
+                error_code: None,
+                raw_response: Some(Box::new(raw)),
+            },
+            "partition key range gone",
+        )
+    }
+
+    #[test]
+    fn convert_gone_error_to_service_unavailable_preserves_substatus() {
+        let converted = convert_gone_to_service_unavailable(
+            Err(gone_error_with_substatus("1002")),
+            SubStatusCode::PARTITION_KEY_RANGE_GONE,
+        );
+        let err = converted.expect_err("a Gone error must remain an error");
+        assert_eq!(err.http_status(), Some(StatusCode::ServiceUnavailable));
+        assert_eq!(
+            get_substatus_code_from_error(&err),
+            Some(SubStatusCode::PARTITION_KEY_RANGE_GONE),
+            "the original sub-status must be preserved on the 503"
+        );
+    }
+
+    #[test]
+    fn convert_gone_ok_response_to_service_unavailable_preserves_substatus() {
+        let mut headers = azure_core::http::headers::Headers::new();
+        headers.insert(SUB_STATUS, "1002");
+        let response = RawResponse::from_bytes(StatusCode::Gone, headers, Vec::new());
+
+        let converted = convert_gone_to_service_unavailable(
+            Ok(response),
+            SubStatusCode::PARTITION_KEY_RANGE_GONE,
+        )
+        .expect("ok response must remain ok");
+        assert_eq!(converted.status(), StatusCode::ServiceUnavailable);
+        assert_eq!(
+            get_substatus_code_from_response(&converted),
+            Some(SubStatusCode::PARTITION_KEY_RANGE_GONE)
+        );
+    }
+
+    #[test]
+    fn convert_leaves_non_gone_results_untouched() {
+        let response = RawResponse::from_bytes(
+            StatusCode::Ok,
+            azure_core::http::headers::Headers::new(),
+            Vec::new(),
+        );
+        let converted = convert_gone_to_service_unavailable(
+            Ok(response),
+            SubStatusCode::PARTITION_KEY_RANGE_GONE,
+        )
+        .expect("non-gone ok stays ok");
+        assert_eq!(converted.status(), StatusCode::Ok);
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/src/routing/container_cache.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/routing/container_cache.rs
@@ -6,6 +6,7 @@ use crate::cosmos_request::CosmosRequest;
 use crate::operation_context::OperationType;
 use crate::pipeline::GatewayPipeline;
 use crate::routing::global_endpoint_manager::GlobalEndpointManager;
+use crate::routing::metadata_hedging::MetadataHedgingStrategy;
 use crate::{
     models::ContainerProperties, resource_context::ResourceLink, CosmosResponse,
     ReadContainerOptions,
@@ -27,6 +28,7 @@ pub(crate) struct ContainerCache {
     container_link: ResourceLink,
     global_endpoint_manager: Arc<GlobalEndpointManager>,
     container_properties_cache: AsyncCache<String, ContainerProperties>,
+    hedging: Option<Arc<MetadataHedgingStrategy>>,
 }
 
 impl ContainerCache {
@@ -48,6 +50,19 @@ impl ContainerCache {
         container_link: ResourceLink,
         global_endpoint_manager: Arc<GlobalEndpointManager>,
     ) -> Self {
+        Self::new_with_hedging(pipeline, container_link, global_endpoint_manager, None)
+    }
+
+    /// Creates a `ContainerCache`, optionally wired with a shared metadata hedging
+    /// strategy. When `hedging` is `Some`, Collection Reads are routed through the
+    /// strategy (cross-region hedging on a slow/regionally-failing primary); when `None`,
+    /// they take the unchanged single-endpoint path.
+    pub(crate) fn new_with_hedging(
+        pipeline: Arc<GatewayPipeline>,
+        container_link: ResourceLink,
+        global_endpoint_manager: Arc<GlobalEndpointManager>,
+        hedging: Option<Arc<MetadataHedgingStrategy>>,
+    ) -> Self {
         // No TTL-based expiry is needed.
         let container_properties_cache = AsyncCache::new(None);
 
@@ -56,6 +71,7 @@ impl ContainerCache {
             container_link,
             global_endpoint_manager,
             container_properties_cache,
+            hedging,
         }
     }
 
@@ -139,19 +155,42 @@ impl ContainerCache {
         container_link: ResourceLink,
         _options: Option<ReadContainerOptions>,
     ) -> azure_core::Result<CosmosResponse<ContainerProperties>> {
-        let mut cosmos_request =
+        let cosmos_request =
             CosmosRequest::builder(OperationType::Read, container_link.clone()).build()?;
-
-        let location_endpoint = self
-            .global_endpoint_manager
-            .resolve_service_endpoint(&cosmos_request);
-        cosmos_request
-            .request_context
-            .route_to_location_endpoint(cosmos_request.resource_link.url(&location_endpoint));
 
         let ctx_owned = Context::default().with_value(container_link);
 
-        self.pipeline.send(cosmos_request, ctx_owned).await
+        match &self.hedging {
+            // Hedged path: the strategy resolves the primary endpoint, races a single
+            // cross-region hedge, and returns the authoritative winner.
+            Some(strategy) => {
+                let hedged = Box::pin(strategy.execute::<ContainerProperties>(
+                    cosmos_request,
+                    ctx_owned,
+                    &self.pipeline,
+                    &self.global_endpoint_manager,
+                ))
+                .await?;
+                tracing::debug!(
+                    hedge_fired = hedged.hedge_fired,
+                    hedge_won = hedged.hedge_won,
+                    winning_region = %hedged.winning_endpoint,
+                    "metadata hedging: collection read"
+                );
+                Ok(hedged.response)
+            }
+            // Unchanged single-endpoint path.
+            None => {
+                let mut cosmos_request = cosmos_request;
+                let location_endpoint = self
+                    .global_endpoint_manager
+                    .resolve_service_endpoint(&cosmos_request);
+                cosmos_request.request_context.route_to_location_endpoint(
+                    cosmos_request.resource_link.url(&location_endpoint),
+                );
+                self.pipeline.send(cosmos_request, ctx_owned).await
+            }
+        }
     }
 }
 

--- a/sdk/cosmos/azure_data_cosmos/src/routing/container_cache.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/routing/container_cache.rs
@@ -153,44 +153,53 @@ impl ContainerCache {
     async fn read_container_properties_by_id(
         &self,
         container_link: ResourceLink,
+        options: Option<ReadContainerOptions>,
+    ) -> azure_core::Result<CosmosResponse<ContainerProperties>> {
+        // Hedged path is isolated behind a boxed future so its state never inflates the
+        // common (non-hedged) path future.
+        if let Some(strategy) = self.hedging.clone() {
+            return Box::pin(self.hedged_container_read(strategy, container_link, options)).await;
+        }
+
+        // Unchanged single-endpoint path.
+        let mut cosmos_request =
+            CosmosRequest::builder(OperationType::Read, container_link.clone()).build()?;
+        let location_endpoint = self
+            .global_endpoint_manager
+            .resolve_service_endpoint(&cosmos_request);
+        cosmos_request
+            .request_context
+            .route_to_location_endpoint(cosmos_request.resource_link.url(&location_endpoint));
+        let ctx_owned = Context::default().with_value(container_link);
+        self.pipeline.send(cosmos_request, ctx_owned).await
+    }
+
+    /// Runs the Collection Read through the metadata hedging strategy. Kept as a separate
+    /// (boxed at the call site) future so the hedge state does not enlarge the common path.
+    async fn hedged_container_read(
+        &self,
+        strategy: Arc<MetadataHedgingStrategy>,
+        container_link: ResourceLink,
         _options: Option<ReadContainerOptions>,
     ) -> azure_core::Result<CosmosResponse<ContainerProperties>> {
         let cosmos_request =
             CosmosRequest::builder(OperationType::Read, container_link.clone()).build()?;
-
         let ctx_owned = Context::default().with_value(container_link);
-
-        match &self.hedging {
-            // Hedged path: the strategy resolves the primary endpoint, races a single
-            // cross-region hedge, and returns the authoritative winner.
-            Some(strategy) => {
-                let hedged = Box::pin(strategy.execute::<ContainerProperties>(
-                    cosmos_request,
-                    ctx_owned,
-                    &self.pipeline,
-                    &self.global_endpoint_manager,
-                ))
-                .await?;
-                tracing::debug!(
-                    hedge_fired = hedged.hedge_fired,
-                    hedge_won = hedged.hedge_won,
-                    winning_region = %hedged.winning_endpoint,
-                    "metadata hedging: collection read"
-                );
-                Ok(hedged.response)
-            }
-            // Unchanged single-endpoint path.
-            None => {
-                let mut cosmos_request = cosmos_request;
-                let location_endpoint = self
-                    .global_endpoint_manager
-                    .resolve_service_endpoint(&cosmos_request);
-                cosmos_request.request_context.route_to_location_endpoint(
-                    cosmos_request.resource_link.url(&location_endpoint),
-                );
-                self.pipeline.send(cosmos_request, ctx_owned).await
-            }
-        }
+        let hedged = strategy
+            .execute::<ContainerProperties>(
+                cosmos_request,
+                ctx_owned,
+                &self.pipeline,
+                &self.global_endpoint_manager,
+            )
+            .await?;
+        tracing::debug!(
+            hedge_fired = hedged.hedge_fired,
+            hedge_won = hedged.hedge_won,
+            winning_region = %hedged.winning_endpoint,
+            "metadata hedging: collection read"
+        );
+        Ok(hedged.response)
     }
 }
 

--- a/sdk/cosmos/azure_data_cosmos/src/routing/metadata_hedging.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/routing/metadata_hedging.rs
@@ -1,0 +1,358 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Cross-region hedging for the two hot-path metadata reads (Collection Read and the
+//! first PartitionKeyRange ReadFeed page).
+//!
+//! # Summary
+//! When enabled and eligible, a slow (or regionally-failing) primary metadata read
+//! triggers a single hedged request to another region after a fixed latency threshold.
+//! The first *acceptable* answer wins, with the **primary always authoritative**: a hedge
+//! can only make the read faster, never change the outcome the primary has already
+//! produced at the moment of arbitration.
+//!
+//! This is a latency optimization, not a resilience mechanism — failover is handled by
+//! the metadata retry policy. Ported from the .NET SDK's `MetadataHedgingStrategy`
+//! (Azure/azure-cosmos-dotnet-v3#5999).
+
+use crate::constants::{SubStatusCode, DEFAULT_CONNECTION_TIMEOUT, SUB_STATUS};
+use crate::cosmos_request::CosmosRequest;
+use crate::models::CosmosResponse;
+use crate::pipeline::GatewayPipeline;
+use crate::routing::global_endpoint_manager::GlobalEndpointManager;
+use azure_core::async_runtime::get_async_runtime;
+use azure_core::error::ErrorKind;
+use azure_core::http::{Context, StatusCode};
+use futures::future::{select, Either};
+use std::time::Duration;
+use url::Url;
+
+/// Fixed step added to the first-attempt (connection) timeout to derive the hedge
+/// threshold, mirroring the .NET `DefaultThresholdStep`.
+const DEFAULT_THRESHOLD_STEP: Duration = Duration::from_millis(500);
+
+/// Three-way classification of a single branch's settled outcome.
+///
+/// Mirrors the .NET `BranchOutcome`. The distinction between `RegionalFailure` and
+/// `Definitive` is what makes the "primary is authoritative" invariant safe: only a
+/// `RegionalFailure` on the primary is worth hedging, and only a `Success` hedge may win.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BranchOutcome {
+    /// A successful response (2xx / 304).
+    Success,
+    /// The *region* is at fault (503, 500, 410+LeaseNotFound, 403+DatabaseAccountNotFound,
+    /// or a transport error with no HTTP status). Worth hedging.
+    RegionalFailure,
+    /// A request-level, authoritative answer (any other error). A hedge can never override it.
+    Definitive,
+}
+
+/// Whether a status/sub-status pair means "the region is at fault".
+///
+/// Matches the .NET `MetadataRequestThrottleRetryPolicy.IsRegionalFailure` sub-status set
+/// exactly. Note that a *plain* `410` (PartitionKeyRangeGone) and a *plain* `403`
+/// (WriteForbidden) are **not** regional — they are definitive, so a hedge can never
+/// override them.
+fn is_regional_failure(status: StatusCode, sub_status: Option<SubStatusCode>) -> bool {
+    match status {
+        StatusCode::ServiceUnavailable => true,
+        StatusCode::InternalServerError => true,
+        StatusCode::Gone => sub_status == Some(SubStatusCode::LEASE_NOT_FOUND),
+        StatusCode::Forbidden => sub_status == Some(SubStatusCode::DATABASE_ACCOUNT_NOT_FOUND),
+        _ => false,
+    }
+}
+
+/// Classifies an error branch. A transport error carrying no HTTP status is treated as a
+/// `RegionalFailure` (the connection/region is at fault, so hedging can help).
+fn classify_error(err: &azure_core::Error) -> BranchOutcome {
+    if let ErrorKind::HttpResponse {
+        status,
+        raw_response,
+        ..
+    } = err.kind()
+    {
+        let sub_status = raw_response
+            .as_ref()
+            .and_then(|r| {
+                r.headers()
+                    .get_as::<u32, std::num::ParseIntError>(&SUB_STATUS)
+                    .ok()
+            })
+            .map(SubStatusCode::from);
+        if is_regional_failure(*status, sub_status) {
+            BranchOutcome::RegionalFailure
+        } else {
+            BranchOutcome::Definitive
+        }
+    } else {
+        BranchOutcome::RegionalFailure
+    }
+}
+
+/// Classifies a settled branch result. `Ok` is always `Success` because the gateway
+/// pipeline returns `Err` for every status >= 400.
+fn classify<T>(result: &azure_core::Result<CosmosResponse<T>>) -> BranchOutcome {
+    match result {
+        Ok(_) => BranchOutcome::Success,
+        Err(err) => classify_error(err),
+    }
+}
+
+/// The winning response plus enough metadata for the caller to pin subsequent work
+/// (e.g. later PartitionKeyRange ReadFeed pages) to the region that won.
+pub(crate) struct HedgedResponse<T> {
+    /// The winning response.
+    pub response: CosmosResponse<T>,
+    /// The endpoint that produced the winning response.
+    pub winning_endpoint: Url,
+    /// Whether a hedge was dispatched at all.
+    pub hedge_fired: bool,
+    /// Whether the hedge (as opposed to the primary) produced the winning response.
+    pub hedge_won: bool,
+}
+
+/// Orchestrates bounded, single-hedge, cross-region racing for one metadata read.
+///
+/// One instance is shared per client (via the routing caches). The strategy is
+/// metadata-scoped and must never be applied to data-plane operations.
+#[derive(Debug, Clone)]
+pub(crate) struct MetadataHedgingStrategy {
+    threshold: Duration,
+}
+
+impl MetadataHedgingStrategy {
+    /// Creates a strategy whose threshold is derived from the SDK's control-plane
+    /// connection timeout (`DEFAULT_CONNECTION_TIMEOUT + 500ms`, = 1.5s by default),
+    /// keeping it strictly between the first and second attempt timeouts.
+    pub(crate) fn new() -> Self {
+        Self {
+            threshold: DEFAULT_CONNECTION_TIMEOUT + DEFAULT_THRESHOLD_STEP,
+        }
+    }
+
+    /// Runs `request` against the primary region with at most one threshold-triggered
+    /// cross-region hedge, returning the arbitration winner.
+    ///
+    /// Eligibility for the region count is checked here (a distinct, applicable alternate
+    /// endpoint must exist); the caller is responsible for gating on *which* reads are
+    /// supported (Collection Read, PK-range first page). If no distinct alternate region
+    /// exists, the request is sent to the primary only.
+    pub(crate) async fn execute<T>(
+        &self,
+        request: CosmosRequest,
+        ctx: Context<'_>,
+        pipeline: &GatewayPipeline,
+        endpoint_manager: &GlobalEndpointManager,
+    ) -> azure_core::Result<HedgedResponse<T>> {
+        let operation_type = request.operation_type;
+        let primary_endpoint = endpoint_manager.resolve_service_endpoint(&request);
+
+        // Health-aware alternate selection: first *available* endpoint that isn't the
+        // primary (get_applicable_endpoints orders available-before-unavailable).
+        let alternate_endpoint = endpoint_manager
+            .applicable_endpoints(operation_type, None)
+            .into_iter()
+            .find(|endpoint| *endpoint != primary_endpoint);
+
+        // Ineligible: single region / no distinct alternate. Primary only, unchanged path.
+        let Some(alternate_endpoint) = alternate_endpoint else {
+            let mut primary_request = request;
+            let primary_url = primary_request.resource_link.url(&primary_endpoint);
+            primary_request
+                .request_context
+                .route_to_location_endpoint(primary_url);
+            let response = pipeline.send::<T>(primary_request, ctx).await?;
+            return Ok(HedgedResponse {
+                response,
+                winning_endpoint: primary_endpoint,
+                hedge_fired: false,
+                hedge_won: false,
+            });
+        };
+
+        // Snapshot the hedge request BEFORE dispatching the primary (R17), routing it to a
+        // clean alternate endpoint so primary-side context mutation cannot desync it.
+        let mut hedge_request = request.clone();
+        hedge_request.request_context.clear_route_to_location();
+        let hedge_url = hedge_request.resource_link.url(&alternate_endpoint);
+        hedge_request
+            .request_context
+            .route_to_location_endpoint(hedge_url);
+
+        // Route the primary to its resolved endpoint and dispatch it with a threshold timer.
+        let mut primary_request = request;
+        let primary_url = primary_request.resource_link.url(&primary_endpoint);
+        primary_request
+            .request_context
+            .route_to_location_endpoint(primary_url);
+        let primary_future = Box::pin(pipeline.send::<T>(primary_request, ctx.clone()));
+        let threshold = azure_core::time::Duration::milliseconds(self.threshold.as_millis() as i64);
+        let timer = get_async_runtime().sleep(threshold);
+
+        match select(primary_future, timer).await {
+            // Primary settled before the threshold.
+            Either::Left((primary_result, _timer)) => match classify(&primary_result) {
+                // Fast and authoritative: NO hedge (the common case).
+                BranchOutcome::Success | BranchOutcome::Definitive => Ok(HedgedResponse {
+                    response: primary_result?,
+                    winning_endpoint: primary_endpoint,
+                    hedge_fired: false,
+                    hedge_won: false,
+                }),
+                // Primary regionally failed before the threshold: hedge now.
+                BranchOutcome::RegionalFailure => {
+                    let hedge_result = pipeline.send::<T>(hedge_request, ctx).await;
+                    match classify(&hedge_result) {
+                        BranchOutcome::Success => Ok(HedgedResponse {
+                            response: hedge_result?,
+                            winning_endpoint: alternate_endpoint,
+                            hedge_fired: true,
+                            hedge_won: true,
+                        }),
+                        // Neither branch is good: return the primary's (regional) outcome.
+                        _ => Ok(HedgedResponse {
+                            response: primary_result?,
+                            winning_endpoint: primary_endpoint,
+                            hedge_fired: true,
+                            hedge_won: false,
+                        }),
+                    }
+                }
+            },
+            // Threshold elapsed with the primary still in flight: fire one hedge and race.
+            Either::Right((_elapsed, primary_future)) => {
+                let hedge_future = Box::pin(pipeline.send::<T>(hedge_request, ctx));
+                match select(primary_future, hedge_future).await {
+                    // Primary settled first.
+                    Either::Left((primary_result, hedge_future)) => {
+                        match classify(&primary_result) {
+                            // Primary is authoritative: it wins; the hedge is dropped (cancelled).
+                            BranchOutcome::Success | BranchOutcome::Definitive => {
+                                Ok(HedgedResponse {
+                                    response: primary_result?,
+                                    winning_endpoint: primary_endpoint,
+                                    hedge_fired: true,
+                                    hedge_won: false,
+                                })
+                            }
+                            // Primary regionally failed: await the hedge; it wins only if good.
+                            BranchOutcome::RegionalFailure => {
+                                let hedge_result = hedge_future.await;
+                                match classify(&hedge_result) {
+                                    BranchOutcome::Success => Ok(HedgedResponse {
+                                        response: hedge_result?,
+                                        winning_endpoint: alternate_endpoint,
+                                        hedge_fired: true,
+                                        hedge_won: true,
+                                    }),
+                                    _ => Ok(HedgedResponse {
+                                        response: primary_result?,
+                                        winning_endpoint: primary_endpoint,
+                                        hedge_fired: true,
+                                        hedge_won: false,
+                                    }),
+                                }
+                            }
+                        }
+                    }
+                    // Hedge settled first.
+                    Either::Right((hedge_result, primary_future)) => {
+                        match classify(&hedge_result) {
+                            // Hedge won: the primary is still pending (not yet definitive), so the
+                            // hedge's good answer wins. The primary is dropped (observed/discarded).
+                            BranchOutcome::Success => Ok(HedgedResponse {
+                                response: hedge_result?,
+                                winning_endpoint: alternate_endpoint,
+                                hedge_fired: true,
+                                hedge_won: true,
+                            }),
+                            // Hedge is not good: await the primary and return its outcome.
+                            _ => {
+                                let primary_result = primary_future.await;
+                                Ok(HedgedResponse {
+                                    response: primary_result?,
+                                    winning_endpoint: primary_endpoint,
+                                    hedge_fired: true,
+                                    hedge_won: false,
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use azure_core::http::StatusCode;
+
+    #[test]
+    fn regional_failures_match_dotnet_set() {
+        assert!(is_regional_failure(StatusCode::ServiceUnavailable, None));
+        assert!(is_regional_failure(StatusCode::InternalServerError, None));
+        assert!(is_regional_failure(
+            StatusCode::Gone,
+            Some(SubStatusCode::LEASE_NOT_FOUND)
+        ));
+        assert!(is_regional_failure(
+            StatusCode::Forbidden,
+            Some(SubStatusCode::DATABASE_ACCOUNT_NOT_FOUND)
+        ));
+    }
+
+    #[test]
+    fn plain_410_and_403_are_definitive_not_regional() {
+        // Plain 410 (PartitionKeyRangeGone) must NOT be treated as regional.
+        assert!(!is_regional_failure(StatusCode::Gone, None));
+        assert!(!is_regional_failure(
+            StatusCode::Gone,
+            Some(SubStatusCode::WRITE_FORBIDDEN)
+        ));
+        // Plain 403 (WriteForbidden) must NOT be treated as regional.
+        assert!(!is_regional_failure(StatusCode::Forbidden, None));
+        assert!(!is_regional_failure(
+            StatusCode::Forbidden,
+            Some(SubStatusCode::LEASE_NOT_FOUND)
+        ));
+    }
+
+    #[test]
+    fn definitive_status_codes_are_not_regional() {
+        for status in [
+            StatusCode::NotFound,
+            StatusCode::Conflict,
+            StatusCode::PreconditionFailed,
+            StatusCode::Unauthorized,
+            StatusCode::BadRequest,
+            StatusCode::TooManyRequests,
+        ] {
+            assert!(
+                !is_regional_failure(status, None),
+                "status {status:?} should be definitive, not regional"
+            );
+        }
+    }
+
+    #[test]
+    fn success_result_classifies_as_success() {
+        let ok: azure_core::Result<CosmosResponse<()>> = Err(azure_core::Error::new(
+            ErrorKind::Other,
+            "placeholder to prove Err path compiles",
+        ));
+        // Sanity: an Err with no HTTP status is a regional failure (transport-level).
+        assert_eq!(classify(&ok), BranchOutcome::RegionalFailure);
+    }
+
+    #[test]
+    fn threshold_is_connection_timeout_plus_step() {
+        let strategy = MetadataHedgingStrategy::new();
+        assert_eq!(
+            strategy.threshold,
+            DEFAULT_CONNECTION_TIMEOUT + Duration::from_millis(500)
+        );
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos/src/routing/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/routing/mod.rs
@@ -7,6 +7,7 @@ pub mod container_cache;
 pub mod global_endpoint_manager;
 pub mod global_partition_endpoint_manager;
 pub mod location_cache;
+pub mod metadata_hedging;
 pub mod partition_key_range;
 pub mod partition_key_range_cache;
 pub mod range;

--- a/sdk/cosmos/azure_data_cosmos/src/routing/partition_key_range_cache.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/routing/partition_key_range_cache.rs
@@ -229,33 +229,19 @@ impl PartitionKeyRangeCache {
             )?;
 
             let response = if iteration_count == 1 {
-                match &self.hedging {
-                    // Hedge the FIRST page only. If the hedge wins, pin later pages to it.
-                    Some(strategy) => {
-                        let ctx = Context::default().with_value(pk_range_link.clone());
-                        let hedged = Box::pin(strategy.execute::<()>(
-                            request,
-                            ctx,
-                            &self.pipeline,
-                            &self.endpoint_manager,
-                        ))
-                        .await?;
-                        tracing::debug!(
-                            hedge_fired = hedged.hedge_fired,
-                            hedge_won = hedged.hedge_won,
-                            winning_region = %hedged.winning_endpoint,
-                            "metadata hedging: partition key range first page"
-                        );
-                        if hedged.hedge_won {
-                            pinned_endpoint = Some(hedged.winning_endpoint);
-                        }
-                        hedged.response
+                if let Some(strategy) = self.hedging.clone() {
+                    // Hedge the FIRST page only, isolated behind a boxed future. If the
+                    // hedge wins, pin later pages to the winning region.
+                    let (resp, won_endpoint) =
+                        Box::pin(self.hedged_first_page(strategy, request, pk_range_link)).await?;
+                    if let Some(endpoint) = won_endpoint {
+                        pinned_endpoint = Some(endpoint);
                     }
-                    None => {
-                        let endpoint = self.endpoint_manager.resolve_service_endpoint(&request);
-                        self.send_partition_key_range_request(request, pk_range_link, endpoint)
-                            .await?
-                    }
+                    resp
+                } else {
+                    let endpoint = self.endpoint_manager.resolve_service_endpoint(&request);
+                    self.send_partition_key_range_request(request, pk_range_link, endpoint)
+                        .await?
                 }
             } else {
                 // Pages 2..N: pin to the winning region when a hedge won page 1, otherwise
@@ -341,6 +327,30 @@ impl PartitionKeyRangeCache {
         }
 
         Ok(cosmos_request)
+    }
+
+    /// Runs the first PartitionKeyRange ReadFeed page through the hedging strategy,
+    /// returning the winning response and the winning region *iff* the hedge won (so the
+    /// caller can pin pages 2..N to it). Kept separate (boxed at the call site) so the
+    /// hedge state does not enlarge the routing-map fetch future on the common path.
+    async fn hedged_first_page(
+        &self,
+        strategy: Arc<MetadataHedgingStrategy>,
+        request: CosmosRequest,
+        resource_link: ResourceLink,
+    ) -> azure_core::Result<(CosmosResponse<()>, Option<Url>)> {
+        let ctx = Context::default().with_value(resource_link);
+        let hedged = strategy
+            .execute::<()>(request, ctx, &self.pipeline, &self.endpoint_manager)
+            .await?;
+        tracing::debug!(
+            hedge_fired = hedged.hedge_fired,
+            hedge_won = hedged.hedge_won,
+            winning_region = %hedged.winning_endpoint,
+            "metadata hedging: partition key range first page"
+        );
+        let won_endpoint = hedged.hedge_won.then_some(hedged.winning_endpoint);
+        Ok((hedged.response, won_endpoint))
     }
 
     /// Routes an already-built request to `endpoint` and sends it through the pipeline.

--- a/sdk/cosmos/azure_data_cosmos/src/routing/partition_key_range_cache.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/routing/partition_key_range_cache.rs
@@ -11,6 +11,7 @@ use crate::routing::async_cache::AsyncCache;
 use crate::routing::collection_routing_map::CollectionRoutingMap;
 use crate::routing::container_cache::ContainerCache;
 use crate::routing::global_endpoint_manager::GlobalEndpointManager;
+use crate::routing::metadata_hedging::MetadataHedgingStrategy;
 use crate::routing::partition_key_range::PartitionKeyRange;
 use crate::routing::range::Range;
 use crate::routing::service_identity::ServiceIdentity;
@@ -21,6 +22,7 @@ use azure_core::Error;
 use serde::Deserialize;
 use std::sync::Arc;
 use tracing::info;
+use url::Url;
 
 const PAGE_SIZE_STRING: &str = "-1";
 
@@ -31,6 +33,7 @@ pub(crate) struct PartitionKeyRangeCache {
     container_cache: Arc<ContainerCache>,
     endpoint_manager: Arc<GlobalEndpointManager>,
     database_link: ResourceLink,
+    hedging: Option<Arc<MetadataHedgingStrategy>>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -46,6 +49,26 @@ impl PartitionKeyRangeCache {
         container_cache: Arc<ContainerCache>,
         endpoint_manager: Arc<GlobalEndpointManager>,
     ) -> Self {
+        Self::new_with_hedging(
+            pipeline,
+            database_link,
+            container_cache,
+            endpoint_manager,
+            None,
+        )
+    }
+
+    /// Creates a `PartitionKeyRangeCache`, optionally wired with a shared metadata
+    /// hedging strategy. When `hedging` is `Some`, only the FIRST PartitionKeyRange
+    /// ReadFeed page is hedged; if the hedge wins page 1, later pages are pinned to the
+    /// winning region to keep the change-feed continuation consistent.
+    pub fn new_with_hedging(
+        pipeline: Arc<GatewayPipeline>,
+        database_link: ResourceLink,
+        container_cache: Arc<ContainerCache>,
+        endpoint_manager: Arc<GlobalEndpointManager>,
+        hedging: Option<Arc<MetadataHedgingStrategy>>,
+    ) -> Self {
         // No TTL-based expiry is needed.
         let routing_map_cache = AsyncCache::new(None);
         Self {
@@ -54,6 +77,7 @@ impl PartitionKeyRangeCache {
             container_cache,
             endpoint_manager,
             database_link,
+            hedging,
         }
     }
 
@@ -176,6 +200,9 @@ impl PartitionKeyRangeCache {
         let mut change_feed_next_if_none_match = previous_routing_map
             .as_ref()
             .and_then(|m| m.change_feed_next_if_none_match.clone());
+        // When the hedge wins page 1, later pages are pinned to the winning region so the
+        // change-feed continuation (ETag) stays consistent.
+        let mut pinned_endpoint: Option<Url> = None;
 
         loop {
             iteration_count += 1;
@@ -195,13 +222,50 @@ impl PartitionKeyRangeCache {
                 .feed(ResourceType::Containers)
                 .item(collection_rid)
                 .feed(ResourceType::PartitionKeyRanges);
-            let response = self
-                .execute_partition_key_range_read_change_feed(
-                    collection_rid,
-                    pk_range_link,
-                    change_feed_next_if_none_match,
-                )
-                .await?;
+            let request = self.build_partition_key_range_request(
+                collection_rid,
+                pk_range_link.clone(),
+                change_feed_next_if_none_match.clone(),
+            )?;
+
+            let response = if iteration_count == 1 {
+                match &self.hedging {
+                    // Hedge the FIRST page only. If the hedge wins, pin later pages to it.
+                    Some(strategy) => {
+                        let ctx = Context::default().with_value(pk_range_link.clone());
+                        let hedged = Box::pin(strategy.execute::<()>(
+                            request,
+                            ctx,
+                            &self.pipeline,
+                            &self.endpoint_manager,
+                        ))
+                        .await?;
+                        tracing::debug!(
+                            hedge_fired = hedged.hedge_fired,
+                            hedge_won = hedged.hedge_won,
+                            winning_region = %hedged.winning_endpoint,
+                            "metadata hedging: partition key range first page"
+                        );
+                        if hedged.hedge_won {
+                            pinned_endpoint = Some(hedged.winning_endpoint);
+                        }
+                        hedged.response
+                    }
+                    None => {
+                        let endpoint = self.endpoint_manager.resolve_service_endpoint(&request);
+                        self.send_partition_key_range_request(request, pk_range_link, endpoint)
+                            .await?
+                    }
+                }
+            } else {
+                // Pages 2..N: pin to the winning region when a hedge won page 1, otherwise
+                // take the normal per-page resolution (free to fail over).
+                let endpoint = pinned_endpoint
+                    .clone()
+                    .unwrap_or_else(|| self.endpoint_manager.resolve_service_endpoint(&request));
+                self.send_partition_key_range_request(request, pk_range_link, endpoint)
+                    .await?
+            };
 
             let last_status_code = response.status();
             change_feed_next_if_none_match = response
@@ -251,13 +315,16 @@ impl PartitionKeyRangeCache {
         Ok(routing_map)
     }
 
-    pub async fn execute_partition_key_range_read_change_feed(
+    /// Builds a PartitionKeyRange ReadFeed request (incremental change feed) WITHOUT
+    /// resolving or routing an endpoint. Routing is applied by the caller or by the
+    /// hedging strategy.
+    fn build_partition_key_range_request(
         &self,
         collection_rid: &str,
         resource_link: ResourceLink,
         if_none_match: Option<String>,
-    ) -> azure_core::Result<CosmosResponse<()>> {
-        let builder = CosmosRequest::builder(OperationType::ReadFeed, resource_link.clone());
+    ) -> azure_core::Result<CosmosRequest> {
+        let builder = CosmosRequest::builder(OperationType::ReadFeed, resource_link);
         let mut cosmos_request = builder
             .resource_id(collection_rid.to_string())
             .header(
@@ -273,16 +340,36 @@ impl PartitionKeyRangeCache {
                 .insert(IF_NONE_MATCH.as_str().to_string(), value)
         }
 
-        let endpoint = self
-            .endpoint_manager
-            .resolve_service_endpoint(&cosmos_request);
+        Ok(cosmos_request)
+    }
 
+    /// Routes an already-built request to `endpoint` and sends it through the pipeline.
+    async fn send_partition_key_range_request(
+        &self,
+        mut request: CosmosRequest,
+        resource_link: ResourceLink,
+        endpoint: Url,
+    ) -> azure_core::Result<CosmosResponse<()>> {
         let pk_endpoint = resource_link.url(&endpoint);
-
-        cosmos_request.request_context.location_endpoint_to_route = Some(pk_endpoint);
+        request.request_context.location_endpoint_to_route = Some(pk_endpoint);
         let ctx_owned = Context::default().with_value(resource_link);
+        self.pipeline.send(request, ctx_owned).await
+    }
 
-        self.pipeline.send(cosmos_request, ctx_owned).await
+    pub async fn execute_partition_key_range_read_change_feed(
+        &self,
+        collection_rid: &str,
+        resource_link: ResourceLink,
+        if_none_match: Option<String>,
+    ) -> azure_core::Result<CosmosResponse<()>> {
+        let request = self.build_partition_key_range_request(
+            collection_rid,
+            resource_link.clone(),
+            if_none_match,
+        )?;
+        let endpoint = self.endpoint_manager.resolve_service_endpoint(&request);
+        self.send_partition_key_range_request(request, resource_link, endpoint)
+            .await
     }
 }
 

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_fault_injection.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_fault_injection.rs
@@ -944,3 +944,66 @@ pub async fn fault_injection_enable_disable_rule() -> Result<(), Box<dyn Error>>
     )
     .await
 }
+
+/// Injecting a partition-key-range Gone (410/1002) on point operations must NOT
+/// surface a raw 410 to the caller. The Gone-family is retried within a small
+/// bound and, on exhaustion, converted to 503 Service Unavailable so application
+/// resilience logic (wired for 503, not 410) can classify it. Regression test for
+/// the Rust sibling of Azure/azure-cosmos-dotnet-v3#5924.
+#[tokio::test]
+pub async fn fault_injection_partition_key_range_gone_surfaces_503() -> Result<(), Box<dyn Error>> {
+    let server_error = FaultInjectionResultBuilder::new()
+        .with_error(FaultInjectionErrorType::PartitionIsGone) // 410 / 1002
+        .with_probability(1.0)
+        .build();
+
+    let condition = FaultInjectionConditionBuilder::new()
+        .with_operation_type(FaultOperationType::ReadItem)
+        .build();
+
+    let rule = FaultInjectionRuleBuilder::new("partition-key-range-gone", server_error)
+        .with_condition(condition)
+        .build();
+
+    let fault_builder = FaultInjectionClientBuilder::new().with_rule(Arc::new(rule));
+
+    TestClient::run_with_unique_db(
+        async |run_context, db_client| {
+            let container_id = format!("Container-{}", Uuid::new_v4());
+            let container_client = run_context
+                .create_container_with_throughput(
+                    db_client,
+                    ContainerProperties::new(container_id.clone(), "/partition_key".into()),
+                    ThroughputProperties::manual(400),
+                )
+                .await?;
+
+            let unique_id = Uuid::new_v4().to_string();
+            let item = create_test_item(&unique_id);
+            let pk = format!("Partition-{}", unique_id);
+            let item_id = format!("Item-{}", unique_id);
+
+            container_client.create_item(&pk, &item, None).await?;
+
+            let fault_client = run_context
+                .fault_client()
+                .expect("fault client should be available");
+            let fault_db_client = fault_client.database_client(db_client.id());
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
+
+            let result = fault_container_client
+                .read_item::<TestItem>(&pk, &item_id, None)
+                .await;
+            let err = result.expect_err("read should fail when partition is gone");
+            assert_eq!(
+                Some(StatusCode::ServiceUnavailable),
+                err.http_status(),
+                "terminal 410/1002 must be surfaced as 503, not a raw 410"
+            );
+
+            Ok(())
+        },
+        Some(TestOptions::new().with_fault_injection_builder(fault_builder)),
+    )
+    .await
+}

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_metadata_hedging.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_metadata_hedging.rs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Emulator integration tests for metadata hedging.
+//!
+//! Metadata hedging only *fires* a cross-region hedge when the account exposes at least
+//! two applicable regions. The Cosmos DB emulator is single-region, so these tests verify
+//! the equally-important **safety property** that the emulator can prove deterministically:
+//! enabling hedging must never break the two hot-path metadata reads (Collection Read and
+//! the PartitionKeyRange ReadFeed), and must be a transparent no-op when there is no second
+//! region to hedge to. The multi-region *behavioral* acceptance criteria (a hedge fires,
+//! wins, or is arbitrated against the primary) require a real multi-region account — the
+//! same limitation the `multi_write` failover tests carry — and the decision logic itself
+//! is covered deterministically by the unit tests in
+//! `src/routing/metadata_hedging.rs`.
+
+#![cfg(feature = "key_auth")]
+
+use super::framework;
+
+use azure_core::Uuid;
+use azure_data_cosmos::models::ContainerProperties;
+use framework::{TestClient, TestOptions, TestRunContext};
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+struct TestItem {
+    id: String,
+    partition_key: String,
+    payload: usize,
+}
+
+fn make_item(unique_id: &str, partition: &str, payload: usize) -> TestItem {
+    TestItem {
+        id: format!("Item-{}", unique_id),
+        partition_key: partition.to_string(),
+        payload,
+    }
+}
+
+/// Exercises both metadata caches (Collection Read via container properties, and the
+/// PartitionKeyRange ReadFeed via a cross-partition query) plus item CRUD, asserting that
+/// every operation returns correct data. Used by both the hedging-enabled and the
+/// hedging-disabled tests so they assert identical behavior.
+async fn exercise_metadata_reads(run_context: &TestRunContext) -> Result<(), Box<dyn Error>> {
+    let db_client = run_context.create_db().await?;
+    let container_id = format!("Container-{}", Uuid::new_v4());
+    run_context
+        .create_container(
+            &db_client,
+            ContainerProperties::new(container_id.clone(), "/partition_key".into()),
+            None,
+        )
+        .await?;
+    let container_client = db_client.container_client(&container_id).await;
+
+    // Collection Read: reading container properties routes through ContainerCache.
+    let props = container_client.read(None).await?.into_model()?;
+    assert_eq!(props.id, container_id, "container id round-trips");
+
+    // Item CRUD across two partitions: forces the routing map (PartitionKeyRangeCache)
+    // and the partition-key definition (ContainerCache) to be resolved.
+    let unique_id = Uuid::new_v4().to_string();
+    let item_a = make_item(&format!("{unique_id}-a"), "partition-a", 1);
+    let item_b = make_item(&format!("{unique_id}-b"), "partition-b", 2);
+    let pk_a = item_a.partition_key.clone();
+    let pk_b = item_b.partition_key.clone();
+    let item_a_id = item_a.id.clone();
+
+    container_client.create_item(&pk_a, &item_a, None).await?;
+    container_client.create_item(&pk_b, &item_b, None).await?;
+
+    let read_a = run_context
+        .read_item::<TestItem>(&container_client, &pk_a, &item_a_id, None)
+        .await?
+        .into_model()?;
+    assert_eq!(
+        read_a, item_a,
+        "item round-trips through the hedged read path"
+    );
+
+    // Cross-partition query: exercises the PartitionKeyRange ReadFeed (first page) path.
+    let mut results: Vec<TestItem> = run_context
+        .query_items(
+            &container_client,
+            "SELECT * FROM c",
+            azure_data_cosmos::PartitionKey::EMPTY,
+        )
+        .await?;
+    results.sort_by_key(|item| item.payload);
+    assert_eq!(results.len(), 2, "cross-partition query returns both items");
+    assert_eq!(results[0], item_a);
+    assert_eq!(results[1], item_b);
+
+    Ok(())
+}
+
+/// With metadata hedging ENABLED on a single-region (emulator) account, all metadata reads
+/// and data operations succeed and return correct data. The hedged code path runs but stays
+/// primary-only because there is no second applicable region — proving the feature is a safe
+/// no-op in the single-region case (the common real-world scenario when enabling it).
+#[tokio::test]
+pub async fn metadata_reads_succeed_with_hedging_enabled() -> Result<(), Box<dyn Error>> {
+    TestClient::run_with_options(
+        async |run_context| exercise_metadata_reads(run_context).await,
+        TestOptions::new().with_client_metadata_hedging(true),
+    )
+    .await
+}
+
+/// Control: with metadata hedging DISABLED (the default), the same lifecycle succeeds
+/// identically. Ensures the hedging-enabled test above is asserting parity, not masking a
+/// regression in the unchanged path.
+#[tokio::test]
+pub async fn metadata_reads_succeed_with_hedging_disabled() -> Result<(), Box<dyn Error>> {
+    TestClient::run_with_options(
+        async |run_context| exercise_metadata_reads(run_context).await,
+        TestOptions::new().with_client_metadata_hedging(false),
+    )
+    .await
+}

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/mod.rs
@@ -5,6 +5,7 @@ mod cosmos_containers;
 mod cosmos_databases;
 mod cosmos_fault_injection;
 mod cosmos_items;
+mod cosmos_metadata_hedging;
 mod cosmos_offers;
 mod cosmos_query;
 

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
@@ -57,6 +57,8 @@ pub struct TestOptions {
     /// Application region for the fault injection client.
     /// Used in combination with `fault_injection_builder`.
     pub fault_client_application_region: Option<RegionName>,
+    /// Whether to enable metadata hedging on the normal (non-fault) client.
+    pub client_metadata_hedging_enabled: bool,
     /// Timeout for the test. If None, uses DEFAULT_TEST_TIMEOUT.
     pub timeout: Option<Duration>,
 }
@@ -84,6 +86,12 @@ impl TestOptions {
     /// Sets the application region for the fault injection client.
     pub fn with_fault_client_application_region(mut self, region: RegionName) -> Self {
         self.fault_client_application_region = Some(region);
+        self
+    }
+
+    /// Enables metadata hedging on the normal (non-fault) client.
+    pub fn with_client_metadata_hedging(mut self, enabled: bool) -> Self {
+        self.client_metadata_hedging_enabled = enabled;
         self
     }
 
@@ -187,20 +195,28 @@ impl TestClient {
     pub async fn from_env_with_fault_options(
         fault_client_application_region: Option<RegionName>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        Self::from_env_inner(None, None, fault_client_application_region).await
+        Self::from_env_inner(None, None, fault_client_application_region, false).await
     }
 
     pub async fn from_env(
         application_region: Option<RegionName>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        Self::from_env_inner(application_region, None, None).await
+        Self::from_env_inner(application_region, None, None, false).await
+    }
+
+    /// Like [`from_env`](Self::from_env) but enables metadata hedging on the client.
+    pub async fn from_env_with_hedging(
+        application_region: Option<RegionName>,
+        metadata_hedging_enabled: bool,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::from_env_inner(application_region, None, None, metadata_hedging_enabled).await
     }
 
     pub async fn from_env_with_fault_builder(
         fault_builder: FaultInjectionClientBuilder,
         application_region: Option<RegionName>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        Self::from_env_inner(None, Some(fault_builder), application_region).await
+        Self::from_env_inner(None, Some(fault_builder), application_region, false).await
     }
 
     /// Creates a new [`TestClient`] from local environment variables.
@@ -212,6 +228,7 @@ impl TestClient {
         application_region: Option<RegionName>,
         fault_builder: Option<FaultInjectionClientBuilder>,
         fault_client_application_region: Option<RegionName>,
+        metadata_hedging_enabled: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let Ok(env_var) = std::env::var(CONNECTION_STRING_ENV_VAR) else {
             // No connection string provided, so we'll skip tests that require it.
@@ -235,6 +252,7 @@ impl TestClient {
                     true,
                     fault_builder,
                     None,
+                    metadata_hedging_enabled,
                 )
                 .await
             }
@@ -245,6 +263,7 @@ impl TestClient {
                     false,
                     fault_builder,
                     fault_client_application_region,
+                    metadata_hedging_enabled,
                 )
                 .await
             }
@@ -257,6 +276,7 @@ impl TestClient {
         mut allow_invalid_certificates: bool,
         fault_builder: Option<FaultInjectionClientBuilder>,
         fault_client_application_region: Option<RegionName>,
+        metadata_hedging_enabled: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let connection_string: ConnectionString = connection_string.parse()?;
 
@@ -275,6 +295,11 @@ impl TestClient {
         // Apply application region for the client
         if let Some(region) = application_region.or(fault_client_application_region) {
             builder = builder.with_application_region(region);
+        }
+
+        // Enable metadata hedging on the client when requested.
+        if metadata_hedging_enabled {
+            builder = builder.with_metadata_hedging_enabled(true);
         }
 
         // Configure invalid certificate acceptance (e.g., for emulator)
@@ -359,7 +384,11 @@ impl TestClient {
             .with_env_filter(EnvFilter::from_default_env())
             .try_init();
 
-        let test_client = Self::from_env(options.client_application_region.clone()).await?;
+        let test_client = Self::from_env_with_hedging(
+            options.client_application_region.clone(),
+            options.client_metadata_hedging_enabled,
+        )
+        .await?;
 
         // Create fault injection client if builder or application region were provided
         // builder should be passed in for emulator tests to ensure the FaultClient


### PR DESCRIPTION
## Summary

Ports **bounded cross-region hedging** for the two hot-path metadata cache reads from the .NET SDK ([Azure/azure-cosmos-dotnet-v3#5999](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5999)) to the Rust Cosmos SDK:

1. **Collection Read** — container properties (`ContainerCache`).
2. **PartitionKeyRange ReadFeed** — routing map, **first page only** (`PartitionKeyRangeCache`).

When enabled and the account has >= 2 applicable regions, a slow or regionally-failing primary metadata read triggers a **single** hedge to another region after a threshold (`DEFAULT_CONNECTION_TIMEOUT + 500ms`, ~1.5s). The **primary stays authoritative**: a hedge can only win by being faster *and* producing a good answer, and can never override a definitive outcome the primary has already produced.

## Rollout note

This ships **default-OFF (opt-in)** for the initial release. The intended end state is **default-ON after a soak period**.

## Design

- **New `MetadataHedgingStrategy`** (`routing/metadata_hedging.rs`): eligibility, threshold timer, primary-vs-hedge race, three-way outcome classification (`Success` / `RegionalFailure` / `Definitive`), background loser-draining.
- **Dedicated `is_regional_failure`** matching the .NET `IsRegionalFailure` sub-status set exactly: regional = `503`, `500`, `410+LeaseNotFound`, `403+DatabaseAccountNotFound`. Plain `410` (PartitionKeyRangeGone) and plain `403` (WriteForbidden) are **definitive**.
- **First-page-only PK-range hedging**: pages 2..N are pinned to the winning region only when the hedge won page 1, preserving the change-feed ETag continuation.
- **Runtime-agnostic**: the race uses `futures::select` + `get_async_runtime().sleep()` — no `tokio` in library code.
- **Opt-in**: `CosmosClientBuilder::with_metadata_hedging_enabled(bool)` + `CosmosClientOptions`, plus the `AZURE_COSMOS_METADATA_HEDGING_ENABLED` env var override.
- **Loser region is not recorded as failed** (matches .NET), so hedging does not fight the sequential metadata retry policy.

## Testing

- **Unit tests**: regional-failure classification incl. plain 410/403 = definitive, threshold derivation, transport-error classification.
- **Emulator integration tests** (`cosmos_metadata_hedging.rs`): enabling hedging never breaks the two metadata reads and is a transparent no-op on a single-region account.
- **Verified locally:** full emulator suite (43 tests) passes, lib unit tests (426) pass, `cargo fmt --check` clean, `cargo clippy --all-targets` clean.
- **Not covered here (requires a real multi-region account):** the multi-region behavioral criteria where a hedge actually fires/wins. The emulator is single-region (the existing `multi_write` tests carry the same limitation); the decision logic is covered by the unit tests.