### PR TITLE
Handle Cargo crate path layouts

### DIFF
--- a/eng/scripts/Pack-Crates.ps1
+++ b/eng/scripts/Pack-Crates.ps1
@@ -120,6 +120,30 @@ function Create-ApiViewFile($package) {
   "$packagePath/review/$packageName.rust.json"
 }
 
+function Get-CratePath(
+  $package,
+  [bool] $ReleaseBuild
+) {
+  $crateFileName = "$($package.name)-$($package.version).crate"
+  $rootCratePath = [System.IO.Path]::Combine($RepoRoot, "target", "package", $crateFileName)
+  $tmpCratePath = [System.IO.Path]::Combine($RepoRoot, "target", "package", "tmp-crate", $crateFileName)
+  $candidatePaths = if ($ReleaseBuild) {
+    @($tmpCratePath, $rootCratePath)
+  }
+  else {
+    @($rootCratePath, $tmpCratePath)
+  }
+
+  foreach ($candidatePath in $candidatePaths) {
+    if (Test-Path -Path $candidatePath) {
+      return $candidatePath
+    }
+  }
+
+  LogError "Failed to find packaged crate for '$($package.name)'. Checked '$($candidatePaths -join "', '")'."
+  exit 1
+}
+
 $originalLocation = Get-Location
 try {
   Set-Location $RepoRoot
@@ -166,17 +190,10 @@ try {
     foreach ($package in $packages) {
       $sourcePath = [System.IO.Path]::Combine($RepoRoot, "target", "package", "$($package.name)-$($package.version)")
 
-      # The .crate file location depends on the Cargo subcommand. `cargo publish` (used with -Release)
-      # writes it to target/package/tmp-crate as an intermediate artifact since
-      # https://github.com/rust-lang/cargo/pull/15915 (Rust 1.93), while `cargo package` writes it
-      # directly to target/package as a final artifact.
-      $crateFileName = "$($package.name)-$($package.version).crate"
-      if ($Release) {
-        $cratePath = [System.IO.Path]::Combine($RepoRoot, "target", "package", "tmp-crate", $crateFileName)
-      }
-      else {
-        $cratePath = [System.IO.Path]::Combine($RepoRoot, "target", "package", $crateFileName)
-      }
+      # Cargo uses different .crate output locations depending on command and version.
+      # Prefer the expected layout for the current build mode, but fall back to the
+      # other known location so the pack pipeline works on both 1.92 and newer toolchains.
+      $cratePath = Get-CratePath -package $package -ReleaseBuild $Release
 
       $targetPath = [System.IO.Path]::Combine($OutputPath, $package.name)
       $targetContentsPath = [System.IO.Path]::Combine($targetPath, "contents")


### PR DESCRIPTION
Probe both legacy and tmp-crate output locations when copying packed crate artifacts so release packing works with the pinned 1.92 toolchain and newer Cargo versions.

PR #4700 updated Pack-Crates.ps1 for Cargo 1.93+ output, but the pack pipeline still runs the 1.92 PackToolchain pinned in PR #4324.
PR #4666 added the replacement API generation tool that should help unblock the future toolchain bump tracked in #4737.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 06d12fb0-b7b9-4470-875f-9ec66ff9f936
