### PR TITLE
Keep sample deps on stable releases

### DIFF
--- a/eng/scripts/Update-PackageVersion.ps1
+++ b/eng/scripts/Update-PackageVersion.ps1
@@ -56,6 +56,7 @@ Write-Host "  Directory: $($pkgProperties.DirectoryPath)"
 Write-Host "  ChangeLogPath: $($pkgProperties.ChangeLogPath)"
 
 $releasedVersion = $pkgProperties.Version
+$releasedSemVer = [AzureEngSemanticVersion]::new($releasedVersion)
 
 #If we're just bumping the version with no release date, we want to set the changelog entry to unreleased
 $setChangeLogEntryToUnreleased = !$ReleaseDate -and !$NewVersionString
@@ -91,8 +92,13 @@ if ($content -ne $updated) {
   Write-Host "Updating dependencies in Cargo.toml files."
   Invoke-LoggedCommand "cargo +$resolvedToolchain -Zscript '$RepoRoot/eng/scripts/update-pathversions.rs' update" | Out-Null
 
-  Write-Host "Updating sample dependency versions in Cargo.toml files."
-  Invoke-LoggedCommand "cargo +$resolvedToolchain -Zscript '$RepoRoot/eng/scripts/update-samples.rs' '$PackageName@$releasedVersion'" | Out-Null
+  if (!$releasedSemVer.IsPrerelease) {
+    Write-Host "Updating sample dependency versions in Cargo.toml files."
+    Invoke-LoggedCommand "cargo +$resolvedToolchain -Zscript '$RepoRoot/eng/scripts/update-samples.rs' '$PackageName@$releasedVersion'" | Out-Null
+  }
+  else {
+    Write-Host "Skipping sample dependency updates for prerelease version $releasedVersion."
+  }
 
   Write-Host "Updating Cargo.lock using 'cargo update --workspace'."
   Invoke-LoggedCommand "cargo update --workspace" | Out-Null

--- a/eng/scripts/update-pathversions.rs
+++ b/eng/scripts/update-pathversions.rs
@@ -28,7 +28,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let repo_root = script_root.join("../..").canonicalize()?;
 
     // find all Cargo.toml files in the repo_root directory
-    let exclude_dirs = vec![repo_root.join("eng"), repo_root.join("target")];
+    let exclude_dirs = vec![
+        repo_root.join("eng"),
+        // Sample manifests should stay on the latest stable published versions unless they
+        // intentionally use a path dependency to highlight unpublished functionality.
+        repo_root.join("samples"),
+        repo_root.join("target"),
+    ];
 
     let toml_files = load_cargo_toml_files(&repo_root, &exclude_dirs)?;
 

--- a/eng/scripts/update-samples.rs
+++ b/eng/scripts/update-samples.rs
@@ -5,11 +5,13 @@ edition = "2021"
 description = "In sample Cargo.toml files in the repo, update dependency versions from crate@version arguments."
 
 [dependencies]
+semver = "1.0"
 regex = "1.5"
 toml_edit = "0.22"
 ---
 
 use regex::Regex;
+use semver::Version;
 use std::collections::BTreeMap;
 use std::io::{Error as IoError, ErrorKind, Write};
 use std::{env, error::Error, fs, path::Path, path::PathBuf};
@@ -17,6 +19,11 @@ use toml_edit::{value, DocumentMut, Item, Table};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let released_versions = parse_released_versions(env::args().skip(1))?;
+    if released_versions.is_empty() {
+        println!("No sample dependency updates required: no stable versions were provided.");
+        return Ok(());
+    }
+
     let script_root = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
     let repo_root = script_root.join("../..").canonicalize()?;
     let sample_root = repo_root.join("samples");
@@ -56,17 +63,19 @@ fn parse_released_versions(
             .into());
         }
 
+        let parsed_version = Version::parse(version).map_err(|err| {
+            IoError::new(
+                ErrorKind::InvalidInput,
+                format!("invalid released version argument '{arg}': {err}"),
+            )
+        })?;
+
+        if !parsed_version.pre.is_empty() {
+            continue;
+        }
+
         released_versions.insert(crate_name.to_string(), version.to_string());
     }
-
-    if released_versions.is_empty() {
-        return Err(IoError::new(
-            ErrorKind::InvalidInput,
-            "requires at least one crate@version argument",
-        )
-        .into());
-    }
-
     Ok(released_versions)
 }
 

--- a/samples/AGENTS.md
+++ b/samples/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS.md
+
+Follow [../AGENTS.md](../AGENTS.md).
+
+## Samples
+
+- Use the latest stable published versions of repo crates.
+- Use path dependencies only to show unpublished functionality that cannot live in a crate's `examples/` directory.
+- Never use path dependencies for convenience or to track unreleased versions.


### PR DESCRIPTION
Skip samples in update-pathversions.rs so prerelease sweeps do not
rewrite sample manifests.

Update Update-PackageVersion.ps1 and update-samples.rs to only
refresh sample dependency versions for stable releases, and treat
prerelease-only inputs as a no-op.

Add samples/AGENTS.md guidance for stable sample dependencies and
limited path dependency use.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 1ce46b6b-095f-4a5b-ae31-5acc1004ccfc
