### PR TITLE
Add DiagnosticsContext foundation to Cosmos driver

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Added `tokio` feature to `default` features.
 - Changed `default_ttl` and `analytical_storage_ttl` fields on `ContainerProperties` from `Option<Duration>` to `TimeToLive`, a new enum with variants `Forever`, `NoDefault`, and `Seconds(u32)`, to correctly handle the `-1` wire value (TTL enabled with no default expiration).
 
+### Bugs Fixed
+
+- Fixed `410 Gone` responses carrying a partition-key-range routing sub-status (`1000` NameCacheIsStale, `1002` PartitionKeyRangeGone, `1007` CompletingSplit) escaping the retry pipeline as a raw, unclassifiable `410` (returned directly to the caller on writes, or after non-curative cross-region failover on reads). These are now retried within a small bound — flagging a routing-cache refresh so SDK-routing paths re-resolve stale routing information — and, on exhaustion, surfaced as `503 Service Unavailable` with the original sub-status preserved. This aligns the surfaced status with the rest of the Gone family so application-layer retry/circuit-breaker logic (wired for `503`, not `410`) can classify it.
+
 ## 0.31.0 (2026-02-25)
 
 ### Features Added

--- a/sdk/cosmos/azure_data_cosmos/src/handler/retry_handler.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/handler/retry_handler.rs
@@ -4,7 +4,7 @@
 use crate::cosmos_request::CosmosRequest;
 use crate::retry_policies::client_retry_policy::ClientRetryPolicy;
 use crate::retry_policies::metadata_request_retry_policy::MetadataRequestRetryPolicy;
-use crate::retry_policies::{RetryPolicy, RetryResult};
+use crate::retry_policies::{convert_gone_to_service_unavailable, RetryPolicy, RetryResult};
 use crate::routing::global_endpoint_manager::GlobalEndpointManager;
 use crate::routing::global_partition_endpoint_manager::GlobalPartitionEndpointManager;
 use async_trait::async_trait;
@@ -139,7 +139,15 @@ impl RetryHandler for BackOffRetryHandler {
             let retry_result = retry_policy.should_retry(&result).await;
 
             match retry_result {
-                RetryResult::DoNotRetry => return result,
+                RetryResult::DoNotRetry => {
+                    // If the data-plane policy exhausted its partition-key-range Gone
+                    // budget, surface the terminal failure as 503 (preserving the
+                    // original sub-status) instead of letting a raw 410 escape.
+                    if let Some(sub_status) = retry_policy.terminal_gone_substatus() {
+                        return convert_gone_to_service_unavailable(result, sub_status);
+                    }
+                    return result;
+                }
                 RetryResult::Retry { after } => get_async_runtime().sleep(after).await,
             }
         }

--- a/sdk/cosmos/azure_data_cosmos/src/retry_policies/client_retry_policy.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/retry_policies/client_retry_policy.rs
@@ -29,6 +29,13 @@ const MAX_RETRY_COUNT_ON_ENDPOINT_FAILURE: usize = 120;
 /// the endpoint unavailable.
 const MAX_RETRY_COUNT_ON_CONNECTION_FAILURE: usize = 3;
 
