### PR TITLE
Align dependency policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,9 +149,11 @@ You are an expert Rust programmer. You write safe, efficient, maintainable, and 
 ### Dependencies
 
 - Dependencies should be defined in the root workspace's `Cargo.toml` file.
-- Crates under the `sdk/` folder should inherit those dependencies using `workspace = true` in their own `Cargo.toml` files.
-- Service crates should generally use workspace-managed internal dependencies, which typically resolve to published versions.
-- If a crate needs unreleased changes from `sdk/core`, use an explicit `path + version` dependency on that core crate instead of `workspace = true`.
+- Published dependencies should generally inherit the root workspace entry with `workspace = true`; this is the default for crates under `sdk/`.
+- When a crate needs unreleased changes, depend on the local crate with both `path` and `version`.
+- Local dev-dependencies should generally be `path`-only so `cargo package` can validate publishable crates without requiring unpublished versions from crates.io.
+- In `sdk/core`, keep dependency versions managed from the root workspace and use local `path + version` only when the core stack (`typespec -> typespec_client_core -> azure_core`) must move together on unreleased changes.
+- Outside `sdk/core`, crates should usually inherit workspace dependencies that resolve to published versions; switch to local `path + version` on `sdk/core` crates only when they require unreleased core changes.
 
 ### General
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,13 +286,10 @@ dependencies = [
  "azure_core_macros 1.0.0",
  "bytes",
  "futures",
- "hmac",
- "openssl",
  "pin-project",
  "rustc_version",
  "serde",
  "serde_json",
- "sha2",
  "tokio",
  "tracing",
  "typespec 1.1.0",
@@ -306,8 +303,8 @@ dependencies = [
  "async-lock",
  "async-trait",
  "azure_core_examples",
- "azure_core_macros 1.0.0",
- "azure_core_test",
+ "azure_core_macros 1.1.0-beta.1",
+ "azure_core_test 0.2.0",
  "bytes",
  "clap",
  "criterion",
@@ -327,8 +324,8 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec 1.1.0",
- "typespec_client_core 1.1.0",
+ "typespec 1.2.0-beta.1",
+ "typespec_client_core 1.2.0-beta.1",
  "ureq",
 ]
 
@@ -359,7 +356,7 @@ name = "azure_core_amqp"
 version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
- "azure_core 1.1.0",
+ "azure_core 1.2.0-beta.1",
  "fe2o3-amqp",
  "fe2o3-amqp-cbs",
  "fe2o3-amqp-ext",
@@ -372,8 +369,8 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec 1.1.0",
- "typespec_macros 1.0.0",
+ "typespec 1.2.0-beta.1",
+ "typespec_macros 1.1.0-beta.1",
 ]
 
 [[package]]
