### PR TITLE
Use Azure PROwner for creating the pull request

### DIFF
--- a/eng/pipelines/templates/stages/archetype-rust-release.yml
+++ b/eng/pipelines/templates/stages/archetype-rust-release.yml
@@ -193,7 +193,7 @@ stages:
 
           - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
             parameters:
-              PROwnwer: 'Azure'
+              PROwner: 'Azure'
               PRBranchName: increment-package-version-${{parameters.ServiceDirectory}}-$(Build.BuildId)
               CommitMsg: "Increment package version after release of ${{ join(', ', parameters.Artifacts.*.name) }}"
               PRTitle: "Increment versions for ${{parameters.ServiceDirectory}} releases"

--- a/eng/pipelines/templates/stages/archetype-rust-release.yml
+++ b/eng/pipelines/templates/stages/archetype-rust-release.yml
@@ -193,6 +193,7 @@ stages:
 
           - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
             parameters:
+              PROwnwer: 'Azure'
               PRBranchName: increment-package-version-${{parameters.ServiceDirectory}}-$(Build.BuildId)
               CommitMsg: "Increment package version after release of ${{ join(', ', parameters.Artifacts.*.name) }}"
               PRTitle: "Increment versions for ${{parameters.ServiceDirectory}} releases"


### PR DESCRIPTION
This pull request makes a minor update to the Azure Pipelines template for Rust releases, specifically in the pull request creation step. The main change is the addition of the `PROwnwer` parameter set to `'Azure'` when creating a pull request after a package release.

* Added the `PROwnwer` parameter with value `'Azure'` to the `create-pull-request.yml` template in the `archetype-rust-release.yml` pipeline, ensuring pull requests are correctly attributed to the Azure team.