### PR TITLE
Update core package versions and fix dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,8 @@ You are an expert Rust programmer. You write safe, efficient, maintainable, and 
 
 - Dependencies should be defined in the root workspace's `Cargo.toml` file.
 - Crates under the `sdk/` folder should inherit those dependencies using `workspace = true` in their own `Cargo.toml` files.
+- Service crates should generally use workspace-managed internal dependencies, which typically resolve to published versions.
+- If a crate needs unreleased changes from `sdk/core`, use an explicit `path + version` dependency on that core crate instead of `workspace = true`.
 
 ### General
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -413,13 +413,13 @@ Release builds will fail if a library depends on another Azure SDK for Rust libr
 
 #### Workspace dependencies
 
-The root `Cargo.toml` file represents released versions of crates commonly used by other Azure SDK for Rust libraries. To use a released version of a library, use `workspace = true` in your library's `Cargo.toml`.
+The root `Cargo.toml` file is the source of truth for common internal dependencies. Service crates should generally use `workspace = true`, which typically resolves to the latest published internal crate.
 
 ```toml
 azure_core = { workspace = true }
 ```
 
-If an SDK library depends on an unreleased SDK library, specify that dependency using a `path`-based dependency with a `version` matching the crate version, which is required for the library to release:
+If a crate needs unreleased changes from `sdk/core`, use an explicit `path`-based dependency with a matching `version` instead of `workspace = true`:
 
 ```toml
 azure_core = { path = "../../core/azure_core", version = "0.31.0" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,30 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e41cbd819986ba41904c207d8ffc4106f8f8352a548d773e9554906379bb2fb"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core_macros 1.0.0",
+ "bytes",
+ "futures",
+ "hmac",
+ "openssl",
+ "pin-project",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "tracing",
+ "typespec 1.1.0",
+ "typespec_client_core 1.1.0",
+]
+
+[[package]]
+name = "azure_core"
 version = "1.2.0-beta.1"
 dependencies = [
  "async-lock",
@@ -302,9 +326,31 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec",
- "typespec_client_core",
+ "typespec 1.1.0",
+ "typespec_client_core 1.1.0",
  "ureq",
+]
+
+[[package]]
+name = "azure_core_amqp"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4d270c927b83dbee3c6f5fb5340b38c6019452eeb6ea097f40148ec164fafe1"
+dependencies = [
+ "async-trait",
+ "azure_core 1.1.0",
+ "fe2o3-amqp",
+ "fe2o3-amqp-cbs",
+ "fe2o3-amqp-ext",
+ "fe2o3-amqp-management",
+ "fe2o3-amqp-types",
+ "serde",
+ "serde_amqp",
+ "serde_bytes",
+ "tokio",
+ "tracing",
+ "typespec 1.1.0",
+ "typespec_macros 1.0.0",
 ]
 
 [[package]]
@@ -312,7 +358,7 @@ name = "azure_core_amqp"
 version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 1.1.0",
  "fe2o3-amqp",
  "fe2o3-amqp-cbs",
  "fe2o3-amqp-ext",
@@ -325,7 +371,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec",
+ "typespec 1.1.0",
  "typespec_macros 1.0.0",
 ]
 
@@ -334,7 +380,7 @@ name = "azure_core_examples"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 1.2.0-beta.1",
  "base64 0.22.1",
  "futures",
  "serde",
@@ -367,14 +413,26 @@ dependencies = [
 
 [[package]]
 name = "azure_core_opentelemetry"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71bd721089367eee3399ab7820052421ddb35916327d70d14667303617dfd21"
+dependencies = [
+ "azure_core 1.1.0",
+ "opentelemetry 0.31.0",
+ "opentelemetry_sdk 0.31.0",
+ "tracing",
+]
+
+[[package]]
+name = "azure_core_opentelemetry"
 version = "1.1.0-beta.1"
 dependencies = [
- "azure_core",
+ "azure_core 1.1.0",
  "azure_core_test",
  "azure_core_test_macros",
- "azure_identity",
- "opentelemetry",
- "opentelemetry_sdk",
+ "azure_identity 1.0.0",
+ "opentelemetry 0.32.0",
+ "opentelemetry_sdk 0.32.1",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -385,10 +443,10 @@ name = "azure_core_test"
 version = "0.2.0"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 1.1.0",
  "azure_core_examples",
  "azure_core_test_macros",
- "azure_identity",
+ "azure_identity 1.0.0",
  "clap",
  "dotenvy",
  "flate2",
@@ -424,10 +482,10 @@ version = "0.37.0"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 1.1.0",
  "azure_core_test",
  "azure_data_cosmos_driver",
- "azure_identity",
+ "azure_identity 1.0.0",
  "base64 0.22.1",
  "clap",
  "futures",
@@ -449,7 +507,7 @@ name = "azure_data_cosmos_benchmarks"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 1.1.0",
  "azure_data_cosmos_driver",
  "criterion",
  "tokio",
@@ -463,9 +521,9 @@ dependencies = [
  "arc-swap",
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 1.1.0",
  "azure_data_cosmos_macros",
- "azure_identity",
+ "azure_identity 1.0.0",
  "backtrace",
  "base64 0.22.1",
  "bytes",
@@ -491,7 +549,7 @@ dependencies = [
 name = "azure_data_cosmos_driver_native"
 version = "0.1.0"
 dependencies = [
- "azure_core",
+ "azure_core 1.1.0",
  "azure_data_cosmos_driver",
  "cbindgen",
  "futures",
@@ -515,10 +573,10 @@ name = "azure_data_cosmos_perf"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 1.1.0",
  "azure_data_cosmos",
  "azure_data_cosmos_driver",
- "azure_identity",
+ "azure_identity 1.0.0",
  "clap",
  "console-subscriber",
  "futures",
@@ -536,11 +594,29 @@ dependencies = [
 
 [[package]]
 name = "azure_identity"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32edf96b356ca7c51d7590c4925cc36efc3947a5da4468e8e0b25c56ecbb3de5"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core 1.1.0",
+ "futures",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "azure_identity"
 version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 1.1.0",
  "azure_core_examples",
  "azure_core_test",
  "clap",
@@ -566,10 +642,10 @@ dependencies = [
  "async-lock",
  "async-stream",
  "async-trait",
- "azure_core",
- "azure_core_amqp",
+ "azure_core 1.1.0",
+ "azure_core_amqp 1.1.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "azure_messaging_eventhubs",
  "base64 0.22.1",
  "criterion",
@@ -591,17 +667,17 @@ name = "azure_messaging_eventhubs_checkpointstore_blob"
 version = "0.9.0"
 dependencies = [
  "async-trait",
- "azure_core",
- "azure_core_opentelemetry",
+ "azure_core 1.1.0",
+ "azure_core_opentelemetry 1.0.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "azure_messaging_eventhubs",
  "azure_storage_blob",
  "futures",
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "opentelemetry-appender-tracing",
  "opentelemetry-stdout",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.32.1",
  "serde",
  "serde_json",
  "time",
@@ -617,10 +693,10 @@ dependencies = [
  "async-lock",
  "async-stream",
  "async-trait",
- "azure_core",
- "azure_core_amqp",
+ "azure_core 1.1.0",
+ "azure_core_amqp 1.1.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "futures",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
@@ -638,9 +714,9 @@ version = "1.1.0-beta.2"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 1.1.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "azure_security_keyvault_keys",
  "azure_security_keyvault_test",
  "futures",
@@ -660,9 +736,9 @@ version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 1.1.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "azure_security_keyvault_test",
  "criterion",
  "futures",
@@ -683,9 +759,9 @@ version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 1.1.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "azure_security_keyvault_test",
  "futures",
  "include-file",
@@ -711,10 +787,10 @@ version = "1.1.0-beta.1"
 dependencies = [
  "async-stream",
  "async-trait",
- "azure_core",
- "azure_core_opentelemetry",
+ "azure_core 1.1.0",
+ "azure_core_opentelemetry 1.1.0-beta.1",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "azure_storage_blob_test",
  "azure_storage_common",
  "azure_storage_sas",
@@ -722,9 +798,9 @@ dependencies = [
  "clap",
  "flate2",
  "futures",
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "opentelemetry-stdout",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.32.1",
  "percent-encoding",
  "pin-project",
  "rand 0.10.1",
@@ -741,9 +817,9 @@ name = "azure_storage_blob_test"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 1.1.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "azure_storage_blob",
  "bytes",
  "futures",
@@ -754,7 +830,7 @@ dependencies = [
 name = "azure_storage_common"
 version = "0.1.0"
 dependencies = [
- "azure_core",
+ "azure_core 1.1.0",
  "serde",
  "serde_json",
  "time",
@@ -765,16 +841,16 @@ name = "azure_storage_queue"
 version = "1.1.0-beta.1"
 dependencies = [
  "async-trait",
- "azure_core",
- "azure_core_opentelemetry",
+ "azure_core 1.1.0",
+ "azure_core_opentelemetry 1.1.0-beta.1",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 1.0.0",
  "azure_storage_common",
  "azure_storage_sas",
  "clap",
  "futures",
  "opentelemetry-stdout",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.32.1",
  "rand 0.10.1",
  "serde",
  "time",
@@ -786,7 +862,7 @@ dependencies = [
 name = "azure_storage_sas"
 version = "0.1.0"
 dependencies = [
- "azure_core",
+ "azure_core 1.1.0",
  "azure_storage_common",
  "base64 0.22.1",
  "hmac",
@@ -2480,6 +2556,20 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
@@ -2498,7 +2588,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -2511,8 +2601,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1b1c6a247d79091f0062a5f4bd058589525cf987a8d4c169440d9c1be72f0ad"
 dependencies = [
  "chrono",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.32.0",
+ "opentelemetry_sdk 0.32.1",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.31.0",
+ "percent-encoding",
+ "rand 0.9.4",
+ "thiserror",
 ]
 
 [[package]]
@@ -2524,7 +2629,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
@@ -4073,6 +4178,21 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "typespec"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "753a2fe021e407d4fc9ee6f4f0a33403cc306d5c54c4e4ebe1b8cbde0ca052b9"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "quick-xml",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "typespec"
 version = "1.2.0-beta.1"
 dependencies = [
  "base64 0.22.1",
@@ -4083,6 +4203,32 @@ dependencies = [
  "serde_json",
  "thiserror",
  "url",
+]
+
+[[package]]
+name = "typespec_client_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0373af0f9d4f580b3a1a9d9639cedaabe015ed262b35bfbe13941bfb14fe1ea6"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "pin-project",
+ "rand 0.10.1",
+ "reqwest",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tracing",
+ "typespec 1.1.0",
+ "typespec_macros 1.0.0",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -4105,7 +4251,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec",
+ "typespec 1.1.0",
  "typespec_macros 1.0.0",
  "url",
  "uuid",
@@ -4134,7 +4280,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.117",
  "tokio",
- "typespec_client_core",
+ "typespec_client_core 1.1.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "1.1.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "azure_core_amqp"
-version = "1.1.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "azure_core",
@@ -4073,7 +4073,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "typespec"
-version = "1.1.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "typespec_client_core"
-version = "1.1.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,12 +48,12 @@ rust-version = "1.88"
 [workspace.dependencies.typespec]
 default-features = false
 path = "sdk/core/typespec"
-version = "1.1.0"
+version = "1.2.0-beta.1"
 
 [workspace.dependencies.typespec_client_core]
 default-features = false
 path = "sdk/core/typespec_client_core"
-version = "1.1.0"
+version = "1.2.0-beta.1"
 
 [workspace.dependencies.typespec_macros]
 version = "1.0.0"
@@ -61,14 +61,14 @@ version = "1.0.0"
 [workspace.dependencies.azure_core]
 default-features = false
 path = "sdk/core/azure_core"
-version = "1.1.0"
+version = "1.2.0-beta.1"
 
 [workspace.dependencies.azure_core_macros]
 version = "1.0.0"
 
 [workspace.dependencies.azure_core_amqp]
 path = "sdk/core/azure_core_amqp"
-version = "1.1.0"
+version = "1.2.0-beta.1"
 
 [workspace.dependencies.azure_core_opentelemetry]
 # azure_core_opentelemetry should only ever be in dev-dependencies herein

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,28 +47,24 @@ rust-version = "1.88"
 
 [workspace.dependencies.typespec]
 default-features = false
-path = "sdk/core/typespec"
-version = "1.2.0-beta.1"
+version = "1.1.0"
 
 [workspace.dependencies.typespec_client_core]
 default-features = false
-path = "sdk/core/typespec_client_core"
-version = "1.2.0-beta.1"
+version = "1.1.0"
 
 [workspace.dependencies.typespec_macros]
 version = "1.0.0"
 
 [workspace.dependencies.azure_core]
 default-features = false
-path = "sdk/core/azure_core"
-version = "1.2.0-beta.1"
+version = "1.1.0"
 
 [workspace.dependencies.azure_core_macros]
 version = "1.0.0"
 
 [workspace.dependencies.azure_core_amqp]
-path = "sdk/core/azure_core_amqp"
-version = "1.2.0-beta.1"
+version = "1.1.0"
 
 [workspace.dependencies.azure_core_opentelemetry]
 # azure_core_opentelemetry should only ever be in dev-dependencies herein

--- a/sdk/core/AGENTS.md
+++ b/sdk/core/AGENTS.md
@@ -25,3 +25,17 @@ These rules apply in addition to the repository root [AGENTS.md](../../AGENTS.md
 - Prefer `workspace = true` in `sdk/core` crate manifests when inheriting workspace-managed dependencies.
 - For unreleased local `sdk/core` dependencies, use the workspace table for the needed `path + version` entry.
 - Keep crates in next-release state in their own manifests; manage cross-crate version wiring from the workspace table.
+
+### Published vs. unpublished graphs
+
+- Mixing published and local versions of `typespec`, `typespec_client_core`, `azure_core`, or crates that expose their types can create duplicate-type failures.
+- Common breakage looks like mismatched `ClientOptions`, `TokenCredential`, or trait implementations that appear identical but come from different crate instances.
+- When changing one side of a test/example graph to local source, check all directly exchanged public types in that graph and keep them on the same crate instance.
+
+### Example and documentation stub crates
+
+- `azure_core_examples` is a non-published helper crate for compile-only examples and docs. It intentionally depends on local `sdk/core/azure_core` by path.
+- Keep stubbed example APIs small and shaped like the public APIs they stand in for, but do not add real behavior unless tests need it.
+- Organize identity stubs in `azure_core_examples::identity` per credential module, mirroring `azure_identity` where practical, and re-export them from `identity/mod.rs`.
+- For markdown compile tests, alias helper modules to the public crate names used in docs (for example `use azure_core_examples::identity as azure_identity;`).
+- If a compile-only test needs just one or two service types and would otherwise mix published and local `azure_core` graphs, prefer a tiny local stub in that test module over broad dependency rewiring.

--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.2.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.1.0 (2026-07-09)
 
 ### Features Added

--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_core"
-version = "1.1.0"
+version = "1.2.0-beta.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Core crate"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/core/azure_core_amqp/CHANGELOG.md
+++ b/sdk/core/azure_core_amqp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.2.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.1.0 (2026-07-09)
 
 ### Features Added

--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -3,7 +3,7 @@
 # AMQP Stack for consumption by packages in the Azure SDK.
 [package]
 name = "azure_core_amqp"
-version = "1.1.0"
+version = "1.2.0-beta.1"
 description = "Rust client library for the AMQP protocol"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/core/azure_core_examples/src/lib.rs
+++ b/sdk/core/azure_core_examples/src/lib.rs
@@ -11,4 +11,4 @@ pub mod client;
 pub mod identity;
 pub mod secrets;
 
-pub use azure_core::credentials;
+pub use azure_core::{credentials, error, http, Error, Result};

--- a/sdk/core/azure_core_opentelemetry/Cargo.toml
+++ b/sdk/core/azure_core_opentelemetry/Cargo.toml
@@ -25,7 +25,7 @@ tracing.workspace = true
 [dev-dependencies]
 azure_core_test = { workspace = true, features = ["tracing"] }
 azure_core_test_macros.workspace = true
-azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
+azure_identity.workspace = true
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 tokio.workspace = true
 tracing-subscriber.workspace = true

--- a/sdk/core/azure_core_test/Cargo.toml
+++ b/sdk/core/azure_core_test/Cargo.toml
@@ -22,7 +22,7 @@ tracing = ["tracing-subscriber"]
 async-trait.workspace = true
 azure_core = { workspace = true, default-features = false, features = ["test"] }
 azure_core_test_macros.workspace = true
-azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
+azure_identity.workspace = true
 clap.workspace = true
 dotenvy = "0.15.7"
 flate2.workspace = true

--- a/sdk/core/azure_core_test/tests/readme.rs
+++ b/sdk/core/azure_core_test/tests/readme.rs
@@ -4,8 +4,32 @@
 #![allow(unknown_lints)]
 #![allow(unnameable_test_items)]
 
-use azure_core_examples::secrets as azure_security_keyvault_secrets;
 use include_file::include_markdown;
+
+mod azure_security_keyvault_secrets {
+    use azure_core::{credentials::TokenCredential, fmt::SafeDebug, http::ClientOptions};
+    use std::sync::Arc;
+
+    #[derive(Default, SafeDebug)]
+    pub struct SecretClientOptions {
+        pub client_options: ClientOptions,
+    }
+
+    // This local stub keeps the README compile test on azure_core_test's published-core graph.
+    // Reusing azure_core_examples::secrets::SecretClient would pull in local sdk/core/azure_core
+    // and cause type mismatches for ClientOptions and TokenCredential during workspace-wide builds.
+    pub struct SecretClient;
+
+    impl SecretClient {
+        pub fn new(
+            _endpoint: &str,
+            _credential: Arc<dyn TokenCredential>,
+            _options: Option<SecretClientOptions>,
+        ) -> azure_core::Result<Self> {
+            Ok(Self)
+        }
+    }
+}
 
 #[ignore = "only compile doc examples"]
 #[tokio::test]

--- a/sdk/core/typespec/CHANGELOG.md
+++ b/sdk/core/typespec/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.2.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.1.0 (2026-07-09)
 
 ### Features Added

--- a/sdk/core/typespec/Cargo.toml
+++ b/sdk/core/typespec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typespec"
-version = "1.1.0"
+version = "1.2.0-beta.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/sdk/core/typespec_client_core/CHANGELOG.md
+++ b/sdk/core/typespec_client_core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.2.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.1.0 (2026-07-09)
 
 ### Features Added

--- a/sdk/core/typespec_client_core/Cargo.toml
+++ b/sdk/core/typespec_client_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typespec_client_core"
-version = "1.1.0"
+version = "1.2.0-beta.1"
 authors.workspace = true
 edition.workspace = true
 description = "Client runtime for TypeSpec-generated libraries."

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -49,7 +49,7 @@ azure_core_test = { workspace = true, features = ["tracing"] }
 azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", default-features = false, features = [
   "__internal_test_diagnostics_construction",
 ] }
-azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
+azure_identity.workspace = true
 clap.workspace = true
 reqwest = { workspace = true, features = ["http2"] }
 serde = { workspace = true, features = ["derive"] }

--- a/sdk/cosmos/azure_data_cosmos_driver/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_driver/Cargo.toml
@@ -40,7 +40,7 @@ url.workspace = true
 uuid = { workspace = true, features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
-azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
+azure_identity.workspace = true
 quick-xml.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = [

--- a/sdk/cosmos/azure_data_cosmos_perf/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_perf/Cargo.toml
@@ -14,7 +14,7 @@ async-trait.workspace = true
 azure_core = { workspace = true, features = ["reqwest"] }
 azure_data_cosmos = { path = "../azure_data_cosmos", features = ["key_auth"] }
 azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver" }
-azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
+azure_identity.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 console-subscriber = { workspace = true, optional = true }
 futures.workspace = true

--- a/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
@@ -22,7 +22,7 @@ async-stream.workspace = true
 async-trait.workspace = true
 azure_core = { workspace = true, default-features = false }
 # Requires AmqpSessionOptions::with_unbounded_windows from azure_core_amqp 1.1.0 (issue #4570).
-azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.1.0" }
+azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.2.0-beta.1" }
 base64.workspace = true
 futures.workspace = true
 hmac.workspace = true
@@ -36,7 +36,7 @@ tracing.workspace = true
 rustc_version.workspace = true
 
 [dev-dependencies]
-azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.1.0", features = ["test"] }
+azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.2.0-beta.1", features = ["test"] }
 azure_core_test = { workspace = true, features = ["tracing"] }
 azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
 azure_messaging_eventhubs = { path = ".", features = [

--- a/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
@@ -21,8 +21,7 @@ async-lock.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 azure_core = { workspace = true, default-features = false }
-# Requires AmqpSessionOptions::with_unbounded_windows from azure_core_amqp 1.1.0 (issue #4570).
-azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.2.0-beta.1" }
+azure_core_amqp.workspace = true
 base64.workspace = true
 futures.workspace = true
 hmac.workspace = true
@@ -36,9 +35,9 @@ tracing.workspace = true
 rustc_version.workspace = true
 
 [dev-dependencies]
-azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.2.0-beta.1", features = ["test"] }
+azure_core_amqp = { workspace = true, features = ["test"] }
 azure_core_test = { workspace = true, features = ["tracing"] }
-azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
+azure_identity.workspace = true
 azure_messaging_eventhubs = { path = ".", features = [
   "in_memory_checkpoint_store",
 ] }

--- a/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/Cargo.toml
@@ -30,9 +30,9 @@ time = { workspace = true, features = ["serde"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
-azure_core_opentelemetry = { path = "../../core/azure_core_opentelemetry", version = "1.1.0-beta.1" }
+azure_core_opentelemetry.workspace = true
 azure_core_test = { workspace = true, features = ["tracing"] }
-azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
+azure_identity.workspace = true
 opentelemetry.workspace = true
 opentelemetry-appender-tracing.workspace = true
 opentelemetry-stdout.workspace = true

--- a/sdk/identity/azure_identity/tests/migration.rs
+++ b/sdk/identity/azure_identity/tests/migration.rs
@@ -2,8 +2,28 @@
 // Licensed under the MIT License.
 
 #![allow(dead_code)]
-use azure_core_examples::secrets as azure_security_keyvault_secrets;
+#![allow(
+    clippy::needless_update,
+    reason = "documentation examples intentionally use ..Default::default()"
+)]
 use include_file::include_markdown;
+
+mod azure_security_keyvault_secrets {
+    use azure_core::credentials::TokenCredential;
+    use std::sync::Arc;
+
+    pub struct SecretClient;
+
+    impl SecretClient {
+        pub fn new(
+            _endpoint: &str,
+            _credential: Arc<dyn TokenCredential>,
+            _options: Option<()>,
+        ) -> azure_core::Result<Self> {
+            Ok(Self)
+        }
+    }
+}
 
 #[ignore = "only compile doc examples"]
 #[tokio::test]

--- a/sdk/identity/azure_identity/tests/readme.rs
+++ b/sdk/identity/azure_identity/tests/readme.rs
@@ -2,8 +2,28 @@
 // Licensed under the MIT License.
 
 #![allow(dead_code)]
-use azure_core_examples::secrets as azure_security_keyvault_secrets;
+#![allow(
+    clippy::needless_update,
+    reason = "documentation examples intentionally use ..Default::default()"
+)]
 use include_file::include_markdown;
+
+mod azure_security_keyvault_secrets {
+    use azure_core::credentials::TokenCredential;
+    use std::sync::Arc;
+
+    pub struct SecretClient;
+
+    impl SecretClient {
+        pub fn new(
+            _endpoint: &str,
+            _credential: Arc<dyn TokenCredential>,
+            _options: Option<()>,
+        ) -> azure_core::Result<Self> {
+            Ok(Self)
+        }
+    }
+}
 
 #[ignore = "only compile doc examples"]
 #[tokio::test]

--- a/sdk/keyvault/azure_security_keyvault_certificates/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_certificates/Cargo.toml
@@ -29,7 +29,7 @@ tokio = { workspace = true }
 azure_core_test = { workspace = true, features = [
   "tracing",
 ] }
-azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
+azure_identity.workspace = true
 azure_security_keyvault_keys = { path = "../azure_security_keyvault_keys" }
 azure_security_keyvault_test = { path = "../azure_security_keyvault_test" }
 include-file.workspace = true

--- a/sdk/keyvault/azure_security_keyvault_keys/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_keys/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = { workspace = true }
 azure_core_test = { workspace = true, features = [
   "tracing",
 ] }
-azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
+azure_identity.workspace = true
 azure_security_keyvault_test = { path = "../azure_security_keyvault_test" }
 criterion.workspace = true
 include-file.workspace = true

--- a/sdk/keyvault/azure_security_keyvault_secrets/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_secrets/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { workspace = true }
 azure_core_test = { workspace = true, features = [
   "tracing",
 ] }
-azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
+azure_identity.workspace = true
 azure_security_keyvault_test = { path = "../azure_security_keyvault_test" }
 include-file.workspace = true
 rand.workspace = true

--- a/sdk/servicebus/azure_messaging_servicebus/Cargo.toml
+++ b/sdk/servicebus/azure_messaging_servicebus/Cargo.toml
@@ -21,8 +21,7 @@ async-lock.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 azure_core = { workspace = true, default-features = false }
-# Requires AmqpSessionOptions::with_unbounded_windows from azure_core_amqp 1.1.0 (issue #4570).
-azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.2.0-beta.1" }
+azure_core_amqp.workspace = true
 futures.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
@@ -34,9 +33,9 @@ tracing.workspace = true
 default = ["azure_core_amqp/default"]
 
 [dev-dependencies]
-azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.2.0-beta.1", features = ["test"] }
+azure_core_amqp = { workspace = true, features = ["test"] }
 azure_core_test = { workspace = true, features = ["tracing"] }
-azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
+azure_identity.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }

--- a/sdk/servicebus/azure_messaging_servicebus/Cargo.toml
+++ b/sdk/servicebus/azure_messaging_servicebus/Cargo.toml
@@ -22,7 +22,7 @@ async-stream.workspace = true
 async-trait.workspace = true
 azure_core = { workspace = true, default-features = false }
 # Requires AmqpSessionOptions::with_unbounded_windows from azure_core_amqp 1.1.0 (issue #4570).
-azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.1.0" }
+azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.2.0-beta.1" }
 futures.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
@@ -34,7 +34,7 @@ tracing.workspace = true
 default = ["azure_core_amqp/default"]
 
 [dev-dependencies]
-azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.1.0", features = ["test"] }
+azure_core_amqp = { path = "../../core/azure_core_amqp", version = "1.2.0-beta.1", features = ["test"] }
 azure_core_test = { workspace = true, features = ["tracing"] }
 azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
 serde_json.workspace = true

--- a/sdk/storage/azure_storage_blob/Cargo.toml
+++ b/sdk/storage/azure_storage_blob/Cargo.toml
@@ -39,13 +39,13 @@ tokio = { workspace = true, optional = true, features = [
 workspace = true
 
 [dev-dependencies]
-azure_core_opentelemetry = { path = "../../core/azure_core_opentelemetry", version = "1.1.0-beta.1" }
+azure_core_opentelemetry.path = "../../core/azure_core_opentelemetry"
 azure_core_test = { workspace = true, features = [
   "tracing",
 ] }
-azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
+azure_identity.workspace = true
 azure_storage_blob_test.path = "../azure_storage_blob_test"
-azure_storage_sas = { path = "../azure_storage_sas", version = "0.1.0" }
+azure_storage_sas.path = "../azure_storage_sas"
 clap = { workspace = true, features = ["env"] }
 flate2.workspace = true
 futures.workspace = true

--- a/sdk/storage/azure_storage_blob_test/Cargo.toml
+++ b/sdk/storage/azure_storage_blob_test/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 async-trait.workspace = true
 azure_core = { workspace = true, features = ["xml"] }
 azure_core_test.workspace = true
-azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
+azure_identity.workspace = true
 azure_storage_blob.path = "../azure_storage_blob"
 bytes.workspace = true
 futures.workspace = true

--- a/sdk/storage/azure_storage_queue/Cargo.toml
+++ b/sdk/storage/azure_storage_queue/Cargo.toml
@@ -27,10 +27,10 @@ time.workspace = true
 workspace = true
 
 [dev-dependencies]
-azure_core_opentelemetry = { path = "../../core/azure_core_opentelemetry", version = "1.1.0-beta.1" }
+azure_core_opentelemetry.path = "../../core/azure_core_opentelemetry"
 azure_core_test = { workspace = true, features = ["tracing"] }
-azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
-azure_storage_sas = { path = "../azure_storage_sas", version = "0.1.0" }
+azure_identity.workspace = true
+azure_storage_sas.path = "../azure_storage_sas"
 clap.workspace = true
 futures.workspace = true
 opentelemetry-stdout.workspace = true


### PR DESCRIPTION
This pull request updates core crate versions to `1.2.0-beta.1`, improves workspace dependency management, and clarifies best practices for handling published and local crate graphs. It also fixes dependency wiring in several crates to consistently use workspace-managed versions, and adds guidance and stubs to prevent duplicate-type errors in compile-only tests.

**Version updates:**

* Bumped versions of `azure_core`, `azure_core_amqp`, `typespec`, and `typespec_client_core` to `1.2.0-beta.1` in their respective `Cargo.toml` and `CHANGELOG.md` files. [[1]](diffhunk://#diff-f16333216bea183042a05224a76a8a5289bd94d21d96cce514e8dc4b45d70ec3L3-R3) [[2]](diffhunk://#diff-04ba9431d9ff4c7fcdf841ed6f946bf48cc4c2c2850243cdef87cd16aefe082fL6-R6) [[3]](diffhunk://#diff-27748a52911f6fdee4f13537c5a5e851977e85edad3823624fe3673d3465d513L3-R3) [[4]](diffhunk://#diff-405283a9b6c5811de7f679ba9237cab96310997add982334092856894109dcddL3-R3) [[5]](diffhunk://#diff-24e4f774e8047aed765853154c6016964877a9707caa7016b4e82b4505212f1aR3-R12) [[6]](diffhunk://#diff-dc9f8f8c22530c920605e6b521fd657858f7fd7f6a6d172bade472dd16ed4673R3-R12) [[7]](diffhunk://#diff-84f8f651579aeffbbe043c9ba964df1c3cf770b36847d44c1cd6a26610419c98R3-R12) [[8]](diffhunk://#diff-188a7668f13f2b1f3ea771a8d103a558f390c4be8d5dc0ba5870fa3b51a22f92R3-R12)

**Dependency management improvements:**

* Updated workspace dependency guidance in `AGENTS.md` and `CONTRIBUTING.md`, clarifying when to use `workspace = true` vs. explicit `path + version` dependencies for unreleased crates. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R153-R154) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L416-R422)
* Removed explicit `path` fields from `[workspace.dependencies]` in the root `Cargo.toml` to rely on workspace resolution.

**Consistent workspace dependency wiring:**

* Updated multiple crates (`azure_core_opentelemetry`, `azure_core_test`, `azure_data_cosmos`, `azure_data_cosmos_driver`, `azure_data_cosmos_perf`, `azure_messaging_eventhubs`) to use `azure_identity.workspace = true` and `azure_core_amqp.workspace = true` instead of local path dependencies, ensuring consistency and preventing duplicate-type errors. [[1]](diffhunk://#diff-74b50c807e3991760a44a9a42804b4f9a98d0c64d2c03dced02818a0d1d3bd51L28-R28) [[2]](diffhunk://#diff-03dde4928bbba99aa5bdbab458a8ca88ab2ec67c3742c68f985681649f8cb65aL25-R25) [[3]](diffhunk://#diff-7d6418a37ff2be6ed1cbfc3382e55c7c1925da32e70cc28c6e17841a521e2d35L52-R52) [[4]](diffhunk://#diff-e88ccd29a5723513603d930d833d57bdb20427e8b1a20c3bbc48acecc2bd464bL43-R43) [[5]](diffhunk://#diff-cb56f7c73fb5e97083f94b1b8f3fc48905b7a1a85a55d1c147689bc2fbc2c434L17-R17) [[6]](diffhunk://#diff-985d1c9b6dc003e9f9ae2535d38caa1dcc36996adb873149c8eac0d4781de55aL24-R24) [[7]](diffhunk://#diff-985d1c9b6dc003e9f9ae2535d38caa1dcc36996adb873149c8eac0d4781de55aL39-R40)

**Guidance and stubs for compile-only tests:**

* Added documentation and examples in `sdk/core/AGENTS.md` on avoiding duplicate-type failures when mixing published and local crate graphs, and detailed the purpose and usage of `azure_core_examples`.
* In `sdk/core/azure_core_test/tests/readme.rs`, replaced a module import with a local stub for `SecretClient` to prevent type mismatches in compile-only tests.
* Broadened re-exports in `azure_core_examples/src/lib.rs` to include more `azure_core` types for test convenience.