### PR TITLE
Add CFSClean enforcement

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -39,6 +39,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
+      networkIsolationPolicy: Permissive, CFSClean
       # only enable autoBaseline for the internal build of rust-core on main branch
       featureFlags:
         autoBaseline: ${{ parameters.AutoBaseline }}


### PR DESCRIPTION
This pull request updates the pipeline configuration to adjust the network isolation policy for builds. The key change is:

Pipeline configuration:

* Set the `networkIsolationPolicy` to `Permissive, CFSClean` in the `1es-redirect.yml` pipeline template, which may affect how network access is managed during builds.

https://dev.azure.com/azure-sdk/internal/_build?definitionId=7442