### PR TITLE
Make core test crates unpublished

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,12 +77,10 @@ version = "1.0.0"
 [workspace.dependencies.azure_core_test]
 # azure_core_test should only ever be in dev-dependencies herein
 path = "sdk/core/azure_core_test"
-version = "0.2.0"
 
 [workspace.dependencies.azure_core_test_macros]
 # azure_core_test_macros should only ever be in dev-dependencies herein
 path = "sdk/core/azure_core_test_macros"
-version = "0.2.0"
 
 [workspace.dependencies.azure_identity]
 # azure_identity should only ever be in dev-dependencies herein

--- a/eng/scripts/shared/Cargo.ps1
+++ b/eng/scripts/shared/Cargo.ps1
@@ -43,22 +43,17 @@ function Test-ShouldPackDependency(
     return $false
   }
 
-  if ($dependency['kind'] -ne 'dev') {
-    return $true
-  }
-
-  # `cargo package` verification can resolve publishable workspace
-  # dev-dependencies from crates.io after rewriting path dependencies. Pack
-  # them alongside the requested crate, but skip helper crates that set
-  # `publish = false` because they cannot be packaged for upload anyway.
-  return $null -eq $dependencyPackage.publish
+  # `cargo package` can verify path-only dev-dependencies without packing them
+  # as separate crates first, so only non-dev path dependencies need to be
+  # expanded into the package set.
+  return $dependency['kind'] -ne 'dev'
 }
 
 function Get-CargoPackages() {
   $metadata = Get-CargoMetadata
 
-  # Path based dependencies are assumed to be unreleased package versions. In
-  # non-release builds these should be packed as well.
+  # Path based non-dev dependencies are assumed to be unreleased package
+  # versions. In non-release builds these should be packed as well.
   foreach ($package in $metadata.packages) {
     $package.UnreleasedDependencies = @()
     foreach ($dependency in $package.dependencies) {

--- a/sdk/core/azure_core_test/Cargo.toml
+++ b/sdk/core/azure_core_test/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "azure_core_test"
 version = "0.2.0"
+publish = false
 description = "Utilities for testing client libraries built on azure_core."
 readme = "README.md"
 authors.workspace = true

--- a/sdk/core/azure_core_test_macros/Cargo.toml
+++ b/sdk/core/azure_core_test_macros/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "azure_core_test_macros"
 version = "0.2.0"
+publish = false
 description = "Procedural macros for testing client libraries built on azure_core."
 readme = "README.md"
 authors.workspace = true


### PR DESCRIPTION
Use path-only workspace dependencies for azure_core_test and
azure_core_test_macros so packaging validation does not require
publishing those test-only crates.

Update Cargo.ps1 to stop expanding path-only dev-dependencies into
the package set, which matches the verified cargo package behavior.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 23ea0806-4db4-4177-8e69-44f476d463bf
