### PR TITLE
cosmos: Fix up azure_core/azure_identity references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,10 +287,13 @@ dependencies = [
  "azure_core_macros 1.0.0",
  "bytes",
  "futures",
+ "hmac",
+ "openssl",
  "pin-project",
  "rustc_version",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tracing",
  "typespec 1.1.0",
@@ -517,10 +520,10 @@ version = "0.37.0"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core 1.2.0-beta.1",
- "azure_core_test 0.2.0",
+ "azure_core 1.1.0",
+ "azure_core_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure_data_cosmos_driver",
- "azure_identity 1.1.0-beta.1",
+ "azure_identity 1.0.0",
  "base64",
  "clap",
  "futures",
@@ -542,7 +545,7 @@ name = "azure_data_cosmos_benchmarks"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "azure_core 1.2.0-beta.1",
+ "azure_core 1.1.0",
  "azure_data_cosmos_driver",
  "criterion",
  "tokio",
@@ -556,9 +559,9 @@ dependencies = [
  "arc-swap",
  "async-lock",
  "async-trait",
- "azure_core 1.2.0-beta.1",
+ "azure_core 1.1.0",
  "azure_data_cosmos_macros 0.2.0",
- "azure_identity 1.1.0-beta.1",
+ "azure_identity 1.0.0",
  "backtrace",
  "base64",
  "bytes",
@@ -584,7 +587,7 @@ dependencies = [
 name = "azure_data_cosmos_driver_native"
 version = "0.1.0"
 dependencies = [
- "azure_core 1.2.0-beta.1",
+ "azure_core 1.1.0",
  "azure_data_cosmos_driver",
  "cbindgen",
  "futures",
@@ -619,10 +622,10 @@ name = "azure_data_cosmos_perf"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "azure_core 1.2.0-beta.1",
+ "azure_core 1.1.0",
  "azure_data_cosmos",
  "azure_data_cosmos_driver",
- "azure_identity 1.1.0-beta.1",
+ "azure_identity 1.0.0",
  "clap",
  "console-subscriber",
  "futures",

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["api-bindings"]
 [dependencies]
 async-lock.workspace = true
 async-trait.workspace = true
-azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1", default-features = false }
+azure_core = { workspace = true, default-features = false }
 azure_data_cosmos_driver = { version = "0.6.0", path = "../azure_data_cosmos_driver", default-features = false }
 base64.workspace = true
 futures.workspace = true
@@ -32,7 +32,7 @@ url.workspace = true
 # `tokio test-util` entries below merge into existing features and add no
 # compile-time cost.
 [dev-dependencies]
-azure_core_test = { path = "../../core/azure_core_test", features = ["tracing"] }
+azure_core_test = { workspace = true, features = ["tracing"] }
 # Re-declare the driver here with the internal test-only diagnostics-construction feature.
 # Putting it in dev-dependencies (instead of [dependencies]) means downstream consumers
 # of `azure_data_cosmos` do NOT compile with this feature enabled — the driver's
@@ -49,7 +49,7 @@ azure_core_test = { path = "../../core/azure_core_test", features = ["tracing"] 
 azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", default-features = false, features = [
   "__internal_test_diagnostics_construction",
 ] }
-azure_identity = { path = "../../identity/azure_identity" }
+azure_identity.workspace = true
 clap.workspace = true
 reqwest = { workspace = true, features = ["http2"] }
 serde = { workspace = true, features = ["derive"] }

--- a/sdk/cosmos/azure_data_cosmos_benchmarks/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_benchmarks/Cargo.toml
@@ -19,7 +19,7 @@ harness = false
 
 [dependencies]
 async-trait.workspace = true
-azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1" }
+azure_core.workspace = true
 azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", version = "0.6.0", features = [
   "__internal_mocking",
   "__internal_backtrace_bench",

--- a/sdk/cosmos/azure_data_cosmos_driver/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_driver/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["api-bindings"]
 arc-swap.workspace = true
 async-lock.workspace = true
 async-trait.workspace = true
-azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1", default-features = false, features = [
+azure_core = { workspace = true, default-features = false, features = [
   "hmac_rust",
 ] }
 azure_data_cosmos_macros = "0.2.0"
@@ -40,7 +40,7 @@ url.workspace = true
 uuid = { workspace = true, features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
-azure_identity = { path = "../../identity/azure_identity" }
+azure_identity.workspace = true
 quick-xml.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = [

--- a/sdk/cosmos/azure_data_cosmos_driver_native/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/Cargo.toml
@@ -31,7 +31,7 @@ azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", version = "0.
 # `azure_core::credentials` and `Url::parse` is the gate for the account
 # endpoint. Both are zero-cost wrappers around existing driver deps so
 # they don't grow the closure.
-azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1", default-features = false }
+azure_core = { workspace = true, default-features = false }
 url = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time", "macros"] }
 # `FutureExt::catch_unwind` is used by the submit pipeline to keep the
@@ -43,7 +43,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 # Path-only — the driver crate is not (yet) a workspace dependency.
-azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1", default-features = false }
+azure_core = { workspace = true, default-features = false }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time", "macros", "test-util"] }
 
 [build-dependencies]

--- a/sdk/cosmos/azure_data_cosmos_perf/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_perf/Cargo.toml
@@ -11,10 +11,10 @@ rust-version.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1", features = ["reqwest"] }
+azure_core = { workspace = true, features = ["reqwest"] }
 azure_data_cosmos = { path = "../azure_data_cosmos", version = "0.37.0", features = ["key_auth"] }
 azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", version = "0.6.0" }
-azure_identity = { path = "../../identity/azure_identity", version = "1.1.0-beta.1" }
+azure_identity = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 console-subscriber = { workspace = true, optional = true }
 futures.workspace = true


### PR DESCRIPTION
Fix up our `azure_core` and `azure_identity` references back to the latest released versions, instead of unreleased in-repo versions.