### PR TITLE
fix(amqp): keep link properties through the fe2o3 builder chain

### DIFF
--- a/sdk/core/azure_core_amqp/CHANGELOG.md
+++ b/sdk/core/azure_core_amqp/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Link properties set through `AmqpReceiverOptions::properties` and `AmqpSenderOptions::properties` now reach the Attach frame. The fe2o3 link builder methods that change the builder type (`name`, `target`, `sender` and `receiver`) rebuild the builder and reset the properties to the default value; only `source` keeps them. Both builder chains called `properties` before `name`, so every link property was discarded and the link attached without it. Event Hubs sends the consumer owner level as the `com.microsoft:epoch` link property, so this made `OpenReceiverOptions::owner_level` a silent no-op.
+- Link properties set through `AmqpReceiverOptions::properties` and `AmqpSenderOptions::properties` now reach the Attach frame. They were discarded before the link attached.
 
 ### Other Changes
 

--- a/sdk/core/azure_core_amqp/CHANGELOG.md
+++ b/sdk/core/azure_core_amqp/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Link properties set through `AmqpReceiverOptions::properties` and `AmqpSenderOptions::properties` now reach the Attach frame. The fe2o3 link builder methods that change the builder type (`name`, `target`, `sender` and `receiver`) rebuild the builder and reset the properties to the default value; only `source` keeps them. Both builder chains called `properties` before `name`, so every link property was discarded and the link attached without it. Event Hubs sends the consumer owner level as the `com.microsoft:epoch` link property, so this made `OpenReceiverOptions::owner_level` a silent no-op.
+
 ### Other Changes
 
 ## 1.1.0 (2026-07-09)

--- a/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
@@ -20,6 +20,38 @@ pub(crate) struct Fe2o3AmqpReceiver {
     receiver: OnceLock<Mutex<fe2o3_amqp::Receiver>>,
 }
 