+/// Maximum number of in-line retries for the partition-key-range Gone family
+/// (410 with sub-status 1000/1002/1007) before the terminal outcome is surfaced
+/// as 503 Service Unavailable. A small fixed bound (one routing-cache refresh +
+/// one retry) mirrors the dedicated PartitionKeyRangeGone retry policy used by
+/// the other Cosmos SDKs and avoids retry amplification on writes.
+const MAX_RETRY_COUNT_ON_PARTITION_KEY_RANGE_GONE: usize = 1;
+
 /// Context information for routing retry attempts to specific endpoints.
 #[derive(Clone, Debug)]
 struct RetryContext {
@@ -66,6 +73,20 @@ pub(crate) struct ClientRetryPolicy {
     /// Counter tracking the number of consecutive connection failure retry attempts
     /// on the current endpoint before marking it unavailable.
     connection_retry_count: usize,
+
+    /// Counter tracking the number of partition-key-range Gone (410.1000/1002/1007)
+    /// retry attempts for the current request.
+    partition_key_range_gone_retry_count: usize,
+
+    /// When set, the next `before_send_request` flags the request for a routing-cache
+    /// refresh (name cache, partition-key-range and collection routing map) so that
+    /// SDK-routing paths re-resolve a stale routing map instead of replaying it.
+    refresh_routing_on_next_attempt: bool,
+
+    /// Set when the partition-key-range Gone family has exhausted its in-line retry
+    /// budget. Signals the retry handler to surface the terminal failure as
+    /// 503 Service Unavailable while preserving this original Cosmos sub-status.
+    terminal_gone_substatus: Option<SubStatusCode>,
 
     /// Whether the current request is a read operation (true) or write operation (false)
     operation_type: Option<OperationType>,
@@ -117,6 +138,9 @@ impl ClientRetryPolicy {
             session_token_retry_count: 0,
             service_unavailable_retry_count: 0,
             connection_retry_count: 0,
+            partition_key_range_gone_retry_count: 0,
+            refresh_routing_on_next_attempt: false,
+            terminal_gone_substatus: None,
             operation_type: None,
             request: None,
             can_use_multiple_write_locations: false,
@@ -214,6 +238,16 @@ impl ClientRetryPolicy {
         {
             self.partition_key_range_location_cache
                 .try_add_partition_level_location_override(request);
+        }
+
+        // If a prior attempt hit the partition-key-range Gone family, flag the
+        // request so SDK-routing paths refresh the (now demonstrably stale)
+        // routing caches before this attempt instead of replaying the stale map.
+        if self.refresh_routing_on_next_attempt {
+            request.force_name_cache_refresh = true;
+            request.force_partition_key_range_refresh = true;
+            request.force_collection_routing_map_refresh = true;
+            self.refresh_routing_on_next_attempt = false;
         }
 
         self.request = Some(request.clone());
@@ -497,6 +531,45 @@ impl ClientRetryPolicy {
         }
     }
 
+    /// Handles the partition-key-range Gone family (410.1000/1002/1007).
+    ///
+    /// A 410 carrying one of these sub-statuses means the routing information the
+    /// request was resolved against is stale (a split/merge/migration moved the
+    /// range). We retry a small, fixed number of times, flagging a routing-cache
+    /// refresh for the next attempt so SDK-routing paths re-resolve instead of
+    /// replaying the stale map. Once the bound is exhausted we stop retrying and
+    /// record the sub-status so the retry handler can surface the terminal failure
+    /// as 503 Service Unavailable (preserving the sub-status) rather than letting a
+    /// raw, unclassifiable 410 escape to the caller.
+    ///
+    /// Applies to reads and writes alike: a 410 from routing resolution means the
+    /// operation was not applied, so retrying a write is safe.
+    fn should_retry_on_partition_key_range_gone(
+        &mut self,
+        sub_status: SubStatusCode,
+    ) -> RetryResult {
+        self.partition_key_range_gone_retry_count += 1;
+
+        if self.partition_key_range_gone_retry_count <= MAX_RETRY_COUNT_ON_PARTITION_KEY_RANGE_GONE
+        {
+            self.refresh_routing_on_next_attempt = true;
+            return RetryResult::Retry {
+                after: Duration::ZERO,
+            };
+        }
+
+        // Bound exhausted: surface as 503 with the original sub-status preserved.
+        self.terminal_gone_substatus = Some(sub_status);
+        RetryResult::DoNotRetry
+    }
+
+    /// Returns the sub-status to preserve when a terminal partition-key-range Gone
+    /// must be surfaced as 503 Service Unavailable, or `None` if no such conversion
+    /// is pending. Consulted by the retry handler after a `DoNotRetry` decision.
+    pub(crate) fn terminal_gone_substatus(&self) -> Option<SubStatusCode> {
+        self.terminal_gone_substatus
+    }
+
     /// Routes HTTP status codes to appropriate retry handling logic.
     ///
     /// # Summary
@@ -587,6 +660,26 @@ impl ClientRetryPolicy {
             && sub_status_code == Some(SubStatusCode::LEASE_NOT_FOUND)
         {
             return Some(self.should_retry_on_unavailable_endpoint_status_codes());
+        }
+
+        // Gone - partition-key-range staleness family (410.1000 NameCacheIsStale,
+        // 410.1002 PartitionKeyRangeGone, 410.1007 CompletingSplit). This must be
+        // matched on the (Gone, sub-status) tuple: sub-status 1002 is also used by
+        // 404 ReadSessionNotAvailable (handled above), so keying on sub-status
+        // alone would conflate the two. Without this branch a 410.1002 escapes the
+        // pipeline as a raw, unclassifiable 410 (writes) or burns non-curative
+        // cross-region failover (reads). Instead we drive a bounded routing-cache
+        // refresh + retry and, on exhaustion, surface 503 (see the retry handler).
+        if status_code == StatusCode::Gone
+            && matches!(
+                sub_status_code,
+                Some(SubStatusCode::NAME_CACHE_IS_STALE)
+                    | Some(SubStatusCode::PARTITION_KEY_RANGE_GONE)
+                    | Some(SubStatusCode::COMPLETING_SPLIT)
+            )
+        {
+            // sub_status_code is Some in every arm of the match above.
+            return Some(self.should_retry_on_partition_key_range_gone(sub_status_code.unwrap()));
         }
 
         // For read operations, retry on any status code that is not explicitly non-retryable.
@@ -1011,6 +1104,101 @@ mod tests {
             }
             _ => panic!("Expected retry for Gone with LeaseNotFound on write"),
         }
+    }
+
+    #[tokio::test]
+    async fn gone_partition_key_range_retries_then_converts_to_503_read() {
+        let mut policy = create_test_policy_with_preferred_locations();
+        policy.operation_type = Some(OperationType::Read);
+        let error = create_error_with_substatus(
+            StatusCode::Gone,
+            SubStatusCode::PARTITION_KEY_RANGE_GONE.value() as u32,
+        );
+
+        // First 410/1002: bounded retry, routing refresh flagged, no terminal conversion yet.
+        let first = policy.should_retry_error(&error).await;
+        assert!(first.is_retry(), "first 410/1002 should retry");
+        assert_eq!(policy.partition_key_range_gone_retry_count, 1);
+        assert!(policy.refresh_routing_on_next_attempt);
+        assert!(policy.terminal_gone_substatus().is_none());
+
+        // Second 410/1002: bound exhausted -> stop retrying, terminal 503 conversion pending.
+        let second = policy.should_retry_error(&error).await;
+        assert!(!second.is_retry(), "second 410/1002 should stop retrying");
+        assert_eq!(
+            policy.terminal_gone_substatus(),
+            Some(SubStatusCode::PARTITION_KEY_RANGE_GONE),
+            "terminal Gone must surface as 503 preserving sub-status 1002"
+        );
+    }
+
+    #[tokio::test]
+    async fn gone_partition_key_range_retries_then_converts_to_503_write() {
+        // Writes must also recover: a 410 from routing resolution means the
+        // operation was not applied, so a bounded retry is safe (Q4=B).
+        let mut policy = create_test_policy_with_preferred_locations();
+        policy.operation_type = Some(OperationType::Create);
+        let error = create_error_with_substatus(
+            StatusCode::Gone,
+            SubStatusCode::PARTITION_KEY_RANGE_GONE.value() as u32,
+        );
+
+        assert!(
+            policy.should_retry_error(&error).await.is_retry(),
+            "writes must also retry a 410/1002"
+        );
+        assert!(
+            !policy.should_retry_error(&error).await.is_retry(),
+            "writes must stop after the bound and convert"
+        );
+        assert_eq!(
+            policy.terminal_gone_substatus(),
+            Some(SubStatusCode::PARTITION_KEY_RANGE_GONE)
+        );
+    }
+
+    #[tokio::test]
+    async fn gone_name_cache_stale_and_completing_split_take_gone_branch() {
+        for ss in [
+            SubStatusCode::NAME_CACHE_IS_STALE,
+            SubStatusCode::COMPLETING_SPLIT,
+        ] {
+            let mut policy = create_test_policy_with_preferred_locations();
+            policy.operation_type = Some(OperationType::Read);
+            let error = create_error_with_substatus(StatusCode::Gone, ss.value() as u32);
+
+            assert!(
+                policy.should_retry_error(&error).await.is_retry(),
+                "410/{} should take the Gone-family retry branch",
+                ss.value()
+            );
+            assert_eq!(policy.partition_key_range_gone_retry_count, 1);
+            assert!(policy.refresh_routing_on_next_attempt);
+        }
+    }
+
+    #[tokio::test]
+    async fn not_found_session_not_available_not_treated_as_gone() {
+        // 404/1002 ReadSessionNotAvailable shares sub-status 1002 with 410/1002
+        // PartitionKeyRangeGone. It must keep the session-retry path, untouched by
+        // the new Gone-family branch (regression guard for the overloaded 1002).
+        let mut policy = create_test_policy();
+        policy.operation_type = Some(OperationType::Read);
+        let error = create_error_with_substatus(
+            StatusCode::NotFound,
+            SubStatusCode::READ_SESSION_NOT_AVAILABLE.value() as u32,
+        );
+
+        let _ = policy.should_retry_error(&error).await;
+        assert_eq!(
+            policy.session_token_retry_count, 1,
+            "404/1002 must use the session-not-available path"
+        );
+        assert_eq!(
+            policy.partition_key_range_gone_retry_count, 0,
+            "404/1002 must NOT use the Gone-family path"
+        );
+        assert!(policy.terminal_gone_substatus().is_none());
     }
 
     #[tokio::test]

--- a/sdk/cosmos/azure_data_cosmos/src/retry_policies/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/retry_policies/mod.rs
@@ -11,6 +11,7 @@ use crate::retry_policies::client_retry_policy::ClientRetryPolicy;
 use crate::retry_policies::metadata_request_retry_policy::MetadataRequestRetryPolicy;
 use crate::retry_policies::resource_throttle_retry_policy::ResourceThrottleRetryPolicy;
 use azure_core::error::ErrorKind;
+use azure_core::http::headers::Headers;
 use azure_core::http::{RawResponse, StatusCode};
 use azure_core::time::Duration;
 
@@ -124,6 +125,61 @@ impl RetryPolicy {
             RetryPolicy::ResourceThrottle(p) => p.should_retry(response).await,
             RetryPolicy::Metadata(p) => p.should_retry(response).await,
         }
+    }
+
+    /// Returns the Cosmos sub-status to preserve when a terminal partition-key-range
+    /// Gone (410.1000/1002/1007) must be surfaced as 503 Service Unavailable instead
+    /// of a raw 410, or `None` when no such conversion is pending. Only the data-plane
+    /// [`ClientRetryPolicy`] produces this signal.
+    pub fn terminal_gone_substatus(&self) -> Option<SubStatusCode> {
+        match self {
+            RetryPolicy::Client(p) => p.terminal_gone_substatus(),
+            RetryPolicy::ResourceThrottle(_) | RetryPolicy::Metadata(_) => None,
+        }
+    }
+}
+
+/// Rewrites a terminal partition-key-range Gone result (410 with sub-status
+/// 1000/1002/1007) into a 503 Service Unavailable while preserving the original
+/// Cosmos sub-status, so application-layer resilience logic (which is wired for
+/// 503, not 410) can classify and react to it.
+///
+/// Cosmos gateway responses for non-success status codes arrive here as an
+/// `Err(HttpResponse { status: Gone, .. })`; the rare `Ok(RawResponse)` form with a
+/// Gone status is handled too. Any other result is returned unchanged.
+pub(crate) fn convert_gone_to_service_unavailable(
+    result: azure_core::Result<RawResponse>,
+    sub_status: SubStatusCode,
+) -> azure_core::Result<RawResponse> {
+    let mut headers = match &result {
+        Ok(response) if response.status() == StatusCode::Gone => response.headers().clone(),
+        Err(err) if err.http_status() == Some(StatusCode::Gone) => Headers::new(),
+        // Not a Gone result: leave it untouched.
+        _ => return result,
+    };
+    headers.insert(SUB_STATUS, sub_status.to_string());
+
+    match result {
+        Ok(_) => Ok(RawResponse::from_bytes(
+            StatusCode::ServiceUnavailable,
+            headers,
+            Vec::new(),
+        )),
+        Err(_) => Err(azure_core::Error::with_message(
+            ErrorKind::HttpResponse {
+                status: StatusCode::ServiceUnavailable,
+                error_code: Some("ServiceUnavailable".to_string()),
+                raw_response: Some(Box::new(RawResponse::from_bytes(
+                    StatusCode::ServiceUnavailable,
+                    headers,
+                    Vec::new(),
+                ))),
+            },
+            format!(
+                "partition key range is gone (sub-status {sub_status}); routing information was stale \
+                 and could not be refreshed within the retry budget, surfaced as 503 Service Unavailable"
+            ),
+        )),
     }
 }
 
