### PR TITLE
Fix in-memory-emulator split bug resulting in skipping documents

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/query_comparison.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/query_comparison.rs
@@ -698,15 +698,7 @@ async fn query_results_match_across_physical_partition_topologies() -> Result<()
     Ok(())
 }
 
-// TODO(cosmos): remove `#[ignore]` once the driver's mid-query-split resume bug
-// is fixed in a separate PR. The emulator side is complete: it now returns
-// `410/1002 PartitionKeyRangeGone` for a query pinned to a split-away pkrange and
-// bumps the routing-map ETag on split, so the driver correctly enters split
-// recovery. The remaining failure is a driver bug — resuming a continuation
-// across the split drops the last leaf's tail document (returns 8/9) — that lives
-// in the split-recovery continuation snapshot, not in this test or the emulator.
 #[tokio::test]
-#[ignore = "driver bug (separate PR): resume across a mid-query partition split drops the last document (8/9); emulator 410-Gone + ETag-on-split fidelity is in place"]
 async fn query_resume_survives_mid_query_split() -> Result<(), Box<dyn Error>> {
     // Regression coverage for resuming a query continuation ACROSS a physical
     // partition split. The container starts as a single physical partition; we

--- a/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/operations.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/operations.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 
 use azure_core::http::headers::{HeaderName, HeaderValue, Headers};
 use azure_core::http::{AsyncRawResponse, StatusCode};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::config::ContainerConfig;
 use super::dispatch::{OperationType, ParsedRequest};
@@ -41,6 +41,9 @@ use crate::driver::pipeline::patch_eval::apply_patch_ops;
 use crate::models::PatchInstructions;
 use crate::models::{
     EffectivePartitionKey, PartitionKeyDefinition, PartitionKeyValue as ModelPartitionKeyValue,
+};
+use crate::query::ast::{
+    SqlCollection, SqlCollectionExpression, SqlQuery, SqlScalarExpression, SqlSelectSpec,
 };
 
 static OFFER_REPLACE_PENDING: HeaderName = HeaderName::from_static("x-ms-offer-replace-pending");
@@ -2150,6 +2153,97 @@ fn paginate_values(
     Ok((page, next))
 }
 
+#[derive(Clone)]
+struct DocumentFeedItem {
+    body: serde_json::Value,
+    cursor: DocumentFeedCursor,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct DocumentFeedCursor {
+    epk: Epk,
+    id: String,
+}
+
+#[derive(Deserialize, Serialize)]
+struct DocumentFeedCursorToken {
+    kind: String,
+    epk: String,
+    id: String,
+}
+
+const DOCUMENT_FEED_CURSOR_TOKEN_KIND: &str = "document_feed_cursor_v1";
+
+impl DocumentFeedCursor {
+    fn to_token(&self) -> String {
+        serde_json::to_string(&DocumentFeedCursorToken {
+            kind: DOCUMENT_FEED_CURSOR_TOKEN_KIND.to_owned(),
+            epk: self.epk.to_hex(),
+            id: self.id.clone(),
+        })
+        .expect("document feed cursor token serialization cannot fail")
+    }
+
+    fn parse(token: &str, start: Instant) -> Result<Self, AsyncRawResponse> {
+        let token: DocumentFeedCursorToken = serde_json::from_str(token)
+            .map_err(|_| invalid_continuation_response("Invalid continuation token", start))?;
+        if token.kind != DOCUMENT_FEED_CURSOR_TOKEN_KIND {
+            return Err(invalid_continuation_response(
+                "Invalid continuation token kind",
+                start,
+            ));
+        }
+        Ok(Self {
+            epk: Epk::from(token.epk.as_str()),
+            id: token.id,
+        })
+    }
+}
+
+fn invalid_continuation_response(message: &str, start: Instant) -> AsyncRawResponse {
+    error_response(
+        StatusCode::BadRequest,
+        None,
+        "BadRequest",
+        message,
+        0.0,
+        "",
+        start,
+    )
+    .build()
+}
+
+fn paginate_document_feed_items(
+    items: Vec<DocumentFeedItem>,
+    max_item_count: Option<i32>,
+    continuation: Option<&str>,
+    start: Instant,
+) -> Result<(Vec<serde_json::Value>, Option<String>), AsyncRawResponse> {
+    let offset = match continuation {
+        Some(token) => {
+            let cursor = DocumentFeedCursor::parse(token, start)?;
+            items.partition_point(|item| item.cursor <= cursor)
+        }
+        None => 0,
+    };
+
+    let total = items.len();
+    let limit = match max_item_count {
+        Some(n) if n > 0 => n as usize,
+        _ => total.saturating_sub(offset),
+    };
+    let end = offset.saturating_add(limit).min(total);
+    let page_items = if offset >= total {
+        Vec::new()
+    } else {
+        items[offset..end].to_vec()
+    };
+    let next = (end < total)
+        .then(|| page_items.last().map(|item| item.cursor.to_token()))
+        .flatten();
+    Ok((page_items.into_iter().map(|item| item.body).collect(), next))
+}
+
 #[derive(Clone, Copy)]
 struct FeedPageOptions<'a> {
     max_item_count: Option<i32>,
@@ -2193,6 +2287,48 @@ fn success_feed_response(
     start: Instant,
 ) -> AsyncRawResponse {
     let (page, next) = match paginate_values(
+        items,
+        page_options.max_item_count,
+        page_options.continuation,
+        start,
+    ) {
+        Ok(v) => v,
+        Err(response) => return response,
+    };
+    let item_count = page.len() as u32;
+    let body = feed_to_json(envelope_name, page, rid);
+    let mut builder = success_response(
+        StatusCode::Ok,
+        &body,
+        1.0,
+        &feed_headers.session_token,
+        start,
+    )
+    .with_item_count(item_count);
+    if let Some(lsn) = feed_headers.lsn {
+        builder = builder.with_lsn(lsn);
+    }
+    if let Some(id) = feed_headers.partition_key_range_id {
+        builder = builder.with_header_value(PARTITION_KEY_RANGE_ID.clone(), id);
+    }
+    if let Some(id) = feed_headers.internal_partition_id {
+        builder = builder.with_header_value(INTERNAL_PARTITION_ID.clone(), id);
+    }
+    if let Some(next) = next {
+        builder = builder.with_header_value(CONTINUATION.clone(), next);
+    }
+    builder.build()
+}
+
+fn success_document_feed_response(
+    envelope_name: &str,
+    rid: impl Into<String>,
+    items: Vec<DocumentFeedItem>,
+    page_options: FeedPageOptions<'_>,
+    feed_headers: FeedResponseHeaders,
+    start: Instant,
+) -> AsyncRawResponse {
+    let (page, next) = match paginate_document_feed_items(
         items,
         page_options.max_item_count,
         page_options.continuation,
@@ -2311,6 +2447,208 @@ fn execute_query_feed(
         feed_headers,
         start,
     )
+}
+
+fn execute_document_query_feed(
+    envelope_name: &str,
+    rid: impl Into<String>,
+    documents: Vec<DocumentFeedItem>,
+    parsed: &ParsedRequest,
+    request_body: &[u8],
+    feed_headers: FeedResponseHeaders,
+    start: Instant,
+) -> AsyncRawResponse {
+    let (query, parameters) = match parse_query_spec(request_body, start) {
+        Ok(v) => v,
+        Err(response) => return response,
+    };
+    match query_document_feed_items(&query, &parameters, &documents) {
+        Ok(Some(results)) => success_document_feed_response(
+            envelope_name,
+            rid,
+            results,
+            FeedPageOptions::from_request(parsed),
+            feed_headers,
+            start,
+        ),
+        Ok(None) => {
+            let values: Vec<_> = documents.into_iter().map(|doc| doc.body).collect();
+            let results = match crate::query::eval::query_documents(&query, &parameters, &values) {
+                Ok(results) => results,
+                Err(e) => {
+                    return error_response(
+                        StatusCode::BadRequest,
+                        None,
+                        "BadRequest",
+                        &e.to_string(),
+                        0.0,
+                        "",
+                        start,
+                    )
+                    .build();
+                }
+            };
+            success_feed_response(
+                envelope_name,
+                rid,
+                results,
+                FeedPageOptions::from_request(parsed),
+                feed_headers,
+                start,
+            )
+        }
+        Err(e) => error_response(
+            StatusCode::BadRequest,
+            None,
+            "BadRequest",
+            &e.to_string(),
+            0.0,
+            "",
+            start,
+        )
+        .build(),
+    }
+}
+
+fn query_document_feed_items(
+    sql: &str,
+    parameters: &[(String, serde_json::Value)],
+    documents: &[DocumentFeedItem],
+) -> crate::error::Result<Option<Vec<DocumentFeedItem>>> {
+    let program = crate::query::parse(sql).map_err(|e| {
+        crate::error::CosmosError::builder()
+            .with_status(crate::error::CosmosStatus::SERIALIZATION_RESPONSE_BODY_INVALID)
+            .with_message(format!("failed to parse query: {e}"))
+            .with_source(e)
+            .build()
+    })?;
+    let query = &program.query;
+    if !supports_document_cursor_continuation(query) {
+        return Ok(None);
+    }
+
+    let mut results = Vec::new();
+    for document in documents {
+        if crate::query::eval::matches_query(&document.body, query, parameters).map_err(|e| {
+            crate::error::CosmosError::builder()
+                .with_status(crate::error::CosmosStatus::new(StatusCode::BadRequest))
+                .with_message(e.to_string())
+                .build()
+        })? {
+            let body =
+                crate::query::eval::project(&document.body, query, parameters).map_err(|e| {
+                    crate::error::CosmosError::builder()
+                        .with_status(crate::error::CosmosStatus::new(StatusCode::BadRequest))
+                        .with_message(e.to_string())
+                        .build()
+                })?;
+            results.push(DocumentFeedItem {
+                body,
+                cursor: document.cursor.clone(),
+            });
+        }
+    }
+    Ok(Some(results))
+}
+
+fn supports_document_cursor_continuation(query: &SqlQuery) -> bool {
+    if query.select.distinct
+        || query.select.top.is_some()
+        || query.group_by.is_some()
+        || query.order_by.is_some()
+        || query.offset_limit.is_some()
+        || !is_plain_root_from(query)
+    {
+        return false;
+    }
+    match &query.select.spec {
+        SqlSelectSpec::Star => true,
+        SqlSelectSpec::List(items) => !items
+            .iter()
+            .any(|item| contains_aggregate_expression(&item.expression)),
+        SqlSelectSpec::Value(expr) => !contains_aggregate_expression(expr),
+    }
+}
+
+fn is_plain_root_from(query: &SqlQuery) -> bool {
+    match &query.from {
+        None => true,
+        Some(from) => matches!(
+            &from.collection,
+            SqlCollectionExpression::Aliased {
+                collection: SqlCollection::Path { path, .. },
+                ..
+            } if path.is_empty()
+        ),
+    }
+}
+
+fn contains_aggregate_expression(expr: &SqlScalarExpression) -> bool {
+    match expr {
+        SqlScalarExpression::FunctionCall {
+            name, is_udf, args, ..
+        } => {
+            (!is_udf
+                && matches!(
+                    name.to_ascii_uppercase().as_str(),
+                    "COUNT" | "SUM" | "AVG" | "MIN" | "MAX"
+                ))
+                || args.iter().any(contains_aggregate_expression)
+        }
+        SqlScalarExpression::Binary { left, right, .. }
+        | SqlScalarExpression::Coalesce { left, right } => {
+            contains_aggregate_expression(left) || contains_aggregate_expression(right)
+        }
+        SqlScalarExpression::Unary { operand, .. }
+        | SqlScalarExpression::IsNull {
+            expression: operand,
+            ..
+        } => contains_aggregate_expression(operand),
+        SqlScalarExpression::Conditional {
+            condition,
+            if_true,
+            if_false,
+        } => {
+            contains_aggregate_expression(condition)
+                || contains_aggregate_expression(if_true)
+                || contains_aggregate_expression(if_false)
+        }
+        SqlScalarExpression::Between {
+            expression,
+            low,
+            high,
+            ..
+        } => {
+            contains_aggregate_expression(expression)
+                || contains_aggregate_expression(low)
+                || contains_aggregate_expression(high)
+        }
+        SqlScalarExpression::In {
+            expression, items, ..
+        } => {
+            contains_aggregate_expression(expression)
+                || items.iter().any(contains_aggregate_expression)
+        }
+        SqlScalarExpression::Like {
+            expression,
+            pattern,
+            ..
+        } => contains_aggregate_expression(expression) || contains_aggregate_expression(pattern),
+        SqlScalarExpression::MemberRef { source, .. } => contains_aggregate_expression(source),
+        SqlScalarExpression::MemberIndexer { source, index } => {
+            contains_aggregate_expression(source) || contains_aggregate_expression(index)
+        }
+        SqlScalarExpression::ArrayCreate(items) => items.iter().any(contains_aggregate_expression),
+        SqlScalarExpression::ObjectCreate(props) => props
+            .iter()
+            .any(|prop| contains_aggregate_expression(&prop.expression)),
+        SqlScalarExpression::Exists(_)
+        | SqlScalarExpression::Subquery(_)
+        | SqlScalarExpression::Array(_) => true,
+        SqlScalarExpression::Literal(_)
+        | SqlScalarExpression::PropertyRef(_)
+        | SqlScalarExpression::ParameterRef(_) => false,
+    }
 }
 
 fn handle_read_feed_databases(
@@ -2600,7 +2938,7 @@ fn collect_item_documents(
     region_name: &str,
     parsed: &ParsedRequest,
     start: Instant,
-) -> Result<(String, Vec<serde_json::Value>, String, FeedResponseHeaders), AsyncRawResponse> {
+) -> Result<(String, Vec<DocumentFeedItem>, String, FeedResponseHeaders), AsyncRawResponse> {
     let db_id = parsed.db_id.as_deref().unwrap_or("");
     let coll_id = parsed.coll_id.as_deref().unwrap_or("");
     let region_ref = match store.region(region_name) {
@@ -2722,7 +3060,13 @@ fn collect_item_documents(
                 if end_epk.as_ref().is_some_and(|max| epk >= max) {
                     continue;
                 }
-                docs.extend(logical.values().map(|doc| doc.body.clone()));
+                docs.extend(logical.iter().map(|(id, doc)| DocumentFeedItem {
+                    body: doc.body.clone(),
+                    cursor: DocumentFeedCursor {
+                        epk: epk.clone(),
+                        id: id.clone(),
+                    },
+                }));
             }
         }
         let (partition_key_range_id, internal_partition_id) = if multiple_partitions {
@@ -2762,7 +3106,7 @@ fn handle_read_feed_items(
     match collect_item_documents(store, region_name, parsed, start) {
         Ok((rid, docs, token, mut headers)) => {
             headers.session_token = token;
-            success_feed_response(
+            success_document_feed_response(
                 "Documents",
                 rid,
                 docs,
@@ -2785,7 +3129,15 @@ fn handle_query_items(
     match collect_item_documents(store, region_name, parsed, start) {
         Ok((rid, docs, token, mut headers)) => {
             headers.session_token = token;
-            execute_query_feed("Documents", rid, docs, parsed, request_body, headers, start)
+            execute_document_query_feed(
+                "Documents",
+                rid,
+                docs,
+                parsed,
+                request_body,
+                headers,
+                start,
+            )
         }
         Err(response) => response,
     }
@@ -5101,4 +5453,69 @@ fn container_not_found(db_id: &str, coll_id: &str, start: Instant) -> AsyncRawRe
         start,
     )
     .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn document_item(epk: &str, id: &str) -> DocumentFeedItem {
+        DocumentFeedItem {
+            body: serde_json::json!({ "id": id }),
+            cursor: DocumentFeedCursor {
+                epk: Epk::from(epk),
+                id: id.to_owned(),
+            },
+        }
+    }
+
+    fn ids(values: &[serde_json::Value]) -> Vec<&str> {
+        values
+            .iter()
+            .map(|value| value["id"].as_str().expect("test document has id"))
+            .collect()
+    }
+
+    #[test]
+    fn document_feed_cursor_skips_already_returned_low_child_prefix_after_split() {
+        let start = Instant::now();
+        let parent = vec![
+            document_item("01", "hash-a-0"),
+            document_item("02", "hash-a-1"),
+            document_item("80", "hash-e-0"),
+        ];
+        let (_page, continuation) =
+            paginate_document_feed_items(parent, Some(1), None, start).unwrap();
+
+        let low_child = vec![
+            document_item("01", "hash-a-0"),
+            document_item("02", "hash-a-1"),
+        ];
+        let (page, next) =
+            paginate_document_feed_items(low_child, Some(10), continuation.as_deref(), start)
+                .unwrap();
+
+        assert_eq!(ids(&page), vec!["hash-a-1"]);
+        assert!(next.is_none());
+    }
+
+    #[test]
+    fn document_feed_cursor_does_not_skip_high_child_after_split() {
+        let start = Instant::now();
+        let parent = vec![
+            document_item("01", "hash-a-0"),
+            document_item("02", "hash-a-1"),
+            document_item("80", "hash-e-0"),
+        ];
+        let (_page, continuation) =
+            paginate_document_feed_items(parent, Some(1), None, start).unwrap();
+
+        let high_child = vec![document_item("80", "hash-e-0")];
+        let (page, next) =
+            paginate_document_feed_items(high_child, Some(10), continuation.as_deref(), start)
+                .unwrap();
+
+        assert_eq!(ids(&page), vec!["hash-e-0"]);
+        assert!(next.is_none());
+    }
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/operations.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/operations.rs
@@ -2193,11 +2193,21 @@ impl DocumentFeedCursor {
                 start,
             ));
         }
+        if !is_even_length_hex(&token.epk) {
+            return Err(invalid_continuation_response(
+                "Invalid continuation token EPK",
+                start,
+            ));
+        }
         Ok(Self {
             epk: Epk::from(token.epk.as_str()),
             id: token.id,
         })
     }
+}
+
+fn is_even_length_hex(value: &str) -> bool {
+    value.len() % 2 == 0 && value.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 fn invalid_continuation_response(message: &str, start: Instant) -> AsyncRawResponse {
@@ -5517,5 +5527,18 @@ mod tests {
 
         assert_eq!(ids(&page), vec!["hash-e-0"]);
         assert!(next.is_none());
+    }
+
+    #[test]
+    fn document_feed_cursor_rejects_malformed_epk_hex() {
+        let token = serde_json::to_string(&DocumentFeedCursorToken {
+            kind: DOCUMENT_FEED_CURSOR_TOKEN_KIND.to_owned(),
+            epk: "00zz".to_owned(),
+            id: "item1".to_owned(),
+        })
+        .unwrap();
+
+        let err = DocumentFeedCursor::parse(&token, Instant::now()).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BadRequest);
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/operations.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/operations.rs
@@ -2207,7 +2207,7 @@ impl DocumentFeedCursor {
 }
 
 fn is_even_length_hex(value: &str) -> bool {
-    value.len() % 2 == 0 && value.bytes().all(|b| b.is_ascii_hexdigit())
+    value.len().is_multiple_of(2) && value.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 fn invalid_continuation_response(message: &str, start: Instant) -> AsyncRawResponse {
@@ -3079,6 +3079,7 @@ fn collect_item_documents(
                 }));
             }
         }
+        docs.sort_by(|left, right| left.cursor.cmp(&right.cursor));
         let (partition_key_range_id, internal_partition_id) = if multiple_partitions {
             (None, None)
         } else {
@@ -5540,5 +5541,22 @@ mod tests {
 
         let err = DocumentFeedCursor::parse(&token, Instant::now()).unwrap_err();
         assert_eq!(err.status(), StatusCode::BadRequest);
+    }
+
+    #[test]
+    fn document_feed_cursor_pagination_requires_cursor_sorted_items() {
+        let start = Instant::now();
+        let mut items = vec![
+            document_item("80", "hash-e-0"),
+            document_item("01", "hash-a-0"),
+            document_item("02", "hash-a-1"),
+        ];
+        items.sort_by(|left, right| left.cursor.cmp(&right.cursor));
+
+        let (page, continuation) =
+            paginate_document_feed_items(items, Some(1), None, start).unwrap();
+
+        assert_eq!(ids(&page), vec!["hash-a-0"]);
+        assert!(continuation.is_some());
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/operations.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/operations.rs
@@ -3,7 +3,7 @@
 
 //! Point operation and control-plane operation handlers.
 
-// cspell:ignore acked llsn
+// cspell:ignore acked hexdigit llsn
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/emulator_tests/driver_item_operations.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/emulator_tests/driver_item_operations.rs
@@ -127,7 +127,7 @@ pub async fn control_plane_uses_metadata_pipeline() -> Result<(), Box<dyn Error>
         let item_json = serde_json::to_vec(&test_item)?;
 
         let result = context
-            .create_item(&container, &test_item.id, test_item.pk.clone(), &item_json)
+            .create_seed_item(&container, &test_item.id, test_item.pk.clone(), &item_json)
             .await?;
 
         // Verify item creation succeeded
@@ -164,7 +164,7 @@ pub async fn diagnostics_contain_expected_fields() -> Result<(), Box<dyn Error>>
         let item_json = serde_json::to_vec(&item)?;
 
         let result = context
-            .create_item(&container, &item.id, item.pk.clone(), &item_json)
+            .create_seed_item(&container, &item.id, item.pk.clone(), &item_json)
             .await?;
 
         let diagnostics = result.diagnostics();

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/emulator_tests/driver_partition_failover.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/emulator_tests/driver_partition_failover.rs
@@ -80,7 +80,7 @@ pub async fn pkrange_fetch_503_falls_back_gracefully_to_data_operation(
             // Create an item — succeeds even though pkrange pre-resolution is failing.
             let item_json = br#"{"id": "pkrange-fallback-1", "pk": "pk1", "value": "test"}"#;
             context
-                .create_item(&container, "pkrange-fallback-1", "pk1", item_json)
+                .create_seed_item(&container, "pkrange-fallback-1", "pk1", item_json)
                 .await
                 .expect("CreateItem must succeed even when pkrange metadata fetch returns 503");
 
@@ -153,7 +153,7 @@ pub async fn pkrange_fetch_transient_failure_then_recovers() -> Result<(), Box<d
                 let body =
                     format!(r#"{{"id": "pkrange-transient-{i}", "pk": "pk1", "value": "test"}}"#);
                 context
-                    .create_item(
+                    .create_seed_item(
                         &container,
                         &format!("pkrange-transient-{i}"),
                         "pk1",
@@ -226,7 +226,7 @@ pub async fn partition_split_on_read_retries_and_succeeds() -> Result<(), Box<dy
         // Seed an item (no fault on writes — rule only targets ReadItem).
         let item_json = br#"{"id": "split-item-1", "pk": "pk1", "value": "test"}"#;
         context
-            .create_item(&container, "split-item-1", "pk1", item_json)
+            .create_seed_item(&container, "split-item-1", "pk1", item_json)
             .await?;
 
         // The first read should hit the 410 and retry, then succeed on the second attempt.
@@ -355,7 +355,7 @@ pub async fn partition_split_on_read_exhausts_retries_and_fails() -> Result<(), 
         // Seed an item (fault only targets reads).
         let item_json = br#"{"id": "split-persistent-1", "pk": "pk1", "value": "test"}"#;
         context
-            .create_item(&container, "split-persistent-1", "pk1", item_json)
+            .create_seed_item(&container, "split-persistent-1", "pk1", item_json)
             .await?;
 
         // With a persistent 410 on all reads, the driver exhausts its retry budget.

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/emulator_tests/driver_patch.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/emulator_tests/driver_patch.rs
@@ -64,7 +64,7 @@ pub async fn cosmos_patch_basic_set() -> Result<(), Box<dyn Error>> {
             let initial_bytes = serde_json::to_vec(&initial)?;
 
             context
-                .create_item(&container, item_id, pk, &initial_bytes)
+                .create_seed_item(&container, item_id, pk, &initial_bytes)
                 .await?;
 
             let spec = PatchInstructions::from(vec![PatchOperation::set("/deleted", json!(true))]);
@@ -118,7 +118,7 @@ pub async fn cosmos_patch_pk_guard() -> Result<(), Box<dyn Error>> {
             let pk = "tenant-a";
             let initial = json!({ "id": item_id, "pk": pk, "name": "n" });
             context
-                .create_item(&container, item_id, pk, &serde_json::to_vec(&initial)?)
+                .create_seed_item(&container, item_id, pk, &serde_json::to_vec(&initial)?)
                 .await?;
 
             // Each op below targets the PK path directly.
@@ -204,7 +204,7 @@ pub async fn cosmos_patch_pk_guard_hierarchical() -> Result<(), Box<dyn Error>> 
             });
             let pk: PartitionKey = (tenant, user).into();
             context
-                .create_item(
+                .create_seed_item(
                     &container,
                     item_id,
                     pk.clone(),
@@ -830,19 +830,17 @@ pub async fn cosmos_patch_semantics() -> Result<(), Box<dyn Error>> {
                 let pk = format!("pk-{idx:03}");
                 let initial = seed_document(case, &item_id, &pk);
 
+                let initial_body = serde_json::to_vec(&initial)?;
                 context
-                    .create_item(
-                        &container,
-                        &item_id,
-                        pk.clone(),
-                        &serde_json::to_vec(&initial)?,
-                    )
+                    .create_seed_item(&container, &item_id, pk.clone(), &initial_body)
                     .await
                     .unwrap_or_else(|e| panic!("[{}] seed failed: {e}", case.id));
 
                 let spec = PatchInstructions::from(case.ops.clone());
                 let result = context
-                    .patch_item(&container, &item_id, pk.clone(), &spec, None)
+                    .retry_transient_transport(&format!("[{}] patch", case.id), || {
+                        context.patch_item(&container, &item_id, pk.clone(), &spec, None)
+                    })
                     .await;
 
                 match (&case.expected, result) {
@@ -982,7 +980,7 @@ pub async fn cosmos_patch_412_retry() -> Result<(), Box<dyn Error>> {
             let pk = "p1";
             let initial = json!({ "id": item_id, "pk": pk, "value": 0 });
             context
-                .create_item(&container, item_id, pk, &serde_json::to_vec(&initial)?)
+                .create_seed_item(&container, item_id, pk, &serde_json::to_vec(&initial)?)
                 .await?;
 
             let spec = PatchInstructions::from(vec![PatchOperation::increment("/value", 1i64)]);
@@ -1054,7 +1052,7 @@ pub async fn cosmos_patch_412_exhaustion() -> Result<(), Box<dyn Error>> {
             let pk = "p1";
             let initial = json!({ "id": item_id, "pk": pk, "value": 0 });
             context
-                .create_item(&container, item_id, pk, &serde_json::to_vec(&initial)?)
+                .create_seed_item(&container, item_id, pk, &serde_json::to_vec(&initial)?)
                 .await?;
 
             let max_attempts = std::num::NonZeroU8::new(2).unwrap();

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/framework/test_client.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/framework/test_client.rs
@@ -11,6 +11,7 @@ use azure_data_cosmos_driver::CosmosDriver;
 use azure_data_cosmos_driver::{
     diagnostics::{DiagnosticsContext, PipelineType, TransportSecurity},
     driver::CosmosDriverRuntime,
+    error::CosmosError,
     models::{
         AccountReference, ConnectionString, ContainerReference, CosmosOperation, CosmosResponse,
         DatabaseReference, ItemReference, PartitionKey,
@@ -21,7 +22,7 @@ use azure_data_cosmos_driver::{
     },
     SubStatusCode,
 };
-use std::{error::Error, future::Future, sync::Arc};
+use std::{error::Error, future::Future, sync::Arc, time::Duration};
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 
@@ -581,6 +582,55 @@ impl DriverTestRunContext {
         Ok(builder.build())
     }
 
+    fn is_transport_generated_503(error: &(dyn Error + 'static)) -> bool {
+        let mut current = Some(error);
+        while let Some(err) = current {
+            if let Some(cosmos) = err.downcast_ref::<CosmosError>() {
+                return cosmos.status().is_transport_generated_503();
+            }
+            current = err.source();
+        }
+        false
+    }
+
+    /// Retries setup/seed operations that fail with a synthetic transport-generated
+    /// 503. Emulator and live-test accounts can briefly publish regional
+    /// endpoints before DNS is ready, which makes otherwise unrelated tests flaky
+    /// while they seed data. This helper is intentionally opt-in so tests that
+    /// assert operation failures do not mask the failure being exercised.
+    pub async fn retry_transient_transport<T, F, Fut>(
+        &self,
+        operation: &str,
+        mut f: F,
+    ) -> Result<T, Box<dyn Error>>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = Result<T, Box<dyn Error>>>,
+    {
+        let mut delay = Duration::from_millis(250);
+        let mut last_error = None;
+        for attempt in 1..=6 {
+            match f().await {
+                Ok(result) => return Ok(result),
+                Err(error) if Self::is_transport_generated_503(error.as_ref()) && attempt < 6 => {
+                    last_error = Some(error.to_string());
+                    eprintln!(
+                        "transient transport failure during {operation}; retrying attempt {attempt}/6 after {delay:?}: {}",
+                        last_error.as_deref().unwrap_or("<unknown>")
+                    );
+                    tokio::time::sleep(delay).await;
+                    delay = (delay * 2).min(Duration::from_secs(5));
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Err(format!(
+            "{operation} failed after transient transport retries: {}",
+            last_error.unwrap_or_else(|| "<no error captured>".into())
+        )
+        .into())
+    }
+
     /// Creates a database using the driver.
     pub async fn create_database(
         &self,
@@ -777,6 +827,22 @@ impl DriverTestRunContext {
         Ok(result)
     }
 
+    /// Creates an item as setup data, retrying transient transport-generated
+    /// 503s that can occur while emulator/live-test regional DNS converges.
+    pub async fn create_seed_item(
+        &self,
+        container: &ContainerReference,
+        item_id: &str,
+        partition_key: impl Into<PartitionKey>,
+        body: &[u8],
+    ) -> Result<CosmosResponse, Box<dyn Error>> {
+        let partition_key = partition_key.into();
+        self.retry_transient_transport("seed create item", || {
+            self.create_item(container, item_id, partition_key.clone(), body)
+        })
+        .await
+    }
+
     /// Creates an item by partition key only (item id is embedded in `body`).
     ///
     /// Convenience overload for tests that include the item id inside the JSON
@@ -791,6 +857,19 @@ impl DriverTestRunContext {
         body: &[u8],
     ) -> Result<CosmosResponse, Box<dyn Error>> {
         self.create_item(container, "_", partition_key, body).await
+    }
+
+    /// Creates an item as setup data by partition key only, retrying transient
+    /// transport-generated 503s. See [`create_seed_item`](Self::create_seed_item).
+    pub async fn create_seed_item_with_pk(
+        &self,
+        container: &ContainerReference,
+        partition_key: impl Into<PartitionKey>,
+        body: &[u8],
+    ) -> Result<CosmosResponse, Box<dyn Error>> {
+        let partition_key = partition_key.into();
+        self.create_seed_item(container, "_", partition_key, body)
+            .await
     }
 
     /// Reads an item using the driver.

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/in_memory_emulator_tests/query.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/in_memory_emulator_tests/query.rs
@@ -58,7 +58,11 @@ async fn query_items_filters_projects_and_paginates() {
     let response = ctx.emulator.execute_request(&req).await.unwrap();
     let (status, headers, body) = collect_response(response).await;
     assert_eq!(status, StatusCode::Ok);
-    assert_eq!(headers.get_optional_str(&CONTINUATION), Some("1"));
+    let continuation = headers
+        .get_optional_str(&CONTINUATION)
+        .expect("first page should return a continuation")
+        .to_owned();
+    assert!(continuation.contains("document_feed_cursor_v1"));
     let docs = body["Documents"].as_array().unwrap();
     assert_eq!(docs.len(), 1);
     assert_eq!(docs[0], serde_json::json!({"id": "item2"}));
@@ -74,7 +78,7 @@ async fn query_items_filters_projects_and_paginates() {
     req.headers_mut()
         .insert(MAX_ITEM_COUNT.clone(), HeaderValue::from_static("1"));
     req.headers_mut()
-        .insert(CONTINUATION.clone(), HeaderValue::from_static("1"));
+        .insert(CONTINUATION.clone(), HeaderValue::from(continuation));
 
     let response = ctx.emulator.execute_request(&req).await.unwrap();
     let (status, headers, body) = collect_response(response).await;

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/in_memory_emulator_tests/read_feed.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/in_memory_emulator_tests/read_feed.rs
@@ -73,7 +73,11 @@ async fn read_document_feed_paginates_documents() {
     let (status, headers, body) = collect_response(response).await;
     assert_eq!(status, StatusCode::Ok);
     assert_eq!(headers.get_optional_str(&ITEM_COUNT), Some("2"));
-    assert_eq!(headers.get_optional_str(&CONTINUATION), Some("2"));
+    let continuation = headers
+        .get_optional_str(&CONTINUATION)
+        .expect("first page should return a continuation")
+        .to_owned();
+    assert!(continuation.contains("document_feed_cursor_v1"));
     let documents = body["Documents"].as_array().unwrap();
     assert_eq!(documents.len(), 2);
     assert_eq!(documents[0]["id"], "item1");
@@ -83,7 +87,7 @@ async fn read_document_feed_paginates_documents() {
     req.headers_mut()
         .insert(MAX_ITEM_COUNT.clone(), HeaderValue::from_static("2"));
     req.headers_mut()
-        .insert(CONTINUATION.clone(), HeaderValue::from_static("2"));
+        .insert(CONTINUATION.clone(), HeaderValue::from(continuation));
 
     let response = ctx.emulator.execute_request(&req).await.unwrap();
     let (status, headers, body) = collect_response(response).await;


### PR DESCRIPTION
## Summary

Adds query comparison coverage for the in-memory emulator, including continuation resume across a physical partition split and HPK/FeedScope targeting scenarios.

The bug was caused by the emulator using numeric offsets as document-feed continuations, which are not stable when a parent partition token is replayed against post-split child ranges. The fix switches simple document feed/query continuations to stable `(EPK, id)` cursors and makes split routing-map changes observable by returning `410/1002 PartitionKeyRangeGone` for gone ranges and bumping the container ETag on split.

## Validation

Validated with focused resume-across-split coverage, driver/wrapper in-memory emulator suites, clippy, build, and cspell.