### PR TITLE
refactor(eventhubs)!: harden public API for 1.0 (non_exhaustive + TryFrom)

### DIFF
--- a/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Breaking Changes
 
 - On the receive path, the `amqp:link:stolen` AMQP condition is no longer auto-retried. A receiver displaced by a higher-or-equal-epoch attacher now surfaces the error (translated to `EventHubsError::ConsumerDisconnected` by `EventReceiver::stream_events`) instead of silently re-attaching. Sender, CBS, and management operations retain the historical retry-on-stolen behavior.
+- Marked the crate's public data, options, and error types `#[non_exhaustive]` so fields and variants can be added after the 1.0 API freeze without a further major version bump. Affected types: the `MessageId`, `StartLocation`, and `ProcessorStrategy` enums; the `SendBatchOptions`, `SendEventOptions`, `SendMessageOptions`, `AddEventDataOptions`, `EventDataBatchOptions`, `OpenReceiverOptions`, `StartPosition`, and `RetryOptions` options structs; and the `EventHubProperties`, `EventHubPartitionProperties`, `Checkpoint`, `Ownership`, `StartPositions`, and `EventHubsError` data structs. External code can no longer build these with a struct literal or exhaustively match the enums; construct the structs from `Default::default()` and set the public fields, and add a wildcard arm when matching the enums.
+- Changed the fallible `MessageId` conversions from `From` to `TryFrom` to remove panics from the public API before 1.0. `Uuid`, `Vec<u8>`, `String`, and `u64` now implement `TryFrom<MessageId>` (returning `Result<_, EventHubsError>`) instead of `From<MessageId>`, which previously panicked when the `MessageId` variant did not match the target type. The infallible conversions into `MessageId` and between `MessageId` and `AmqpMessageId` are unchanged.
 
 ### Bugs Fixed
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/README.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/README.md
@@ -218,12 +218,12 @@ async fn receive_events(client: &ConsumerClient) -> Result<(), Box<dyn std::erro
     let message_receiver = client
         .open_receiver_on_partition(
             "0".to_string(),
-            Some(OpenReceiverOptions {
-                start_position: Some(StartPosition {
-                    location: StartLocation::Earliest,
-                    ..Default::default()
-                }),
-                ..Default::default()
+            Some({
+                let mut start_position = StartPosition::default();
+                start_position.location = StartLocation::Earliest;
+                let mut options = OpenReceiverOptions::default();
+                options.start_position = Some(start_position);
+                options
             }),
         )
         .await?;

--- a/sdk/eventhubs/azure_messaging_eventhubs/benches/benchmarks.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/benches/benchmarks.rs
@@ -210,8 +210,10 @@ fn send_benchmark(c: &mut Criterion) {
                 client
                     .send_event(
                         event_data,
-                        Some(SendEventOptions {
-                            partition_id: Some("0".to_string()),
+                        Some({
+                            let mut options = SendEventOptions::default();
+                            options.partition_id = Some("0".to_string());
+                            options
                         }),
                     )
                     .await

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_batch_produce_events.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_batch_produce_events.rs
@@ -17,9 +17,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let credential = DeveloperToolsCredential::new(None)?;
 
     let client = ProducerClient::builder()
-        .with_retry_options(RetryOptions {
-            initial_delay: Duration::milliseconds(100),
-            ..Default::default()
+        .with_retry_options({
+            let mut retry_options = RetryOptions::default();
+            retry_options.initial_delay = Duration::milliseconds(100);
+            retry_options
         })
         .open(
             eventhub_namespace.as_str(),
@@ -38,9 +39,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Send the message to each partition using a batch sender.
     for partition_id in properties.partition_ids {
         let batch = client
-            .create_batch(Some(EventDataBatchOptions {
-                partition_id: Some(partition_id.clone()),
-                ..Default::default()
+            .create_batch(Some({
+                let mut options = EventDataBatchOptions::default();
+                options.partition_id = Some(partition_id.clone());
+                options
             }))
             .await?;
         if batch.try_add_event_data(message, None)? {

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_connection_string.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_connection_string.rs
@@ -40,8 +40,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     producer
         .send_event(
             marker.clone(),
-            Some(SendEventOptions {
-                partition_id: Some(partition_id.clone()),
+            Some({
+                let mut options = SendEventOptions::default();
+                options.partition_id = Some(partition_id.clone());
+                options
             }),
         )
         .await?;
@@ -55,13 +57,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let receiver = consumer
         .open_receiver_on_partition(
             partition_id.clone(),
-            Some(OpenReceiverOptions {
-                start_position: Some(StartPosition {
-                    location: StartLocation::SequenceNumber(start_sequence),
-                    inclusive: false,
-                }),
-                receive_timeout: Some(Duration::seconds(30)),
-                ..Default::default()
+            Some({
+                let mut start_position = StartPosition::default();
+                start_position.location = StartLocation::SequenceNumber(start_sequence);
+                start_position.inclusive = false;
+                let mut options = OpenReceiverOptions::default();
+                options.start_position = Some(start_position);
+                options.receive_timeout = Some(Duration::seconds(30));
+                options
             }),
         )
         .await?;

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_events.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_events.rs
@@ -35,13 +35,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let receiver = consumer
         .open_receiver_on_partition(
             properties.partition_ids[0].clone(),
-            Some(OpenReceiverOptions {
-                start_position: Some(StartPosition {
-                    location: StartLocation::Earliest,
-                    ..Default::default()
-                }),
-                receive_timeout: Some(Duration::seconds(5)),
-                ..Default::default()
+            Some({
+                let mut start_position = StartPosition::default();
+                start_position.location = StartLocation::Earliest;
+                let mut options = OpenReceiverOptions::default();
+                options.start_position = Some(start_position);
+                options.receive_timeout = Some(Duration::seconds(5));
+                options
             }),
         )
         .await?;

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_produce_events.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_produce_events.rs
@@ -34,8 +34,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     client
         .send_event(
             vec![2, 4, 8, 16],
-            Some(SendEventOptions {
-                partition_id: Some("0".to_string()),
+            Some({
+                let mut options = SendEventOptions::default();
+                options.partition_id = Some("0".to_string());
+                options
             }),
         )
         .await?;

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_tracing_subscriber.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_tracing_subscriber.rs
@@ -56,8 +56,10 @@ impl EventHubsLayer {
                 if let Err(err) = producer_clone
                     .send_event(
                         event,
-                        Some(SendEventOptions {
-                            partition_id: Some("0".to_string()),
+                        Some({
+                            let mut options = SendEventOptions::default();
+                            options.partition_id = Some("0".to_string());
+                            options
                         }),
                     )
                     .await

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/retry.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/retry.rs
@@ -33,6 +33,7 @@ pub(crate) enum ErrorRecoveryAction {
 
 /// Options for configuring exponential backoff retry behavior.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct RetryOptions {
     /// The initial backoff delay (Default is 100ms).
     pub initial_delay: Duration,

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -428,6 +428,7 @@ impl ConsumerClient {
 
 /// Represents the options for receiving events from an Event Hub.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct OpenReceiverOptions {
     /// The owner level for messages being retrieved.
     pub owner_level: Option<i64>,
@@ -447,6 +448,7 @@ impl OpenReceiverOptions {}
 
 /// Represents the starting position of a consumer when receiving events from an Event Hub.
 #[derive(Debug, Default, PartialEq, Clone)]
+#[non_exhaustive]
 pub enum StartLocation {
     /// The starting position is specified by an offset.
     Offset(String),
@@ -479,45 +481,36 @@ pub(crate) const SEQUENCE_NUMBER_ANNOTATION: &str = "amqp.annotation.x-opt-seque
 /// ```
 /// use azure_messaging_eventhubs::{StartPosition, StartLocation};
 ///
-/// let start_position = StartPosition{
-///   location: StartLocation::SequenceNumber(12345),
-///    ..Default::default()};;
+/// let mut start_position = StartPosition::default();
+/// start_position.location = StartLocation::SequenceNumber(12345);
 /// ```
 ///
 /// ```
 /// use azure_messaging_eventhubs::{StartPosition, StartLocation};
 ///
-/// let start_position = StartPosition{
-///  location: StartLocation::EnqueuedTime(std::time::SystemTime::now()),
-///  ..Default::default()
-/// };
+/// let mut start_position = StartPosition::default();
+/// start_position.location = StartLocation::EnqueuedTime(std::time::SystemTime::now());
 /// ```
 ///
 /// ```
 /// use azure_messaging_eventhubs::{StartPosition, StartLocation};
 ///
-/// let start_position = StartPosition{
-///   location: StartLocation::Offset("12345".to_string()),
-///   ..Default::default()
-/// };
+/// let mut start_position = StartPosition::default();
+/// start_position.location = StartLocation::Offset("12345".to_string());
 /// ```
 ///
 /// ```
 /// use azure_messaging_eventhubs::{StartPosition, StartLocation};
 ///
-/// let start_position = StartPosition{
-///   location: StartLocation::Earliest,
-///   ..Default::default()
-/// };
+/// let mut start_position = StartPosition::default();
+/// start_position.location = StartLocation::Earliest;
 /// ```
 ///
 /// ```
 /// use azure_messaging_eventhubs::{StartPosition, StartLocation};
 ///
-/// let start_position = StartPosition{
-///   location: StartLocation::Latest,
-///   ..Default::default()
-/// };
+/// let mut start_position = StartPosition::default();
+/// start_position.location = StartLocation::Latest;
 /// ```
 ///
 /// ```
@@ -527,6 +520,7 @@ pub(crate) const SEQUENCE_NUMBER_ANNOTATION: &str = "amqp.annotation.x-opt-seque
 /// ```
 ///
 #[derive(Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct StartPosition {
     /// The location of the starting position.
     pub location: StartLocation,

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/error.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/error.rs
@@ -37,6 +37,7 @@ pub enum ErrorKind {
 }
 
 /// Represents an error that can occur in the Event Hubs module.
+#[non_exhaustive]
 pub struct EventHubsError {
     /// The kind of error that occurred.
     pub kind: ErrorKind,

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/mod.rs
@@ -88,6 +88,7 @@ pub trait CheckpointStore: Send + Sync {
 }
 
 #[derive(Clone, Debug, Copy)]
+#[non_exhaustive]
 /// Represents the strategy for load balancing event processing.
 ///
 /// The choice of strategy can impact the performance and efficiency

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/models.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/models.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 /// for a specific partition. It helps in resuming event processing from
 /// the correct position in case of failures or restarts.
 #[derive(Debug, Default, Clone)]
+#[non_exhaustive]
 pub struct Checkpoint {
     /// The fully qualified namespace of the Event Hub.
     pub fully_qualified_namespace: String,
@@ -80,6 +81,7 @@ impl Checkpoint {
 /// by different consumers in a consumer group. It helps in load balancing
 /// and ensuring that each partition is processed by only one consumer at a time.
 #[derive(Debug, Default, Clone)]
+#[non_exhaustive]
 pub struct Ownership {
     /// The fully qualified namespace of the Event Hub.
     pub fully_qualified_namespace: String,
@@ -142,6 +144,7 @@ impl Ownership {
 /// position based on various criteria, such as the latest event, a specific
 /// offset, or a specific sequence number.
 #[derive(Debug, Default)]
+#[non_exhaustive]
 pub struct StartPositions {
     /// The starting position for each partition in the Event Hub.
     /// The key is the partition ID, and the value is the starting position.

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/models/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/models/mod.rs
@@ -29,6 +29,7 @@ pub mod builders {
 /// Event sent to an Event Hub.
 pub use event_data::EventData;
 
+use crate::error::EventHubsError;
 use azure_core::Uuid;
 use azure_core_amqp::message::AmqpMessageId;
 use std::fmt::Debug;
@@ -65,6 +66,7 @@ use std::time::SystemTime;
 /// ```
 ///
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct EventHubProperties {
     /// The name of the Event Hubs instance.
     pub name: String,
@@ -107,6 +109,7 @@ pub struct EventHubProperties {
 /// ```
 ///
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct EventHubPartitionProperties {
     /// The unique identifier of the partition.
     pub id: String,
@@ -138,6 +141,7 @@ pub struct EventHubPartitionProperties {
 /// assured to be globally unique.
 ///
 #[derive(Debug, PartialEq, Clone)]
+#[non_exhaustive]
 pub enum MessageId {
     /// A binary representation of the message identifier.
     Binary(Vec<u8>),
@@ -182,38 +186,54 @@ impl From<String> for MessageId {
     }
 }
 
-impl From<MessageId> for Uuid {
-    fn from(message_id: MessageId) -> Self {
+impl TryFrom<MessageId> for Uuid {
+    type Error = EventHubsError;
+
+    fn try_from(message_id: MessageId) -> std::result::Result<Self, Self::Error> {
         match message_id {
-            MessageId::Uuid(uuid) => uuid,
-            _ => panic!("Cannot convert MessageId to Uuid"),
+            MessageId::Uuid(uuid) => Ok(uuid),
+            _ => Err(EventHubsError::with_message(
+                "Cannot convert MessageId to Uuid",
+            )),
         }
     }
 }
 
-impl From<MessageId> for Vec<u8> {
-    fn from(message_id: MessageId) -> Self {
+impl TryFrom<MessageId> for Vec<u8> {
+    type Error = EventHubsError;
+
+    fn try_from(message_id: MessageId) -> std::result::Result<Self, Self::Error> {
         match message_id {
-            MessageId::Binary(binary) => binary,
-            _ => panic!("Cannot convert MessageId to Vec<u8>"),
+            MessageId::Binary(binary) => Ok(binary),
+            _ => Err(EventHubsError::with_message(
+                "Cannot convert MessageId to Vec<u8>",
+            )),
         }
     }
 }
 
-impl From<MessageId> for String {
-    fn from(message_id: MessageId) -> Self {
+impl TryFrom<MessageId> for String {
+    type Error = EventHubsError;
+
+    fn try_from(message_id: MessageId) -> std::result::Result<Self, Self::Error> {
         match message_id {
-            MessageId::String(string) => string,
-            _ => panic!("Cannot convert MessageId to String"),
+            MessageId::String(string) => Ok(string),
+            _ => Err(EventHubsError::with_message(
+                "Cannot convert MessageId to String",
+            )),
         }
     }
 }
 
-impl From<MessageId> for u64 {
-    fn from(message_id: MessageId) -> Self {
+impl TryFrom<MessageId> for u64 {
+    type Error = EventHubsError;
+
+    fn try_from(message_id: MessageId) -> std::result::Result<Self, Self::Error> {
         match message_id {
-            MessageId::Ulong(ulong) => ulong,
-            _ => panic!("Cannot convert MessageId to u64"),
+            MessageId::Ulong(ulong) => Ok(ulong),
+            _ => Err(EventHubsError::with_message(
+                "Cannot convert MessageId to u64",
+            )),
         }
     }
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
@@ -9,6 +9,8 @@ use std::sync::Mutex;
 use tracing::{debug, warn};
 
 /// Represents the options that can be set when adding event data to an [`EventDataBatch`].
+#[derive(Default)]
+#[non_exhaustive]
 pub struct AddEventDataOptions {}
 
 struct EventDataBatchState {
@@ -347,14 +349,14 @@ impl<'a> EventDataBatch<'a> {
 /// ```
 /// use azure_messaging_eventhubs::EventDataBatchOptions;
 ///
-/// let options = EventDataBatchOptions{
-///    max_size_in_bytes: Some(1024),
-///    partition_key: Some("pk".to_string()),
-///    partition_id: Some("12".to_string()),
-///    ..Default::default()};
+/// let mut options = EventDataBatchOptions::default();
+/// options.max_size_in_bytes = Some(1024);
+/// options.partition_key = Some("pk".to_string());
+/// options.partition_id = Some("12".to_string());
 /// ```
 ///
 #[derive(Default)]
+#[non_exhaustive]
 pub struct EventDataBatchOptions {
     /// The maximum size of the batch in bytes.
     pub max_size_in_bytes: Option<u64>,

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
@@ -28,6 +28,7 @@ pub(crate) mod batch;
 pub(crate) const DEFAULT_EVENTHUBS_APPLICATION: &str = "DefaultApplicationName";
 
 #[derive(Default, Debug, Clone)]
+#[non_exhaustive]
 /// Represents the options that can be set when submitting a batch of event data.
 pub struct SendBatchOptions {}
 
@@ -69,6 +70,7 @@ pub struct ProducerClient {
 /// If the partition is not specified, the Event Hub will automatically select a partition.
 ///
 #[derive(Default, Debug)]
+#[non_exhaustive]
 pub struct SendEventOptions {
     /// The id of the partition to which the event should be sent.
     pub partition_id: Option<String>,
@@ -78,6 +80,7 @@ pub struct SendEventOptions {
 /// The `SendMessageOptions` can be used to specify the partition to which the message should be sent.
 /// If the partition is not specified, the Event Hub will automatically select a partition.
 #[derive(Default, Debug)]
+#[non_exhaustive]
 pub struct SendMessageOptions {
     /// The id of the partition to which the message should be sent.
     pub partition_id: Option<String>,

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_checkpoint_store.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_checkpoint_store.rs
@@ -20,15 +20,13 @@ use tracing::info;
 fn test_update_ownership() {
     common::setup();
     let store = InMemoryCheckpointStore::new();
-    let ownership = Ownership {
-        fully_qualified_namespace: "namespace".to_string(),
-        event_hub_name: "event_hub".to_string(),
-        consumer_group: "consumer_group".to_string(),
-        partition_id: "partition_id".to_string(),
-        owner_id: Some("owner_id".to_string()),
-        etag: Some("etag".into()),
-        ..Default::default()
-    };
+    let mut ownership = Ownership::default();
+    ownership.fully_qualified_namespace = "namespace".to_string();
+    ownership.event_hub_name = "event_hub".to_string();
+    ownership.consumer_group = "consumer_group".to_string();
+    ownership.partition_id = "partition_id".to_string();
+    ownership.owner_id = Some("owner_id".to_string());
+    ownership.etag = Some("etag".into());
     let result = store.update_ownership(&ownership);
     assert!(result.is_ok());
 }
@@ -37,13 +35,11 @@ fn test_update_ownership() {
 fn test_update_ownership_invalid() {
     common::setup();
     let store = InMemoryCheckpointStore::new();
-    let ownership = Ownership {
-        fully_qualified_namespace: "fqdn.servicebus.windows.net".to_string(),
-        partition_id: "partition_id".to_string(),
-        owner_id: Some("owner_id".to_string()),
-        etag: Some("etag".into()),
-        ..Default::default()
-    };
+    let mut ownership = Ownership::default();
+    ownership.fully_qualified_namespace = "fqdn.servicebus.windows.net".to_string();
+    ownership.partition_id = "partition_id".to_string();
+    ownership.owner_id = Some("owner_id".to_string());
+    ownership.etag = Some("etag".into());
     let result = store.update_ownership(&ownership);
     assert!(result.is_err());
     assert_eq!(*result.unwrap_err().kind(), AzureErrorKind::Other);
@@ -53,13 +49,11 @@ fn test_update_ownership_invalid() {
 async fn test_update_checkpoint() {
     common::setup();
     let store = InMemoryCheckpointStore::new();
-    let checkpoint = Checkpoint {
-        fully_qualified_namespace: "namespace".to_string(),
-        event_hub_name: "event_hub".to_string(),
-        consumer_group: "consumer_group".to_string(),
-        partition_id: "partition_id".to_string(),
-        ..Default::default()
-    };
+    let mut checkpoint = Checkpoint::default();
+    checkpoint.fully_qualified_namespace = "namespace".to_string();
+    checkpoint.event_hub_name = "event_hub".to_string();
+    checkpoint.consumer_group = "consumer_group".to_string();
+    checkpoint.partition_id = "partition_id".to_string();
     let result = store.update_checkpoint(checkpoint).await;
     assert!(result.is_ok());
 }
@@ -68,13 +62,11 @@ async fn test_update_checkpoint() {
 async fn test_list_checkpoints() {
     common::setup();
     let store = InMemoryCheckpointStore::new();
-    let checkpoint = Checkpoint {
-        fully_qualified_namespace: "namespace".to_string(),
-        event_hub_name: "event_hub".to_string(),
-        consumer_group: "consumer_group".to_string(),
-        partition_id: "partition_id".to_string(),
-        ..Default::default()
-    };
+    let mut checkpoint = Checkpoint::default();
+    checkpoint.fully_qualified_namespace = "namespace".to_string();
+    checkpoint.event_hub_name = "event_hub".to_string();
+    checkpoint.consumer_group = "consumer_group".to_string();
+    checkpoint.partition_id = "partition_id".to_string();
     info!("Adding checkpoint: {checkpoint:?}");
     store.update_checkpoint(checkpoint).await.unwrap();
 
@@ -107,14 +99,13 @@ async fn checkpoints() -> azure_core::Result<()> {
         .unwrap();
     assert_eq!(checkpoints.len(), 0);
 
-    let checkpoint = Checkpoint {
-        fully_qualified_namespace: "ns.servicebus.windows.net".to_string(),
-        event_hub_name: "event-hub-name".to_string(),
-        consumer_group: "consumer-group".to_string(),
-        partition_id: test_name.clone(),
-        offset: Some("offset".to_string()),
-        sequence_number: Some(0),
-    };
+    let mut checkpoint = Checkpoint::default();
+    checkpoint.fully_qualified_namespace = "ns.servicebus.windows.net".to_string();
+    checkpoint.event_hub_name = "event-hub-name".to_string();
+    checkpoint.consumer_group = "consumer-group".to_string();
+    checkpoint.partition_id = test_name.clone();
+    checkpoint.offset = Some("offset".to_string());
+    checkpoint.sequence_number = Some(0);
 
     // Even though we added a checkpoint in one namespace, it doesn't change the older namespace.
     checkpoint_store

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_consumer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_consumer.rs
@@ -166,14 +166,14 @@ async fn receive_events_on_all_partitions(ctx: TestContext) -> Result<(), Box<dy
         let receiver = client
             .open_receiver_on_partition(
                 partition_id,
-                Some(OpenReceiverOptions {
-                    start_position: Some(StartPosition {
-                        location: azure_messaging_eventhubs::StartLocation::Earliest,
-                        ..Default::default()
-                    }),
+                Some({
+                    let mut start_position = StartPosition::default();
+                    start_position.location = azure_messaging_eventhubs::StartLocation::Earliest;
+                    let mut options = OpenReceiverOptions::default();
+                    options.start_position = Some(start_position);
                     // Timeout for individual receive operations.
-                    receive_timeout: Some(Duration::seconds(5)),
-                    ..Default::default()
+                    options.receive_timeout = Some(Duration::seconds(5));
+                    options
                 }),
             )
             .await?;
@@ -252,14 +252,14 @@ async fn multiple_receivers_on_one_partition(ctx: TestContext) -> Result<(), Box
         let receiver = client
             .open_receiver_on_partition(
                 eh_properties.partition_ids[0].clone(),
-                Some(OpenReceiverOptions {
-                    start_position: Some(StartPosition {
-                        location: azure_messaging_eventhubs::StartLocation::Earliest,
-                        ..Default::default()
-                    }),
+                Some({
+                    let mut start_position = StartPosition::default();
+                    start_position.location = azure_messaging_eventhubs::StartLocation::Earliest;
+                    let mut options = OpenReceiverOptions::default();
+                    options.start_position = Some(start_position);
                     // Timeout for individual receive operations.
-                    receive_timeout: Some(Duration::seconds(5)),
-                    ..Default::default()
+                    options.receive_timeout = Some(Duration::seconds(5));
+                    options
                 }),
             )
             .await?;
@@ -275,14 +275,14 @@ async fn multiple_receivers_on_one_partition(ctx: TestContext) -> Result<(), Box
         let receiver = client
             .open_receiver_on_partition(
                 eh_properties.partition_ids[0].clone(),
-                Some(OpenReceiverOptions {
-                    start_position: Some(StartPosition {
-                        location: azure_messaging_eventhubs::StartLocation::Earliest,
-                        ..Default::default()
-                    }),
+                Some({
+                    let mut start_position = StartPosition::default();
+                    start_position.location = azure_messaging_eventhubs::StartLocation::Earliest;
+                    let mut options = OpenReceiverOptions::default();
+                    options.start_position = Some(start_position);
                     // Timeout for individual receive operations.
-                    receive_timeout: Some(Duration::seconds(5)),
-                    ..Default::default()
+                    options.receive_timeout = Some(Duration::seconds(5));
+                    options
                 }),
             )
             .await?;
@@ -347,14 +347,14 @@ async fn receive_lots_of_events(ctx: TestContext) -> Result<(), Box<dyn Error>> 
     let receiver = client
         .open_receiver_on_partition(
             "0".to_string(),
-            Some(OpenReceiverOptions {
-                start_position: Some(StartPosition {
-                    location: azure_messaging_eventhubs::StartLocation::Earliest,
-                    ..Default::default()
-                }),
+            Some({
+                let mut start_position = StartPosition::default();
+                start_position.location = azure_messaging_eventhubs::StartLocation::Earliest;
+                let mut options = OpenReceiverOptions::default();
+                options.start_position = Some(start_position);
                 // Timeout for individual receive operations.
-                receive_timeout: Some(Duration::seconds(5)),
-                ..Default::default()
+                options.receive_timeout = Some(Duration::seconds(5));
+                options
             }),
         )
         .await?;

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_consumer_error.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_consumer_error.rs
@@ -28,8 +28,10 @@ async fn consumer_error(ctx: TestContext) -> Result<()> {
             producer
                 .send_event(
                     event,
-                    Some(SendEventOptions {
-                        partition_id: Some("0".into()),
+                    Some({
+                        let mut options = SendEventOptions::default();
+                        options.partition_id = Some("0".into());
+                        options
                     }),
                 )
                 .await?;
@@ -56,13 +58,13 @@ async fn consumer_error(ctx: TestContext) -> Result<()> {
     let receiver = consumer
         .open_receiver_on_partition(
             properties.partition_ids[0].clone(),
-            Some(OpenReceiverOptions {
-                start_position: Some(StartPosition {
-                    location: StartLocation::Earliest,
-                    ..Default::default()
-                }),
-                //                receive_timeout: Some(azure_core::time::Duration::seconds(1)),
-                ..Default::default()
+            Some({
+                let mut start_position = StartPosition::default();
+                start_position.location = StartLocation::Earliest;
+                let mut options = OpenReceiverOptions::default();
+                options.start_position = Some(start_position);
+                //                options.receive_timeout = Some(azure_core::time::Duration::seconds(1));
+                options
             }),
         )
         .await?;

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs
@@ -307,23 +307,20 @@ async fn receive_events_from_processor(ctx: TestContext) -> Result<()> {
             "[{partition_id}]: Last enqueued sequence number: {}",
             partition_info.last_enqueued_sequence_number
         );
-        start_positions.insert(
-            partition_id,
-            StartPosition {
-                location: StartLocation::SequenceNumber(
-                    partition_info.last_enqueued_sequence_number,
-                ),
-                inclusive: false,
-            },
-        );
+        let mut start_position = StartPosition::default();
+        start_position.location =
+            StartLocation::SequenceNumber(partition_info.last_enqueued_sequence_number);
+        start_position.inclusive = false;
+        start_positions.insert(partition_id, start_position);
     }
 
     let processor = create_processor(
         consumer_client,
         Duration::seconds(20),
-        Some(StartPositions {
-            per_partition: start_positions,
-            ..Default::default()
+        Some({
+            let mut start_positions_options = StartPositions::default();
+            start_positions_options.per_partition = start_positions;
+            start_positions_options
         }),
     )
     .await?;
@@ -352,9 +349,8 @@ async fn receive_events_from_processor(ctx: TestContext) -> Result<()> {
 
         for i in 0..10 {
             let event_data = format!("Hello world {}", i);
-            let send_event_options = SendEventOptions {
-                partition_id: Some(partition_client.get_partition_id().to_string()),
-            };
+            let mut send_event_options = SendEventOptions::default();
+            send_event_options.partition_id = Some(partition_client.get_partition_id().to_string());
             producer_client
                 .send_event(event_data, Some(send_event_options))
                 .await

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_producer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_producer.rs
@@ -307,9 +307,10 @@ async fn test_create_and_send_batch(ctx: TestContext) -> Result<(), Box<dyn Erro
     }
     {
         let batch = client
-            .create_batch(Some(EventDataBatchOptions {
-                partition_id: Some("0".to_string()),
-                ..Default::default()
+            .create_batch(Some({
+                let mut options = EventDataBatchOptions::default();
+                options.partition_id = Some("0".to_string());
+                options
             }))
             .await?;
         for i in 0..10 {
@@ -426,9 +427,10 @@ async fn test_overload_batch(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     info!("Client is open.");
     {
         let mut batch = client
-            .create_batch(Some(EventDataBatchOptions {
-                partition_id: Some("0".to_string()),
-                ..Default::default()
+            .create_batch(Some({
+                let mut options = EventDataBatchOptions::default();
+                options.partition_id = Some("0".to_string());
+                options
             }))
             .await?;
         trace!("Batch created.");
@@ -449,9 +451,10 @@ async fn test_overload_batch(ctx: TestContext) -> Result<(), Box<dyn Error>> {
                 assert!(result.is_ok());
                 // Recreate the batch to continue adding messages
                 batch = client
-                    .create_batch(Some(EventDataBatchOptions {
-                        partition_id: Some("0".to_string()),
-                        ..Default::default()
+                    .create_batch(Some({
+                        let mut options = EventDataBatchOptions::default();
+                        options.partition_id = Some("0".to_string());
+                        options
                     }))
                     .await?;
             }

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_round_trip.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_round_trip.rs
@@ -39,10 +39,11 @@ async fn test_round_trip_batch(ctx: TestContext) -> Result<(), Box<dyn Error>> {
 
     let start_sequence = partition_properties.last_enqueued_sequence_number;
     let batch = producer
-        .create_batch(Some(EventDataBatchOptions {
-            partition_id: Some(EVENTHUB_PARTITION.to_string()),
-            partition_key: Some("My Partition Key.".to_string()),
-            ..Default::default()
+        .create_batch(Some({
+            let mut options = EventDataBatchOptions::default();
+            options.partition_id = Some(EVENTHUB_PARTITION.to_string());
+            options.partition_key = Some("My Partition Key.".to_string());
+            options
         }))
         .await?;
 
@@ -104,12 +105,12 @@ async fn test_round_trip_batch(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     let receiver = consumer
         .open_receiver_on_partition(
             EVENTHUB_PARTITION.to_string(),
-            Some(OpenReceiverOptions {
-                start_position: Some(StartPosition {
-                    location: StartLocation::SequenceNumber(start_sequence),
-                    ..Default::default()
-                }),
-                ..Default::default()
+            Some({
+                let mut start_position = StartPosition::default();
+                start_position.location = StartLocation::SequenceNumber(start_sequence);
+                let mut options = OpenReceiverOptions::default();
+                options.start_position = Some(start_position);
+                options
             }),
         )
         .await?;
@@ -175,8 +176,10 @@ async fn test_round_trip_connection_string(_ctx: TestContext) -> Result<(), Box<
     producer
         .send_event(
             marker.clone(),
-            Some(SendEventOptions {
-                partition_id: Some(partition_id.clone()),
+            Some({
+                let mut options = SendEventOptions::default();
+                options.partition_id = Some(partition_id.clone());
+                options
             }),
         )
         .await?;
@@ -188,13 +191,13 @@ async fn test_round_trip_connection_string(_ctx: TestContext) -> Result<(), Box<
     let receiver = consumer
         .open_receiver_on_partition(
             partition_id.clone(),
-            Some(OpenReceiverOptions {
-                start_position: Some(StartPosition {
-                    location: StartLocation::SequenceNumber(start_sequence),
-                    ..Default::default()
-                }),
-                receive_timeout: Some(Duration::seconds(30)),
-                ..Default::default()
+            Some({
+                let mut start_position = StartPosition::default();
+                start_position.location = StartLocation::SequenceNumber(start_sequence);
+                let mut options = OpenReceiverOptions::default();
+                options.start_position = Some(start_position);
+                options.receive_timeout = Some(Duration::seconds(30));
+                options
             }),
         )
         .await?;


### PR DESCRIPTION
## Summary

This is a BREAKING change to `azure_messaging_eventhubs`, intended to land before the 1.0.0 API freeze. It marks the crate's public data, options, and error types `#[non_exhaustive]` and converts four panicking `MessageId` conversions from `From` to `TryFrom`. Neither change can be made after 1.0 without a major version bump, so they are grouped here as pre-1.0 hardening.

## Motivation

`#[non_exhaustive]` lets new fields and enum variants be added after 1.0 without breaking downstream code, which is not possible once the public surface is frozen. The four `From<MessageId>` impls that produced `Uuid`, `Vec<u8>`, `String`, and `u64` panicked whenever the `MessageId` variant did not match the requested target type, putting a panic on an infallible-looking conversion in the public API; `TryFrom` surfaces the mismatch as a recoverable error instead.

## Changes

- Added `#[non_exhaustive]` to the `MessageId`, `StartLocation`, and `ProcessorStrategy` enums; the `SendBatchOptions`, `SendEventOptions`, `SendMessageOptions`, `AddEventDataOptions`, `EventDataBatchOptions`, `OpenReceiverOptions`, `StartPosition`, and `RetryOptions` options structs; and the `EventHubProperties`, `EventHubPartitionProperties`, `Checkpoint`, `Ownership`, `StartPositions`, and `EventHubsError` data structs. `ErrorKind` and `ConnectionString` already had it.
- Added a `Default` derive to `AddEventDataOptions` so external code keeps a construction path now that the empty struct literal is no longer usable outside the crate. The other affected structs already derived or implemented `Default`.
- Changed `Uuid`, `Vec<u8>`, `String`, and `u64` to implement `TryFrom<MessageId>` (with `Error = EventHubsError`) instead of `From<MessageId>`. The error reuses the crate's existing `EventHubsError` type to keep the public error surface unified. The infallible conversions into `MessageId`, and between `MessageId` and `AmqpMessageId`, remain `From`.
- Updated the crate's doc examples (including the README rendered into the crate docs), integration tests, examples, and benchmark to construct the now-non_exhaustive structs via `Default::default()` plus public-field assignment, since struct-literal and functional-record-update construction and exhaustive enum matching are no longer available to external code.
- Recorded both breaking changes under `## 0.15.0 (Unreleased)` in the CHANGELOG.

## Validation

- `cargo build -p azure_messaging_eventhubs --all-features`: pass
- `cargo clippy -p azure_messaging_eventhubs --all-targets --all-features -- -D warnings`: pass
- `cargo test -p azure_messaging_eventhubs --all-features`: pass (offline unit and doc tests; live `#[recorded::test(live)]` tests self-skip without credentials)
- `cargo fmt -p azure_messaging_eventhubs -- --check`: clean