@@ -282,5 +338,67 @@ mod tests {
     fn credential_is_not_sent() {
         let err = azure_core::Error::with_message(ErrorKind::Credential, "auth failed");
         assert_eq!(err.request_sent_status(), RequestSentStatus::NotSent);
+    }
+
+    fn gone_error_with_substatus(value: &str) -> azure_core::Error {
+        let mut headers = azure_core::http::headers::Headers::new();
+        headers.insert(SUB_STATUS, value.to_string());
+        let raw = RawResponse::from_bytes(StatusCode::Gone, headers, Vec::new());
+        azure_core::Error::new(
+            ErrorKind::HttpResponse {
+                status: StatusCode::Gone,
+                error_code: None,
+                raw_response: Some(Box::new(raw)),
+            },
+            "partition key range gone",
+        )
+    }
+
+    #[test]
+    fn convert_gone_error_to_service_unavailable_preserves_substatus() {
+        let converted = convert_gone_to_service_unavailable(
+            Err(gone_error_with_substatus("1002")),
+            SubStatusCode::PARTITION_KEY_RANGE_GONE,
+        );
+        let err = converted.expect_err("a Gone error must remain an error");
+        assert_eq!(err.http_status(), Some(StatusCode::ServiceUnavailable));
+        assert_eq!(
+            get_substatus_code_from_error(&err),
+            Some(SubStatusCode::PARTITION_KEY_RANGE_GONE),
+            "the original sub-status must be preserved on the 503"
+        );
+    }
+
+    #[test]
+    fn convert_gone_ok_response_to_service_unavailable_preserves_substatus() {
+        let mut headers = azure_core::http::headers::Headers::new();
+        headers.insert(SUB_STATUS, "1002");
+        let response = RawResponse::from_bytes(StatusCode::Gone, headers, Vec::new());
+
+        let converted = convert_gone_to_service_unavailable(
+            Ok(response),
+            SubStatusCode::PARTITION_KEY_RANGE_GONE,
+        )
+        .expect("ok response must remain ok");
+        assert_eq!(converted.status(), StatusCode::ServiceUnavailable);
+        assert_eq!(
+            get_substatus_code_from_response(&converted),
+            Some(SubStatusCode::PARTITION_KEY_RANGE_GONE)
+        );
+    }
+
+    #[test]
+    fn convert_leaves_non_gone_results_untouched() {
+        let response = RawResponse::from_bytes(
+            StatusCode::Ok,
+            azure_core::http::headers::Headers::new(),
+            Vec::new(),
+        );
+        let converted = convert_gone_to_service_unavailable(
+            Ok(response),
+            SubStatusCode::PARTITION_KEY_RANGE_GONE,
+        )
+        .expect("non-gone ok stays ok");
+        assert_eq!(converted.status(), StatusCode::Ok);
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_fault_injection.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_fault_injection.rs
@@ -944,3 +944,66 @@ pub async fn fault_injection_enable_disable_rule() -> Result<(), Box<dyn Error>>
     )
     .await
 }
