### PR TITLE
[Storage] Photon Proof-of-Concept

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +58,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -122,6 +145,83 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "arrow-array"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9486151b2f0785bafc6fa04fc5c99fcb4495455662e58787ea32eaaed33c4192"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4776577a87794bfdf0b4e90e2ea12454fa7738ea2823c4be5b9d1851da7b434"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-data"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38fe43e2e8704360f1464e6e8cc4fc381ef02cc4fb0192afa8df1aaa0115c66"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29dac499fcbc6ba74ee0324057821d381929a48526a3966bd9dffb44aa06d98c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e4969dc350d571766247143ab36a5187d095d3d3690970408bc630d47c69e5"
+
+[[package]]
+name = "arrow-select"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402770dba90865359d98d1ef92ef16e23d75c0cca9c2c880c8a05468b7743bf9"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
 
 [[package]]
 name = "async-compression"
@@ -788,6 +888,9 @@ dependencies = [
 name = "azure_storage_blob"
 version = "1.1.0-beta.2"
 dependencies = [
+ "arrow-array",
+ "arrow-ipc",
+ "arrow-schema",
  "async-stream",
  "async-trait",
  "azure_core 1.1.0",
@@ -1041,7 +1144,9 @@ version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
+ "iana-time-zone",
  "num-traits",
+ "windows-link",
 ]
 
 [[package]]
@@ -1199,6 +1304,26 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -1574,6 +1699,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,6 +1949,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -1823,7 +1959,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -2019,6 +2155,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2317,6 +2477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,10 +2615,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2461,6 +2655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3784,6 +3979,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/sdk/storage/azure_storage_blob/Cargo.toml
+++ b/sdk/storage/azure_storage_blob/Cargo.toml
@@ -18,6 +18,9 @@ default = ["tokio", "azure_core/default"]
 tokio = ["dep:tokio", "azure_core/tokio"]
 
 [dependencies]
+arrow-array = "59.1.0"
+arrow-ipc = "59.1.0"
+arrow-schema = "59.1.0"
 async-stream.workspace = true
 async-trait.workspace = true
 azure_core = { workspace = true, features = ["xml"] }

--- a/sdk/storage/azure_storage_blob/src/arrow_decode.rs
+++ b/sdk/storage/azure_storage_blob/src/arrow_decode.rs
@@ -1,0 +1,153 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Prototype: decode an Apache Arrow IPC stream `list_blobs` response into the
+//! generated [`ListBlobsResponse`] model.
+//!
+//! This exists to prototype Arrow-stream support for the flat blob listing API.
+//! Only the subset of columns needed by the prototype is mapped. Envelope
+//! fields (container name, prefix, marker, max results, service endpoint) are
+//! not carried as Arrow columns and are left unset.
+
+use crate::models::{BlobItem, BlobProperties, ListBlobsResponse};
+use arrow_array::{
+    Array, BooleanArray, Int64Array, RecordBatch, StringArray, TimestampMicrosecondArray,
+    TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt64Array,
+};
+use arrow_ipc::reader::StreamReader;
+use arrow_schema::{ArrowError, DataType, TimeUnit};
+use azure_core::{
+    base64,
+    error::{Error, ErrorKind},
+    http::Etag,
+    time::OffsetDateTime,
+    Result,
+};
+
+/// Metadata key on the Arrow schema holding the continuation token.
+const NEXT_MARKER_KEY: &str = "NextMarker";
+
+/// Decodes an Apache Arrow IPC stream (`application/vnd.apache.arrow.stream`)
+/// returned by the flat `list_blobs` API into a [`ListBlobsResponse`].
+pub(crate) fn decode_arrow_list_blobs(bytes: &[u8]) -> Result<ListBlobsResponse> {
+    let reader = StreamReader::try_new(bytes, None).map_err(to_error)?;
+
+    // The continuation token lives in schema-level metadata, not a column.
+    let next_marker = reader
+        .schema()
+        .metadata()
+        .get(NEXT_MARKER_KEY)
+        .filter(|marker| !marker.is_empty())
+        .cloned();
+
+    let mut blob_items = Vec::new();
+    for batch in reader {
+        let batch = batch.map_err(to_error)?;
+        for row in 0..batch.num_rows() {
+            blob_items.push(row_to_blob_item(&batch, row));
+        }
+    }
+
+    Ok(ListBlobsResponse {
+        blob_items,
+        next_marker,
+        ..Default::default()
+    })
+}
+
+fn row_to_blob_item(batch: &RecordBatch, row: usize) -> BlobItem {
+    let properties = BlobProperties {
+        creation_time: timestamp_at(batch, "Creation-Time", row),
+        last_modified: timestamp_at(batch, "Last-Modified", row),
+        blob_type: string_at(batch, "BlobType", row).and_then(|s| s.parse().ok()),
+        etag: string_at(batch, "Etag", row).map(Etag::from),
+        content_length: u64_at(batch, "Content-Length", row),
+        content_type: string_at(batch, "Content-Type", row),
+        content_md5: string_at(batch, "Content-MD5", row).and_then(|s| base64::decode(s).ok()),
+        access_tier: string_at(batch, "AccessTier", row).and_then(|s| s.parse().ok()),
+        lease_state: string_at(batch, "LeaseState", row).and_then(|s| s.parse().ok()),
+        lease_status: string_at(batch, "LeaseStatus", row).and_then(|s| s.parse().ok()),
+        server_encrypted: bool_at(batch, "ServerEncrypted", row),
+        ..Default::default()
+    };
+
+    BlobItem {
+        name: string_at(batch, "Name", row),
+        properties: Some(properties),
+        ..Default::default()
+    }
+}
+
+fn to_error(error: ArrowError) -> Error {
+    Error::new(ErrorKind::DataConversion, error)
+}
+
+/// Returns the column with the given name, or `None` if it is absent.
+fn column<'a>(batch: &'a RecordBatch, name: &str) -> Option<&'a dyn Array> {
+    let index = batch.schema().index_of(name).ok()?;
+    Some(batch.column(index).as_ref())
+}
+
+fn string_at(batch: &RecordBatch, name: &str, row: usize) -> Option<String> {
+    let array = column(batch, name)?
+        .as_any()
+        .downcast_ref::<StringArray>()?;
+    (!array.is_null(row)).then(|| array.value(row).to_string())
+}
+
+fn bool_at(batch: &RecordBatch, name: &str, row: usize) -> Option<bool> {
+    let array = column(batch, name)?
+        .as_any()
+        .downcast_ref::<BooleanArray>()?;
+    (!array.is_null(row)).then(|| array.value(row))
+}
+
+fn u64_at(batch: &RecordBatch, name: &str, row: usize) -> Option<u64> {
+    let array = column(batch, name)?;
+    if array.is_null(row) {
+        return None;
+    }
+    if let Some(array) = array.as_any().downcast_ref::<UInt64Array>() {
+        Some(array.value(row))
+    } else if let Some(array) = array.as_any().downcast_ref::<Int64Array>() {
+        u64::try_from(array.value(row)).ok()
+    } else {
+        None
+    }
+}
+
+fn timestamp_at(batch: &RecordBatch, name: &str, row: usize) -> Option<OffsetDateTime> {
+    let array = column(batch, name)?;
+    if array.is_null(row) {
+        return None;
+    }
+    let nanos: i128 = match array.data_type() {
+        DataType::Timestamp(TimeUnit::Second, _) => {
+            array
+                .as_any()
+                .downcast_ref::<TimestampSecondArray>()?
+                .value(row) as i128
+                * 1_000_000_000
+        }
+        DataType::Timestamp(TimeUnit::Millisecond, _) => {
+            array
+                .as_any()
+                .downcast_ref::<TimestampMillisecondArray>()?
+                .value(row) as i128
+                * 1_000_000
+        }
+        DataType::Timestamp(TimeUnit::Microsecond, _) => {
+            array
+                .as_any()
+                .downcast_ref::<TimestampMicrosecondArray>()?
+                .value(row) as i128
+                * 1_000
+        }
+        DataType::Timestamp(TimeUnit::Nanosecond, _) => array
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()?
+            .value(row) as i128,
+        _ => return None,
+    };
+    OffsetDateTime::from_unix_timestamp_nanos(nanos).ok()
+}

--- a/sdk/storage/azure_storage_blob/src/generated/clients/append_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/append_blob_client.rs
@@ -581,7 +581,7 @@ impl AppendBlobClient {
 }
 
 /// Default value for [`AppendBlobClientOptions::version`].
-pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+pub(crate) const DEFAULT_VERSION: &str = "2026-06-06";
 
 impl Default for AppendBlobClientOptions {
     fn default() -> Self {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/append_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/append_blob_client.rs
@@ -581,7 +581,7 @@ impl AppendBlobClient {
 }
 
 /// Default value for [`AppendBlobClientOptions::version`].
-pub(crate) const DEFAULT_VERSION: &str = "2026-06-06";
+pub(crate) const DEFAULT_VERSION: &str = "2026-12-06";
 
 impl Default for AppendBlobClientOptions {
     fn default() -> Self {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_client.rs
@@ -1574,7 +1574,7 @@ impl BlobClient {
 }
 
 /// Default value for [`BlobClientOptions::version`].
-pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+pub(crate) const DEFAULT_VERSION: &str = "2026-06-06";
 
 impl Default for BlobClientOptions {
     fn default() -> Self {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_client.rs
@@ -584,6 +584,9 @@ impl BlobClient {
     /// * [`content_range`()](crate::generated::models::BlobClientDownloadInternalResultHeaders::content_range) - content-range
     /// * [`etag`()](crate::generated::models::BlobClientDownloadInternalResultHeaders::etag) - etag
     /// * [`last_modified`()](crate::generated::models::BlobClientDownloadInternalResultHeaders::last_modified) - last-modified
+    /// * [`access_tier`()](crate::generated::models::BlobClientDownloadInternalResultHeaders::access_tier) - x-ms-access-tier
+    /// * [`access_tier_change_time`()](crate::generated::models::BlobClientDownloadInternalResultHeaders::access_tier_change_time) - x-ms-access-tier-change-time
+    /// * [`access_tier_inferred`()](crate::generated::models::BlobClientDownloadInternalResultHeaders::access_tier_inferred) - x-ms-access-tier-inferred
     /// * [`blob_committed_block_count`()](crate::generated::models::BlobClientDownloadInternalResultHeaders::blob_committed_block_count) - x-ms-blob-committed-block-count
     /// * [`blob_content_md5`()](crate::generated::models::BlobClientDownloadInternalResultHeaders::blob_content_md5) - x-ms-blob-content-md5
     /// * [`is_sealed`()](crate::generated::models::BlobClientDownloadInternalResultHeaders::is_sealed) - x-ms-blob-sealed
@@ -611,6 +614,7 @@ impl BlobClient {
     /// * [`object_replication_rules`()](crate::generated::models::BlobClientDownloadInternalResultHeaders::object_replication_rules) - x-ms-or
     /// * [`object_replication_policy_id`()](crate::generated::models::BlobClientDownloadInternalResultHeaders::object_replication_policy_id) - x-ms-or-policy-id
     /// * [`is_server_encrypted`()](crate::generated::models::BlobClientDownloadInternalResultHeaders::is_server_encrypted) - x-ms-server-encrypted
+    /// * [`smart_access_tier`()](crate::generated::models::BlobClientDownloadInternalResultHeaders::smart_access_tier) - x-ms-smart-access-tier
     /// * [`tag_count`()](crate::generated::models::BlobClientDownloadInternalResultHeaders::tag_count) - x-ms-tag-count
     /// * [`version_id`()](crate::generated::models::BlobClientDownloadInternalResultHeaders::version_id) - x-ms-version-id
     ///
@@ -845,6 +849,7 @@ impl BlobClient {
     /// * [`object_replication_policy_id`()](crate::generated::models::BlobClientGetPropertiesResultHeaders::object_replication_policy_id) - x-ms-or-policy-id
     /// * [`rehydrate_priority`()](crate::generated::models::BlobClientGetPropertiesResultHeaders::rehydrate_priority) - x-ms-rehydrate-priority
     /// * [`is_server_encrypted`()](crate::generated::models::BlobClientGetPropertiesResultHeaders::is_server_encrypted) - x-ms-server-encrypted
+    /// * [`smart_access_tier`()](crate::generated::models::BlobClientGetPropertiesResultHeaders::smart_access_tier) - x-ms-smart-access-tier
     /// * [`tag_count`()](crate::generated::models::BlobClientGetPropertiesResultHeaders::tag_count) - x-ms-tag-count
     /// * [`version_id`()](crate::generated::models::BlobClientGetPropertiesResultHeaders::version_id) - x-ms-version-id
     ///
@@ -1574,7 +1579,7 @@ impl BlobClient {
 }
 
 /// Default value for [`BlobClientOptions::version`].
-pub(crate) const DEFAULT_VERSION: &str = "2026-06-06";
+pub(crate) const DEFAULT_VERSION: &str = "2026-12-06";
 
 impl Default for BlobClientOptions {
     fn default() -> Self {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
@@ -766,7 +766,11 @@ impl BlobContainerClient {
                     query_builder.build();
                 }
                 let mut request = Request::new(url, Method::Get);
-                request.insert_header("accept", "application/vnd.apache.arrow.stream");
+                // Prefer the Apache Arrow stream but allow the server to fall back to XML.
+                request.insert_header(
+                    "accept",
+                    "application/vnd.apache.arrow.stream,application/xml",
+                );
                 request.insert_header("x-ms-version", &version);
                 let pipeline = pipeline.clone();
                 Box::pin(async move {
@@ -784,32 +788,49 @@ impl BlobContainerClient {
                         .await?;
                     let (status, headers, body) = rsp.deconstruct();
                     // Prototype: dump the raw wire payload before transcoding so we can
-                    // confirm the server returned an Apache Arrow IPC stream (not XML).
+                    // confirm what format the server actually returned (Arrow vs XML).
                     {
                         let preview_len = body.len().min(64);
                         let preview = &body[..preview_len];
                         println!(
                             "list_blobs raw wire body: {} bytes, content-type: {:?}",
                             body.len(),
-                            headers
-                                .get_optional_str(&azure_core::http::headers::CONTENT_TYPE)
+                            headers.get_optional_str(&azure_core::http::headers::CONTENT_TYPE)
                         );
-                        println!("list_blobs raw wire first {preview_len} bytes (hex): {preview:02x?}");
+                        println!(
+                            "list_blobs raw wire first {preview_len} bytes (hex): {preview:02x?}"
+                        );
                     }
-                    // Prototype: the server returns an Apache Arrow IPC stream, but the rest
-                    // of the pipeline (the next-marker extraction below and the caller's
-                    // `into_model()`) expects XML. Decode the Arrow response into the model,
-                    // then re-serialize it to XML so it flows through the existing pipeline.
-                    //
-                    // TODO: Need to address to actually see performance gains by supporting
-                    // arrow. Decoding Arrow and re-encoding to XML (then re-decoding
-                    // downstream in `into_model()`) does an extra encode+decode round-trip
-                    // that negates Arrow's client-side CPU benefit. Productionization should
-                    // decode the Arrow stream directly into the model without the XML
-                    // round-trip.
-                    let model = crate::arrow_decode::decode_arrow_list_blobs(&body)?;
-                    let next_marker = model.next_marker.clone();
-                    let body = xml::to_xml(&model)?;
+                    // The response format is dictated by the server's `Content-Type`, not by
+                    // what we requested: even when Arrow is requested the server may fall
+                    // back to XML. Branch on the response so both formats are handled.
+                    let is_arrow = headers
+                        .get_optional_str(&azure_core::http::headers::CONTENT_TYPE)
+                        .is_some_and(|content_type| {
+                            content_type.contains("application/vnd.apache.arrow.stream")
+                        });
+                    let (body, next_marker) = if is_arrow {
+                        // Prototype: the server returned an Apache Arrow IPC stream, but the
+                        // rest of the pipeline (the next-marker handling below and the
+                        // caller's `into_model()`) expects XML. Decode the Arrow response
+                        // into the model, then re-serialize it to XML so it flows through the
+                        // existing pipeline.
+                        //
+                        // TODO: Need to address to actually see performance gains by
+                        // supporting arrow. Decoding Arrow and re-encoding to XML (then
+                        // re-decoding downstream in `into_model()`) does an extra
+                        // encode+decode round-trip that negates Arrow's client-side CPU
+                        // benefit. Production-ready should decode the Arrow stream directly
+                        // into the model without the XML round-trip.
+                        let model = crate::arrow_decode::decode_arrow_list_blobs(&body)?;
+                        let next_marker = model.next_marker.clone();
+                        (xml::to_xml(&model)?, next_marker)
+                    } else {
+                        // The server returned XML directly; pass the body through unchanged
+                        // and extract the continuation token from it.
+                        let page: BlobContainerClientListBlobsPage = xml::from_xml(&body)?;
+                        (body.into(), page.next_marker)
+                    };
                     let rsp = RawResponse::from_bytes(status, headers, body).into();
                     Ok(match next_marker {
                         Some(next_marker) if !next_marker.is_empty() => PagerResult::More {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
@@ -766,7 +766,7 @@ impl BlobContainerClient {
                     query_builder.build();
                 }
                 let mut request = Request::new(url, Method::Get);
-                request.insert_header("accept", "application/xml");
+                request.insert_header("accept", "application/vnd.apache.arrow.stream");
                 request.insert_header("x-ms-version", &version);
                 let pipeline = pipeline.clone();
                 Box::pin(async move {
@@ -783,9 +783,35 @@ impl BlobContainerClient {
                         )
                         .await?;
                     let (status, headers, body) = rsp.deconstruct();
-                    let res: BlobContainerClientListBlobsPage = xml::from_xml(&body)?;
+                    // Prototype: dump the raw wire payload before transcoding so we can
+                    // confirm the server returned an Apache Arrow IPC stream (not XML).
+                    {
+                        let preview_len = body.len().min(64);
+                        let preview = &body[..preview_len];
+                        println!(
+                            "list_blobs raw wire body: {} bytes, content-type: {:?}",
+                            body.len(),
+                            headers
+                                .get_optional_str(&azure_core::http::headers::CONTENT_TYPE)
+                        );
+                        println!("list_blobs raw wire first {preview_len} bytes (hex): {preview:02x?}");
+                    }
+                    // Prototype: the server returns an Apache Arrow IPC stream, but the rest
+                    // of the pipeline (the next-marker extraction below and the caller's
+                    // `into_model()`) expects XML. Decode the Arrow response into the model,
+                    // then re-serialize it to XML so it flows through the existing pipeline.
+                    //
+                    // TODO: Need to address to actually see performance gains by supporting
+                    // arrow. Decoding Arrow and re-encoding to XML (then re-decoding
+                    // downstream in `into_model()`) does an extra encode+decode round-trip
+                    // that negates Arrow's client-side CPU benefit. Productionization should
+                    // decode the Arrow stream directly into the model without the XML
+                    // round-trip.
+                    let model = crate::arrow_decode::decode_arrow_list_blobs(&body)?;
+                    let next_marker = model.next_marker.clone();
+                    let body = xml::to_xml(&model)?;
                     let rsp = RawResponse::from_bytes(status, headers, body).into();
-                    Ok(match res.next_marker {
+                    Ok(match next_marker {
                         Some(next_marker) if !next_marker.is_empty() => PagerResult::More {
                             response: rsp,
                             continuation: PagerContinuation::Token(next_marker),
@@ -1158,7 +1184,7 @@ impl BlobContainerClient {
 }
 
 /// Default value for [`BlobContainerClientOptions::version`].
-pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+pub(crate) const DEFAULT_VERSION: &str = "2026-06-06";
 
 impl Default for BlobContainerClientOptions {
     fn default() -> Self {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
@@ -11,11 +11,13 @@ use crate::generated::models::{
     BlobContainerClientFindBlobsByTagsOptions, BlobContainerClientGetAccessPolicyOptions,
     BlobContainerClientGetAccountInfoOptions, BlobContainerClientGetAccountInfoResult,
     BlobContainerClientGetPropertiesOptions, BlobContainerClientGetPropertiesResult,
+    BlobContainerClientListBlobFlatSegmentApacheArrowOptions,
     BlobContainerClientListBlobsHierarchicalOptions, BlobContainerClientListBlobsOptions,
     BlobContainerClientReleaseLeaseOptions, BlobContainerClientReleaseLeaseResult,
     BlobContainerClientRenewLeaseOptions, BlobContainerClientRenewLeaseResult,
     BlobContainerClientSetAccessPolicyOptions, BlobContainerClientSetMetadataOptions,
-    FilteredBlobResponse, ListBlobsHierarchicalResponse, ListBlobsResponse, SignedIdentifiers,
+    FilteredBlobResponse, ListBlobsAcceptFormat, ListBlobsHierarchicalResponse, ListBlobsResponse,
+    SignedIdentifiers,
 };
 use azure_core::{
     error::CheckSuccessOptions,
@@ -707,6 +709,117 @@ impl BlobContainerClient {
         Ok(rsp.into())
     }
 
+    /// Returns a list of the blobs in the specified container, allowing the response format to be selected via the Accept header.
+    ///
+    /// # Arguments
+    ///
+    /// * `accept` - The Accept header indicating the format in which the response should be returned.
+    /// * `options` - Optional parameters for the request.
+    #[tracing::function("Storage.Blob.BlobContainerClient.listBlobFlatSegmentApacheArrow")]
+    pub fn list_blob_flat_segment_apache_arrow(
+        &self,
+        accept: ListBlobsAcceptFormat,
+        options: Option<BlobContainerClientListBlobFlatSegmentApacheArrowOptions<'_>>,
+    ) -> Result<Pager<ListBlobsResponse, XmlFormat>> {
+        let options = options.unwrap_or_default().into_owned();
+        let pipeline = self.pipeline.clone();
+        let mut first_url = self.endpoint.clone();
+        let mut query_builder = first_url.query_builder();
+        query_builder
+            .append_pair("comp", "list")
+            .append_pair("restype", "container");
+        if let Some(include) = options.include.as_ref() {
+            query_builder.set_pair(
+                "include",
+                include
+                    .iter()
+                    .map(|i| i.to_string())
+                    .collect::<Vec<String>>()
+                    .join(","),
+            );
+        }
+        if let Some(marker) = options.marker.as_ref() {
+            query_builder.set_pair("marker", marker);
+        }
+        if let Some(maxresults) = options.maxresults {
+            query_builder.set_pair("maxresults", maxresults.to_string());
+        }
+        if let Some(prefix) = options.prefix.as_ref() {
+            query_builder.set_pair("prefix", prefix);
+        }
+        if let Some(start_from) = options.start_from.as_ref() {
+            query_builder.set_pair("startFrom", start_from);
+        }
+        if let Some(timeout) = options.timeout {
+            query_builder.set_pair("timeout", timeout.to_string());
+        }
+        query_builder.build();
+        #[derive(serde::Deserialize)]
+        struct BlobContainerClientListBlobFlatSegmentApacheArrowPage {
+            #[serde(rename = "NextMarker")]
+            next_marker: Option<String>,
+        }
+
+        let version = self.version.clone();
+        Ok(Pager::new(
+            move |marker: PagerState, pager_options| {
+                let mut url = first_url.clone();
+                if let PagerState::More(marker) = marker {
+                    let mut query_builder = url.query_builder();
+                    query_builder.set_pair("marker", marker.as_ref());
+                    query_builder.build();
+                }
+                let mut request = Request::new(url, Method::Get);
+                // Now allows for setting the "accept" header. For now piloting an enum with choices (auto, XML, arrow)
+                request.insert_header("accept", accept.to_string());
+                request.insert_header("x-ms-version", &version);
+                let pipeline = pipeline.clone();
+                Box::pin(async move {
+                    let rsp = pipeline
+                        .send(
+                            &pager_options.context,
+                            &mut request,
+                            Some(PipelineSendOptions {
+                                check_success: CheckSuccessOptions {
+                                    success_codes: &[200],
+                                },
+                                ..Default::default()
+                            }),
+                        )
+                        .await?;
+                    let (status, headers, body) = rsp.deconstruct();
+                    let is_arrow = headers
+                        .get_optional_str(&azure_core::http::headers::CONTENT_TYPE)
+                        .is_some_and(|content_type| {
+                            content_type.contains("application/vnd.apache.arrow.stream")
+                        });
+                    // Condition on whether we got back XML or arrow (since you can request arrow but may hit XML fallback)
+                    let (body, next_marker) = if is_arrow {
+                        // PROOF-OF-CONCEPT ONLY: This currently decodes arrow then re-encoding to XML to make the return type happy.
+                        //  (re-decoded later in `into_model()`). Therefore this adds a full round-trip, negating the benefits of adding arrow support.
+                        // Discussion point: How to smooth over the return type issue (Result<Pager<ListBlobsResponse, XmlFormat>>).
+                        let model = crate::arrow_decode::decode_arrow_list_blobs(&body)?;
+                        let next_marker = model.next_marker.clone();
+                        (xml::to_xml(&model)?, next_marker)
+                    } else {
+                        let page: BlobContainerClientListBlobFlatSegmentApacheArrowPage =
+                            xml::from_xml(&body)?;
+                        (body.into(), page.next_marker)
+                    };
+                    let rsp = RawResponse::from_bytes(status, headers, body).into();
+                    Ok(match next_marker {
+                        Some(next_marker) if !next_marker.is_empty() => PagerResult::More {
+                            response: rsp,
+                            continuation: PagerContinuation::Token(next_marker),
+                        },
+                        _ => PagerResult::Done { response: rsp },
+                    })
+                })
+            },
+            Some(options.method_options),
+        ))
+    }
+
     /// Returns a list of the blobs in the specified container.
     ///
     /// # Arguments
@@ -766,11 +879,7 @@ impl BlobContainerClient {
                     query_builder.build();
                 }
                 let mut request = Request::new(url, Method::Get);
-                // Prefer the Apache Arrow stream but allow the server to fall back to XML.
-                request.insert_header(
-                    "accept",
-                    "application/vnd.apache.arrow.stream,application/xml",
-                );
+                request.insert_header("accept", "application/xml");
                 request.insert_header("x-ms-version", &version);
                 let pipeline = pipeline.clone();
                 Box::pin(async move {
@@ -787,52 +896,9 @@ impl BlobContainerClient {
                         )
                         .await?;
                     let (status, headers, body) = rsp.deconstruct();
-                    // Prototype: dump the raw wire payload before transcoding so we can
-                    // confirm what format the server actually returned (Arrow vs XML).
-                    {
-                        let preview_len = body.len().min(64);
-                        let preview = &body[..preview_len];
-                        println!(
-                            "list_blobs raw wire body: {} bytes, content-type: {:?}",
-                            body.len(),
-                            headers.get_optional_str(&azure_core::http::headers::CONTENT_TYPE)
-                        );
-                        println!(
-                            "list_blobs raw wire first {preview_len} bytes (hex): {preview:02x?}"
-                        );
-                    }
-                    // The response format is dictated by the server's `Content-Type`, not by
-                    // what we requested: even when Arrow is requested the server may fall
-                    // back to XML. Branch on the response so both formats are handled.
-                    let is_arrow = headers
-                        .get_optional_str(&azure_core::http::headers::CONTENT_TYPE)
-                        .is_some_and(|content_type| {
-                            content_type.contains("application/vnd.apache.arrow.stream")
-                        });
-                    let (body, next_marker) = if is_arrow {
-                        // Prototype: the server returned an Apache Arrow IPC stream, but the
-                        // rest of the pipeline (the next-marker handling below and the
-                        // caller's `into_model()`) expects XML. Decode the Arrow response
-                        // into the model, then re-serialize it to XML so it flows through the
-                        // existing pipeline.
-                        //
-                        // TODO: Need to address to actually see performance gains by
-                        // supporting arrow. Decoding Arrow and re-encoding to XML (then
-                        // re-decoding downstream in `into_model()`) does an extra
-                        // encode+decode round-trip that negates Arrow's client-side CPU
-                        // benefit. Production-ready should decode the Arrow stream directly
-                        // into the model without the XML round-trip.
-                        let model = crate::arrow_decode::decode_arrow_list_blobs(&body)?;
-                        let next_marker = model.next_marker.clone();
-                        (xml::to_xml(&model)?, next_marker)
-                    } else {
-                        // The server returned XML directly; pass the body through unchanged
-                        // and extract the continuation token from it.
-                        let page: BlobContainerClientListBlobsPage = xml::from_xml(&body)?;
-                        (body.into(), page.next_marker)
-                    };
+                    let res: BlobContainerClientListBlobsPage = xml::from_xml(&body)?;
                     let rsp = RawResponse::from_bytes(status, headers, body).into();
-                    Ok(match next_marker {
+                    Ok(match res.next_marker {
                         Some(next_marker) if !next_marker.is_empty() => PagerResult::More {
                             response: rsp,
                             continuation: PagerContinuation::Token(next_marker),
@@ -1205,7 +1271,7 @@ impl BlobContainerClient {
 }
 
 /// Default value for [`BlobContainerClientOptions::version`].
-pub(crate) const DEFAULT_VERSION: &str = "2026-06-06";
+pub(crate) const DEFAULT_VERSION: &str = "2026-12-06";
 
 impl Default for BlobContainerClientOptions {
     fn default() -> Self {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
@@ -454,7 +454,7 @@ impl BlobServiceClient {
 }
 
 /// Default value for [`BlobServiceClientOptions::version`].
-pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+pub(crate) const DEFAULT_VERSION: &str = "2026-06-06";
 
 impl Default for BlobServiceClientOptions {
     fn default() -> Self {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
@@ -454,7 +454,7 @@ impl BlobServiceClient {
 }
 
 /// Default value for [`BlobServiceClientOptions::version`].
-pub(crate) const DEFAULT_VERSION: &str = "2026-06-06";
+pub(crate) const DEFAULT_VERSION: &str = "2026-12-06";
 
 impl Default for BlobServiceClientOptions {
     fn default() -> Self {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/block_blob_client.rs
@@ -931,7 +931,7 @@ impl BlockBlobClient {
 }
 
 /// Default value for [`BlockBlobClientOptions::version`].
-pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+pub(crate) const DEFAULT_VERSION: &str = "2026-06-06";
 
 impl Default for BlockBlobClientOptions {
     fn default() -> Self {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/block_blob_client.rs
@@ -587,6 +587,7 @@ impl BlockBlobClient {
     /// * [`content_md5`()](crate::generated::models::BlockBlobClientUploadBlobFromUrlResultHeaders::content_md5) - content-md5
     /// * [`etag`()](crate::generated::models::BlockBlobClientUploadBlobFromUrlResultHeaders::etag) - etag
     /// * [`last_modified`()](crate::generated::models::BlockBlobClientUploadBlobFromUrlResultHeaders::last_modified) - last-modified
+    /// * [`content_crc64`()](crate::generated::models::BlockBlobClientUploadBlobFromUrlResultHeaders::content_crc64) - x-ms-content-crc64
     /// * [`encryption_key_sha256`()](crate::generated::models::BlockBlobClientUploadBlobFromUrlResultHeaders::encryption_key_sha256) - x-ms-encryption-key-sha256
     /// * [`encryption_scope`()](crate::generated::models::BlockBlobClientUploadBlobFromUrlResultHeaders::encryption_scope) - x-ms-encryption-scope
     /// * [`is_server_encrypted`()](crate::generated::models::BlockBlobClientUploadBlobFromUrlResultHeaders::is_server_encrypted) - x-ms-request-server-encrypted
@@ -931,7 +932,7 @@ impl BlockBlobClient {
 }
 
 /// Default value for [`BlockBlobClientOptions::version`].
-pub(crate) const DEFAULT_VERSION: &str = "2026-06-06";
+pub(crate) const DEFAULT_VERSION: &str = "2026-12-06";
 
 impl Default for BlockBlobClientOptions {
     fn default() -> Self {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/page_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/page_blob_client.rs
@@ -1005,7 +1005,7 @@ impl PageBlobClient {
 }
 
 /// Default value for [`PageBlobClientOptions::version`].
-pub(crate) const DEFAULT_VERSION: &str = "2026-06-06";
+pub(crate) const DEFAULT_VERSION: &str = "2026-12-06";
 
 impl Default for PageBlobClientOptions {
     fn default() -> Self {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/page_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/page_blob_client.rs
@@ -1005,7 +1005,7 @@ impl PageBlobClient {
 }
 
 /// Default value for [`PageBlobClientOptions::version`].
-pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+pub(crate) const DEFAULT_VERSION: &str = "2026-06-06";
 
 impl Default for PageBlobClientOptions {
     fn default() -> Self {

--- a/sdk/storage/azure_storage_blob/src/generated/models/enums.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/enums.rs
@@ -54,6 +54,9 @@ pub enum AccessTier {
     /// The Premium access tier.
     Premium,
 
+    /// The Smart access tier.
+    Smart,
+
     /// Any other value not defined in `AccessTier`.
     UnknownValue(String),
 }
@@ -88,6 +91,9 @@ pub enum ArchiveStatus {
 
     /// The archive status is rehydrating pending to Hot.
     RehydratePendingToHot,
+
+    /// The archive status is rehydrating pending to Smart.
+    RehydratePendingToSmart,
 
     /// Any other value not defined in `ArchiveStatus`.
     UnknownValue(String),
@@ -255,6 +261,20 @@ pub enum LeaseStatus {
 
     /// The lease is unlocked.
     Unlocked,
+}
+
+/// Specifies the format in which a blob listing should be returned.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ListBlobsAcceptFormat {
+    /// Return the listing as an Apache Arrow stream, falling back to XML if Arrow is unavailable.
+    Arrow,
+
+    /// Let the SDK choose the best available format. Currently emits the Apache Arrow stream, falling back to XML if Arrow is
+    /// unavailable.
+    Auto,
+
+    /// Return the listing as XML.
+    Xml,
 }
 
 /// Specifies additional datasets to include when listing blobs in a container.

--- a/sdk/storage/azure_storage_blob/src/generated/models/enums_impl.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/enums_impl.rs
@@ -7,9 +7,9 @@ use super::{
     AccessTier, AccountKind, ArchiveStatus, BlobCopySourceTags, BlobDeleteType, BlobType,
     BlockListType, CopyStatus, DeleteSnapshotsOptionType, EncryptionAlgorithmType,
     FileShareTokenIntent, FilterBlobsIncludeItem, GeoReplicationStatusType, ImmutabilityPolicyMode,
-    LeaseDuration, LeaseState, LeaseStatus, ListBlobsIncludeItem, ListContainersIncludeType,
-    PremiumPageBlobAccessTier, PublicAccessType, RehydratePriority, SequenceNumberActionType,
-    SkuName, StorageErrorCode,
+    LeaseDuration, LeaseState, LeaseStatus, ListBlobsAcceptFormat, ListBlobsIncludeItem,
+    ListContainersIncludeType, PremiumPageBlobAccessTier, PublicAccessType, RehydratePriority,
+    SequenceNumberActionType, SkuName, StorageErrorCode,
 };
 use azure_core::error::{Error, ErrorKind};
 use std::{
@@ -37,6 +37,7 @@ impl<'a> From<&'a AccessTier> for &'a str {
             AccessTier::P70 => "P70",
             AccessTier::P80 => "P80",
             AccessTier::Premium => "Premium",
+            AccessTier::Smart => "Smart",
             AccessTier::UnknownValue(s) => s.as_ref(),
         }
     }
@@ -62,6 +63,7 @@ impl FromStr for AccessTier {
             "P70" => AccessTier::P70,
             "P80" => AccessTier::P80,
             "Premium" => AccessTier::Premium,
+            "Smart" => AccessTier::Smart,
             _ => AccessTier::UnknownValue(s.to_string()),
         })
     }
@@ -86,6 +88,7 @@ impl AsRef<str> for AccessTier {
             AccessTier::P70 => "P70",
             AccessTier::P80 => "P80",
             AccessTier::Premium => "Premium",
+            AccessTier::Smart => "Smart",
             AccessTier::UnknownValue(s) => s.as_str(),
         }
     }
@@ -110,6 +113,7 @@ impl Display for AccessTier {
             AccessTier::P70 => f.write_str("P70"),
             AccessTier::P80 => f.write_str("P80"),
             AccessTier::Premium => f.write_str("Premium"),
+            AccessTier::Smart => f.write_str("Smart"),
             AccessTier::UnknownValue(s) => f.write_str(s.as_str()),
         }
     }
@@ -163,6 +167,7 @@ impl<'a> From<&'a ArchiveStatus> for &'a str {
             ArchiveStatus::RehydratePendingToCold => "rehydrate-pending-to-cold",
             ArchiveStatus::RehydratePendingToCool => "rehydrate-pending-to-cool",
             ArchiveStatus::RehydratePendingToHot => "rehydrate-pending-to-hot",
+            ArchiveStatus::RehydratePendingToSmart => "rehydrate-pending-to-smart",
             ArchiveStatus::UnknownValue(s) => s.as_ref(),
         }
     }
@@ -175,6 +180,7 @@ impl FromStr for ArchiveStatus {
             "rehydrate-pending-to-cold" => ArchiveStatus::RehydratePendingToCold,
             "rehydrate-pending-to-cool" => ArchiveStatus::RehydratePendingToCool,
             "rehydrate-pending-to-hot" => ArchiveStatus::RehydratePendingToHot,
+            "rehydrate-pending-to-smart" => ArchiveStatus::RehydratePendingToSmart,
             _ => ArchiveStatus::UnknownValue(s.to_string()),
         })
     }
@@ -186,6 +192,7 @@ impl AsRef<str> for ArchiveStatus {
             ArchiveStatus::RehydratePendingToCold => "rehydrate-pending-to-cold",
             ArchiveStatus::RehydratePendingToCool => "rehydrate-pending-to-cool",
             ArchiveStatus::RehydratePendingToHot => "rehydrate-pending-to-hot",
+            ArchiveStatus::RehydratePendingToSmart => "rehydrate-pending-to-smart",
             ArchiveStatus::UnknownValue(s) => s.as_str(),
         }
     }
@@ -197,6 +204,7 @@ impl Display for ArchiveStatus {
             ArchiveStatus::RehydratePendingToCold => f.write_str("rehydrate-pending-to-cold"),
             ArchiveStatus::RehydratePendingToCool => f.write_str("rehydrate-pending-to-cool"),
             ArchiveStatus::RehydratePendingToHot => f.write_str("rehydrate-pending-to-hot"),
+            ArchiveStatus::RehydratePendingToSmart => f.write_str("rehydrate-pending-to-smart"),
             ArchiveStatus::UnknownValue(s) => f.write_str(s.as_str()),
         }
     }
@@ -694,6 +702,47 @@ impl Display for LeaseStatus {
         match self {
             LeaseStatus::Locked => Display::fmt("locked", f),
             LeaseStatus::Unlocked => Display::fmt("unlocked", f),
+        }
+    }
+}
+
+impl FromStr for ListBlobsAcceptFormat {
+    type Err = Error;
+    fn from_str(s: &str) -> ::core::result::Result<Self, <Self as FromStr>::Err> {
+        #[allow(unreachable_patterns)]
+        Ok(match s {
+            "application/vnd.apache.arrow.stream,application/xml" => ListBlobsAcceptFormat::Arrow,
+            "application/vnd.apache.arrow.stream,application/xml" => ListBlobsAcceptFormat::Auto,
+            "application/xml" => ListBlobsAcceptFormat::Xml,
+            _ => {
+                return Err(Error::with_message_fn(ErrorKind::DataConversion, || {
+                    format!("unknown variant of ListBlobsAcceptFormat found: \"{s}\"")
+                }))
+            }
+        })
+    }
+}
+
+impl AsRef<str> for ListBlobsAcceptFormat {
+    fn as_ref(&self) -> &str {
+        match self {
+            ListBlobsAcceptFormat::Arrow => "application/vnd.apache.arrow.stream,application/xml",
+            ListBlobsAcceptFormat::Auto => "application/vnd.apache.arrow.stream,application/xml",
+            ListBlobsAcceptFormat::Xml => "application/xml",
+        }
+    }
+}
+
+impl Display for ListBlobsAcceptFormat {
+    fn fmt(&self, f: &mut Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            ListBlobsAcceptFormat::Arrow => {
+                Display::fmt("application/vnd.apache.arrow.stream,application/xml", f)
+            }
+            ListBlobsAcceptFormat::Auto => {
+                Display::fmt("application/vnd.apache.arrow.stream,application/xml", f)
+            }
+            ListBlobsAcceptFormat::Xml => Display::fmt("application/xml", f),
         }
     }
 }

--- a/sdk/storage/azure_storage_blob/src/generated/models/enums_serde.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/enums_serde.rs
@@ -7,9 +7,9 @@ use super::{
     AccessTier, AccountKind, ArchiveStatus, BlobCopySourceTags, BlobDeleteType, BlobType,
     BlockListType, CopyStatus, DeleteSnapshotsOptionType, EncryptionAlgorithmType,
     FileShareTokenIntent, FilterBlobsIncludeItem, GeoReplicationStatusType, ImmutabilityPolicyMode,
-    LeaseDuration, LeaseState, LeaseStatus, ListBlobsIncludeItem, ListContainersIncludeType,
-    PremiumPageBlobAccessTier, PublicAccessType, RehydratePriority, SequenceNumberActionType,
-    SkuName, StorageErrorCode,
+    LeaseDuration, LeaseState, LeaseStatus, ListBlobsAcceptFormat, ListBlobsIncludeItem,
+    ListContainersIncludeType, PremiumPageBlobAccessTier, PublicAccessType, RehydratePriority,
+    SequenceNumberActionType, SkuName, StorageErrorCode,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -328,6 +328,25 @@ impl<'de> Deserialize<'de> for LeaseStatus {
 }
 
 impl Serialize for LeaseStatus {
+    fn serialize<S>(&self, s: S) -> ::core::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        s.serialize_str(self.as_ref())
+    }
+}
+
+impl<'de> Deserialize<'de> for ListBlobsAcceptFormat {
+    fn deserialize<D>(deserializer: D) -> ::core::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+impl Serialize for ListBlobsAcceptFormat {
     fn serialize<S>(&self, s: S) -> ::core::result::Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/sdk/storage/azure_storage_blob/src/generated/models/header_traits.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/header_traits.rs
@@ -100,6 +100,7 @@ const REQUEST_SERVER_ENCRYPTED: HeaderName =
     HeaderName::from_static("x-ms-request-server-encrypted");
 const SERVER_ENCRYPTED: HeaderName = HeaderName::from_static("x-ms-server-encrypted");
 const SKU_NAME: HeaderName = HeaderName::from_static("x-ms-sku-name");
+const SMART_ACCESS_TIER: HeaderName = HeaderName::from_static("x-ms-smart-access-tier");
 const SNAPSHOT: HeaderName = HeaderName::from_static("x-ms-snapshot");
 const TAG_COUNT: HeaderName = HeaderName::from_static("x-ms-tag-count");
 const VERSION_ID: HeaderName = HeaderName::from_static("x-ms-version-id");
@@ -628,6 +629,9 @@ pub(crate) trait BlobClientDownloadInternalResultHeaders: private::Sealed {
     fn content_range(&self) -> Result<Option<String>>;
     fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
+    fn access_tier(&self) -> Result<Option<String>>;
+    fn access_tier_change_time(&self) -> Result<Option<OffsetDateTime>>;
+    fn access_tier_inferred(&self) -> Result<Option<bool>>;
     fn blob_committed_block_count(&self) -> Result<Option<i32>>;
     fn blob_content_md5(&self) -> Result<Option<Vec<u8>>>;
     fn is_sealed(&self) -> Result<Option<bool>>;
@@ -655,6 +659,7 @@ pub(crate) trait BlobClientDownloadInternalResultHeaders: private::Sealed {
     fn object_replication_rules(&self) -> Result<HashMap<String, String>>;
     fn object_replication_policy_id(&self) -> Result<Option<String>>;
     fn is_server_encrypted(&self) -> Result<Option<bool>>;
+    fn smart_access_tier(&self) -> Result<Option<String>>;
     fn tag_count(&self) -> Result<Option<i64>>;
     fn version_id(&self) -> Result<Option<String>>;
 }
@@ -705,6 +710,23 @@ impl BlobClientDownloadInternalResultHeaders for AsyncResponse<BlobClientDownloa
         Headers::get_optional_with(self.headers(), &LAST_MODIFIED, |h| {
             parse_rfc7231(h.as_str())
         })
+    }
+
+    /// The access tier of the blob.
+    fn access_tier(&self) -> Result<Option<String>> {
+        Headers::get_optional_as(self.headers(), &ACCESS_TIER)
+    }
+
+    /// The time the tier was changed on the blob. This is only returned if the tier on the blob was ever set.
+    fn access_tier_change_time(&self) -> Result<Option<OffsetDateTime>> {
+        Headers::get_optional_with(self.headers(), &ACCESS_TIER_CHANGE_TIME, |h| {
+            parse_rfc7231(h.as_str())
+        })
+    }
+
+    /// Included if the access tier is inferred.
+    fn access_tier_inferred(&self) -> Result<Option<bool>> {
+        Headers::get_optional_as(self.headers(), &ACCESS_TIER_INFERRED)
     }
 
     /// The number of committed blocks present in the blob.
@@ -869,6 +891,11 @@ impl BlobClientDownloadInternalResultHeaders for AsyncResponse<BlobClientDownloa
         Headers::get_optional_as(self.headers(), &SERVER_ENCRYPTED)
     }
 
+    /// The underlying tier of a smart tier blob. Only returned if the blob is in Smart tier.
+    fn smart_access_tier(&self) -> Result<Option<String>> {
+        Headers::get_optional_as(self.headers(), &SMART_ACCESS_TIER)
+    }
+
     /// The number of tags associated with the blob.
     fn tag_count(&self) -> Result<Option<i64>> {
         Headers::get_optional_as(self.headers(), &TAG_COUNT)
@@ -990,6 +1017,7 @@ pub trait BlobClientGetPropertiesResultHeaders: private::Sealed {
     fn object_replication_policy_id(&self) -> Result<Option<String>>;
     fn rehydrate_priority(&self) -> Result<Option<RehydratePriority>>;
     fn is_server_encrypted(&self) -> Result<Option<bool>>;
+    fn smart_access_tier(&self) -> Result<Option<String>>;
     fn tag_count(&self) -> Result<Option<i64>>;
     fn version_id(&self) -> Result<Option<String>>;
 }
@@ -1229,6 +1257,11 @@ impl BlobClientGetPropertiesResultHeaders for Response<BlobClientGetPropertiesRe
     /// Indicates whether the contents of the request are successfully encrypted.
     fn is_server_encrypted(&self) -> Result<Option<bool>> {
         Headers::get_optional_as(self.headers(), &SERVER_ENCRYPTED)
+    }
+
+    /// The underlying tier of a smart tier blob. Only returned if the blob is in Smart tier.
+    fn smart_access_tier(&self) -> Result<Option<String>> {
+        Headers::get_optional_as(self.headers(), &SMART_ACCESS_TIER)
     }
 
     /// The number of tags associated with the blob.
@@ -1996,6 +2029,7 @@ pub trait BlockBlobClientUploadBlobFromUrlResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<Vec<u8>>>;
     fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
+    fn content_crc64(&self) -> Result<Option<Vec<u8>>>;
     fn encryption_key_sha256(&self) -> Result<Option<String>>;
     fn encryption_scope(&self) -> Result<Option<String>>;
     fn is_server_encrypted(&self) -> Result<Option<bool>>;
@@ -2019,6 +2053,13 @@ impl BlockBlobClientUploadBlobFromUrlResultHeaders
     fn last_modified(&self) -> Result<Option<OffsetDateTime>> {
         Headers::get_optional_with(self.headers(), &LAST_MODIFIED, |h| {
             parse_rfc7231(h.as_str())
+        })
+    }
+
+    /// The CRC64 hash of the content.
+    fn content_crc64(&self) -> Result<Option<Vec<u8>>> {
+        Headers::get_optional_with(self.headers(), &CONTENT_CRC64, |h| {
+            base64::decode(h.as_str())
         })
     }
 

--- a/sdk/storage/azure_storage_blob/src/generated/models/method_options.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/method_options.rs
@@ -1008,6 +1008,51 @@ pub struct BlobContainerClientGetPropertiesOptions<'a> {
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to `BlobContainerClient::list_blob_flat_segment_apache_arrow()`
+#[derive(Clone, Default, SafeDebug)]
+pub struct BlobContainerClientListBlobFlatSegmentApacheArrowOptions<'a> {
+    /// Specify to include additional, optional information.
+    pub include: Option<Vec<ListBlobsIncludeItem>>,
+
+    /// An opaque string value that identifies the portion of the result set to return with this operation.
+    pub marker: Option<String>,
+
+    /// Specifies the maximum number of resources to return. If the request does not specify maxresults, or specifies a value
+    /// greater than 5000, the server will return up to 5000 items.
+    pub maxresults: Option<i32>,
+
+    /// Allows customization of the method call.
+    pub method_options: PagerOptions<'a>,
+
+    /// Filters the results to return only resources whose name begins with the specified prefix.
+    pub prefix: Option<String>,
+
+    /// Specifies the relative path to list paths from. For non-recursive list, only one entity level is supported; for recursive
+    /// list, multiple entity levels are supported. (Inclusive)
+    pub start_from: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](\"<https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\>")
+    pub timeout: Option<i32>,
+}
+
+impl BlobContainerClientListBlobFlatSegmentApacheArrowOptions<'_> {
+    /// Transforms this [`BlobContainerClientListBlobFlatSegmentApacheArrowOptions`] into a new `BlobContainerClientListBlobFlatSegmentApacheArrowOptions` that owns the underlying data, cloning it if necessary.
+    pub fn into_owned(self) -> BlobContainerClientListBlobFlatSegmentApacheArrowOptions<'static> {
+        BlobContainerClientListBlobFlatSegmentApacheArrowOptions {
+            include: self.include,
+            marker: self.marker,
+            maxresults: self.maxresults,
+            method_options: PagerOptions {
+                context: self.method_options.context.into_owned(),
+                ..self.method_options
+            },
+            prefix: self.prefix,
+            start_from: self.start_from,
+            timeout: self.timeout,
+        }
+    }
+}
+
 /// Options to be passed to `BlobContainerClient::list_blobs_hierarchical()`
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientListBlobsHierarchicalOptions<'a> {

--- a/sdk/storage/azure_storage_blob/src/generated/models/models.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/models.rs
@@ -441,6 +441,10 @@ pub struct BlobProperties {
     #[serde(rename = "ServerEncrypted", skip_serializing_if = "Option::is_none")]
     pub server_encrypted: Option<bool>,
 
+    /// The smart access tier of the blob.
+    #[serde(rename = "SmartAccessTier", skip_serializing_if = "Option::is_none")]
+    pub smart_access_tier: Option<AccessTier>,
+
     /// The number of tags for the blob.
     #[serde(rename = "TagCount", skip_serializing_if = "Option::is_none")]
     pub tag_count: Option<i32>,

--- a/sdk/storage/azure_storage_blob/src/lib.rs
+++ b/sdk/storage/azure_storage_blob/src/lib.rs
@@ -7,6 +7,7 @@
 #![allow(dead_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+mod arrow_decode;
 pub(crate) mod buffers;
 pub mod clients;
 #[allow(unused_imports)]

--- a/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
@@ -142,6 +142,55 @@ async fn test_list_blobs(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+/// Prototype observation test: lists blobs and dumps the raw response so we can
+/// inspect exactly what comes over the wire (e.g. when the `Accept` header is
+/// set to `application/vnd.apache.arrow.stream`). Run with `--nocapture` to see
+/// the printed output.
+#[recorded::test]
+async fn test_list_blobs_observe_raw(ctx: TestContext) -> Result<(), Box<dyn Error>> {
+    // Recording Setup
+    let recording = ctx.recording();
+    let container_client =
+        get_container_client(recording, false, StorageAccount::Standard, None).await?;
+
+    container_client.create(None).await?;
+    create_test_blob(&container_client.blob_client("testblob1"), None, None).await?;
+
+    let mut list_blobs_response = container_client.list_blobs(None)?.into_pages();
+    let page = list_blobs_response
+        .try_next()
+        .await?
+        .expect("expected at least one page");
+
+    let (status, headers, body) = page.deconstruct();
+    println!("list_blobs status: {status:?}");
+    println!(
+        "list_blobs content-type: {:?}",
+        headers.get_optional_str(&azure_core::http::headers::CONTENT_TYPE)
+    );
+    println!("list_blobs body length: {} bytes", body.len());
+    let preview_len = body.len().min(64);
+    println!(
+        "list_blobs body first {preview_len} bytes (hex): {}",
+        body[..preview_len]
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+    println!(
+        "list_blobs body first {preview_len} bytes (utf8 lossy): {}",
+        String::from_utf8_lossy(&body[..preview_len])
+    );
+
+    // Basic sanity: the request succeeded and we got some bytes back.
+    assert_eq!(StatusCode::Ok, status);
+    assert!(!body.is_empty(), "expected a non-empty response body");
+
+    container_client.delete(None).await?;
+    Ok(())
+}
+
 #[recorded::test]
 async fn test_list_blobs_with_continuation(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Recording Setup

--- a/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
@@ -14,9 +14,10 @@ use azure_storage_blob::models::{
     BlobContainerClientBreakLeaseOptions, BlobContainerClientChangeLeaseResultHeaders,
     BlobContainerClientCreateOptions, BlobContainerClientFindBlobsByTagsOptions,
     BlobContainerClientGetAccountInfoResultHeaders, BlobContainerClientGetPropertiesResultHeaders,
-    BlobContainerClientListBlobsHierarchicalOptions, BlobContainerClientListBlobsOptions,
+    BlobContainerClientListBlobFlatSegmentApacheArrowOptions,
+    BlobContainerClientListBlobsHierarchicalOptions,
     BlobContainerClientSetMetadataOptions, BlobType, BlockBlobClientUploadOptions, LeaseState,
-    ListBlobsIncludeItem, SignedIdentifiers, StorageErrorCode,
+    ListBlobsAcceptFormat, ListBlobsIncludeItem, SignedIdentifiers, StorageErrorCode,
 };
 use azure_storage_blob::StorageError;
 use common::{
@@ -123,7 +124,9 @@ async fn test_list_blobs(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     )
     .await?;
 
-    let mut list_blobs_response = container_client.list_blobs(None)?.into_pages();
+    let mut list_blobs_response = container_client
+        .list_blob_flat_segment_apache_arrow(ListBlobsAcceptFormat::Xml, None)?
+        .into_pages();
 
     let page = list_blobs_response.try_next().await?;
     let list_blob_segment_response = page.unwrap().into_model()?;
@@ -156,32 +159,33 @@ async fn test_list_blobs_observe_raw(ctx: TestContext) -> Result<(), Box<dyn Err
     container_client.create(None).await?;
     create_test_blob(&container_client.blob_client("testblob1"), None, None).await?;
 
-    let mut list_blobs_response = container_client.list_blobs(None)?.into_pages();
+    let mut list_blobs_response = container_client
+        .list_blob_flat_segment_apache_arrow(ListBlobsAcceptFormat::Auto, None)?
+        .into_pages();
     let page = list_blobs_response
         .try_next()
         .await?
         .expect("expected at least one page");
 
     let (status, headers, body) = page.deconstruct();
-    println!("list_blobs status: {status:?}");
-    println!(
-        "list_blobs content-type: {:?}",
-        headers.get_optional_str(&azure_core::http::headers::CONTENT_TYPE)
-    );
-    println!("list_blobs body length: {} bytes", body.len());
+    let content_type = headers.get_optional_str(&azure_core::http::headers::CONTENT_TYPE);
     let preview_len = body.len().min(64);
+    let hex_preview = body[..preview_len]
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    println!("┌─ list_blobs raw response ─────────────────────────────");
+    println!("│ status       : {status:?}");
+    println!("│ content-type : {content_type:?}");
+    println!("│ body length  : {} bytes", body.len());
+    println!("│ first {preview_len} bytes (hex)  : {hex_preview}");
     println!(
-        "list_blobs body first {preview_len} bytes (hex): {}",
-        body[..preview_len]
-            .iter()
-            .map(|b| format!("{b:02x}"))
-            .collect::<Vec<_>>()
-            .join(" ")
-    );
-    println!(
-        "list_blobs body first {preview_len} bytes (utf8 lossy): {}",
+        "│ first {preview_len} bytes (utf8) : {}",
         String::from_utf8_lossy(&body[..preview_len])
     );
+    println!("└───────────────────────────────────────────────────────");
 
     // Basic sanity: the request succeeded and we got some bytes back.
     assert_eq!(StatusCode::Ok, status);
@@ -231,12 +235,12 @@ async fn test_list_blobs_with_continuation(ctx: TestContext) -> Result<(), Box<d
     .await?;
 
     // Continuation Token with Token Provided
-    let list_blobs_options = BlobContainerClientListBlobsOptions {
+    let list_blobs_options = BlobContainerClientListBlobFlatSegmentApacheArrowOptions {
         maxresults: Some(2),
         ..Default::default()
     };
     let mut list_blobs_response = container_client
-        .list_blobs(Some(list_blobs_options))?
+        .list_blob_flat_segment_apache_arrow(ListBlobsAcceptFormat::Xml, Some(list_blobs_options))?
         .into_pages();
     let first_page = list_blobs_response.try_next().await?;
     let list_blob_segment_response = first_page.unwrap().into_model()?;
@@ -249,12 +253,12 @@ async fn test_list_blobs_with_continuation(ctx: TestContext) -> Result<(), Box<d
         assert!(blob_names.contains(&blob_name));
         assert_eq!(BlobType::BlockBlob, blob_type);
     }
-    let list_blobs_options = BlobContainerClientListBlobsOptions {
+    let list_blobs_options = BlobContainerClientListBlobFlatSegmentApacheArrowOptions {
         marker: continuation_token,
         ..Default::default()
     };
     let mut list_blobs_response = container_client
-        .list_blobs(Some(list_blobs_options.clone()))?
+        .list_blob_flat_segment_apache_arrow(ListBlobsAcceptFormat::Xml, Some(list_blobs_options.clone()))?
         .into_pages();
     let second_page = list_blobs_response.try_next().await?;
     let list_blob_segment_response = second_page.unwrap().into_model()?;
@@ -269,7 +273,7 @@ async fn test_list_blobs_with_continuation(ctx: TestContext) -> Result<(), Box<d
 
     // Continuation Token, Automatic Paging
     let mut pager_response = container_client
-        .list_blobs(Some(list_blobs_options))?
+        .list_blob_flat_segment_apache_arrow(ListBlobsAcceptFormat::Xml, Some(list_blobs_options))?
         .into_pages();
     let mut page_count = 0;
 
@@ -331,7 +335,9 @@ async fn test_list_blobs_decodes_xml_invalid_names(ctx: TestContext) -> Result<(
     }
 
     // List blobs and verify the names are correctly percent-decoded
-    let mut list_blobs_response = container_client.list_blobs(None)?.into_pages();
+    let mut list_blobs_response = container_client
+        .list_blob_flat_segment_apache_arrow(ListBlobsAcceptFormat::Xml, None)?
+        .into_pages();
     let page = list_blobs_response.try_next().await?;
     let list_blob_segment_response = page.unwrap().into_model()?;
     let blob_items = list_blob_segment_response.blob_items;
@@ -686,13 +692,16 @@ async fn test_list_blobs_with_include_options(ctx: TestContext) -> Result<(), Bo
 
     // List with both Metadata and Tags includes
     let page = container_client
-        .list_blobs(Some(BlobContainerClientListBlobsOptions {
-            include: Some(vec![
-                ListBlobsIncludeItem::Metadata,
-                ListBlobsIncludeItem::Tags,
-            ]),
-            ..Default::default()
-        }))?
+        .list_blob_flat_segment_apache_arrow(
+            ListBlobsAcceptFormat::Xml,
+            Some(BlobContainerClientListBlobFlatSegmentApacheArrowOptions {
+                include: Some(vec![
+                    ListBlobsIncludeItem::Metadata,
+                    ListBlobsIncludeItem::Tags,
+                ]),
+                ..Default::default()
+            }),
+        )?
         .into_pages()
         .try_next()
         .await?
@@ -742,10 +751,13 @@ async fn test_list_blobs_with_prefix(ctx: TestContext) -> Result<(), Box<dyn Err
     create_test_blob(&container_client.blob_client(&blob_no_prefix), None, None).await?;
 
     let page = container_client
-        .list_blobs(Some(BlobContainerClientListBlobsOptions {
-            prefix: Some(prefix.to_string()),
-            ..Default::default()
-        }))?
+        .list_blob_flat_segment_apache_arrow(
+            ListBlobsAcceptFormat::Xml,
+            Some(BlobContainerClientListBlobFlatSegmentApacheArrowOptions {
+                prefix: Some(prefix.to_string()),
+                ..Default::default()
+            }),
+        )?
         .into_pages()
         .try_next()
         .await?
@@ -780,7 +792,7 @@ async fn test_list_blobs_with_uncommitted_blobs_include(
 
     // Without UncommittedBlobs Include Scenario
     let page_without = container_client
-        .list_blobs(None)?
+        .list_blob_flat_segment_apache_arrow(ListBlobsAcceptFormat::Xml, None)?
         .into_pages()
         .try_next()
         .await?
@@ -796,10 +808,13 @@ async fn test_list_blobs_with_uncommitted_blobs_include(
 
     // With UncommittedBlobs Include Scenario
     let page_with = container_client
-        .list_blobs(Some(BlobContainerClientListBlobsOptions {
-            include: Some(vec![ListBlobsIncludeItem::UncommittedBlobs]),
-            ..Default::default()
-        }))?
+        .list_blob_flat_segment_apache_arrow(
+            ListBlobsAcceptFormat::Xml,
+            Some(BlobContainerClientListBlobFlatSegmentApacheArrowOptions {
+                include: Some(vec![ListBlobsIncludeItem::UncommittedBlobs]),
+                ..Default::default()
+            }),
+        )?
         .into_pages()
         .try_next()
         .await?
@@ -837,7 +852,7 @@ async fn test_list_blobs_with_deleted_include(ctx: TestContext) -> Result<(), Bo
 
     // Without Deleted Include Scenario
     let page_without = container_client
-        .list_blobs(None)?
+        .list_blob_flat_segment_apache_arrow(ListBlobsAcceptFormat::Xml, None)?
         .into_pages()
         .try_next()
         .await?
@@ -853,10 +868,13 @@ async fn test_list_blobs_with_deleted_include(ctx: TestContext) -> Result<(), Bo
 
     // With Deleted Include Scenario
     let page_with = container_client
-        .list_blobs(Some(BlobContainerClientListBlobsOptions {
-            include: Some(vec![ListBlobsIncludeItem::Deleted]),
-            ..Default::default()
-        }))?
+        .list_blob_flat_segment_apache_arrow(
+            ListBlobsAcceptFormat::Xml,
+            Some(BlobContainerClientListBlobFlatSegmentApacheArrowOptions {
+                include: Some(vec![ListBlobsIncludeItem::Deleted]),
+                ..Default::default()
+            }),
+        )?
         .into_pages()
         .try_next()
         .await?
@@ -898,10 +916,13 @@ async fn test_list_blobs_with_copy_include(ctx: TestContext) -> Result<(), Box<d
 
     // Copy Include Scenario
     let page = container_client
-        .list_blobs(Some(BlobContainerClientListBlobsOptions {
-            include: Some(vec![ListBlobsIncludeItem::Copy]),
-            ..Default::default()
-        }))?
+        .list_blob_flat_segment_apache_arrow(
+            ListBlobsAcceptFormat::Xml,
+            Some(BlobContainerClientListBlobFlatSegmentApacheArrowOptions {
+                include: Some(vec![ListBlobsIncludeItem::Copy]),
+                ..Default::default()
+            }),
+        )?
         .into_pages()
         .try_next()
         .await?

--- a/sdk/storage/azure_storage_blob/tsp-location.yaml
+++ b/sdk/storage/azure_storage_blob/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/storage/data-plane/BlobStorage
-commit: 2cbf8269594238dba4c0211f821ac36c0bc9544f
+commit: 38af6a48aa64dcb9440ceb6274b50530ebc7c4ea
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 


### PR DESCRIPTION
Prototype end-to-end support for receiving the flat blob listing as an Apache Arrow IPC stream, decoding it into the existing `ListBlobsResponse` model. This proves correctness of the wire format and decode path; it is **not** yet a performance win (see "What's left").

### What this covers

- **New listing method** `BlobContainerClient::list_blob_flat_segment_apache_arrow(accept, options)` that exposes an `accept: ListBlobsAcceptFormat` enum (`Arrow` / `Auto` / `Xml`). `Arrow`/`Auto` request `application/vnd.apache.arrow.stream,application/xml`; `Xml` requests `application/xml`. In actuality, we would just implement this change to `list_blobs` and make it optional.
- **Response content negotiation** — the pager closure branches on the response `Content-Type` (server-dictated, not the request `Accept`), so both an Arrow stream and an XML fallback are handled correctly.
- **Arrow decoder** (`src/arrow_decode.rs`) — decodes an Arrow IPC stream into `ListBlobsResponse`: per-row `BlobItem`/`BlobProperties` for a subset of columns (name, timestamps, blob type, etag, content length/type, Content-MD5, access tier, lease state/status, server-encrypted) plus `NextMarker` from schema metadata.
- **Dependencies** — `arrow-array`, `arrow-ipc`, `arrow-schema` (59.1.0).
- **Tests** — `test_list_blobs_observe_raw` dumps the raw wire response (via `Auto`). Existing `list_blobs` tests are temporarily pointed at the new method with `Xml` to confirm the original XML path still works.

### What's left

- **Direct Arrow decode (the actual perf win).** Today the Arrow branch decodes then re-encodes to XML so the existing `XmlFormat` pipeline can re-parse it downstream - a full round-trip that is *slower* than XML. Production ready code needs a real `ArrowFormat` that decodes Arrow straight into the model with no XML round-trip.
- **Configurable `Accept`** via options/client (deferred) rather than a required positional argument.
- **Full field coverage** — envelope fields (container name, prefix, marker, max results, service endpoint) and map-typed columns (tags, metadata) are not yet mapped from Arrow.
- **Codegen / TypeSpec fixes** — (1) all edits live in `generated/` and will be overwritten by `tsp-client update`; the emitter must learn to produce this. (2) `ListBlobsAcceptFormat::{Arrow, Auto}` map to the same `Accept` string, making `Auto` unreachable in `FromStr` (currently suppressed).
- **Revert the temporary test diversion** back to `list_blobs`, and add proper Arrow + XML recordings.
- How to smooth over the introduction of the arrow format given we already are locked to the current response:
`Result<Pager<ListBlobsResponse, XmlFormat>>`