### PR TITLE
fix(eventhubs): surface a stolen receiver link as ConsumerDisconnected

### DIFF
--- a/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### Bugs Fixed
 
 - Increased `DEFAULT_PARTITION_EXPIRATION_DURATION` from 10 seconds to 60 seconds. The previous default was shorter than `DEFAULT_UPDATE_INTERVAL` (30 seconds), so ownership records expired between load-balancing cycles. The load balancer perpetually saw `current=0` for every consumer and continuously re-claimed partitions, causing widespread duplicate event processing. `EventProcessorBuilder::build` now rejects configurations where `partition_expiration_duration <= update_interval`. ([#3851](https://github.com/Azure/azure-sdk-for-rust/issues/3851))
-- A partition stolen by a higher-or-equal-epoch attacher now surfaces as `ErrorKind::ConsumerDisconnected` when the broker reports `amqp:link:stolen` on a re-attach, not only on an in-flight receive. Other attach failures inside the receive loop are retryable again.
+- A partition stolen by a higher-or-equal-epoch attacher now surfaces as `ErrorKind::ConsumerDisconnected` when the broker reports `amqp:link:stolen` on a re-attach, not only on an in-flight receive. Other attach failures inside the receive loop now classify by their own kind. The wrapper reported all of them as a message error, which the retry decider treated as non-retryable.
 - The `EventProcessor`'s load-balancer reconciliation now closes the underlying AMQP receiver for any partition that has been reassigned to another consumer, so the consumer's `stream_events()` resolves and the loop can terminate. Previously a stolen partition's client could continue to attempt receives until the broker tore down the link.
 
 ### Other Changes

--- a/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bugs Fixed
 
 - Increased `DEFAULT_PARTITION_EXPIRATION_DURATION` from 10 seconds to 60 seconds. The previous default was shorter than `DEFAULT_UPDATE_INTERVAL` (30 seconds), so ownership records expired between load-balancing cycles. The load balancer perpetually saw `current=0` for every consumer and continuously re-claimed partitions, causing widespread duplicate event processing. `EventProcessorBuilder::build` now rejects configurations where `partition_expiration_duration <= update_interval`. ([#3851](https://github.com/Azure/azure-sdk-for-rust/issues/3851))
+- A partition stolen by a higher-or-equal-epoch attacher now surfaces as `ErrorKind::ConsumerDisconnected` when the broker reports `amqp:link:stolen` on a re-attach, not only on an in-flight receive. Other attach failures inside the receive loop are retryable again.
 - The `EventProcessor`'s load-balancer reconciliation now closes the underlying AMQP receiver for any partition that has been reassigned to another consumer, so the consumer's `stream_events()` resolves and the loop can terminate. Previously a stolen partition's client could continue to attempt receives until the broker tore down the link.
 
 ### Other Changes

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/connection.rs
@@ -91,6 +91,13 @@ pub(crate) struct RecoverableConnection {
 
     #[cfg(test)]
     forced_error: Mutex<Option<AmqpError>>,
+
+    // Separate from `forced_error`, which the per-operation wrappers
+    // (receive, send, management call) consume. This slot is consumed only
+    // by `ensure_receiver`, so a test can fail an attach without changing
+    // how the operation wrappers behave.
+    #[cfg(test)]
+    forced_attach_error: Mutex<Option<AmqpError>>,
 }
 
 unsafe impl Send for RecoverableConnection {}
@@ -200,6 +207,8 @@ impl RecoverableConnection {
                 authorizer,
                 #[cfg(test)]
                 forced_error: Mutex::new(None),
+                #[cfg(test)]
+                forced_attach_error: Mutex::new(None),
             }
         })
     }
@@ -231,6 +240,35 @@ impl RecoverableConnection {
             .forced_error
             .lock()
             .expect("Forced error lock is poisoned")
+            .take();
+        v.map_or(Ok(()), Err)
+    }
+
+    /// Makes the next `ensure_receiver` call fail with `error`.
+    ///
+    /// The injected error takes the same return path as a rejected link
+    /// attach: out of the `get_or_try_init` closure, through
+    /// `ensure_receiver` and `get_receiver`, and into the caller's error
+    /// handling. Tests use this to drive the attach-failure branch of
+    /// `EventReceiver::stream_events` without a live broker.
+    #[cfg(test)]
+    pub(crate) fn force_attach_error(&self, error: AmqpError) -> Result<()> {
+        use crate::EventHubsError;
+
+        let mut err = self
+            .forced_attach_error
+            .lock()
+            .map_err(|e| EventHubsError::with_message(e.to_string()))?;
+        *err = Some(error);
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn get_forced_attach_error(&self) -> azure_core_amqp::error::Result<()> {
+        let v = self
+            .forced_attach_error
+            .lock()
+            .expect("Forced attach error lock is poisoned")
             .take();
         v.map_or(Ok(()), Err)
     }
@@ -632,6 +670,12 @@ impl RecoverableConnection {
         let cell = self.receiver_cell(source_url).await;
         let receiver = cell
             .get_or_try_init(|| async {
+                // Test seam: fail the attach with an injected error before
+                // any network activity. The error leaves this closure on the
+                // same path a rejected `receiver.attach` below takes.
+                #[cfg(test)]
+                self.get_forced_attach_error()?;
+
                 self.ensure_connection().await?;
                 self.authorizer.authorize_path(self, source_url).await?;
 
@@ -995,31 +1039,10 @@ impl RecoverableConnection {
 
     /// Returns true if `amqp_error` is, or wraps via its [`std::error::Error::source`]
     /// chain, an [`AmqpErrorKind::AmqpDescribedError`] whose condition is `LinkStolen`.
-    /// Mirrors the bounded walk in [`Self::classify_azure_core_chain`].
+    /// The stream translation uses the same walk, so both agree on what counts
+    /// as a stolen link.
     fn is_link_stolen(amqp_error: &AmqpError) -> bool {
-        use std::error::Error as _;
-        const MAX_DEPTH: usize = 16;
-        fn is_stolen(e: &AmqpError) -> bool {
-            matches!(
-                e.kind(),
-                AmqpErrorKind::AmqpDescribedError(d)
-                    if matches!(d.condition, AmqpErrorCondition::LinkStolen)
-            )
-        }
-        if is_stolen(amqp_error) {
-            return true;
-        }
-        let mut cause: Option<&(dyn std::error::Error + 'static)> = amqp_error.source();
-        for _ in 0..MAX_DEPTH {
-            let Some(c) = cause else { break };
-            if let Some(amqp) = c.downcast_ref::<AmqpError>() {
-                if is_stolen(amqp) {
-                    return true;
-                }
-            }
-            cause = c.source();
-        }
-        false
+        crate::error::find_link_stolen(amqp_error).is_some()
     }
 
     /// Walks the [`std::error::Error::source`] chain looking for a wrapped [`AmqpError`]

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/mod.rs
@@ -4,7 +4,7 @@
 mod claims_based_security;
 mod connection;
 mod management;
-mod receiver;
+pub(crate) mod receiver;
 mod sender;
 
 pub(crate) use connection::RecoverableConnection;

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/receiver.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/recoverable/receiver.rs
@@ -40,6 +40,22 @@ impl RecoverableReceiver {
     fn should_retry_receive_operation(e: &AmqpError) -> ErrorRecoveryAction {
         RecoverableConnection::should_retry_receive_error(e)
     }
+
+    /// Wraps an `ensure_receiver` failure so the original error stays reachable
+    /// through the source chain.
+    ///
+    /// A re-attach that the broker rejects with `amqp:link:stolen` arrives here
+    /// as an `AmqpDescribedError`. Flattening it into a message string would
+    /// destroy the condition, so the retry decider and the stream translation
+    /// could no longer tell a stolen partition from any other attach failure.
+    /// This mirrors the wrapper the sender and CBS paths use.
+    pub(crate) fn ensure_receiver_error(e: AmqpError) -> AmqpError {
+        AmqpError::from(azure_core::Error::with_error(
+            AzureErrorKind::Other,
+            e,
+            "Failed to ensure receiver",
+        ))
+    }
 }
 
 impl Drop for RecoverableReceiver {
@@ -102,9 +118,7 @@ impl AmqpReceiverApis for RecoverableReceiver {
                             &self.receiver_options,
                         )
                         .await
-                        .map_err(|e| {
-                            AmqpError::with_message(format!("Failed to ensure receiver: {e}"))
-                        })?
+                        .map_err(Self::ensure_receiver_error)?
                 };
                 if let Some(delivery_timeout) = self.timeout {
                     select! {
@@ -144,5 +158,75 @@ impl AmqpReceiverApis for RecoverableReceiver {
 
     async fn release_delivery(&self, _delivery: &azure_core_amqp::AmqpDelivery) -> Result<()> {
         unimplemented!("AmqpReceiverClient does not support release_delivery operation");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::{find_link_stolen, ErrorKind};
+    use azure_core_amqp::{
+        error::{AmqpErrorCondition, AmqpErrorKind},
+        AmqpDescribedError,
+    };
+
+    fn stolen() -> AmqpError {
+        AmqpError::from(AmqpErrorKind::AmqpDescribedError(AmqpDescribedError::new(
+            AmqpErrorCondition::LinkStolen,
+            None,
+            Default::default(),
+        )))
+    }
+
+    // The broker rejects a re-attach at the old epoch with `amqp:link:stolen`.
+    // The wrapper must keep that condition reachable. Before the fix the
+    // wrapper was `AmqpError::with_message`, which has no source, so the
+    // condition was gone and the stream reported a plain AMQP error.
+    #[test]
+    fn ensure_receiver_error_keeps_link_stolen_reachable() {
+        let wrapped = RecoverableReceiver::ensure_receiver_error(stolen());
+        assert!(
+            find_link_stolen(&wrapped).is_some(),
+            "wrapper lost the link-stolen condition: {wrapped}"
+        );
+    }
+
+    // The retry decider must see through the wrapper and refuse to reattach a
+    // stolen link.
+    #[test]
+    fn ensure_receiver_error_is_not_retried_when_link_stolen() {
+        let wrapped = RecoverableReceiver::ensure_receiver_error(stolen());
+        assert_eq!(
+            RecoverableReceiver::should_retry_receive_operation(&wrapped),
+            ErrorRecoveryAction::ReturnError
+        );
+    }
+
+    // The wrapped error must still convert into the typed variant once it
+    // reaches the caller.
+    #[test]
+    fn ensure_receiver_error_surfaces_as_consumer_disconnected() {
+        let wrapped = RecoverableReceiver::ensure_receiver_error(stolen());
+        let described = find_link_stolen(&wrapped).cloned();
+        let error = crate::error::EventHubsError::from(ErrorKind::ConsumerDisconnected(described));
+        assert!(matches!(
+            error.kind,
+            ErrorKind::ConsumerDisconnected(Some(_))
+        ));
+    }
+
+    // A non-stolen attach failure keeps its own classification, so the retry
+    // layer can still recover a transport-level attach failure.
+    #[test]
+    fn ensure_receiver_error_preserves_other_kinds() {
+        let inner = AmqpError::from(AmqpErrorKind::LinkClosedByRemote(Box::new(
+            std::io::Error::other("closed"),
+        )));
+        let wrapped = RecoverableReceiver::ensure_receiver_error(inner);
+        assert!(find_link_stolen(&wrapped).is_none());
+        assert_eq!(
+            RecoverableReceiver::should_retry_receive_operation(&wrapped),
+            ErrorRecoveryAction::ReconnectLink
+        );
     }
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/event_receiver.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/event_receiver.rs
@@ -3,14 +3,14 @@
 
 use crate::{
     common::recoverable::RecoverableConnection,
-    error::{ErrorKind, EventHubsError, Result},
+    error::{find_link_stolen, ErrorKind, EventHubsError, Result},
     models::ReceivedEventData,
 };
 use async_stream::try_stream;
 use azure_core::{http::Url, time::Duration};
 use azure_core_amqp::{
-    error::{AmqpErrorCondition, AmqpErrorKind},
-    AmqpDeliveryApis as _, AmqpError, AmqpReceiverApis as _, AmqpReceiverOptions, AmqpSource,
+    error::AmqpErrorKind, AmqpDeliveryApis as _, AmqpError, AmqpReceiverApis as _,
+    AmqpReceiverOptions, AmqpSource,
 };
 use futures::Stream;
 use std::sync::{
@@ -31,18 +31,21 @@ fn translate_receive_error(
     partition_id: &str,
     source_url: &Url,
 ) -> EventHubsError {
+    // The condition can be wrapped: a re-attach rejected with `amqp:link:stolen`
+    // reaches this point inside the `ensure_receiver` wrapper, so look at the
+    // whole source chain and not only the top-level kind.
+    if let Some(described) = find_link_stolen(&error) {
+        // Broker displaced this consumer (a higher epoch/owner attached).
+        // Recoverable on the processor path, so warn rather than error.
+        warn!(
+            partition_id = %partition_id,
+            source_url = %source_url,
+            condition = ?described.condition,
+            "Receiver link stolen by the broker (epoch displacement); mapping to ConsumerDisconnected."
+        );
+        return EventHubsError::from(ErrorKind::ConsumerDisconnected(Some(described.clone())));
+    }
     if let AmqpErrorKind::AmqpDescribedError(described) = error.kind() {
-        if matches!(described.condition, AmqpErrorCondition::LinkStolen) {
-            // Broker displaced this consumer (a higher epoch/owner attached).
-            // Recoverable on the processor path, so warn rather than error.
-            warn!(
-                partition_id = %partition_id,
-                source_url = %source_url,
-                condition = ?described.condition,
-                "Receiver link stolen by the broker (epoch displacement); mapping to ConsumerDisconnected."
-            );
-            return EventHubsError::from(ErrorKind::ConsumerDisconnected(Some(described.clone())));
-        }
         warn!(
             partition_id = %partition_id,
             source_url = %source_url,
@@ -58,6 +61,34 @@ fn translate_receive_error(
         );
     }
     EventHubsError::from(error)
+}
+
+/// Maps `amqp:link:stolen` on the attach path to `ConsumerDisconnected`.
+///
+/// The stream re-attaches on every loop iteration, so the broker can reject the
+/// attach itself with `amqp:link:stolen` rather than failing an in-flight
+/// receive. Without this, the same displacement would surface as a plain
+/// `ErrorKind::AmqpError` only because it took the attach path.
+fn translate_attach_error(
+    error: EventHubsError,
+    partition_id: &str,
+    source_url: &Url,
+) -> EventHubsError {
+    let ErrorKind::AmqpError(amqp_error) = &error.kind else {
+        return error;
+    };
+    match find_link_stolen(amqp_error) {
+        Some(described) => {
+            warn!(
+                partition_id = %partition_id,
+                source_url = %source_url,
+                condition = ?described.condition,
+                "Receiver attach rejected by the broker (epoch displacement); mapping to ConsumerDisconnected."
+            );
+            EventHubsError::from(ErrorKind::ConsumerDisconnected(Some(described.clone())))
+        }
+        None => error,
+    }
 }
 
 /// A message receiver that can be used to receive messages from an Event Hub.
@@ -203,7 +234,8 @@ impl EventReceiver {
                     self.message_source.clone(),
                     self.receiver_options.clone(),
                     self.timeout
-                ).instrument(span.clone()).await?;
+                ).instrument(span.clone()).await
+                    .map_err(|e| translate_attach_error(e, &self.partition_id, &self.source_url))?;
 
                 let delivery = receiver
                     .receive_delivery()
@@ -247,5 +279,183 @@ impl EventReceiver {
 impl Drop for EventReceiver {
     fn drop(&mut self) {
         trace!("Dropping EventReceiver for partition {}", self.partition_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use azure_core_amqp::{error::AmqpErrorCondition, AmqpDescribedError};
+
+    fn source_url() -> Url {
+        Url::parse("amqps://example.servicebus.windows.net/eh/Partitions/0").unwrap()
+    }
+
+    fn stolen() -> AmqpError {
+        AmqpError::from(AmqpErrorKind::AmqpDescribedError(AmqpDescribedError::new(
+            AmqpErrorCondition::LinkStolen,
+            Some("New receiver with higher epoch of '1' is created".to_string()),
+            Default::default(),
+        )))
+    }
+
+    /// Wraps an error exactly as the receive retry loop does for an attach
+    /// failure. This calls the production wrapper rather than copying its
+    /// shape, so a change to the wrapper cannot leave these tests passing
+    /// against a shape that no longer exists.
+    fn wrapped_in_ensure_receiver(inner: AmqpError) -> AmqpError {
+        crate::common::recoverable::receiver::RecoverableReceiver::ensure_receiver_error(inner)
+    }
+
+    // A stolen link reported directly on the receive path is the case the
+    // 0.15.0 CHANGELOG documents.
+    #[test]
+    fn translate_receive_error_maps_top_level_link_stolen() {
+        let translated = translate_receive_error(stolen(), "0", &source_url());
+        assert!(matches!(
+            translated.kind,
+            ErrorKind::ConsumerDisconnected(Some(_))
+        ));
+    }
+
+    // The broker can reject the re-attach instead of the in-flight receive. The
+    // condition then reaches the stream wrapped by `ensure_receiver`. Before the
+    // fix this wrapper was a message string, so the condition was lost and the
+    // caller saw `ErrorKind::AmqpError`.
+    #[test]
+    fn translate_receive_error_maps_link_stolen_wrapped_by_ensure_receiver() {
+        let translated =
+            translate_receive_error(wrapped_in_ensure_receiver(stolen()), "0", &source_url());
+        assert!(
+            matches!(translated.kind, ErrorKind::ConsumerDisconnected(Some(_))),
+            "expected ConsumerDisconnected, got {:?}",
+            translated.kind
+        );
+    }
+
+    // Other conditions must keep their existing shape.
+    #[test]
+    fn translate_receive_error_passes_other_conditions_through() {
+        let other = AmqpError::from(AmqpErrorKind::AmqpDescribedError(AmqpDescribedError::new(
+            AmqpErrorCondition::ServerBusyError,
+            None,
+            Default::default(),
+        )));
+        let translated = translate_receive_error(other, "0", &source_url());
+        assert!(matches!(translated.kind, ErrorKind::AmqpError(_)));
+    }
+
+    #[test]
+    fn translate_receive_error_passes_non_described_errors_through() {
+        let translated =
+            translate_receive_error(AmqpError::with_message("boom"), "0", &source_url());
+        assert!(matches!(translated.kind, ErrorKind::AmqpError(_)));
+    }
+
+    // The stream re-attaches on every loop iteration, so a displacement can be
+    // reported by `get_receiver` and never touch the receive path at all.
+    #[test]
+    fn translate_attach_error_maps_link_stolen() {
+        let attach_error = EventHubsError::from(stolen());
+        let translated = translate_attach_error(attach_error, "0", &source_url());
+        assert!(
+            matches!(translated.kind, ErrorKind::ConsumerDisconnected(Some(_))),
+            "expected ConsumerDisconnected, got {:?}",
+            translated.kind
+        );
+    }
+
+    #[test]
+    fn translate_attach_error_maps_link_stolen_wrapped_in_azure_core() {
+        let attach_error = EventHubsError::from(wrapped_in_ensure_receiver(stolen()));
+        let translated = translate_attach_error(attach_error, "0", &source_url());
+        assert!(
+            matches!(translated.kind, ErrorKind::ConsumerDisconnected(Some(_))),
+            "expected ConsumerDisconnected, got {:?}",
+            translated.kind
+        );
+    }
+
+    /// Builds an `EventReceiver` over a real `RecoverableConnection` whose
+    /// next receiver attach fails with `attach_error`. No network activity
+    /// happens: the injected error stops `ensure_receiver` before it opens
+    /// a connection.
+    fn receiver_with_failing_attach(attach_error: AmqpError) -> EventReceiver {
+        let connection = RecoverableConnection::new(
+            Url::parse("amqps://example.servicebus.windows.net").unwrap(),
+            None,
+            None,
+            Arc::new(azure_core_test::credentials::MockCredential),
+            Default::default(),
+            None,
+        );
+        connection.force_attach_error(attach_error).unwrap();
+        EventReceiver::new(
+            connection,
+            AmqpReceiverOptions::default(),
+            AmqpSource::builder()
+                .with_address(source_url().to_string())
+                .build(),
+            source_url(),
+            "0".to_string(),
+            None,
+        )
+    }
+
+    // Drives the real stream. The function-level tests above prove what
+    // `translate_attach_error` does when it is called; only this test proves
+    // that `stream_events` calls it on the `get_receiver` failure path. If
+    // the `map_err` at that call site is removed, the error surfaces as
+    // `ErrorKind::AmqpError` and this test fails.
+    #[tokio::test]
+    async fn stream_events_maps_stolen_attach_to_consumer_disconnected() {
+        use futures::StreamExt;
+
+        let receiver = receiver_with_failing_attach(stolen());
+        let mut stream = std::pin::pin!(receiver.stream_events());
+        let error = stream
+            .next()
+            .await
+            .expect("the stream yields the attach failure")
+            .expect_err("the injected attach error must surface");
+        assert!(
+            matches!(error.kind, ErrorKind::ConsumerDisconnected(Some(_))),
+            "expected ConsumerDisconnected, got {:?}",
+            error.kind
+        );
+    }
+
+    // A non-stolen attach failure must keep its kind through the same path,
+    // so callers cannot mistake a transport failure for a stolen partition.
+    #[tokio::test]
+    async fn stream_events_passes_other_attach_errors_through() {
+        use futures::StreamExt;
+
+        let receiver = receiver_with_failing_attach(AmqpError::with_message("attach failed"));
+        let mut stream = std::pin::pin!(receiver.stream_events());
+        let error = stream
+            .next()
+            .await
+            .expect("the stream yields the attach failure")
+            .expect_err("the injected attach error must surface");
+        assert!(
+            matches!(error.kind, ErrorKind::AmqpError(_)),
+            "expected AmqpError, got {:?}",
+            error.kind
+        );
+    }
+
+    // An attach that fails for any other reason keeps its kind, so callers that
+    // match on `ConsumerDisconnected` do not treat a transport failure as a
+    // stolen partition.
+    #[test]
+    fn translate_attach_error_passes_other_errors_through() {
+        let attach_error = EventHubsError::from(AmqpError::with_message("attach failed"));
+        let translated = translate_attach_error(attach_error, "0", &source_url());
+        assert!(matches!(translated.kind, ErrorKind::AmqpError(_)));
+
+        let attach_error = EventHubsError::with_message("not an AMQP error");
+        let translated = translate_attach_error(attach_error, "0", &source_url());
+        assert!(matches!(translated.kind, ErrorKind::SimpleMessage(_)));
     }
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/error.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/error.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All Rights Reserved.
 // Licensed under the MIT License.
 
-use azure_core_amqp::{AmqpDescribedError, AmqpError};
+use azure_core_amqp::{
+    error::{AmqpErrorCondition, AmqpErrorKind},
+    AmqpDescribedError, AmqpError,
+};
 use std::borrow::Cow;
 
 /// A specialized `Result` type for Event Hubs operations.
@@ -90,6 +93,45 @@ impl From<ErrorKind> for EventHubsError {
     fn from(kind: ErrorKind) -> Self {
         Self { kind }
     }
+}
+
+/// Maximum number of links to follow in an error source chain. It stops a
+/// pathological self-referential chain from looping forever.
+const MAX_ERROR_CHAIN_DEPTH: usize = 16;
+
+/// Returns the `amqp:link:stolen` described error if `error` is one, or wraps
+/// one in its [`std::error::Error::source`] chain.
+///
+/// The condition can arrive at the top level (an in-flight receive, or a
+/// re-attach that the broker rejected) or wrapped through `azure_core::Error`
+/// by the `ensure_*` wrappers. Both must be recognized, so the whole chain is
+/// walked instead of only the top-level kind.
+pub(crate) fn find_link_stolen(error: &AmqpError) -> Option<&AmqpDescribedError> {
+    use std::error::Error as _;
+    fn described(e: &AmqpError) -> Option<&AmqpDescribedError> {
+        match e.kind() {
+            AmqpErrorKind::AmqpDescribedError(d)
+                if matches!(d.condition, AmqpErrorCondition::LinkStolen) =>
+            {
+                Some(d)
+            }
+            _ => None,
+        }
+    }
+    if let Some(d) = described(error) {
+        return Some(d);
+    }
+    let mut cause: Option<&(dyn std::error::Error + 'static)> = error.source();
+    for _ in 0..MAX_ERROR_CHAIN_DEPTH {
+        let c = cause?;
+        if let Some(amqp) = c.downcast_ref::<AmqpError>() {
+            if let Some(d) = described(amqp) {
+                return Some(d);
+            }
+        }
+        cause = c.source();
+    }
+    None
 }
 
 impl From<AmqpError> for EventHubsError {


### PR DESCRIPTION
## Summary

A receiver displaced by a higher-or-equal-epoch attacher reported `ErrorKind::AmqpError("Failed to ensure receiver: ...")`. It now reports `ErrorKind::ConsumerDisconnected`.

This change alone covers a displacement by a HIGHER epoch. The equal-epoch case needs #4815 as well. `EventProcessor` opens every receiver at owner level 0, so two processor instances are an equal-epoch contest, and that scenario needs both changes. See Changes for the measurements.

## Motivation

The 0.15.0 changelog, added by #4439, tells consumers to match on `ErrorKind::ConsumerDisconnected` to detect a stolen partition and re-acquire a client. That pattern did not work.

`ensure_receiver` flattened every attach failure into `AmqpError::with_message(format!("Failed to ensure receiver: {e}"))`. `AmqpErrorKind::SimpleMessage` returns `None` from `source()`, so the flattening cut the described error out of the chain. The re-attach rejection carries a proper `AmqpDescribedError`, and the wrapper discarded it. The existing test `receive_error_link_stolen_returns_error_top_level_and_wrapped` asserts against the `azure_core::Error::with_error` shape that the sender and CBS paths use, so it never covered this wrapper.

`get_receiver` returned through a `?` that reached no translation. A first-attach or post-recovery rejection therefore surfaced untranslated.

The flattening had a second effect. Every attach failure collapsed to `SimpleMessage`, so the retry decider fell through to its catch-all `ReturnError` arm. Ordinary transient attach failures inside the receive loop lost their real classification.

## Changes

`ensure_receiver`'s error path moves into `ensure_receiver_error` and uses `azure_core::Error::with_error(..., e, "Failed to ensure receiver")`, so the described error stays reachable through the source chain.

A new `pub(crate) find_link_stolen(&AmqpError) -> Option<&AmqpDescribedError>` walks the source chain once, with a bound of 16 hops. The retry decider and both translation points share it. `is_link_stolen` in the connection now calls it, which removes a duplicate walk. `translate_receive_error` uses it instead of reading only the top-level kind, and a new `translate_attach_error` covers the `get_receiver` path.

This change does not touch the retry policy. With the wrapper fixed, `should_retry_receive_error` reads the stolen condition through the chain and returns `ReturnError`, so the intent of #4439 takes effect.

A `#[cfg(test)]` slot on `RecoverableConnection` fails the next `ensure_receiver`. It is separate from `forced_error`, which the per-operation wrappers consume, because the stream calls `get_receiver` before `receive_delivery` on every loop iteration. The injected error leaves the init closure on the same path a rejected attach takes, which makes the attach branch of `stream_events` reachable without a broker.

This change does not break the API. `ErrorKind` is `#[non_exhaustive]`, and no variant is added or removed.

### Why the equal-epoch case needs #4815

A live run measured both cases, with the owner level reaching the wire.

At a higher epoch the broker refuses the re-attach, and that refusal carries the described error this change reads. The displaced receiver reports `ConsumerDisconnected(Some(LinkStolen))`.

At an equal epoch the broker accepts every attach and the later attacher wins. Across 86 seconds it accepted 15 attaches, refused none, and sent 13 Detach frames with condition `LinkStolen`. The refusal path does not fire, so this change has nothing to read. The recoverable layer sees an opaque link-state error, re-attaches, and steals the link back. The two receivers traded the partition about every 5 seconds and neither reported an error.

#4815 makes the in-flight stolen condition readable. With it applied, the same equal-epoch contest reports `ConsumerDisconnected(Some(LinkStolen))` about 7 seconds after the second receiver attaches, after exactly one Attach. Two `EventProcessor` instances behave the same way: without #4815 a displacement is silent or opaque, and with it every displaced partition reader reports the documented kind.

## Test plan

- [x] `cargo test -p azure_messaging_eventhubs --lib`: 122 passed, 0 failed.
- [x] Four tests fail before the fix. `translate_receive_error_maps_link_stolen_wrapped_by_ensure_receiver` fails with the reported symptom: `got AmqpError(AMQP Error: Azure Core Error: Failed to ensure receiver)`.
- [x] `stream_events_maps_stolen_attach_to_consumer_disconnected` fails when the `map_err` at the `get_receiver` call site is deleted, which guards the wiring. `stream_events_passes_other_attach_errors_through` guards the other direction.
- [x] Live run, higher epoch: the displaced receiver reports `ConsumerDisconnected(Some(LinkStolen))`.
- [x] Live run, equal epoch: silent link trading without #4815, and `ConsumerDisconnected(Some(LinkStolen))` with it.
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and cspell with the repo config are clean.

## Related

#4815 is required for the `EventProcessor` scenario, which is an equal-epoch contest. Merge that one as well.

#4805 puts the owner level on the wire and has merged. Without it no displacement happens at all.