### PR TITLE
chore(amqp): stabilize azure_core_amqp 1.1.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "azure_core_amqp"
-version = "1.1.0-beta.1"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "azure_core",

--- a/sdk/core/azure_core_amqp/CHANGELOG.md
+++ b/sdk/core/azure_core_amqp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
+## 1.1.0 (2026-07-08)
 
 ### Features Added
 

--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -3,7 +3,7 @@
 # AMQP Stack for consumption by packages in the Azure SDK.
 [package]
 name = "azure_core_amqp"
-version = "1.1.0-beta.1"
+version = "1.1.0"
 description = "Rust client library for the AMQP protocol"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
@@ -21,8 +21,8 @@ async-lock.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 azure_core = { workspace = true, default-features = false }
-# Unreleased: needs AmqpSessionOptions::with_unbounded_windows from 1.1.0-beta.1 (issue #4570).
-azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.1.0-beta.1" }
+# Needs AmqpSessionOptions::with_unbounded_windows, released in azure_core_amqp 1.1.0 (issue #4570).
+azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.1.0" }
 base64.workspace = true
 futures.workspace = true
 hmac.workspace = true
@@ -36,7 +36,7 @@ tracing.workspace = true
 rustc_version.workspace = true
 
 [dev-dependencies]
-azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.1.0-beta.1", features = ["test"] }
+azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.1.0", features = ["test"] }
 azure_core_test = { workspace = true, features = ["tracing"] }
 azure_identity.workspace = true
 azure_messaging_eventhubs = { path = ".", features = [

--- a/sdk/servicebus/azure_messaging_servicebus/Cargo.toml
+++ b/sdk/servicebus/azure_messaging_servicebus/Cargo.toml
@@ -21,8 +21,8 @@ async-lock.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 azure_core = { workspace = true, default-features = false }
-# Unreleased: needs AmqpSessionOptions::with_unbounded_windows from 1.1.0-beta.1 (issue #4570).
-azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.1.0-beta.1" }
+# Needs AmqpSessionOptions::with_unbounded_windows, released in azure_core_amqp 1.1.0 (issue #4570).
+azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.1.0" }
 futures.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
@@ -34,7 +34,7 @@ tracing.workspace = true
 default = ["azure_core_amqp/default"]
 
 [dev-dependencies]
-azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.1.0-beta.1", features = ["test"] }
+azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.1.0", features = ["test"] }
 azure_core_test = { workspace = true, features = ["tracing"] }
 azure_identity.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Summary

Stabilizes `azure_core_amqp` from the `1.1.0-beta.1` pre-release to a published `1.1.0` release, and repoints `azure_messaging_eventhubs` and `azure_messaging_servicebus` at the released version.

## Motivation

`azure_messaging_eventhubs` and `azure_messaging_servicebus` are currently pinned to the unreleased `azure_core_amqp` `1.1.0-beta.1` solely for `AmqpSessionOptions::with_unbounded_windows`, added in #4575 (issue #4570).
A stable 1.0 crate cannot depend on a pre-release dependency, so this pin blocks the Event Hubs (and Service Bus) 1.0 release.
The `1.1.0-beta.1` delta over the shipped `1.0.0` is exactly that one additive helper, so it can be released as `1.1.0` without further changes.

## Changes

- `sdk/core/azure_core_amqp/Cargo.toml`: bump `version` from `1.1.0-beta.1` to `1.1.0`.
- `sdk/core/azure_core_amqp/CHANGELOG.md`: change the top heading from `## 1.1.0-beta.1 (Unreleased)` to `## 1.1.0 (2026-07-08)`, leaving its entries intact.
- `sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml`: update the `azure_core_amqp` dependency version to `1.1.0` in both `[dependencies]` and `[dev-dependencies]`, keeping the `path` dependency, and update the explanatory comment to reference the released version.
- `sdk/servicebus/azure_messaging_servicebus/Cargo.toml`: same treatment as `azure_messaging_eventhubs`.