### PR TITLE
Use released versions for samples

### DIFF
--- a/eng/scripts/Update-PackageVersion.ps1
+++ b/eng/scripts/Update-PackageVersion.ps1
@@ -55,6 +55,8 @@ Write-Host "  Version: $($pkgProperties.Version)"
 Write-Host "  Directory: $($pkgProperties.DirectoryPath)"
 Write-Host "  ChangeLogPath: $($pkgProperties.ChangeLogPath)"
 
+$releasedVersion = $pkgProperties.Version
+
 #If we're just bumping the version with no release date, we want to set the changelog entry to unreleased
 $setChangeLogEntryToUnreleased = !$ReleaseDate -and !$NewVersionString
 
@@ -62,12 +64,12 @@ if ($NewVersionString) {
   $packageSemVer = [AzureEngSemanticVersion]::new($NewVersionString)
 }
 else {
-  $packageSemVer = [AzureEngSemanticVersion]::new($pkgProperties.Version)
+  $packageSemVer = [AzureEngSemanticVersion]::new($releasedVersion)
   $packageSemVer.IncrementAndSetToPrerelease();
 }
 
 if ($packageSemVer.HasValidPrereleaseLabel() -ne $true) {
-  Write-Error "Invalid prerelease label: $packageSemVer"
+  LogError "Invalid prerelease label: $packageSemVer"
   exit 1
 }
 
@@ -88,6 +90,9 @@ if ($content -ne $updated) {
 
   Write-Host "Updating dependencies in Cargo.toml files."
   Invoke-LoggedCommand "cargo +$resolvedToolchain -Zscript '$RepoRoot/eng/scripts/update-pathversions.rs' update" | Out-Null
+
+  Write-Host "Updating sample dependency versions in Cargo.toml files."
+  Invoke-LoggedCommand "cargo +$resolvedToolchain -Zscript '$RepoRoot/eng/scripts/update-samples.rs' '$PackageName@$releasedVersion'" | Out-Null
 
   Write-Host "Updating Cargo.lock using 'cargo update --workspace'."
   Invoke-LoggedCommand "cargo update --workspace" | Out-Null

--- a/eng/scripts/update-pathversions.rs
+++ b/eng/scripts/update-pathversions.rs
@@ -2,7 +2,7 @@
 ---
 [package]
 edition = "2021"
-description = "In all Cargo.toml files in the repo, for all dependencies that have both path and version properties, update the version property to the version in the package."
+description = "In all Cargo.toml files in the repo, for all dependencies that have both path and version properties, or for workspace samples, update the version property to the version in the package."
 
 [dependencies]
 regex = "1.5"
@@ -41,12 +41,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             toml_file.document.as_table_mut(),
             &package_versions,
             should_add,
+            toml_file.is_sample_manifest,
         );
 
         // if the toml file has a workspace table, update the workspace table
         if let Some(workspace) = toml_file.document.get_mut("workspace") {
             if let Some(table) = workspace.as_table_mut() {
-                update_package_versions(table, &package_versions, should_add);
+                update_package_versions(
+                    table,
+                    &package_versions,
+                    should_add,
+                    toml_file.is_sample_manifest,
+                );
             }
         }
 
@@ -79,12 +85,14 @@ fn load_cargo_toml_files(
         let package_version = package_table
             .and_then(|table| table.get("version"))
             .and_then(Item::as_str);
+        let is_sample_manifest = path.starts_with(repo_root.join("samples"));
 
         toml_files.push(TomlInfo {
             path,
             package_name: package_name.map(|s| s.to_string()),
             package_version: package_version.map(|s| s.to_string()),
             is_publish_disabled: publish_property == Some(false),
+            is_sample_manifest,
             document: doc,
         });
     }
