### PR TITLE
Update devcontainer configuration and scripts

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/devcontainers/rust:1-1-bullseye
 
 USER vscode
 
-# Install nightly toolchain to give access to nightly features for docs-site build.
-RUN rustup toolchain install nightly
+# Install pinned stable from rust-toolchain.toml. Pinned nightly setup is done in .devcontainer/oncreate.
+RUN rustup install
 
 # Install pre-requisite tools
 RUN cargo install \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,3 @@
-FROM mcr.microsoft.com/devcontainers/rust:1-1-bullseye
+FROM mcr.microsoft.com/devcontainers/rust:1-bullseye
 
 USER vscode
-
-# Install pinned stable from rust-toolchain.toml. Pinned nightly setup is done in .devcontainer/oncreate.
-RUN rustup install
-
-# Install pre-requisite tools
-RUN cargo install \
-    cargo-watch \
-    http-server

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,34 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/azure-cli:1": {
+      "version": "1.3.0",
+      "resolved": "ghcr.io/devcontainers/features/azure-cli@sha256:d98f1066c077be0fa9d115b718f458bd803e415181b4a96f82a6f5d9f77241ac",
+      "integrity": "sha256:d98f1066c077be0fa9d115b718f458bd803e415181b4a96f82a6f5d9f77241ac"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:4": {
+      "version": "4.0.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5",
+      "integrity": "sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5"
+    },
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      "version": "2.5.0",
+      "resolved": "ghcr.io/devcontainers/features/dotnet@sha256:0fc16547ed4db6d7ff2a9f5981d2b93eb314e568affb9958029ad794f1f9a093",
+      "integrity": "sha256:0fc16547ed4db6d7ff2a9f5981d2b93eb314e568affb9958029ad794f1f9a093"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/powershell:2": {
+      "version": "2.0.2",
+      "resolved": "ghcr.io/devcontainers/features/powershell@sha256:82ea3880c5706ac3963f1b5e940a7f5871835393a5472f80008148b995d58d61",
+      "integrity": "sha256:82ea3880c5706ac3963f1b5e940a7f5871835393a5472f80008148b995d58d61"
+    },
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/sshd@sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee",
+      "integrity": "sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,14 @@
 {
   "name": "Azure SDK for Rust",
   "build": {
-    "dockerfile": "Dockerfile"
+    "dockerfile": "Dockerfile",
+    "options": [
+      "--platform=linux/amd64"
+    ]
   },
+  "runArgs": [
+    "--platform=linux/amd64"
+  ],
   "onCreateCommand": ".devcontainer/oncreate",
   "features": {
     "ghcr.io/devcontainers/features/azure-cli:1": {},
@@ -27,8 +33,6 @@
     "vscode": {
       "extensions": [
         "editorconfig.editorconfig",
-        "github.copilot-chat",
-        "ms-vscode.powershell",
         "rust-lang.rust-analyzer",
         "streetsidesoftware.code-spell-checker",
         "tamasfe.even-better-toml",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,11 +8,11 @@
   "onCreateCommand": ".devcontainer/oncreate",
   "features": {
     "ghcr.io/devcontainers/features/azure-cli:1": {},
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:4": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/sshd:1": {},
     "ghcr.io/devcontainers/features/dotnet:2": {},
-    "ghcr.io/devcontainers/features/powershell:1": {}
+    "ghcr.io/devcontainers/features/powershell:2": {}
   },
   "customizations": {
     "codespaces": {
@@ -27,7 +27,8 @@
     "vscode": {
       "extensions": [
         "editorconfig.editorconfig",
-        "GitHub.copilot",
+        "github.copilot-chat",
+        "ms-vscode.powershell",
         "rust-lang.rust-analyzer",
         "streetsidesoftware.code-spell-checker",
         "tamasfe.even-better-toml",

--- a/.devcontainer/oncreate
+++ b/.devcontainer/oncreate
@@ -5,7 +5,7 @@ set -euo pipefail
 echo "Running Azure SDK for Rust devcontainer post create script..."
 
 echo "Updating toolchains..."
-rustup install
+pwsh -NoLogo -NoProfile -File "${PWD}/eng/scripts/Install-RustToolchains.ps1"
 
 echo "Installing test-proxy..."
 dotnet tool update azure.sdk.tools.testproxy --global --prerelease --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json --ignore-failed-sources

--- a/.devcontainer/oncreate
+++ b/.devcontainer/oncreate
@@ -5,7 +5,12 @@ set -euo pipefail
 echo "Running Azure SDK for Rust devcontainer post create script..."
 
 echo "Updating toolchains..."
-pwsh -NoLogo -NoProfile -File "${PWD}/eng/scripts/Install-RustToolchains.ps1"
+pwsh -NoLogo -NoProfile -File "${PWD}/eng/scripts/Install-RustToolchains.ps1" -Nightly
+
+echo "Installing cargo tools..."
+cargo install \
+  cargo-watch \
+  http-server
 
 echo "Installing test-proxy..."
 dotnet tool update azure.sdk.tools.testproxy --global --prerelease --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json --ignore-failed-sources

--- a/.github/instructions/pwsh.instructions.md
+++ b/.github/instructions/pwsh.instructions.md
@@ -44,6 +44,12 @@ applyTo: "eng/**/*.ps1"
     - If you see similar code blocks repeated, extract them into a reusable function
     - Functions should have clear parameters and return values
     - Example: Extract test execution logic into a shared function rather than duplicating it
+- **Do not modify `eng/common` scripts directly**
+    - Treat `eng/common/` as shared upstream engineering infrastructure
+    - Add repository-specific helpers under `eng/scripts/shared/` instead of changing `eng/common/` directly
+- **Use `eng/scripts/shared/common.ps1` for repository-specific shared helpers**
+    - Add new helper imports there and have scripts import that file rather than dot-sourcing multiple repo-local helper files individually
+    - Put new functions in new or existing helper files under `eng/scripts/shared/` as appropriate
 
 ## Parameter Defaults
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,6 @@
 {
   "recommendations": [
     "editorconfig.editorconfig",
-    "github.copilot-chat",
-    "ms-vscode.powershell",
     "rust-lang.rust-analyzer",
     "streetsidesoftware.code-spell-checker",
     "tamasfe.even-better-toml",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "editorconfig.editorconfig",
     "github.copilot-chat",
+    "ms-vscode.powershell",
     "rust-lang.rust-analyzer",
     "streetsidesoftware.code-spell-checker",
     "tamasfe.even-better-toml",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
     "eng/tools/Cargo.toml",
     "eng/scripts/update-cratenames.rs",
     "eng/scripts/update-pathversions.rs",
+    "eng/scripts/update-samples.rs",
     "eng/scripts/verify-dependencies.rs",
     "eng/scripts/verify-keywords.rs",
   ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,21 +1,34 @@
 {
+  "version": "2.0.0",
   "tasks": [
     {
       "label": "Start docs site (requires nightly)",
+      "type": "process",
       "options": {
         "cwd": "${workspaceFolder}"
       },
-      "command": "cargo",
+      "command": "pwsh",
       "args": [
-        "watch",
-        "-s",
-        "RUSTDOCFLAGS=\"--cfg=docsrs --enable-index-page -Z unstable-options\" cargo +nightly doc --all-features --workspace --no-deps",
-        "-s",
-        "http-server --index --port 8080 ./target/doc"
+        "-NoLogo",
+        "-NoProfile",
+        "-File",
+        "${workspaceFolder}/eng/scripts/Watch-RustDocs.ps1"
       ],
       "isBackground": true,
       "problemMatcher": [
-        "$rustc"
+        "$rustc",
+        {
+          "owner": "powershell",
+          "fileLocation": [
+            "absolute"
+          ],
+          "severity": "error",
+          "pattern": {
+            "regexp": "^\\[Error in file (.+?)\\](.*)$",
+            "file": 1,
+            "message": 2
+          }
+        }
       ]
     }
   ]

--- a/eng/scripts/Watch-RustDocs.ps1
+++ b/eng/scripts/Watch-RustDocs.ps1
@@ -1,0 +1,40 @@
+#!/usr/bin/env pwsh
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+#Requires -Version 7.0
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+. ([System.IO.Path]::Combine($PSScriptRoot, '..', 'common', 'scripts', 'common.ps1'))
+. ([System.IO.Path]::Combine($PSScriptRoot, 'shared', 'Cargo.ps1'))
+
+$resolvedToolchain = Get-ResolvedRustToolchain -Toolchain 'nightly'
+if (!$resolvedToolchain) {
+  LogErrorForFile $PSCommandPath "Failed to resolve Rust nightly toolchain."
+  exit 1
+}
+
+$cargoArgs = @(
+  'watch',
+  '-s',
+  "RUSTDOCFLAGS=""--cfg=docsrs --enable-index-page -Z unstable-options"" cargo +$resolvedToolchain doc --all-features --workspace --no-deps",
+  '-s',
+  'http-server --index --port 8080 ./target/doc'
+)
+
+Push-Location $RepoRoot
+try {
+  Write-Host "> cargo $($cargoArgs -join ' ')"
+  & cargo @cargoArgs 2>&1 | ForEach-Object { $_ }
+
+  if ($LASTEXITCODE -ne 0) {
+    LogErrorForFile $PSCommandPath "Command failed to execute: cargo $($cargoArgs -join ' ')"
+    exit $LASTEXITCODE
+  }
+}
+finally {
+  Pop-Location
+}

--- a/eng/scripts/Watch-RustDocs.ps1
+++ b/eng/scripts/Watch-RustDocs.ps1
@@ -6,10 +6,10 @@
 #Requires -Version 7.0
 
 $ErrorActionPreference = 'Stop'
-Set-StrictMode -Version 2.0
 
 . ([System.IO.Path]::Combine($PSScriptRoot, '..', 'common', 'scripts', 'common.ps1'))
-. ([System.IO.Path]::Combine($PSScriptRoot, 'shared', 'Cargo.ps1'))
+. ([System.IO.Path]::Combine($PSScriptRoot, 'shared', 'common.ps1'))
+Set-StrictMode -Version 3
 
 $resolvedToolchain = Get-ResolvedRustToolchain -Toolchain 'nightly'
 if (!$resolvedToolchain) {
@@ -17,24 +17,22 @@ if (!$resolvedToolchain) {
   exit 1
 }
 
-$cargoArgs = @(
-  'watch',
-  '-s',
-  "RUSTDOCFLAGS=""--cfg=docsrs --enable-index-page -Z unstable-options"" cargo +$resolvedToolchain doc --all-features --workspace --no-deps",
-  '-s',
-  'http-server --index --port 8080 ./target/doc'
-)
+$process = Start-PipedProcess `
+  -FilePath 'cargo' `
+  -ArgumentList @(
+    'watch',
+    '-s',
+    "cargo +$resolvedToolchain doc --all-features --workspace --no-deps",
+    '-s',
+    'http-server --index --port 8080 ./target/doc'
+  ) `
+  -WorkingDirectory $RepoRoot `
+  -Environment @{
+    RUSTDOCFLAGS = '--cfg=docsrs --enable-index-page -Z unstable-options'
+  } `
+  -DoNotExitOnFailedExitCode
 
-Push-Location $RepoRoot
-try {
-  Write-Host "> cargo $($cargoArgs -join ' ')"
-  & cargo @cargoArgs 2>&1 | ForEach-Object { $_ }
-
-  if ($LASTEXITCODE -ne 0) {
-    LogErrorForFile $PSCommandPath "Command failed to execute: cargo $($cargoArgs -join ' ')"
-    exit $LASTEXITCODE
-  }
-}
-finally {
-  Pop-Location
+if ($process.ExitCode) {
+  LogErrorForFile $PSCommandPath "Failed to watch Rust docs."
+  exit $process.ExitCode
 }

--- a/eng/scripts/shared/Process.ps1
+++ b/eng/scripts/shared/Process.ps1
@@ -1,0 +1,96 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+function Start-PipedProcess
+{
+  [CmdletBinding()]
+  param
+  (
+    [Parameter(Mandatory = $true)]
+    [string] $FilePath,
+    [string[]] $ArgumentList = @(),
+    [string] $WorkingDirectory,
+    [hashtable] $Environment,
+    [switch] $GroupOutput,
+    [int[]] $AllowedExitCodes = @(0),
+    [switch] $DoNotExitOnFailedExitCode
+  )
+
+  $startTime = Get-Date
+  $Command = "$FilePath $($ArgumentList -join ' ')".Trim()
+
+  if ($GroupOutput) {
+    LogGroupStart $Command
+  }
+  else {
+    Write-Host "> $Command"
+  }
+
+  $processStartInfo = [System.Diagnostics.ProcessStartInfo]::new()
+  $processStartInfo.FileName = $FilePath
+  $processStartInfo.UseShellExecute = $false
+  $processStartInfo.CreateNoWindow = $true
+  $processStartInfo.RedirectStandardOutput = $true
+  $processStartInfo.RedirectStandardError = $true
+
+  if ($WorkingDirectory) {
+    $processStartInfo.WorkingDirectory = $WorkingDirectory
+  }
+
+  foreach ($argument in $ArgumentList) {
+    [void] $processStartInfo.ArgumentList.Add($argument)
+  }
+
+  if ($Environment) {
+    foreach ($entry in $Environment.GetEnumerator()) {
+      if ($null -eq $entry.Value) {
+        [void] $processStartInfo.Environment.Remove([string] $entry.Key)
+      }
+      else {
+        $processStartInfo.Environment[[string] $entry.Key] = [string] $entry.Value
+      }
+    }
+  }
+
+  $process = [System.Diagnostics.Process]::new()
+  $process.StartInfo = $processStartInfo
+
+  if (!$process.Start()) {
+    throw "Failed to start process: $FilePath"
+  }
+
+  $stdoutStream = [Console]::OpenStandardOutput()
+  $stderrStream = [Console]::OpenStandardError()
+  $stdoutTask = $process.StandardOutput.BaseStream.CopyToAsync($stdoutStream)
+  $stderrTask = $process.StandardError.BaseStream.CopyToAsync($stderrStream)
+
+  try {
+    $process.WaitForExit()
+    [System.Threading.Tasks.Task]::WaitAll(@($stdoutTask, $stderrTask))
+    $stdoutStream.Flush()
+    $stderrStream.Flush()
+    $exitCode = $process.ExitCode
+    $duration = (Get-Date) - $startTime
+
+    if ($GroupOutput) {
+      LogGroupEnd
+    }
+
+    if ($exitCode -notin $AllowedExitCodes) {
+      LogError "Command failed to execute ($duration): $Command`n"
+      if (!$DoNotExitOnFailedExitCode) {
+        exit $exitCode
+      }
+    }
+    else {
+      Write-Host "Command succeeded ($duration)`n"
+    }
+  }
+  finally {
+    $process.Dispose()
+  }
+
+  return [pscustomobject]@{
+    ExitCode = $exitCode
+  }
+}

--- a/eng/scripts/shared/common.ps1
+++ b/eng/scripts/shared/common.ps1
@@ -1,0 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+. ([System.IO.Path]::Combine($PSScriptRoot, 'Process.ps1'))
+. ([System.IO.Path]::Combine($PSScriptRoot, 'Cargo.ps1'))


### PR DESCRIPTION
- Replace nightly toolchain installation with stable toolchain setup in Dockerfile.
- Update devcontainer.json to use newer versions of Docker-in-Docker and PowerShell features.
- Modify oncreate script to run PowerShell script for toolchain installation.
- Add new Watch-RustDocs.ps1 script for watching Rust documentation builds.
- Update tasks.json to use PowerShell for starting the docs site.
- Include additional script in settings.json for better project management.