+/// The fe2o3 link builder for a receiver, after the name, source and target are set.
+type Fe2o3ReceiverBuilder = fe2o3_amqp::link::builder::Builder<
+    fe2o3_amqp::link::role::ReceiverMarker,
+    fe2o3_amqp_types::messaging::Target,
+    fe2o3_amqp::link::builder::WithName,
+    fe2o3_amqp::link::builder::WithSource,
+    fe2o3_amqp::link::builder::WithTarget,
+>;
+
+/// Makes the fe2o3 link builder for a receiver.
+///
+/// The order of the builder calls is important. In fe2o3-amqp 0.14, the
+/// `name`, `target`, `sender` and `receiver` methods change the type of the
+/// builder. They rebuild it and set `properties` back to the default value.
+/// Only `source` keeps the properties. So `name` must be called before
+/// `properties`. If it is not, the link properties are dropped and never reach
+/// the Attach frame. Event Hubs sends `com.microsoft:epoch` (the owner level)
+/// as a link property, so the wrong order makes the owner level a silent no-op.
+fn build_receiver_link(source: AmqpSource, options: AmqpReceiverOptions) -> Fe2o3ReceiverBuilder {
+    let name = options.name.unwrap_or_default();
+    let credit_mode = options.credit_mode.unwrap_or_default();
+    let properties = options.properties.unwrap_or_default();
+
+    fe2o3_amqp::Receiver::builder()
+        .name(name)
+        .source(source)
+        .receiver_settle_mode(fe2o3_amqp_types::definitions::ReceiverSettleMode::First)
+        .credit_mode(credit_mode.into())
+        .auto_accept(options.auto_accept)
+        .properties(properties.into())
+}
+
 impl From<ReceiverCreditMode> for fe2o3_amqp::link::receiver::CreditMode {
     fn from(credit_mode: ReceiverCreditMode) -> Self {
         match credit_mode {
@@ -54,19 +86,9 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
             return Err(Self::receiver_already_attached());
         }
         let options = options.unwrap_or_default();
-        let name = options.name.unwrap_or_default();
-        let credit_mode = options.credit_mode.unwrap_or_default();
-        let auto_accept = options.auto_accept;
-        let properties = options.properties.unwrap_or_default();
         let source = source.into();
 
-        let receiver = fe2o3_amqp::Receiver::builder()
-            .receiver_settle_mode(fe2o3_amqp_types::definitions::ReceiverSettleMode::First)
-            .source(source)
-            .credit_mode(credit_mode.into())
-            .auto_accept(auto_accept)
-            .properties(properties.into())
-            .name(name)
+        let receiver = build_receiver_link(source, options)
             .attach(session.implementation.get()?.lock().await.borrow_mut())
             .await
             .map_err(|e| AmqpError::from(Fe2o3ReceiverAttachError(e)))?;
@@ -241,5 +263,59 @@ impl From<fe2o3_amqp::link::RecvError> for AmqpError {
                 AmqpErrorKind::TransportImplementationError(Box::new(e)).into()
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::messaging::AmqpSource;
+    use crate::value::{AmqpOrderedMap, AmqpSymbol, AmqpValue};
+
+    // Makes sure the link properties survive the fe2o3 builder chain. The
+    // `name` method clears the properties, so it must run before
+    // `properties`. Event Hubs sends the owner level as the
+    // `com.microsoft:epoch` link property, and a lost property makes the owner
+    // level a silent no-op.
+    #[test]
+    fn receiver_link_keeps_properties() {
+        let mut properties: AmqpOrderedMap<AmqpSymbol, AmqpValue> = AmqpOrderedMap::new();
+        properties.insert(
+            "com.microsoft.com:receiver-name".into(),
+            AmqpValue::from("test-receiver"),
+        );
+        properties.insert("com.microsoft:epoch".into(), AmqpValue::from(7i64));
+
+        let options = AmqpReceiverOptions {
+            name: Some("test-receiver".into()),
+            properties: Some(properties),
+            credit_mode: Some(ReceiverCreditMode::Auto(300)),
+            auto_accept: true,
+            ..Default::default()
+        };
+        let source = AmqpSource::builder()
+            .with_address("amqps://example.servicebus.windows.net/eh/Partitions/0".to_string())
+            .build();
+
+        let builder = build_receiver_link(source, options);
+
+        assert_eq!(builder.name, "test-receiver");
+        let fields = builder
+            .properties
+            .expect("link properties must survive the builder chain");
+        assert_eq!(
+            fields.get(&fe2o3_amqp_types::primitives::Symbol::from(
+                "com.microsoft:epoch"
+            )),
+            Some(&fe2o3_amqp_types::primitives::Value::Long(7))
+        );
+        assert_eq!(
+            fields.get(&fe2o3_amqp_types::primitives::Symbol::from(
+                "com.microsoft.com:receiver-name"
+            )),
+            Some(&fe2o3_amqp_types::primitives::Value::String(
+                "test-receiver".into()
+            ))
+        );
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
@@ -29,6 +29,63 @@ impl Fe2o3AmqpSender {
     }
 }
 
+/// The fe2o3 link builder for a sender, after the name, source and target are set.
+type Fe2o3SenderBuilder = fe2o3_amqp::link::builder::Builder<
+    fe2o3_amqp::link::role::SenderMarker,
+    fe2o3_amqp_types::messaging::Target,
+    fe2o3_amqp::link::builder::WithName,
+    fe2o3_amqp::link::builder::WithSource,
+    fe2o3_amqp::link::builder::WithTarget,
+>;
+
+/// Makes the fe2o3 link builder for a sender.
+///
+/// The order of the builder calls is important. In fe2o3-amqp 0.14, the
+/// `name`, `target`, `sender` and `receiver` methods change the type of the
+/// builder. They rebuild it and set `properties` back to the default value.
+/// Only `source` keeps the properties. So `name` and `target` must be called
+/// before `properties`. If they are not, the link properties are dropped and
+/// never reach the Attach frame.
+fn build_sender_link(
+    name: String,
+    target: AmqpTarget,
+    options: Option<AmqpSenderOptions>,
+) -> Fe2o3SenderBuilder {
+    let mut builder = fe2o3_amqp::Sender::builder().name(name).target(target);
+
+    if let Some(options) = options {
+        if let Some(sender_settle_mode) = options.sender_settle_mode {
+            builder = builder.sender_settle_mode(sender_settle_mode.into());
+        }
+        if let Some(receiver_settle_mode) = options.receiver_settle_mode {
+            builder = builder.receiver_settle_mode(receiver_settle_mode.into());
+        }
+        if let Some(max_message_size) = options.max_message_size {
+            builder = builder.max_message_size(max_message_size);
+        }
+        if let Some(source) = options.source {
+            builder = builder.source(source);
+        }
+        if let Some(offered_capabilities) = options.offered_capabilities {
+            builder = builder.set_offered_capabilities(
+                offered_capabilities.into_iter().map(Into::into).collect(),
+            );
+        }
+        if let Some(desired_capabilities) = options.desired_capabilities {
+            builder = builder.set_desired_capabilities(
+                desired_capabilities.into_iter().map(Into::into).collect(),
+            );
+        }
+        if let Some(properties) = options.properties {
+            builder = builder.properties(properties.into());
+        }
+        if let Some(initial_delivery_count) = options.initial_delivery_count {
+            builder = builder.initial_delivery_count(initial_delivery_count);
+        }
+    }
+    builder
+}
+
 #[async_trait::async_trait]
 impl AmqpSenderApis for Fe2o3AmqpSender {
     async fn attach(
@@ -38,45 +95,7 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
         target: impl Into<AmqpTarget> + Send,
         options: Option<AmqpSenderOptions>,
     ) -> Result<()> {
-        let mut session_builder = fe2o3_amqp::Sender::builder();
-
-        if let Some(options) = options {
-            // if let Some(link_credit) = options.link_credit {
-            //     session_builder = session_builder.link_credit(link_credit);
-            // }
-            if let Some(sender_settle_mode) = options.sender_settle_mode {
-                session_builder = session_builder.sender_settle_mode(sender_settle_mode.into());
-            }
-            if let Some(receiver_settle_mode) = options.receiver_settle_mode {
-                session_builder = session_builder.receiver_settle_mode(receiver_settle_mode.into());
-            }
-            if let Some(max_message_size) = options.max_message_size {
-                session_builder = session_builder.max_message_size(max_message_size);
-            }
-
-            if let Some(source) = options.source {
-                session_builder = session_builder.source(source);
-            }
-            if let Some(offered_capabilities) = options.offered_capabilities {
-                session_builder = session_builder.set_offered_capabilities(
-                    offered_capabilities.into_iter().map(Into::into).collect(),
-                );
-            }
-            if let Some(desired_capabilities) = options.desired_capabilities {
-                session_builder = session_builder.set_desired_capabilities(
-                    desired_capabilities.into_iter().map(Into::into).collect(),
-                );
-            }
-            if let Some(properties) = options.properties {
-                session_builder = session_builder.properties(properties.into());
-            }
-            if let Some(initial_delivery_count) = options.initial_delivery_count {
-                session_builder = session_builder.initial_delivery_count(initial_delivery_count);
-            }
-        }
-        let sender = session_builder
-            .name(name)
-            .target(target.into())
+        let sender = build_sender_link(name, target.into(), options)
             .attach(session.implementation.get()?.lock().await.borrow_mut())
             .await
             .map_err(AmqpError::from)?;
@@ -242,5 +261,40 @@ impl From<fe2o3_amqp::link::SenderAttachError> for AmqpError {
                 AmqpErrorKind::TransportImplementationError(Box::new(e)).into()
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Makes sure the link properties survive the fe2o3 builder chain. Both
+    // `name` and `target` clear the properties, so they must run before
+    // `properties`.
+    #[test]
+    fn sender_link_keeps_properties() {
+        let mut properties: AmqpOrderedMap<AmqpSymbol, AmqpValue> = AmqpOrderedMap::new();
+        properties.insert("com.microsoft:epoch".into(), AmqpValue::from(3i64));
+
+        let options = AmqpSenderOptions {
+            properties: Some(properties),
+            ..Default::default()
+        };
+        let target = AmqpTarget::builder()
+            .with_address("amqps://example.servicebus.windows.net/eh".to_string())
+            .build();
+
+        let builder = build_sender_link("test-sender".into(), target, Some(options));
+
+        assert_eq!(builder.name, "test-sender");
+        let fields = builder
+            .properties
+            .expect("link properties must survive the builder chain");
+        assert_eq!(
+            fields.get(&fe2o3_amqp_types::primitives::Symbol::from(
+                "com.microsoft:epoch"
+            )),
+            Some(&fe2o3_amqp_types::primitives::Value::Long(3))
+        );
     }
 }


### PR DESCRIPTION
## Summary

Link properties set through `AmqpReceiverOptions::properties` and `AmqpSenderOptions::properties` never reached the AMQP Attach frame. Both builder chains discarded them, so every link attached with `properties: None`.

## Motivation

In fe2o3-amqp 0.14.0, some link builder methods change the type of the builder. These methods rebuild the builder and reset the properties to the default value. `name` (`src/link/builder.rs:185`), `sender` (`:212`), `receiver` (`:239`) and `target` (`:305`) all discard the properties. Only `source` (`:278`) keeps them. Every other setter takes and returns `Self`, so its position in the chain does not matter.

The receiver chain called `.properties(...)` and then `.name(name)`. The sender chain called `.properties(...)`, then `.name(name)`, then `.target(...)`. The published 1.1.0 crate has the same order. The 1.2.0-beta.1 release does not fix either path.

Event Hubs sends the consumer owner level as the `com.microsoft:epoch` link property (`sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs:297-299`). The lost property made `OpenReceiverOptions::owner_level` a no-op. Receivers attached as ordinary readers, and the broker never displaced a lower-epoch consumer. The chain drops `com.microsoft.com:receiver-name` the same way, so the broker names the receiver `'nil'` in its rejection message.

A live run shows the defect. The outgoing Attach frame carries `properties: None`. A local copy of the published crate with the new order makes the broker displace the lower-epoch receiver at once. The broker reports `Receiver 'nil' with a higher epoch '1' already exists`.

Upstream fe2o3-amqp still has the reset on `main`. This change corrects the order in this repository.

## Changes

Each builder chain moves into a helper function, `build_receiver_link` and `build_sender_link`. Each helper calls the type-changing methods first. The receiver helper calls `name` and then `source`. The sender helper calls `name` and then `target`. Every later call returns `Self`, so a later call cannot drop the properties.

A reorder alone is not sufficient. It repairs the receiver but not the sender, because `target` resets the properties one call after `name`.

The helpers also make the chain assertable without a live session. The new tests need that.

Adds `receiver_link_keeps_properties` and `sender_link_keeps_properties`. Both build through the production helpers. Both assert that `com.microsoft:epoch` and the receiver name survive the chain, and that the link name stays intact.

The workspace pins `azure_core_amqp = "1.1.0"` from crates.io with no path override. `azure_messaging_eventhubs` picks up this fix after `azure_core_amqp` ships and the workspace version moves. A fix to the core crate alone does not make `owner_level` work for Event Hubs users.

## Test plan

- [x] `cargo test -p azure_core_amqp --all-features`: 115 passed and 3 passed, 0 failed.
- [x] Both new tests fail with the old order. Restoring the original chain and re-running gives `test result: FAILED. 0 passed; 1 failed`.
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and cspell with the repo config are clean.
- [x] `cargo build -p azure_messaging_eventhubs` still succeeds.
- [ ] Live re-run of `second_processor_displaces_first_with_consumer_disconnected` after `azure_core_amqp` ships and the workspace version moves. That test needs its own repair first.

## Related

Fixes #4804