@@ -132,6 +140,7 @@ fn update_package_versions(
     toml: &mut Table,
     package_versions: &Vec<(String, String, bool)>,
     add: bool,
+    is_sample_manifest: bool,
 ) {
     // for each dependency table, for each package in package_versions
     // if the package is in the dependency table
@@ -154,8 +163,11 @@ fn update_package_versions(
 
                 let has_path_property = dependency.get("path").is_some();
                 let has_version_property = dependency.get("version").is_some();
+                let should_update_sample_version = is_sample_manifest && has_version_property;
 
-                if has_path_property && (has_version_property || should_add) {
+                if (has_path_property || should_update_sample_version)
+                    && (has_version_property || should_add)
+                {
                     dependency["version"] = value(version);
                 }
             }
@@ -183,5 +195,6 @@ struct TomlInfo {
     package_name: Option<String>,
     package_version: Option<String>,
     is_publish_disabled: bool,
+    is_sample_manifest: bool,
     document: DocumentMut,
 }

--- a/eng/scripts/update-pathversions.rs
+++ b/eng/scripts/update-pathversions.rs
@@ -2,7 +2,7 @@
 ---
 [package]
 edition = "2021"
-description = "In all Cargo.toml files in the repo, for all dependencies that have both path and version properties, or for workspace samples, update the version property to the version in the package."
+description = "In all Cargo.toml files in the repo, for all dependencies that have both path and version properties, update the version property to the version in the package."
 
 [dependencies]
 regex = "1.5"
@@ -41,18 +41,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             toml_file.document.as_table_mut(),
             &package_versions,
             should_add,
-            toml_file.is_sample_manifest,
         );
 
         // if the toml file has a workspace table, update the workspace table
         if let Some(workspace) = toml_file.document.get_mut("workspace") {
             if let Some(table) = workspace.as_table_mut() {
-                update_package_versions(
-                    table,
-                    &package_versions,
-                    should_add,
-                    toml_file.is_sample_manifest,
-                );
+                update_package_versions(table, &package_versions, should_add);
             }
         }
 
@@ -85,14 +79,12 @@ fn load_cargo_toml_files(
         let package_version = package_table
             .and_then(|table| table.get("version"))
             .and_then(Item::as_str);
-        let is_sample_manifest = path.starts_with(repo_root.join("samples"));
 
         toml_files.push(TomlInfo {
             path,
             package_name: package_name.map(|s| s.to_string()),
             package_version: package_version.map(|s| s.to_string()),
             is_publish_disabled: publish_property == Some(false),
-            is_sample_manifest,
             document: doc,
         });
     }
@@ -140,7 +132,6 @@ fn update_package_versions(
     toml: &mut Table,
     package_versions: &Vec<(String, String, bool)>,
     add: bool,
-    is_sample_manifest: bool,
 ) {
     // for each dependency table, for each package in package_versions
     // if the package is in the dependency table
@@ -163,11 +154,8 @@ fn update_package_versions(
 
                 let has_path_property = dependency.get("path").is_some();
                 let has_version_property = dependency.get("version").is_some();
-                let should_update_sample_version = is_sample_manifest && has_version_property;
 
-                if (has_path_property || should_update_sample_version)
-                    && (has_version_property || should_add)
-                {
+                if has_path_property && (has_version_property || should_add) {
                     dependency["version"] = value(version);
                 }
             }
@@ -195,6 +183,5 @@ struct TomlInfo {
     package_name: Option<String>,
     package_version: Option<String>,
     is_publish_disabled: bool,
-    is_sample_manifest: bool,
     document: DocumentMut,
 }

--- a/eng/scripts/update-samples.rs
+++ b/eng/scripts/update-samples.rs
@@ -1,0 +1,148 @@
+#!/usr/bin/env -S cargo +nightly-2026-04-14 -Zscript
+---
+[package]
+edition = "2021"
+description = "In sample Cargo.toml files in the repo, update dependency versions from crate@version arguments."
+
+[dependencies]
+regex = "1.5"
+toml_edit = "0.22"
+---
+
+use regex::Regex;
+use std::collections::BTreeMap;
+use std::io::{Error as IoError, ErrorKind, Write};
+use std::{env, error::Error, fs, path::Path, path::PathBuf};
+use toml_edit::{value, DocumentMut, Item, Table};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let released_versions = parse_released_versions(env::args().skip(1))?;
+    let script_root = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
+    let repo_root = script_root.join("../..").canonicalize()?;
+    let sample_root = repo_root.join("samples");
+    let toml_files = load_sample_toml_files(&sample_root)?;
+
+    for path in toml_files {
+        let content = fs::read_to_string(&path)?;
+        let mut document = content.parse::<DocumentMut>()?;
+
+        if update_dependency_versions(document.as_table_mut(), &released_versions) {
+            let mut file = fs::File::create(path)?;
+            fs::File::write_all(&mut file, document.to_string().as_bytes())?;
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_released_versions(
+    args: impl Iterator<Item = String>,
+) -> Result<BTreeMap<String, String>, Box<dyn Error>> {
+    let mut released_versions = BTreeMap::new();
+
+    for arg in args {
+        let (crate_name, version) = arg.split_once('@').ok_or_else(|| {
+            IoError::new(
+                ErrorKind::InvalidInput,
+                format!("invalid released version argument '{arg}'; expected crate@version"),
+            )
+        })?;
+
+        if crate_name.is_empty() || version.is_empty() {
+            return Err(IoError::new(
+                ErrorKind::InvalidInput,
+                format!("invalid released version argument '{arg}'; expected crate@version"),
+            )
+            .into());
+        }
+
+        released_versions.insert(crate_name.to_string(), version.to_string());
+    }
+
+    if released_versions.is_empty() {
+        return Err(IoError::new(
+            ErrorKind::InvalidInput,
+            "requires at least one crate@version argument",
+        )
+        .into());
+    }
+
+    Ok(released_versions)
+}
+
+fn load_sample_toml_files(sample_root: &Path) -> Result<Vec<PathBuf>, Box<dyn Error>> {
+    let mut toml_paths = Vec::new();
+    find_cargo_toml_files(sample_root, &mut toml_paths)?;
+    toml_paths.sort();
+    Ok(toml_paths)
+}
+
+fn find_cargo_toml_files(dir: &Path, toml_paths: &mut Vec<PathBuf>) -> Result<(), Box<dyn Error>> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path.is_dir() {
+            find_cargo_toml_files(&path, toml_paths)?;
+        } else if path.is_file() && path.file_name() == Some("Cargo.toml".as_ref()) {
+            toml_paths.push(path);
+        }
+    }
+
+    Ok(())
+}
+
+fn update_dependency_versions(
+    toml: &mut Table,
+    released_versions: &BTreeMap<String, String>,
+) -> bool {
+    let dependency_tables = get_dependency_tables(toml);
+    let mut updated = false;
+
+    for (_, table) in dependency_tables {
+        for (crate_name, version) in released_versions {
+            if let Some(dependency) = table.get_mut(crate_name) {
+                updated |= update_dependency_version(dependency, version);
+            }
+        }
+    }
+
+    updated
+}
+
+fn update_dependency_version(dependency: &mut Item, version: &str) -> bool {
+    if dependency.get("version").is_some() {
+        if dependency.get("version").and_then(Item::as_str) == Some(version) {
+            return false;
+        }
+
+        dependency["version"] = value(version);
+        return true;
+    }
+
+    if dependency.as_str() == Some(version) {
+        return false;
+    }
+
+    if dependency.is_str() {
+        *dependency = value(version);
+        return true;
+    }
+
+    false
+}
+
+fn get_dependency_tables(toml: &mut Table) -> Vec<(String, &mut Table)> {
+    let re = Regex::new(r"[.-]?dependencies$").unwrap();
+    let mut tables = Vec::new();
+
+    for (key, value) in toml.iter_mut() {
+        if let Some(table) = value.as_table_mut() {
+            if re.is_match(&key) {
+                tables.push((key.to_string(), table));
+            }
+        }
+    }
+
+    tables
+}

--- a/samples/cosmos_read_item_native_tls/Cargo.toml
+++ b/samples/cosmos_read_item_native_tls/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/azure/azure-sdk-for-rust"
 publish = false
 
 [dependencies]
-azure_core = { version = "1.0.0", default-features = false, features = [
+azure_core = { version = "1.2.0-beta.1", default-features = false, features = [
   "reqwest",
   "tokio",
 ] }
@@ -17,7 +17,7 @@ azure_data_cosmos = { path = "../../sdk/cosmos/azure_data_cosmos", default-featu
   "reqwest",
   "native_tls",
 ] }
-azure_identity = { version = "1.0.0", default-features = false, features = [
+azure_identity = { version = "1.1.0-beta.1", default-features = false, features = [
   "tokio",
 ] }
 clap = { version = "4.6.0", features = ["derive", "env"] }

--- a/samples/cosmos_read_item_native_tls/Cargo.toml
+++ b/samples/cosmos_read_item_native_tls/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/azure/azure-sdk-for-rust"
 publish = false
 
 [dependencies]
-azure_core = { version = "1.2.0-beta.1", default-features = false, features = [
+azure_core = { version = "1.1.0", default-features = false, features = [
   "reqwest",
   "tokio",
 ] }
@@ -17,7 +17,7 @@ azure_data_cosmos = { path = "../../sdk/cosmos/azure_data_cosmos", default-featu
   "reqwest",
   "native_tls",
 ] }
-azure_identity = { version = "1.1.0-beta.1", default-features = false, features = [
+azure_identity = { version = "1.0.0", default-features = false, features = [
   "tokio",
 ] }
 clap = { version = "4.6.0", features = ["derive", "env"] }

--- a/samples/list_blobs_native_tls/Cargo.toml
+++ b/samples/list_blobs_native_tls/Cargo.toml
@@ -8,14 +8,14 @@ repository = "https://github.com/azure/azure-sdk-for-rust"
 publish = false
 
 [dependencies]
-azure_core = { version = "1.0.0", default-features = false, features = [
+azure_core = { version = "1.2.0-beta.1", default-features = false, features = [
   "reqwest",
   "reqwest_deflate",
   "reqwest_gzip",
   "tokio",
 ] }
-azure_identity = { version = "1.0.0", default-features = false }
-azure_storage_blob = { version = "1.0.0", default-features = false }
+azure_identity = { version = "1.1.0-beta.1", default-features = false }
+azure_storage_blob = { version = "1.1.0-beta.1", default-features = false }
 clap = { version = "4.6.0", features = ["derive", "env"] }
 futures = "0.3.32"
 reqwest = { version = "0.13.2", features = [

--- a/samples/list_blobs_native_tls/Cargo.toml
+++ b/samples/list_blobs_native_tls/Cargo.toml
@@ -8,14 +8,14 @@ repository = "https://github.com/azure/azure-sdk-for-rust"
 publish = false
 
 [dependencies]
-azure_core = { version = "1.2.0-beta.1", default-features = false, features = [
+azure_core = { version = "1.1.0", default-features = false, features = [
   "reqwest",
   "reqwest_deflate",
   "reqwest_gzip",
   "tokio",
 ] }
-azure_identity = { version = "1.1.0-beta.1", default-features = false }
-azure_storage_blob = { version = "1.1.0-beta.1", default-features = false }
+azure_identity = { version = "1.0.0", default-features = false }
+azure_storage_blob = { version = "1.0.0", default-features = false }
 clap = { version = "4.6.0", features = ["derive", "env"] }
 futures = "0.3.32"
 reqwest = { version = "0.13.2", features = [

--- a/samples/list_blobs_rustls_symcrypt/Cargo.toml
+++ b/samples/list_blobs_rustls_symcrypt/Cargo.toml
@@ -8,14 +8,14 @@ repository = "https://github.com/azure/azure-sdk-for-rust"
 publish = false
 
 [dependencies]
-azure_core = { version = "1.0.0", default-features = false, features = [
+azure_core = { version = "1.2.0-beta.1", default-features = false, features = [
   "reqwest",
   "reqwest_deflate",
   "reqwest_gzip",
   "tokio",
 ] }
-azure_identity = { version = "1.0.0", default-features = false }
-azure_storage_blob = { version = "1.0.0", default-features = false }
+azure_identity = { version = "1.1.0-beta.1", default-features = false }
+azure_storage_blob = { version = "1.1.0-beta.1", default-features = false }
 clap = { version = "4.6.0", features = ["derive", "env"] }
 futures = "0.3.32"
 reqwest = { version = "0.13.2", features = [

--- a/samples/list_blobs_rustls_symcrypt/Cargo.toml
+++ b/samples/list_blobs_rustls_symcrypt/Cargo.toml
@@ -8,14 +8,14 @@ repository = "https://github.com/azure/azure-sdk-for-rust"
 publish = false
 
 [dependencies]
-azure_core = { version = "1.2.0-beta.1", default-features = false, features = [
+azure_core = { version = "1.1.0", default-features = false, features = [
   "reqwest",
   "reqwest_deflate",
   "reqwest_gzip",
   "tokio",
 ] }
-azure_identity = { version = "1.1.0-beta.1", default-features = false }
-azure_storage_blob = { version = "1.1.0-beta.1", default-features = false }
+azure_identity = { version = "1.0.0", default-features = false }
+azure_storage_blob = { version = "1.0.0", default-features = false }
 clap = { version = "4.6.0", features = ["derive", "env"] }
 futures = "0.3.32"
 reqwest = { version = "0.13.2", features = [


### PR DESCRIPTION
Capture the released crate version before bumping to the next prerelease so sample manifests keep depending on the shipped crate versions instead of the next development versions.

- `eng/scripts/Update-PackageVersion.ps1`: keep the current released version, then pass `crate@version` inputs to sample syncing after the package manifest is bumped.
- `eng/scripts/update-samples.rs`: add a dedicated TOML-preserving updater for `samples/**/Cargo.toml` files based on explicit released versions.
- `samples/cosmos_read_item_native_tls/Cargo.toml`, `samples/list_blobs_native_tls/Cargo.toml`, `samples/list_blobs_rustls_symcrypt/Cargo.toml`: align Azure crate dependency versions to the released values.