+
+/// Injecting a partition-key-range Gone (410/1002) on point operations must NOT
+/// surface a raw 410 to the caller. The Gone-family is retried within a small
+/// bound and, on exhaustion, converted to 503 Service Unavailable so application
+/// resilience logic (wired for 503, not 410) can classify it. Regression test for
+/// the Rust sibling of Azure/azure-cosmos-dotnet-v3#5924.
+#[tokio::test]
+pub async fn fault_injection_partition_key_range_gone_surfaces_503() -> Result<(), Box<dyn Error>> {
+    let server_error = FaultInjectionResultBuilder::new()
+        .with_error(FaultInjectionErrorType::PartitionIsGone) // 410 / 1002
+        .with_probability(1.0)
+        .build();
+
+    let condition = FaultInjectionConditionBuilder::new()
+        .with_operation_type(FaultOperationType::ReadItem)
+        .build();
+
+    let rule = FaultInjectionRuleBuilder::new("partition-key-range-gone", server_error)
+        .with_condition(condition)
+        .build();
+
+    let fault_builder = FaultInjectionClientBuilder::new().with_rule(Arc::new(rule));
+
+    TestClient::run_with_unique_db(
+        async |run_context, db_client| {
+            let container_id = format!("Container-{}", Uuid::new_v4());
+            let container_client = run_context
+                .create_container_with_throughput(
+                    db_client,
+                    ContainerProperties::new(container_id.clone(), "/partition_key".into()),
+                    ThroughputProperties::manual(400),
+                )
+                .await?;
+
+            let unique_id = Uuid::new_v4().to_string();
+            let item = create_test_item(&unique_id);
+            let pk = format!("Partition-{}", unique_id);
+            let item_id = format!("Item-{}", unique_id);
+
+            container_client.create_item(&pk, &item, None).await?;
+
+            let fault_client = run_context
+                .fault_client()
+                .expect("fault client should be available");
+            let fault_db_client = fault_client.database_client(db_client.id());
+            let fault_container_client = fault_db_client.container_client(&container_id).await;
+
+            let result = fault_container_client
+                .read_item::<TestItem>(&pk, &item_id, None)
+                .await;
+            let err = result.expect_err("read should fail when partition is gone");
+            assert_eq!(
+                Some(StatusCode::ServiceUnavailable),
+                err.http_status(),
+                "terminal 410/1002 must be surfaced as 503, not a raw 410"
+            );
+
+            Ok(())
+        },
+        Some(TestOptions::new().with_fault_injection_builder(fault_builder)),
+    )
+    .await
+}

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Initial release of `azure_data_cosmos_driver` (core Cosmos DB protocol implementation for cross-language SDK reuse).
   - ([#3772](https://github.com/Azure/azure-sdk-for-rust/pull/3772))
+- Added the `DiagnosticsContext` foundation: `CosmosResponse::diagnostics()` returns the always-collected operation diagnostics (`is_completed`/`is_failure`/`is_threshold_violated`, `duration`, `status`, `total_request_charge`, `contacted_regions`, `operation_name`, `requests`, `to_json_string`), backed by `RequestDiagnostics`, `ExecutionContext`, and `DiagnosticsOptions`/`DiagnosticsVerbosity`.
 
 ### Breaking Changes
 

--- a/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/context.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/context.rs
@@ -1,0 +1,451 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! The operation-level diagnostics context.
+//!
+//! A [`DiagnosticsContext`] is the canonical, always-collected record the driver produces for each
+//! operation. It rolls up the per-attempt [`RequestDiagnostics`] together with operation-level
+//! outcome (status, duration, request charge, contacted regions) and exposes the predicates the SDK
+//! layer uses to decide whether — and how — to emit telemetry.
+//!
+//! The context is produced by a [`DiagnosticsContextBuilder`] during the driver pipeline and is
+//! immutable once [`complete`](DiagnosticsContextBuilder::complete) is called.
+
+use super::request::RequestDiagnostics;
+use crate::models::{ActivityId, CosmosStatus, RequestCharge};
+use crate::options::{DiagnosticsOptions, DiagnosticsThresholds, DiagnosticsVerbosity, Region};
+use azure_core::fmt::SafeDebug;
+use azure_core::http::StatusCode;
+use serde::Serialize;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Canonical operation-level diagnostics for a single Cosmos DB operation.
+///
+/// Obtain one from
+/// [`CosmosResponse::diagnostics`](crate::models::CosmosResponse::diagnostics). The accessors and
+/// predicates here are what the SDK layer consumes to make emission decisions (metrics, tracing,
+/// logging) — the driver itself only ever produces the context, it never emits telemetry.
+#[derive(Clone, SafeDebug)]
+pub struct DiagnosticsContext {
+    operation_name: String,
+    activity_id: ActivityId,
+    is_point_operation: bool,
+    completed: bool,
+    status: CosmosStatus,
+    duration: Duration,
+    total_request_charge: RequestCharge,
+    contacted_regions: Vec<Region>,
+    requests: Vec<RequestDiagnostics>,
+    options: Arc<DiagnosticsOptions>,
+}
+
+impl DiagnosticsContext {
+    /// Returns whether the operation reached a terminal status.
+    ///
+    /// This is `true` whenever the driver recorded a final status for the operation (the common
+    /// case). It is `false` only for a context finalized without one, for example an operation that
+    /// was abandoned before completing.
+    pub fn is_completed(&self) -> bool {
+        self.completed
+    }
+
+    /// Returns whether the operation's final status indicates failure.
+    pub fn is_failure(&self) -> bool {
+        !self.status.is_success()
+    }
+
+    /// Returns whether the operation crossed any of the supplied [`DiagnosticsThresholds`].
+    ///
+    /// Point operations are compared against the point-operation latency threshold and non-point
+    /// operations (queries and feed reads) against the non-point threshold; the total request
+    /// charge is compared against the request-charge threshold. Payload size is not tracked at this
+    /// layer and is ignored.
+    pub fn is_threshold_violated(&self, thresholds: &DiagnosticsThresholds) -> bool {
+        let latency_threshold = if self.is_point_operation {
+            thresholds.point_operation_latency_threshold()
+        } else {
+            thresholds.non_point_operation_latency_threshold()
+        };
+        if let Some(threshold) = latency_threshold {
+            if self.duration >= threshold {
+                return true;
+            }
+        }
+
+        if let Some(charge_threshold) = thresholds.request_charge_threshold() {
+            if self.total_request_charge >= charge_threshold {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Returns the total client-observed duration of the operation.
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+
+    /// Returns the final status of the operation.
+    pub fn status(&self) -> CosmosStatus {
+        self.status
+    }
+
+    /// Returns the total request charge (RU) consumed across every attempt.
+    pub fn total_request_charge(&self) -> f64 {
+        self.total_request_charge.value()
+    }
+
+    /// Returns the distinct regions contacted during the operation, in the order first contacted.
+    pub fn contacted_regions(&self) -> &[Region] {
+        &self.contacted_regions
+    }
+
+    /// Returns the logical operation name (for example `read_item`).
+    pub fn operation_name(&self) -> &str {
+        &self.operation_name
+    }
+
+    /// Returns the client-generated activity id correlating the operation.
+    pub fn activity_id(&self) -> &ActivityId {
+        &self.activity_id
+    }
+
+    /// Returns the per-attempt request diagnostics.
+    pub fn requests(&self) -> &[RequestDiagnostics] {
+        &self.requests
+    }
+
+    /// Renders the context to a JSON string at the requested verbosity.
+    ///
+    /// [`DiagnosticsVerbosity::Default`] resolves to the verbosity configured on the context's
+    /// [`DiagnosticsOptions`]. [`DiagnosticsVerbosity::Summary`] emits the operation-level roll-up
+    /// only; [`DiagnosticsVerbosity::Detailed`] additionally includes every attempt.
+    pub fn to_json_string(&self, verbosity: DiagnosticsVerbosity) -> String {
+        let verbosity = self.resolve_verbosity(verbosity);
+        let include_requests = matches!(verbosity, DiagnosticsVerbosity::Detailed);
+        let view = DiagnosticsView {
+            operation_name: &self.operation_name,
+            activity_id: self.activity_id.as_str(),
+            completed: self.completed,
+            status: self.status.to_string(),
+            duration_ms: duration_ms(self.duration),
+            total_request_charge: self.total_request_charge.value(),
+            contacted_regions: self.contacted_regions.iter().map(Region::as_str).collect(),
+            requests: include_requests.then(|| self.requests.iter().map(request_view).collect()),
+        };
+        serde_json::to_string(&view).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    /// Resolves a possibly-[`Default`](DiagnosticsVerbosity::Default) verbosity to a concrete level.
+    fn resolve_verbosity(&self, verbosity: DiagnosticsVerbosity) -> DiagnosticsVerbosity {
+        match verbosity {
+            DiagnosticsVerbosity::Default => match self.options.default_verbosity() {
+                DiagnosticsVerbosity::Default => DiagnosticsVerbosity::Detailed,
+                other => other,
+            },
+            other => other,
+        }
+    }
+}
+
+/// Builds a [`DiagnosticsContext`] as an operation executes.
+///
+/// The builder is created at the start of an operation, fed one [`RequestDiagnostics`] per attempt
+/// via [`record_request`](Self::record_request), and finalized with
+/// [`complete`](Self::complete).
+pub(crate) struct DiagnosticsContextBuilder {
+    operation_name: String,
+    activity_id: ActivityId,
+    is_point_operation: bool,
+    options: Arc<DiagnosticsOptions>,
+    started_at: Instant,
+    requests: Vec<RequestDiagnostics>,
+}
+
+impl DiagnosticsContextBuilder {
+    /// Starts collecting diagnostics for an operation.
+    pub(crate) fn new(
+        operation_name: impl Into<String>,
+        activity_id: ActivityId,
+        is_point_operation: bool,
+        options: Arc<DiagnosticsOptions>,
+    ) -> Self {
+        Self {
+            operation_name: operation_name.into(),
+            activity_id,
+            is_point_operation,
+            options,
+            started_at: Instant::now(),
+            requests: Vec::new(),
+        }
+    }
+
+    /// Records the diagnostics for one request attempt.
+    pub(crate) fn record_request(&mut self, request: RequestDiagnostics) {
+        self.requests.push(request);
+    }
+
+    /// Finalizes the context.
+    ///
+    /// `final_status` is `Some` for an operation that reached a terminal status (marking the context
+    /// completed) and `None` for one that was abandoned, in which case the status falls back to the
+    /// last recorded attempt (or a synthetic `500` when there were none).
+    pub(crate) fn complete(self, final_status: Option<CosmosStatus>) -> DiagnosticsContext {
+        let duration = self.started_at.elapsed();
+        let completed = final_status.is_some();
+        let status = final_status
+            .or_else(|| self.requests.last().map(RequestDiagnostics::status))
+            .unwrap_or_else(|| CosmosStatus::from_parts(StatusCode::from(500u16), None));
+
+        let total_request_charge = self
+            .requests
+            .iter()
+            .map(RequestDiagnostics::request_charge)
+            .sum();
+
+        let mut contacted_regions: Vec<Region> = Vec::new();
+        for request in &self.requests {
+            if let Some(region) = request.region() {
+                if !contacted_regions.contains(region) {
+                    contacted_regions.push(region.clone());
+                }
+            }
+        }
+
+        DiagnosticsContext {
+            operation_name: self.operation_name,
+            activity_id: self.activity_id,
+            is_point_operation: self.is_point_operation,
+            completed,
+            status,
+            duration,
+            total_request_charge,
+            contacted_regions,
+            requests: self.requests,
+            options: self.options,
+        }
+    }
+}
+
+/// Converts a [`Duration`] to whole milliseconds, saturating at [`u64::MAX`].
+fn duration_ms(duration: Duration) -> u64 {
+    duration.as_millis().min(u128::from(u64::MAX)) as u64
+}
+
+/// Serializable operation-level view produced by [`DiagnosticsContext::to_json_string`].
+#[derive(Serialize)]
+struct DiagnosticsView<'a> {
+    operation_name: &'a str,
+    activity_id: &'a str,
+    completed: bool,
+    status: String,
+    duration_ms: u64,
+    total_request_charge: f64,
+    contacted_regions: Vec<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    requests: Option<Vec<RequestView<'a>>>,
+}
+
+/// Serializable per-attempt view.
+#[derive(Serialize)]
+struct RequestView<'a> {
+    execution_context: &'a str,
+    endpoint: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    region: Option<&'a str>,
+    status: String,
+    request_charge: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    activity_id: Option<&'a str>,
+    duration_ms: u64,
+}
+
+/// Builds a [`RequestView`] borrowing from a [`RequestDiagnostics`].
+fn request_view(request: &RequestDiagnostics) -> RequestView<'_> {
+    RequestView {
+        execution_context: request.execution_context().as_str(),
+        endpoint: request.endpoint(),
+        region: request.region().map(Region::as_str),
+        status: request.status().to_string(),
+        request_charge: request.request_charge().value(),
+        activity_id: request.activity_id().map(ActivityId::as_str),
+        duration_ms: duration_ms(request.duration()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostics::ExecutionContext;
+    use azure_core::http::StatusCode;
+
+    fn options() -> Arc<DiagnosticsOptions> {
+        Arc::new(DiagnosticsOptions::default())
+    }
+
+    fn builder(is_point: bool) -> DiagnosticsContextBuilder {
+        DiagnosticsContextBuilder::new(
+            "read_item",
+            ActivityId::from_static("op-activity"),
+            is_point,
+            options(),
+        )
+    }
+
+    fn ok() -> CosmosStatus {
+        CosmosStatus::new(StatusCode::Ok)
+    }
+
+    fn attempt(status: CosmosStatus, charge: f64, region: Region) -> RequestDiagnostics {
+        RequestDiagnostics::new(ExecutionContext::Initial, "https://acct/", status)
+            .with_region(region)
+            .with_request_charge(RequestCharge::new(charge))
+    }
+
+    #[test]
+    fn completed_success_predicates() {
+        let mut b = builder(true);
+        b.record_request(attempt(ok(), 2.0, Region::WEST_US_2));
+        let ctx = b.complete(Some(ok()));
+
+        assert!(ctx.is_completed());
+        assert!(!ctx.is_failure());
+        assert_eq!(ctx.status().status_code(), StatusCode::Ok);
+        assert_eq!(ctx.operation_name(), "read_item");
+        assert_eq!(ctx.activity_id().as_str(), "op-activity");
+        assert_eq!(ctx.requests().len(), 1);
+    }
+
+    #[test]
+    fn completed_failure_is_failure() {
+        let mut b = builder(true);
+        let err = CosmosStatus::new(StatusCode::TooManyRequests);
+        b.record_request(attempt(err, 0.0, Region::EAST_US));
+        let ctx = b.complete(Some(err));
+
+        assert!(ctx.is_completed());
+        assert!(ctx.is_failure());
+    }
+
+    #[test]
+    fn not_completed_falls_back_to_last_attempt_status() {
+        let mut b = builder(true);
+        let err = CosmosStatus::new(StatusCode::ServiceUnavailable);
+        b.record_request(attempt(err, 0.0, Region::EAST_US));
+        let ctx = b.complete(None);
+
+        assert!(!ctx.is_completed());
+        assert!(ctx.is_failure());
+        assert_eq!(ctx.status().status_code(), StatusCode::ServiceUnavailable);
+    }
+
+    #[test]
+    fn not_completed_with_no_attempts_uses_synthetic_status() {
+        let ctx = builder(true).complete(None);
+        assert!(!ctx.is_completed());
+        assert_eq!(ctx.status().status_code(), StatusCode::from(500u16));
+    }
+
+    #[test]
+    fn total_request_charge_sums_attempts() {
+        let mut b = builder(false);
+        b.record_request(attempt(ok(), 1.5, Region::WEST_US_2));
+        b.record_request(attempt(ok(), 2.5, Region::WEST_US_2));
+        let ctx = b.complete(Some(ok()));
+
+        assert_eq!(ctx.total_request_charge(), 4.0);
+    }
+
+    #[test]
+    fn contacted_regions_are_deduplicated_in_order() {
+        let mut b = builder(false);
+        b.record_request(attempt(ok(), 0.0, Region::WEST_US_2));
+        b.record_request(attempt(ok(), 0.0, Region::EAST_US));
+        b.record_request(attempt(ok(), 0.0, Region::WEST_US_2));
+        let ctx = b.complete(Some(ok()));
+
+        assert_eq!(
+            ctx.contacted_regions(),
+            &[Region::WEST_US_2, Region::EAST_US]
+        );
+    }
+
+    #[test]
+    fn point_latency_threshold_violation() {
+        let mut b = builder(true);
+        b.record_request(attempt(ok(), 0.0, Region::WEST_US_2));
+        let mut ctx = b.complete(Some(ok()));
+        // Force a deterministic duration for the predicate.
+        ctx.duration = Duration::from_millis(200);
+
+        let thresholds = DiagnosticsThresholds::new()
+            .with_point_operation_latency_threshold(Duration::from_millis(100));
+        assert!(ctx.is_threshold_violated(&thresholds));
+
+        // A non-point threshold must not apply to a point operation.
+        let non_point = DiagnosticsThresholds::new()
+            .with_non_point_operation_latency_threshold(Duration::from_millis(100));
+        assert!(!ctx.is_threshold_violated(&non_point));
+    }
+
+    #[test]
+    fn request_charge_threshold_violation() {
+        let mut b = builder(false);
+        b.record_request(attempt(ok(), 6.0, Region::WEST_US_2));
+        let ctx = b.complete(Some(ok()));
+
+        let thresholds =
+            DiagnosticsThresholds::new().with_request_charge_threshold(RequestCharge::new(5.0));
+        assert!(ctx.is_threshold_violated(&thresholds));
+
+        let higher =
+            DiagnosticsThresholds::new().with_request_charge_threshold(RequestCharge::new(10.0));
+        assert!(!ctx.is_threshold_violated(&higher));
+    }
+
+    #[test]
+    fn to_json_detailed_includes_requests() {
+        let mut b = builder(true);
+        b.record_request(
+            attempt(ok(), 3.0, Region::WEST_US_2)
+                .with_activity_id(ActivityId::from_static("svc-1"))
+                .with_duration(Duration::from_millis(7)),
+        );
+        let ctx = b.complete(Some(ok()));
+
+        let json = ctx.to_json_string(DiagnosticsVerbosity::Detailed);
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["operation_name"], "read_item");
+        assert_eq!(value["completed"], true);
+        assert_eq!(value["total_request_charge"], 3.0);
+        assert_eq!(value["requests"].as_array().unwrap().len(), 1);
+        assert_eq!(value["requests"][0]["execution_context"], "initial");
+        assert_eq!(value["requests"][0]["region"], "westus2");
+    }
+
+    #[test]
+    fn to_json_summary_omits_requests() {
+        let mut b = builder(true);
+        b.record_request(attempt(ok(), 3.0, Region::WEST_US_2));
+        let ctx = b.complete(Some(ok()));
+
+        let json = ctx.to_json_string(DiagnosticsVerbosity::Summary);
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(value.get("requests").is_none());
+        assert_eq!(value["contacted_regions"][0], "westus2");
+    }
+
+    #[test]
+    fn to_json_default_resolves_to_options_default() {
+        // The default options resolve `Default` to `Detailed`, which includes requests.
+        let mut b = builder(true);
+        b.record_request(attempt(ok(), 1.0, Region::WEST_US_2));
+        let ctx = b.complete(Some(ok()));
+
+        let json = ctx.to_json_string(DiagnosticsVerbosity::Default);
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(value.get("requests").is_some());
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/mod.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Operation diagnostics for the Cosmos DB driver.
+//!
+//! The driver produces one canonical [`DiagnosticsContext`] per operation, always collected and
+//! surfaced via [`CosmosResponse::diagnostics`](crate::models::CosmosResponse::diagnostics). The
+//! context carries the operation-level outcome plus the per-attempt [`RequestDiagnostics`], and
+//! exposes the predicates and accessors a higher-level SDK uses to decide whether to emit telemetry.
+//!
+//! This module is the plain foundation only: it collects diagnostics into a context but never emits
+//! metrics, traces, or logs itself.
+
+mod context;
+mod request;
+
+pub use context::DiagnosticsContext;
+pub use request::{ExecutionContext, RequestDiagnostics};
+
+pub(crate) use context::DiagnosticsContextBuilder;

--- a/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/request.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/request.rs
@@ -1,0 +1,205 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Per-attempt request diagnostics.
+//!
+//! A [`RequestDiagnostics`] captures the outcome of a single request attempt made while executing
+//! a Cosmos DB operation. A [`DiagnosticsContext`](crate::diagnostics::DiagnosticsContext) rolls up
+//! one or more of these into an operation-level view.
+
+use crate::models::{ActivityId, CosmosStatus, RequestCharge};
+use crate::options::Region;
+use azure_core::fmt::SafeDebug;
+use std::time::Duration;
+
+/// The context in which a request attempt was executed.
+///
+/// This categorizes *why* an attempt was made, which helps when reasoning about retry and
+/// failover behavior.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ExecutionContext {
+    /// The initial attempt (first try).
+    Initial,
+    /// A retry after a transient error (for example `429` or `503`).
+    Retry,
+    /// A transport-level retry within the same region (for example a different HTTP/2 connection).
+    TransportRetry,
+    /// A hedged attempt issued to reduce tail latency.
+    Hedging,
+    /// An attempt against a different region after failover.
+    RegionFailover,
+    /// A circuit-breaker recovery probe.
+    CircuitBreakerProbe,
+}
+
+impl ExecutionContext {
+    /// Returns the stable string representation of this execution context.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ExecutionContext::Initial => "initial",
+            ExecutionContext::Retry => "retry",
+            ExecutionContext::TransportRetry => "transport_retry",
+            ExecutionContext::Hedging => "hedging",
+            ExecutionContext::RegionFailover => "region_failover",
+            ExecutionContext::CircuitBreakerProbe => "circuit_breaker_probe",
+        }
+    }
+}
+
+impl AsRef<str> for ExecutionContext {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for ExecutionContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Diagnostics for a single request attempt within an operation.
+///
+/// Construct one with [`RequestDiagnostics::new`] and enrich it with the builder-style
+/// `with_*` methods before recording it on a
+/// [`DiagnosticsContextBuilder`](crate::diagnostics::DiagnosticsContextBuilder).
+#[derive(Clone, PartialEq, SafeDebug)]
+pub struct RequestDiagnostics {
+    execution_context: ExecutionContext,
+    endpoint: String,
+    region: Option<Region>,
+    status: CosmosStatus,
+    request_charge: RequestCharge,
+    activity_id: Option<ActivityId>,
+    duration: Duration,
+}
+
+impl RequestDiagnostics {
+    /// Creates a new request diagnostics record for an attempt with a known terminal status.
+    pub(crate) fn new(
+        execution_context: ExecutionContext,
+        endpoint: impl Into<String>,
+        status: CosmosStatus,
+    ) -> Self {
+        Self {
+            execution_context,
+            endpoint: endpoint.into(),
+            region: None,
+            status,
+            request_charge: RequestCharge::default(),
+            activity_id: None,
+            duration: Duration::ZERO,
+        }
+    }
+
+    /// Sets the region the attempt targeted.
+    ///
+    /// The driver does not yet resolve per-attempt regions, so this is currently only used by
+    /// tests; production wiring is a follow-up. The [`region`](Self::region) accessor is
+    /// always available and returns `None` until then.
+    #[cfg(test)]
+    pub(crate) fn with_region(mut self, region: Region) -> Self {
+        self.region = Some(region);
+        self
+    }
+
+    /// Sets the request charge (RU) consumed by the attempt.
+    pub(crate) fn with_request_charge(mut self, request_charge: RequestCharge) -> Self {
+        self.request_charge = request_charge;
+        self
+    }
+
+    /// Sets the service-assigned activity id for the attempt.
+    pub(crate) fn with_activity_id(mut self, activity_id: ActivityId) -> Self {
+        self.activity_id = Some(activity_id);
+        self
+    }
+
+    /// Sets the client-observed duration of the attempt.
+    pub(crate) fn with_duration(mut self, duration: Duration) -> Self {
+        self.duration = duration;
+        self
+    }
+
+    /// Returns the execution context of the attempt.
+    pub fn execution_context(&self) -> ExecutionContext {
+        self.execution_context
+    }
+
+    /// Returns the endpoint URL the attempt targeted.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Returns the region the attempt targeted, if known.
+    pub fn region(&self) -> Option<&Region> {
+        self.region.as_ref()
+    }
+
+    /// Returns the terminal status of the attempt.
+    pub fn status(&self) -> CosmosStatus {
+        self.status
+    }
+
+    /// Returns the request charge (RU) consumed by the attempt.
+    pub fn request_charge(&self) -> RequestCharge {
+        self.request_charge
+    }
+
+    /// Returns the service-assigned activity id for the attempt, if known.
+    pub fn activity_id(&self) -> Option<&ActivityId> {
+        self.activity_id.as_ref()
+    }
+
+    /// Returns the client-observed duration of the attempt.
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use azure_core::http::StatusCode;
+
+    fn ok_status() -> CosmosStatus {
+        CosmosStatus::new(StatusCode::Ok)
+    }
+
+    #[test]
+    fn new_sets_defaults() {
+        let req = RequestDiagnostics::new(ExecutionContext::Initial, "https://acct/", ok_status());
+        assert_eq!(req.execution_context(), ExecutionContext::Initial);
+        assert_eq!(req.endpoint(), "https://acct/");
+        assert!(req.region().is_none());
+        assert!(req.activity_id().is_none());
+        assert_eq!(req.request_charge(), RequestCharge::default());
+        assert_eq!(req.duration(), Duration::ZERO);
+    }
+
+    #[test]
+    fn with_setters_enrich_the_record() {
+        let req = RequestDiagnostics::new(ExecutionContext::Retry, "https://west/", ok_status())
+            .with_region(Region::WEST_US_2)
+            .with_request_charge(RequestCharge::new(2.5))
+            .with_activity_id(ActivityId::from_static("act-1"))
+            .with_duration(Duration::from_millis(12));
+
+        assert_eq!(req.execution_context(), ExecutionContext::Retry);
+        assert_eq!(req.region(), Some(&Region::WEST_US_2));
+        assert_eq!(req.request_charge(), RequestCharge::new(2.5));
+        assert_eq!(req.activity_id().map(|a| a.as_str()), Some("act-1"));
+        assert_eq!(req.duration(), Duration::from_millis(12));
+    }
+
+    #[test]
+    fn execution_context_strings() {
+        assert_eq!(ExecutionContext::Initial.as_str(), "initial");
+        assert_eq!(ExecutionContext::TransportRetry.as_str(), "transport_retry");
+        assert_eq!(
+            ExecutionContext::RegionFailover.to_string(),
+            "region_failover"
+        );
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
@@ -4,22 +4,72 @@
 //! Cosmos DB driver instance.
 
 use crate::{
+    diagnostics::{DiagnosticsContextBuilder, ExecutionContext, RequestDiagnostics},
     models::{
         AccountEndpoint, AccountReference, ActivityId, ContainerProperties, ContainerReference,
         CosmosOperation, CosmosResponse, CosmosResponseHeaders, CosmosStatus, DatabaseProperties,
-        DatabaseReference,
+        DatabaseReference, OperationType, ResourceType,
     },
     options::{
-        DriverOptions, OperationOptions, Region, RuntimeOptions, ThroughputControlGroupSnapshot,
+        DiagnosticsOptions, DriverOptions, OperationOptions, Region, RuntimeOptions,
+        ThroughputControlGroupSnapshot,
     },
 };
 use azure_core::http::headers::{HeaderName, HeaderValue};
 use azure_core::http::{Context, Request};
+use std::sync::Arc;
+use std::time::Instant;
 
 use super::{
     transport::{uses_dataplane_pipeline, AuthorizationContext, RequestSentExt, RequestSentStatus},
     CosmosDriverRuntime,
 };
+
+/// Returns the logical operation name for a resource/operation pair.
+///
+/// This is a plain, human-readable name used to populate
+/// [`DiagnosticsContext::operation_name`](crate::diagnostics::DiagnosticsContext::operation_name);
+/// it is not (yet) an OpenTelemetry semantic-convention name.
+fn operation_name_for(operation_type: OperationType, resource_type: ResourceType) -> &'static str {
+    use OperationType::*;
+    use ResourceType::*;
+    match (resource_type, operation_type) {
+        (Document, Read) => "read_item",
+        (Document, Create) => "create_item",
+        (Document, Upsert) => "upsert_item",
+        (Document, Replace) => "replace_item",
+        (Document, Delete) => "delete_item",
+        (Document, ReadFeed) => "read_all_items",
+        (Document, Query) | (Document, SqlQuery) => "query_items",
+        (DocumentCollection, Read) => "read_container",
+        (DocumentCollection, Create) => "create_container",
+        (DocumentCollection, Replace) => "replace_container",
+        (DocumentCollection, Delete) => "delete_container",
+        (DocumentCollection, ReadFeed)
+        | (DocumentCollection, Query)
+        | (DocumentCollection, SqlQuery) => "query_containers",
+        (Database, Read) => "read_database",
+        (Database, Create) => "create_database",
+        (Database, Delete) => "delete_database",
+        (Database, ReadFeed) | (Database, Query) | (Database, SqlQuery) => "query_databases",
+        (StoredProcedure, Execute) => "execute_stored_procedure",
+        (_, Batch) => "execute_batch",
+        _ => "unknown",
+    }
+}
+
+/// Returns whether an operation is a point operation (a single-item read or write) rather than a
+/// query or feed read, used to select the applicable latency threshold.
+fn is_point_operation(operation_type: OperationType) -> bool {
+    !matches!(
+        operation_type,
+        OperationType::Query
+            | OperationType::SqlQuery
+            | OperationType::QueryPlan
+            | OperationType::ReadFeed
+            | OperationType::HeadFeed
+    )
+}
 
 /// Cosmos DB driver instance.
 ///
@@ -237,6 +287,14 @@ impl CosmosDriver {
         const MAX_TRANSPORT_RETRIES: usize = 1;
         let mut attempt = 0usize;
 
+        // Diagnostics are always collected: build the operation context as the pipeline runs.
+        let mut diagnostics = DiagnosticsContextBuilder::new(
+            operation_name_for(operation_type, resource_type),
+            activity_id.clone(),
+            is_point_operation(operation_type),
+            DiagnosticsOptions::shared_default(),
+        );
+
         loop {
             let mut request = Request::new(url.clone(), method);
 
@@ -274,6 +332,7 @@ impl CosmosDriver {
             let mut ctx = Context::default();
             ctx.insert(auth_context.clone());
 
+            let attempt_start = Instant::now();
             let result = pipeline.send(&ctx, &mut request).await;
 
             match result {
@@ -285,10 +344,27 @@ impl CosmosDriver {
                     let body = response.into_body();
                     let status = CosmosStatus::from_parts(status_code, sub_status);
 
+                    // Record the successful attempt on the diagnostics context.
+                    let execution_context = if attempt == 0 {
+                        ExecutionContext::Initial
+                    } else {
+                        ExecutionContext::TransportRetry
+                    };
+                    let mut request_diagnostics =
+                        RequestDiagnostics::new(execution_context, url.as_str(), status)
+                            .with_request_charge(cosmos_headers.request_charge.unwrap_or_default())
+                            .with_duration(attempt_start.elapsed());
+                    if let Some(request_activity_id) = cosmos_headers.activity_id.clone() {
+                        request_diagnostics =
+                            request_diagnostics.with_activity_id(request_activity_id);
+                    }
+                    diagnostics.record_request(request_diagnostics);
+
                     return Ok(CosmosResponse::new(
                         body.as_ref().to_vec(),
                         cosmos_headers,
                         status,
+                        Arc::new(diagnostics.complete(Some(status))),
                     ));
                 }
                 Err(e) => {

--- a/sdk/cosmos/azure_data_cosmos_driver/src/lib.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/lib.rs
@@ -20,11 +20,13 @@
 //! raw bytes (`&[u8]`) and return buffered responses (`Vec<u8>`). Serialization is handled by
 //! the consuming SDK in its native language.
 
+pub mod diagnostics;
 pub mod driver;
 pub mod models;
 pub mod options;
 
 // Re-export key types at crate root
+pub use diagnostics::{DiagnosticsContext, ExecutionContext, RequestDiagnostics};
 pub use driver::{CosmosDriver, CosmosDriverRuntime, CosmosDriverRuntimeBuilder};
 pub use models::{ActivityId, CosmosResponse, CosmosStatus, RequestCharge};
 pub use options::DriverOptions;

--- a/sdk/cosmos/azure_data_cosmos_driver/src/models/cosmos_response.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/models/cosmos_response.rs
@@ -3,12 +3,14 @@
 
 //! Cosmos DB operation result types.
 
+use crate::diagnostics::DiagnosticsContext;
 use crate::models::{CosmosResponseHeaders, CosmosStatus};
+use std::sync::Arc;
 
 /// Result of a Cosmos DB operation.
 ///
-/// Contains the response body (as raw bytes), relevant headers, and comprehensive
-/// status information for the operation.
+/// Contains the response body (as raw bytes), relevant headers, comprehensive
+/// status information, and the always-collected [`DiagnosticsContext`] for the operation.
 ///
 /// # Schema-Agnostic Design
 ///
@@ -24,6 +26,11 @@ use crate::models::{CosmosResponseHeaders, CosmosStatus};
 /// let status = result.status();
 /// println!("Status: {}", status);
 /// println!("RU Charge: {}", result.headers().request_charge.unwrap_or_default().value());
+///
+/// // Diagnostics are always available.
+/// let diagnostics = result.diagnostics();
+/// println!("Operation: {}", diagnostics.operation_name());
+///
 /// if status.is_success() {
 ///     let body = result.into_body();
 ///     // Deserialize body...
@@ -40,17 +47,27 @@ pub struct CosmosResponse {
 
     /// Operation status including HTTP status code and optional sub-status.
     status: CosmosStatus,
+
+    /// Always-collected operation diagnostics.
+    diagnostics: Arc<DiagnosticsContext>,
 }
 
 impl CosmosResponse {
     /// Creates a new `CosmosResponse`.
     ///
-    /// This is typically called by the driver after completing an operation.
-    pub(crate) fn new(body: Vec<u8>, headers: CosmosResponseHeaders, status: CosmosStatus) -> Self {
+    /// This is typically called by the driver after completing an operation, passing the
+    /// [`DiagnosticsContext`] produced while executing it.
+    pub(crate) fn new(
+        body: Vec<u8>,
+        headers: CosmosResponseHeaders,
+        status: CosmosStatus,
+        diagnostics: Arc<DiagnosticsContext>,
+    ) -> Self {
         Self {
             body,
             headers,
             status,
+            diagnostics,
         }
     }
 
@@ -76,12 +93,22 @@ impl CosmosResponse {
     pub fn status(&self) -> CosmosStatus {
         self.status
     }
+
+    /// Returns the operation's diagnostics context.
+    ///
+    /// Diagnostics are always collected, so this never returns `None`. The returned
+    /// [`DiagnosticsContext`] is reference-counted and cheap to clone.
+    pub fn diagnostics(&self) -> Arc<DiagnosticsContext> {
+        self.diagnostics.clone()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::diagnostics::{DiagnosticsContextBuilder, ExecutionContext, RequestDiagnostics};
     use crate::models::{ActivityId, CosmosResponseHeaders, RequestCharge, SubStatusCode};
+    use crate::options::{DiagnosticsOptions, Region};
     use azure_core::http::StatusCode;
 
     fn make_status(
@@ -89,6 +116,22 @@ mod tests {
         sub_status_code: Option<SubStatusCode>,
     ) -> CosmosStatus {
         CosmosStatus::from_parts(status_code.unwrap_or(StatusCode::Ok), sub_status_code)
+    }
+
+    /// Builds a completed diagnostics context recording a single attempt with the given status.
+    fn diagnostics(status: CosmosStatus) -> Arc<DiagnosticsContext> {
+        let mut builder = DiagnosticsContextBuilder::new(
+            "read_item",
+            ActivityId::from_static("test-op"),
+            true,
+            Arc::new(DiagnosticsOptions::default()),
+        );
+        builder.record_request(
+            RequestDiagnostics::new(ExecutionContext::Initial, "https://acct/", status)
+                .with_region(Region::WEST_US_2)
+                .with_request_charge(RequestCharge::new(1.0)),
+        );
+        Arc::new(builder.complete(Some(status)))
     }
 
     #[test]
@@ -99,10 +142,12 @@ mod tests {
             ..Default::default()
         };
 
+        let status = make_status(Some(StatusCode::Ok), None);
         let result = CosmosResponse::new(
             b"{\"id\": \"test\"}".to_vec(),
             headers,
-            make_status(Some(StatusCode::Ok), None),
+            status,
+            diagnostics(status),
         );
 
         let status = result.status();
@@ -118,13 +163,15 @@ mod tests {
 
     #[test]
     fn cosmos_response_error_status() {
+        let status = make_status(
+            Some(StatusCode::TooManyRequests),
+            Some(SubStatusCode::new(3200)),
+        );
         let result = CosmosResponse::new(
             b"{}".to_vec(),
             CosmosResponseHeaders::new(),
-            make_status(
-                Some(StatusCode::TooManyRequests),
-                Some(SubStatusCode::new(3200)),
-            ),
+            status,
+            diagnostics(status),
         );
 
         let status = result.status();
@@ -139,11 +186,8 @@ mod tests {
             request_charge: Some(RequestCharge::new(1.0)),
             ..Default::default()
         };
-        let result = CosmosResponse::new(
-            b"body".to_vec(),
-            headers,
-            make_status(Some(StatusCode::Created), None),
-        );
+        let status = make_status(Some(StatusCode::Created), None);
+        let result = CosmosResponse::new(b"body".to_vec(), headers, status, diagnostics(status));
 
         assert_eq!(result.body(), b"body");
         assert_eq!(result.status().status_code(), StatusCode::Created);
@@ -163,10 +207,33 @@ mod tests {
             Some(StatusCode::NotFound),
             Some(SubStatusCode::READ_SESSION_NOT_AVAILABLE),
         );
-        let result = CosmosResponse::new(b"{}".to_vec(), CosmosResponseHeaders::new(), status);
+        let result = CosmosResponse::new(
+            b"{}".to_vec(),
+            CosmosResponseHeaders::new(),
+            status,
+            diagnostics(status),
+        );
 
         let result_status = result.status();
         assert_eq!(result_status.status_code(), StatusCode::NotFound);
         assert!(result_status.is_read_session_not_available());
+    }
+
+    #[test]
+    fn cosmos_response_exposes_diagnostics() {
+        let status = make_status(Some(StatusCode::Ok), None);
+        let result = CosmosResponse::new(
+            b"{}".to_vec(),
+            CosmosResponseHeaders::new(),
+            status,
+            diagnostics(status),
+        );
+
+        let diag = result.diagnostics();
+        assert_eq!(diag.operation_name(), "read_item");
+        assert!(diag.is_completed());
+        assert!(!diag.is_failure());
+        assert_eq!(diag.requests().len(), 1);
+        assert_eq!(diag.contacted_regions(), &[Region::WEST_US_2]);
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/diagnostics_options.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/diagnostics_options.rs
@@ -1,0 +1,261 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Configuration options for diagnostics output.
+
+use super::env_parsing::{parse_from_env, ValidationBounds};
+use std::sync::{Arc, OnceLock};
+
+/// Default maximum size for summary-mode diagnostic output (8 KB).
+const DEFAULT_MAX_SUMMARY_SIZE_BYTES: usize = 8 * 1024;
+
+/// Minimum allowed size for summary-mode diagnostic output (4 KB).
+const MIN_MAX_SUMMARY_SIZE_BYTES: usize = 4 * 1024;
+
+/// Controls the verbosity level of diagnostic output.
+///
+/// Diagnostics can be rendered at different levels of detail depending on debugging needs versus
+/// log-size constraints. Pass a value to
+/// [`DiagnosticsContext::to_json_string`](crate::diagnostics::DiagnosticsContext::to_json_string).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DiagnosticsVerbosity {
+    /// Use the default verbosity configured on the [`DiagnosticsOptions`].
+    #[default]
+    Default,
+
+    /// Minimal output optimized for log-size limits: operation-level roll-up only, no per-request
+    /// detail.
+    Summary,
+
+    /// Full output including every individual [`RequestDiagnostics`](crate::diagnostics::RequestDiagnostics).
+    Detailed,
+}
+
+impl DiagnosticsVerbosity {
+    /// Returns the string representation of this verbosity level.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DiagnosticsVerbosity::Default => "default",
+            DiagnosticsVerbosity::Summary => "summary",
+            DiagnosticsVerbosity::Detailed => "detailed",
+        }
+    }
+}
+
+impl AsRef<str> for DiagnosticsVerbosity {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for DiagnosticsVerbosity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for DiagnosticsVerbosity {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "default" => Ok(DiagnosticsVerbosity::Default),
+            "summary" | "minimal" => Ok(DiagnosticsVerbosity::Summary),
+            "detailed" | "verbose" => Ok(DiagnosticsVerbosity::Detailed),
+            _ => Err(format!(
+                "unknown diagnostics verbosity: '{s}'; expected 'default', 'summary', or 'detailed'"
+            )),
+        }
+    }
+}
+
+/// Configuration options for diagnostics output.
+///
+/// Controls the default verbosity and the size budget applied when rendering a
+/// [`DiagnosticsContext`](crate::diagnostics::DiagnosticsContext) to a string. Use
+/// [`DiagnosticsOptions::builder`] to construct instances.
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DiagnosticsOptions {
+    /// Maximum size in bytes for summary-mode diagnostic output.
+    pub(crate) max_summary_size_bytes: usize,
+
+    /// Default verbosity used when [`DiagnosticsVerbosity::Default`] is requested.
+    pub(crate) default_verbosity: DiagnosticsVerbosity,
+}
+
+impl Default for DiagnosticsOptions {
+    fn default() -> Self {
+        DiagnosticsOptionsBuilder::new()
+            .build()
+            .expect("default DiagnosticsOptions should always be valid")
+    }
+}
+
+impl DiagnosticsOptions {
+    /// Creates a new builder for [`DiagnosticsOptions`].
+    pub fn builder() -> DiagnosticsOptionsBuilder {
+        DiagnosticsOptionsBuilder::new()
+    }
+
+    /// Returns the maximum size in bytes for summary-mode output.
+    pub fn max_summary_size_bytes(&self) -> usize {
+        self.max_summary_size_bytes
+    }
+
+    /// Returns the default verbosity level.
+    pub fn default_verbosity(&self) -> DiagnosticsVerbosity {
+        self.default_verbosity
+    }
+
+    /// Returns a process-wide shared default, avoiding repeated environment reads on the hot path.
+    pub(crate) fn shared_default() -> Arc<DiagnosticsOptions> {
+        static DEFAULT: OnceLock<Arc<DiagnosticsOptions>> = OnceLock::new();
+        DEFAULT
+            .get_or_init(|| Arc::new(DiagnosticsOptions::default()))
+            .clone()
+    }
+}
+
+/// Builder for [`DiagnosticsOptions`].
+///
+/// Unset values fall back to environment variables and then to sensible defaults.
+///
+/// # Environment Variables
+///
+/// - `AZURE_COSMOS_DIAGNOSTICS_MAX_SUMMARY_SIZE_BYTES`: summary-mode size budget in bytes
+///   (default: `8192`, min: `4096`).
+/// - `AZURE_COSMOS_DIAGNOSTICS_DEFAULT_VERBOSITY`: default verbosity — one of `default`, `summary`,
+///   `detailed` (default: `detailed`).
+///
+/// # Example
+///
+/// ```
+/// use azure_data_cosmos_driver::options::{DiagnosticsOptions, DiagnosticsVerbosity};
+///
+/// let options = DiagnosticsOptions::builder()
+///     .with_max_summary_size_bytes(16 * 1024)
+///     .with_default_verbosity(DiagnosticsVerbosity::Summary)
+///     .build()
+///     .expect("valid options");
+/// ```
+#[non_exhaustive]
+#[derive(Clone, Debug, Default)]
+pub struct DiagnosticsOptionsBuilder {
+    max_summary_size_bytes: Option<usize>,
+    default_verbosity: Option<DiagnosticsVerbosity>,
+}
+
+impl DiagnosticsOptionsBuilder {
+    /// Creates a new builder with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the summary-mode size budget in bytes (must be at least 4096).
+    pub fn with_max_summary_size_bytes(mut self, size: usize) -> Self {
+        self.max_summary_size_bytes = Some(size);
+        self
+    }
+
+    /// Sets the default verbosity level.
+    pub fn with_default_verbosity(mut self, verbosity: DiagnosticsVerbosity) -> Self {
+        self.default_verbosity = Some(verbosity);
+        self
+    }
+
+    /// Builds the [`DiagnosticsOptions`], filling unset values from the environment or defaults.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `max_summary_size_bytes` is below the minimum, or if an environment
+    /// variable fails to parse.
+    pub fn build(self) -> azure_core::Result<DiagnosticsOptions> {
+        let max_summary_size_bytes = parse_from_env(
+            self.max_summary_size_bytes,
+            "AZURE_COSMOS_DIAGNOSTICS_MAX_SUMMARY_SIZE_BYTES",
+            DEFAULT_MAX_SUMMARY_SIZE_BYTES,
+            ValidationBounds::range(MIN_MAX_SUMMARY_SIZE_BYTES, usize::MAX),
+        )?;
+
+        let default_verbosity = match self.default_verbosity {
+            Some(v) => v,
+            None => match std::env::var("AZURE_COSMOS_DIAGNOSTICS_DEFAULT_VERBOSITY") {
+                Ok(v) => v.parse().map_err(|e: String| {
+                    azure_core::Error::with_message(
+                        azure_core::error::ErrorKind::DataConversion,
+                        format!("Failed to parse AZURE_COSMOS_DIAGNOSTICS_DEFAULT_VERBOSITY: {e}"),
+                    )
+                })?,
+                Err(_) => DiagnosticsVerbosity::Detailed,
+            },
+        };
+
+        Ok(DiagnosticsOptions {
+            max_summary_size_bytes,
+            default_verbosity,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults() {
+        let options = DiagnosticsOptions::default();
+        assert_eq!(options.max_summary_size_bytes(), 8 * 1024);
+        assert_eq!(options.default_verbosity(), DiagnosticsVerbosity::Detailed);
+    }
+
+    #[test]
+    fn custom_values() {
+        let options = DiagnosticsOptions::builder()
+            .with_max_summary_size_bytes(16 * 1024)
+            .with_default_verbosity(DiagnosticsVerbosity::Summary)
+            .build()
+            .unwrap();
+
+        assert_eq!(options.max_summary_size_bytes(), 16 * 1024);
+        assert_eq!(options.default_verbosity(), DiagnosticsVerbosity::Summary);
+    }
+
+    #[test]
+    fn max_summary_size_too_small_is_rejected() {
+        let result = DiagnosticsOptions::builder()
+            .with_max_summary_size_bytes(2 * 1024)
+            .build();
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("must be at least 4096"));
+    }
+
+    #[test]
+    fn verbosity_from_str() {
+        assert_eq!(
+            "default".parse::<DiagnosticsVerbosity>().unwrap(),
+            DiagnosticsVerbosity::Default
+        );
+        assert_eq!(
+            "minimal".parse::<DiagnosticsVerbosity>().unwrap(),
+            DiagnosticsVerbosity::Summary
+        );
+        assert_eq!(
+            "VERBOSE".parse::<DiagnosticsVerbosity>().unwrap(),
+            DiagnosticsVerbosity::Detailed
+        );
+        assert!("nonsense".parse::<DiagnosticsVerbosity>().is_err());
+    }
+
+    #[test]
+    fn shared_default_is_stable() {
+        let a = DiagnosticsOptions::shared_default();
+        let b = DiagnosticsOptions::shared_default();
+        assert!(Arc::ptr_eq(&a, &b));
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/mod.rs
@@ -8,6 +8,7 @@
 
 mod connection_pool;
 mod dedicated_gateway;
+mod diagnostics_options;
 mod diagnostics_thresholds;
 mod driver_options;
 mod env_parsing;
@@ -23,6 +24,9 @@ mod triggers;
 
 pub use connection_pool::{ConnectionPoolOptions, ConnectionPoolOptionsBuilder};
 pub use dedicated_gateway::DedicatedGatewayOptions;
+pub use diagnostics_options::{
+    DiagnosticsOptions, DiagnosticsOptionsBuilder, DiagnosticsVerbosity,
+};
 pub use diagnostics_thresholds::DiagnosticsThresholds;
 pub use driver_options::{DriverOptions, DriverOptionsBuilder};
 pub use identity::{CorrelationId, UserAgentSuffix, WorkloadId};


### PR DESCRIPTION
## Why

This lands the always-collected, operation-level `DiagnosticsContext` on the Cosmos **driver** (`azure_data_cosmos_driver`) — the foundational, blocking-root piece that the rest of the Cosmos diagnostics/observability effort stacks on. It is intentionally the *smallest reviewable foundation*: the type surface, accessors/predicates, and unit tests only.

Following the "driver produces the context, SDK decides emission" model, the driver now produces one canonical `Arc<DiagnosticsContext>` per operation and surfaces it via `CosmosResponse::diagnostics()` (non-optional). The driver itself emits **no** telemetry.

**Out of scope (separate, later PRs):** OpenTelemetry, metrics, tracing, tail-sampling, rate limiting, retry-storm bounding, the append-only capture engine, and client-option wiring.

## What

Salvaged the *plain* foundation from the prototype PR #4619, deliberately **dropping the append-only capture engine** (`gate`/`pool`/`recorder`/`encode`), which is deferred to a future PR. Lifted into a fresh branch off `main` rather than rebasing the old prototype.

- **`src/diagnostics/{context,request}.rs`** — `DiagnosticsContext` + its `pub(crate)` `DiagnosticsContextBuilder`, plus `RequestDiagnostics` and `ExecutionContext`. Predicates/accessors: `is_completed`, `is_failure`, `is_threshold_violated`, `duration`, `status`, `total_request_charge`, `contacted_regions`, `operation_name`, `requests`, `to_json_string`. Reuses the existing `DiagnosticsThresholds` on `main` for threshold checks.
- **`src/options/diagnostics_options.rs`** — `DiagnosticsOptions` (+ builder, env-driven) and `DiagnosticsVerbosity`.
- **`src/models/cosmos_response.rs`** — adds `CosmosResponse::diagnostics() -> Arc<DiagnosticsContext>`. Additive & non-breaking (`new()` is `pub(crate)`).
- **`src/driver/cosmos_driver.rs`** — `execute_operation` builds the context as the pipeline runs, records a `RequestDiagnostics` per attempt, and completes it with the final status.
- **`src/lib.rs` / `src/options/mod.rs`** — module wiring and re-exports.
- **CHANGELOG.md** — Features Added entry.

Per-attempt region resolution isn't wired on `main` yet, so `contacted_regions()` is empty in the pipeline path today (the accessor is exercised via unit tests); populating it is a follow-up.

## Verification

- `cargo fmt -p azure_data_cosmos_driver --check` — clean
- `cargo clippy -p azure_data_cosmos_driver --all-features --all-targets` — no warnings
- `cargo test -p azure_data_cosmos_driver --all-features` — 286 lib tests + 39 doc tests pass
- cSpell — clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