@@ -428,10 +425,10 @@ dependencies = [
 name = "azure_core_opentelemetry"
 version = "1.1.0-beta.1"
 dependencies = [
- "azure_core 1.1.0",
- "azure_core_test",
- "azure_core_test_macros",
- "azure_identity 1.0.0",
+ "azure_core 1.2.0-beta.1",
+ "azure_core_test 0.2.0",
+ "azure_core_test_macros 0.2.0",
+ "azure_identity 1.1.0-beta.1",
  "opentelemetry 0.32.0",
  "opentelemetry_sdk 0.32.1",
  "tokio",
@@ -444,10 +441,10 @@ name = "azure_core_test"
 version = "0.2.0"
 dependencies = [
  "async-trait",
- "azure_core 1.1.0",
+ "azure_core 1.2.0-beta.1",
  "azure_core_examples",
- "azure_core_test_macros",
- "azure_identity 1.0.0",
+ "azure_core_test_macros 0.2.0",
+ "azure_identity 1.1.0-beta.1",
  "clap",
  "dotenvy",
  "flate2",
@@ -467,14 +464,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "azure_core_test"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "423811903719b761b345ab1ba1e125100d98e4aa911a676485d6d1dfce67aee5"
+dependencies = [
+ "async-trait",
+ "azure_core 1.1.0",
+ "azure_core_test_macros 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "azure_identity 1.0.0",
+ "clap",
+ "dotenvy",
+ "flate2",
+ "futures",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tar",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "zip",
+]
+
+[[package]]
 name = "azure_core_test_macros"
 version = "0.2.0"
 dependencies = [
- "azure_core_test",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "tokio",
+]
+
+[[package]]
+name = "azure_core_test_macros"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fe1867a46636fc240f3e136379cb498dcebc2ea9f779c5f263346a0df34389f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -483,10 +516,10 @@ version = "0.37.0"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core 1.1.0",
- "azure_core_test",
+ "azure_core 1.2.0-beta.1",
+ "azure_core_test 0.2.0",
  "azure_data_cosmos_driver",
- "azure_identity 1.0.0",
+ "azure_identity 1.1.0-beta.1",
  "base64 0.22.1",
  "clap",
  "futures",
@@ -508,7 +541,7 @@ name = "azure_data_cosmos_benchmarks"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "azure_core 1.1.0",
+ "azure_core 1.2.0-beta.1",
  "azure_data_cosmos_driver",
  "criterion",
  "tokio",
@@ -522,9 +555,9 @@ dependencies = [
  "arc-swap",
  "async-lock",
  "async-trait",
- "azure_core 1.1.0",
+ "azure_core 1.2.0-beta.1",
  "azure_data_cosmos_macros",
- "azure_identity 1.0.0",
+ "azure_identity 1.1.0-beta.1",
  "backtrace",
  "base64 0.22.1",
  "bytes",
@@ -550,7 +583,7 @@ dependencies = [
 name = "azure_data_cosmos_driver_native"
 version = "0.1.0"
 dependencies = [
- "azure_core 1.1.0",
+ "azure_core 1.2.0-beta.1",
  "azure_data_cosmos_driver",
  "cbindgen",
  "futures",
@@ -574,10 +607,10 @@ name = "azure_data_cosmos_perf"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "azure_core 1.1.0",
+ "azure_core 1.2.0-beta.1",
  "azure_data_cosmos",
  "azure_data_cosmos_driver",
- "azure_identity 1.0.0",
+ "azure_identity 1.1.0-beta.1",
  "clap",
  "console-subscriber",
  "futures",
@@ -617,9 +650,9 @@ version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core 1.1.0",
+ "azure_core 1.2.0-beta.1",
  "azure_core_examples",
- "azure_core_test",
+ "azure_core_test 0.2.0",
  "clap",
  "futures",
  "include-file",
@@ -645,7 +678,7 @@ dependencies = [
  "async-trait",
  "azure_core 1.1.0",
  "azure_core_amqp 1.1.0",
- "azure_core_test",
+ "azure_core_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure_identity 1.0.0",
  "azure_messaging_eventhubs",
  "base64 0.22.1",
@@ -670,10 +703,10 @@ dependencies = [
  "async-trait",
  "azure_core 1.1.0",
  "azure_core_opentelemetry 1.0.0",
- "azure_core_test",
+ "azure_core_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure_identity 1.0.0",
  "azure_messaging_eventhubs",
- "azure_storage_blob",
+ "azure_storage_blob 1.0.0",
  "futures",
  "opentelemetry 0.32.0",
  "opentelemetry-appender-tracing",
@@ -696,7 +729,7 @@ dependencies = [
  "async-trait",
  "azure_core 1.1.0",
  "azure_core_amqp 1.1.0",
- "azure_core_test",
+ "azure_core_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure_identity 1.0.0",
  "futures",
  "rand 0.10.1",
@@ -715,9 +748,9 @@ version = "1.1.0-beta.2"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core 1.1.0",
- "azure_core_test",
- "azure_identity 1.0.0",
+ "azure_core 1.2.0-beta.1",
+ "azure_core_test 0.2.0",
+ "azure_identity 1.1.0-beta.1",
  "azure_security_keyvault_keys",
  "azure_security_keyvault_test",
  "futures",
@@ -737,9 +770,9 @@ version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core 1.1.0",
- "azure_core_test",
- "azure_identity 1.0.0",
+ "azure_core 1.2.0-beta.1",
+ "azure_core_test 0.2.0",
+ "azure_identity 1.1.0-beta.1",
  "azure_security_keyvault_test",
  "clap",
  "criterion",
@@ -761,9 +794,9 @@ version = "1.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core 1.1.0",
- "azure_core_test",
- "azure_identity 1.0.0",
+ "azure_core 1.2.0-beta.1",
+ "azure_core_test 0.2.0",
+ "azure_identity 1.1.0-beta.1",
  "azure_security_keyvault_test",
  "clap",
  "futures",
@@ -786,13 +819,32 @@ dependencies = [
 
 [[package]]
 name = "azure_storage_blob"
-version = "1.1.0-beta.2"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1756febbcca86c862ef718b983b505d08bd65a9bc984a915b0a16af4a4c3fe5b"
 dependencies = [
  "async-stream",
  "async-trait",
  "azure_core 1.1.0",
- "azure_core_test",
- "azure_identity 1.0.0",
+ "bytes",
+ "futures",
+ "percent-encoding",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+]
+
+[[package]]
+name = "azure_storage_blob"
+version = "1.1.0-beta.2"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "azure_core 1.2.0-beta.1",
+ "azure_core_test 0.2.0",
+ "azure_identity 1.1.0-beta.1",
  "azure_storage_common",
  "azure_storage_sas",
  "bytes",
@@ -825,9 +877,9 @@ name = "azure_storage_queue"
 version = "1.1.0-beta.2"
 dependencies = [
  "async-trait",
- "azure_core 1.1.0",
- "azure_core_test",
- "azure_identity 1.0.0",
+ "azure_core 1.2.0-beta.1",
+ "azure_core_test 0.2.0",
+ "azure_identity 1.1.0-beta.1",
  "azure_storage_common",
  "azure_storage_sas",
  "futures",
@@ -841,7 +893,7 @@ dependencies = [
 name = "azure_storage_sas"
 version = "0.2.0"
 dependencies = [
- "azure_core 1.1.0",
+ "azure_core 1.2.0-beta.1",
  "azure_storage_common",
  "base64 0.22.1",
  "hmac",
@@ -4198,7 +4250,6 @@ dependencies = [
  "pin-project",
  "rand 0.10.1",
  "reqwest",
- "rust_decimal",
  "serde",
  "serde_json",
  "time",
@@ -4230,8 +4281,8 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec 1.1.0",
- "typespec_macros 1.0.0",
+ "typespec 1.2.0-beta.1",
+ "typespec_macros 1.1.0-beta.1",
  "url",
  "uuid",
 ]
@@ -4259,7 +4310,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.117",
  "tokio",
- "typespec_client_core 1.1.0",
+ "typespec_client_core 1.2.0-beta.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,17 +72,18 @@ version = "1.0.0"
 
 [workspace.dependencies.azure_core_test]
 # azure_core_test should only ever be in dev-dependencies herein
-path = "sdk/core/azure_core_test"
+version = "0.2.0"
 
 [workspace.dependencies.azure_core_test_macros]
 # azure_core_test_macros should only ever be in dev-dependencies herein
-path = "sdk/core/azure_core_test_macros"
+version = "0.2.0"
 
 [workspace.dependencies.azure_identity]
 # azure_identity should only ever be in dev-dependencies herein
 version = "1.0.0"
 
 [workspace.dependencies.azure_storage_blob]
+# azure_storage_blob should only ever be in dev-dependencies herein
 version = "1.0.0"
 
 [workspace.dependencies]

--- a/eng/scripts/verify-dependencies.rs
+++ b/eng/scripts/verify-dependencies.rs
@@ -36,6 +36,10 @@ static EXEMPTIONS: &[(&str, &str)] = &[
     ("azure_core_test", "dotenvy"),
     ("azure_canary", "serde"),
     ("azure_data_cosmos_driver_native", "cbindgen"),
+    (
+        "azure_messaging_eventhubs_checkpointstore_blob",
+        "azure_storage_blob",
+    ),
 ];
 
 fn main() {

--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -16,7 +16,7 @@ rust-version.workspace = true
 [dependencies]
 async-lock.workspace = true
 async-trait.workspace = true
-azure_core_macros.workspace = true
+azure_core_macros = { path = "../azure_core_macros", version = "1.1.0-beta.1" }
 bytes.workspace = true
 futures.workspace = true
 hmac = { workspace = true, optional = true }
@@ -27,8 +27,8 @@ serde_json.workspace = true
 sha2 = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 tracing.workspace = true
-typespec = { workspace = true, features = ["http", "json"] }
-typespec_client_core = { workspace = true, default-features = false, features = [
+typespec = { path = "../typespec", version = "1.2.0-beta.1", features = ["http", "json"] }
+typespec_client_core = { path = "../typespec_client_core", version = "1.2.0-beta.1", default-features = false, features = [
   "derive",
   "http",
   "json",
@@ -38,9 +38,9 @@ typespec_client_core = { workspace = true, default-features = false, features = 
 rustc_version.workspace = true
 
 [dev-dependencies]
-azure_core_examples.path = "../azure_core_examples"
-azure_core_macros.workspace = true
-azure_core_test.path = "../azure_core_test"
+azure_core_examples = { path = "../azure_core_examples" }
+azure_core_macros = { path = "../azure_core_macros" }
+azure_core_test = { path = "../azure_core_test" }
 clap = { workspace = true, features = ["derive"] }
 criterion.workspace = true
 http = "1.4.0"

--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -19,7 +19,7 @@ edition.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-azure_core = { workspace = true, default-features = false }
+azure_core = { path = "../azure_core", version = "1.2.0-beta.1", default-features = false }
 fe2o3-amqp = { workspace = true, optional = true }
 fe2o3-amqp-cbs = { workspace = true, optional = true }
 fe2o3-amqp-ext = { workspace = true, optional = true }
@@ -30,8 +30,8 @@ serde_amqp = { workspace = true, optional = true }
 serde_bytes = { workspace = true, optional = true }
 tokio.workspace = true
 tracing.workspace = true
-typespec.workspace = true
-typespec_macros.workspace = true
+typespec = { path = "../typespec", version = "1.2.0-beta.1" }
+typespec_macros = { path = "../typespec_macros", version = "1.1.0-beta.1" }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/sdk/core/azure_core_examples/Cargo.toml
+++ b/sdk/core/azure_core_examples/Cargo.toml
@@ -17,7 +17,7 @@ autotests = false
 
 [dependencies]
 async-trait.workspace = true
-azure_core = { path = "../azure_core", features = [
+azure_core = { path = "../azure_core", version = "1.2.0-beta.1", features = [
   "reqwest",
   "reqwest_rustls",
   "tokio",

--- a/sdk/core/azure_core_opentelemetry/Cargo.toml
+++ b/sdk/core/azure_core_opentelemetry/Cargo.toml
@@ -17,15 +17,15 @@ rust-version.workspace = true
 default = ["azure_core/default"]
 
 [dependencies]
-azure_core.workspace = true
+azure_core = { path = "../azure_core", version = "1.2.0-beta.1" }
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-azure_core_test = { workspace = true, features = ["tracing"] }
-azure_core_test_macros.workspace = true
-azure_identity.workspace = true
+azure_core_test = { path = "../azure_core_test", features = ["tracing"] }
+azure_core_test_macros = { path = "../azure_core_test_macros" }
+azure_identity = { path = "../../identity/azure_identity" }
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 tokio.workspace = true
 tracing-subscriber.workspace = true

--- a/sdk/core/azure_core_test/Cargo.toml
+++ b/sdk/core/azure_core_test/Cargo.toml
@@ -20,9 +20,9 @@ tracing = ["tracing-subscriber"]
 
 [dependencies]
 async-trait.workspace = true
-azure_core = { workspace = true, default-features = false, features = ["test"] }
-azure_core_test_macros.workspace = true
-azure_identity.workspace = true
+azure_core = { path = "../azure_core", version = "1.2.0-beta.1", default-features = false, features = ["test"] }
+azure_core_test_macros = { path = "../azure_core_test_macros", version = "0.2.0" }
+azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
 clap.workspace = true
 dotenvy = "0.15.7"
 flate2.workspace = true
@@ -49,7 +49,7 @@ url.workspace = true
 zip.workspace = true
 
 [dev-dependencies]
-azure_core_examples.path = "../azure_core_examples"
+azure_core_examples = { path = "../azure_core_examples" }
 clap.workspace = true
 include-file.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "signal"] }

--- a/sdk/core/azure_core_test/src/perf/config_tests.rs
+++ b/sdk/core/azure_core_test/src/perf/config_tests.rs
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Tests for configuration of the performance test runner.
+
+use clap::Args;
+use futures::FutureExt;
+
+use super::*;
+
+#[derive(Subcommand, Debug, Clone)]
+enum ConfigTests {
+    Basic(BasicArgs),
+}
+
+impl PerfTestFactory for ConfigTests {
+    fn create_test(&self) -> CreatePerfTestReturn {
+        async move { Ok(Box::new(NoopPerfTest) as Box<dyn PerfTest>) }.boxed()
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Basic(_) => "basic",
+        }
+    }
+}
+
+#[derive(Args, Debug, Clone, Default)]
+struct BasicArgs {}
+
+struct NoopPerfTest;
+
+#[async_trait::async_trait]
+impl PerfTest for NoopPerfTest {
+    async fn setup(&self, _context: Arc<TestContext>) -> azure_core::Result<()> {
+        Ok(())
+    }
+
+    async fn run(&self, _context: Arc<TestContext>) -> azure_core::Result<()> {
+        Ok(())
+    }
+
+    async fn cleanup(&self, _context: Arc<TestContext>) -> azure_core::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn perf_runner_parses_default_options() {
+    let runner = PerfRunner::<ConfigTests>::with_command_line(
+        env!("CARGO_MANIFEST_DIR"),
+        file!(),
+        vec!["perf-tests", "basic"],
+    )
+    .unwrap();
+
+    assert_eq!(runner.options.iterations, 1);
+    assert_eq!(runner.options.parallel, 1);
+    assert_eq!(runner.options.duration, Duration::seconds(30));
+    assert_eq!(runner.options.warmup, Duration::seconds(5));
+    assert_eq!(runner.options.test_results_filename, "./results.json");
+    assert_eq!(runner.options.results_file, "");
+    assert!(!runner.options.no_cleanup);
+    assert!(!runner.options.disable_progress);
+    assert!(!runner.options.latency);
+    assert!(runner.options.test_proxy.is_none());
+    assert!(matches!(runner.options.subcommand, ConfigTests::Basic(_)));
+}
+
+#[test]
+fn perf_runner_parses_custom_options() {
+    let runner = PerfRunner::<ConfigTests>::with_command_line(
+        env!("CARGO_MANIFEST_DIR"),
+        file!(),
+        vec![
+            "perf-tests",
+            "--iterations",
+            "10",
+            "--parallel",
+            "5",
+            "--duration",
+            "60",
+            "--warmup",
+            "10",
+            "--no-cleanup",
+            "--no-progress",
+            "--latency",
+            "--test-results",
+            "/tmp/results.json",
+            "--results-file",
+            "/tmp/latencies.json",
+            "--test-proxy",
+            "https://example.com",
+            "basic",
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(runner.options.iterations, 10);
+    assert_eq!(runner.options.parallel, 5);
+    assert_eq!(runner.options.duration, Duration::seconds(60));
+    assert_eq!(runner.options.warmup, Duration::seconds(10));
+    assert_eq!(runner.options.test_results_filename, "/tmp/results.json");
+    assert_eq!(runner.options.results_file, "/tmp/latencies.json");
+    assert!(runner.options.no_cleanup);
+    assert!(runner.options.disable_progress);
+    assert!(runner.options.latency);
+    assert_eq!(
+        runner.options.test_proxy.as_ref().map(Url::as_str),
+        Some("https://example.com/")
+    );
+}
+
+#[test]
+fn perf_runner_rejects_invalid_duration() {
+    let error = PerfRunner::<ConfigTests>::with_command_line(
+        env!("CARGO_MANIFEST_DIR"),
+        file!(),
+        vec!["perf-tests", "--duration", "invalid", "basic"],
+    )
+    .unwrap_err();
+
+    assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+}

--- a/sdk/core/azure_core_test/src/perf/mod.rs
+++ b/sdk/core/azure_core_test/src/perf/mod.rs
@@ -464,4 +464,7 @@ impl<T: PerfTestFactory> PerfRunner<T> {
 }
 
 #[cfg(test)]
+mod config_tests;
+
+#[cfg(test)]
 mod framework_tests;

--- a/sdk/core/azure_core_test_macros/Cargo.toml
+++ b/sdk/core/azure_core_test_macros/Cargo.toml
@@ -22,9 +22,5 @@ proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
 
-[dev-dependencies]
-azure_core_test.workspace = true
-tokio.workspace = true
-
 [lints]
 workspace = true

--- a/sdk/core/typespec_client_core/Cargo.toml
+++ b/sdk/core/typespec_client_core/Cargo.toml
@@ -30,8 +30,8 @@ tokio = { workspace = true, optional = true, features = [
   "time",
 ] }
 tracing.workspace = true
-typespec = { workspace = true, default-features = false }
-typespec_macros = { workspace = true, optional = true }
+typespec = { path = "../typespec", version = "1.2.0-beta.1", default-features = false }
+typespec_macros = { path = "../typespec_macros", version = "1.1.0-beta.1", optional = true }
 url.workspace = true
 uuid.workspace = true
 
@@ -39,7 +39,7 @@ uuid.workspace = true
 tokio = { workspace = true, features = ["fs"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
-typespec_macros.workspace = true
+typespec_macros = { path = "../typespec_macros" }
 
 [features]
 default = [

--- a/sdk/core/typespec_macros/Cargo.toml
+++ b/sdk/core/typespec_macros/Cargo.toml
@@ -26,7 +26,7 @@ syn.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
-typespec_client_core = { workspace = true, features = [
+typespec_client_core = { path = "../typespec_client_core", features = [
   "http",
   "json",
   "xml",

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["api-bindings"]
 [dependencies]
 async-lock.workspace = true
 async-trait.workspace = true
-azure_core = { workspace = true, default-features = false }
+azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1", default-features = false }
 azure_data_cosmos_driver = { version = "0.6.0", path = "../azure_data_cosmos_driver", default-features = false }
 base64.workspace = true
 futures.workspace = true
@@ -32,7 +32,7 @@ url.workspace = true
 # `tokio test-util` entries below merge into existing features and add no
 # compile-time cost.
 [dev-dependencies]
-azure_core_test = { workspace = true, features = ["tracing"] }
+azure_core_test = { path = "../../core/azure_core_test", features = ["tracing"] }
 # Re-declare the driver here with the internal test-only diagnostics-construction feature.
 # Putting it in dev-dependencies (instead of [dependencies]) means downstream consumers
 # of `azure_data_cosmos` do NOT compile with this feature enabled — the driver's
@@ -49,7 +49,7 @@ azure_core_test = { workspace = true, features = ["tracing"] }
 azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", default-features = false, features = [
   "__internal_test_diagnostics_construction",
 ] }
-azure_identity.workspace = true
+azure_identity = { path = "../../identity/azure_identity" }
 clap.workspace = true
 reqwest = { workspace = true, features = ["http2"] }
 serde = { workspace = true, features = ["derive"] }

--- a/sdk/cosmos/azure_data_cosmos_benchmarks/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_benchmarks/Cargo.toml
@@ -19,8 +19,8 @@ harness = false
 
 [dependencies]
 async-trait.workspace = true
-azure_core.workspace = true
-azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", features = [
+azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1" }
+azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", version = "0.6.0", features = [
   "__internal_mocking",
   "__internal_backtrace_bench",
 ] }

--- a/sdk/cosmos/azure_data_cosmos_driver/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_driver/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["api-bindings"]
 arc-swap.workspace = true
 async-lock.workspace = true
 async-trait.workspace = true
-azure_core = { workspace = true, default-features = false, features = [
+azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1", default-features = false, features = [
   "hmac_rust",
 ] }
 azure_data_cosmos_macros = { version = "0.3.0", path = "../azure_data_cosmos_macros" }
@@ -40,7 +40,7 @@ url.workspace = true
 uuid = { workspace = true, features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
-azure_identity.workspace = true
+azure_identity = { path = "../../identity/azure_identity" }
 quick-xml.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = [

--- a/sdk/cosmos/azure_data_cosmos_driver_native/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/Cargo.toml
@@ -26,12 +26,12 @@ crate-type = ["cdylib", "staticlib"]
 # HTTP client (the driver's default factory needs either `rustls` or
 # `native_tls` — `rustls` matches the driver's own default and avoids the
 # OpenSSL-on-Windows breakage that bites `native_tls`).
-azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", default-features = false, features = ["tokio", "rustls"] }
+azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", version = "0.6.0", default-features = false, features = ["tokio", "rustls"] }
 # Required at runtime for master-key auth — `Secret` lives in
 # `azure_core::credentials` and `Url::parse` is the gate for the account
 # endpoint. Both are zero-cost wrappers around existing driver deps so
 # they don't grow the closure.
-azure_core = { workspace = true, default-features = false }
+azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1", default-features = false }
 url = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time", "macros"] }
 # `FutureExt::catch_unwind` is used by the submit pipeline to keep the
@@ -43,7 +43,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 # Path-only — the driver crate is not (yet) a workspace dependency.
-azure_core = { workspace = true, default-features = false }
+azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1", default-features = false }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time", "macros", "test-util"] }
 
 [build-dependencies]

--- a/sdk/cosmos/azure_data_cosmos_perf/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_perf/Cargo.toml
@@ -11,10 +11,10 @@ rust-version.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-azure_core = { workspace = true, features = ["reqwest"] }
-azure_data_cosmos = { path = "../azure_data_cosmos", features = ["key_auth"] }
-azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver" }
-azure_identity.workspace = true
+azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1", features = ["reqwest"] }
+azure_data_cosmos = { path = "../azure_data_cosmos", version = "0.37.0", features = ["key_auth"] }
+azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", version = "0.6.0" }
+azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
 clap = { workspace = true, features = ["derive", "env"] }
 console-subscriber = { workspace = true, optional = true }
 futures.workspace = true

--- a/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/Cargo.toml
@@ -22,7 +22,7 @@ rust-version.workspace = true
 async-trait.workspace = true
 azure_core.workspace = true
 azure_messaging_eventhubs = { path = "../azure_messaging_eventhubs", version = "0.15.0" }
-azure_storage_blob = { path = "../../storage/azure_storage_blob", version = "1.1.0-beta.2" }
+azure_storage_blob.workspace = true
 futures.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/examples/processor_with_blob_checkpoints.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/examples/processor_with_blob_checkpoints.rs
@@ -24,9 +24,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let consumer_group =
         env::var("EVENTHUBS_CONSUMER_GROUP").unwrap_or_else(|_| "$Default".to_string());
 
-    let eventhub_namespace =
-        env::var("EVENTHUBS_NAMESPACE").expect("EVENTHUBS_NAMESPACE must be set");
-    let eventhub_name = env::var("EVENTHUB_NAME").expect("EVENTHUB_NAME must be set");
+    let eventhubs_connection_string =
+        env::var("EVENTHUBS_CONNECTION_STRING").expect("EVENTHUBS_CONNECTION_STRING must be set");
+    let eventhub_name = env::var("EVENTHUB_NAME").ok();
 
     info!("Setting up Event Hubs processor with blob checkpoint store...");
 
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let consumer = ConsumerClient::builder()
         .with_application_id("ProcessorExample".to_string())
         .with_consumer_group(consumer_group)
-        .open(&eventhub_namespace, eventhub_name, credential.clone())
+        .open_with_connection_string(&eventhubs_connection_string, eventhub_name.as_deref())
         .await?;
 
     // Create the checkpoint store

--- a/sdk/identity/azure_identity/Cargo.toml
+++ b/sdk/identity/azure_identity/Cargo.toml
@@ -15,7 +15,7 @@ edition.workspace = true
 [dependencies]
 async-lock.workspace = true
 async-trait.workspace = true
-azure_core = { workspace = true, default-features = false }
+azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1", default-features = false }
 futures.workspace = true
 openssl = { workspace = true, optional = true }
 pin-project.workspace = true
@@ -27,7 +27,7 @@ tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-azure_core_test.workspace = true
+azure_core_test.path = "../../core/azure_core_test"
 azure_core_examples.path = "../../core/azure_core_examples"
 clap.workspace = true
 include-file.workspace = true

--- a/sdk/keyvault/azure_security_keyvault_certificates/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_certificates/Cargo.toml
@@ -19,18 +19,18 @@ default = ["azure_core/default"]
 [dependencies]
 async-lock = { workspace = true }
 async-trait = { workspace = true }
-azure_core = { workspace = true }
+azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1" }
 futures = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
-azure_core_test = { workspace = true, features = [
+azure_core_test = { path = "../../core/azure_core_test", features = [
   "tracing",
 ] }
-azure_identity.workspace = true
-azure_security_keyvault_keys = { path = "../azure_security_keyvault_keys" }
+azure_identity = { path = "../../identity/azure_identity" }
+azure_security_keyvault_keys.path = "../azure_security_keyvault_keys"
 azure_security_keyvault_test = { path = "../azure_security_keyvault_test" }
 include-file.workspace = true
 openssl.workspace = true

--- a/sdk/keyvault/azure_security_keyvault_keys/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_keys/Cargo.toml
@@ -19,16 +19,16 @@ default = ["azure_core/default"]
 [dependencies]
 async-lock = { workspace = true }
 async-trait = { workspace = true }
-azure_core = { workspace = true }
+azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1" }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-azure_core_test = { workspace = true, features = [
+azure_core_test = { path = "../../core/azure_core_test", features = [
   "tracing",
 ] }
-azure_identity.workspace = true
+azure_identity = { path = "../../identity/azure_identity" }
 azure_security_keyvault_test = { path = "../azure_security_keyvault_test" }
 clap = { workspace = true, features = ["derive"] }
 criterion.workspace = true

--- a/sdk/keyvault/azure_security_keyvault_secrets/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_secrets/Cargo.toml
@@ -19,7 +19,7 @@ default = ["azure_core/default"]
 [dependencies]
 async-lock = { workspace = true }
 async-trait = { workspace = true }
-azure_core = { workspace = true }
+azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1" }
 clap = { workspace = true, features = ["derive"] }
 futures = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -28,10 +28,10 @@ time = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
-azure_core_test = { workspace = true, features = [
+azure_core_test = { path = "../../core/azure_core_test", features = [
   "tracing",
 ] }
-azure_identity.workspace = true
+azure_identity = { path = "../../identity/azure_identity" }
 azure_security_keyvault_test = { path = "../azure_security_keyvault_test" }
 include-file.workspace = true
 rand.workspace = true

--- a/sdk/storage/azure_storage_blob/Cargo.toml
+++ b/sdk/storage/azure_storage_blob/Cargo.toml
@@ -20,7 +20,7 @@ tokio = ["dep:tokio", "azure_core/tokio"]
 [dependencies]
 async-stream.workspace = true
 async-trait.workspace = true
-azure_core = { workspace = true, features = ["xml"] }
+azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1", features = ["xml"] }
 azure_storage_common = { path = "../azure_storage_common", version = "0.2.0" }
 bytes.workspace = true
 futures.workspace = true
@@ -39,10 +39,10 @@ tokio = { workspace = true, optional = true, features = [
 workspace = true
 
 [dev-dependencies]
-azure_core_test = { workspace = true, features = [
+azure_core_test = { path = "../../core/azure_core_test", features = [
   "tracing",
 ] }
-azure_identity.workspace = true
+azure_identity = { path = "../../identity/azure_identity" }
 azure_storage_sas.path = "../azure_storage_sas"
 clap = { workspace = true, features = ["env"] }
 flate2.workspace = true

--- a/sdk/storage/azure_storage_queue/Cargo.toml
+++ b/sdk/storage/azure_storage_queue/Cargo.toml
@@ -18,7 +18,7 @@ default = ["azure_core/default"]
 
 [dependencies]
 async-trait.workspace = true
-azure_core = { workspace = true, features = ["xml"] }
+azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1", features = ["xml"] }
 azure_storage_common = { path = "../azure_storage_common", version = "0.2.0" }
 serde = { workspace = true }
 time.workspace = true
@@ -27,8 +27,8 @@ time.workspace = true
 workspace = true
 
 [dev-dependencies]
-azure_core_test = { workspace = true, features = ["tracing"] }
-azure_identity.workspace = true
+azure_core_test = { path = "../../core/azure_core_test", features = ["tracing"] }
+azure_identity = { path = "../../identity/azure_identity" }
 azure_storage_sas.path = "../azure_storage_sas"
 futures.workspace = true
 rand.workspace = true

--- a/sdk/storage/azure_storage_sas/Cargo.toml
+++ b/sdk/storage/azure_storage_sas/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["sdk", "cloud"]
 categories = ["api-bindings"]
 
 [dependencies]
-azure_core = { workspace = true }
+azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1" }
 azure_storage_common = { path = "../azure_storage_common", version = "0.2.0" }
 base64 = { workspace = true }
 hmac = { workspace = true }


### PR DESCRIPTION
Carry forward the azure_core_test release updates while
aligning workspace manifests with the published vs unreleased
dependency policy we validated.

- keep published dependencies on workspace-managed versions and
  move unreleased sdk/core consumers in storage, cosmos, and
  keyvault to local path+version dependencies
- make local dev-dependencies path-only so cargo package works
  for publishable crates, and update dependency verification
  guidance to match that policy
- move the perf config tests into azure_core_test, update the
  workspace azure_core_test entries to published 0.2.0, and
  keep checkpointstore packaging on the released blob crate

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 6a806d81-4e70-4e32-bcad-cc1991c4d2c9
