### PR TITLE
fix(amqp): report the link-state kind on a failed receive

### DIFF
--- a/sdk/core/azure_core_amqp/CHANGELOG.md
+++ b/sdk/core/azure_core_amqp/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Link properties set through `AmqpReceiverOptions::properties` and `AmqpSenderOptions::properties` now reach the Attach frame. They were discarded before the link attached.
+- A failed receive now reports the link-state kind the sender path already reports: `AmqpDescribedError` when the remote closed or detached with an AMQP error, and `LinkClosedByRemote` or `LinkDetachedByRemote` otherwise. All of these previously reported `LinkStateError`.
 
 ### Other Changes
 

--- a/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
@@ -247,8 +247,13 @@ impl From<fe2o3_amqp::link::ReceiverAttachError> for AmqpError {
 impl From<fe2o3_amqp::link::RecvError> for AmqpError {
     fn from(e: fe2o3_amqp::link::RecvError) -> Self {
         match e {
-            fe2o3_amqp::link::RecvError::LinkStateError(_) => {
-                AmqpErrorKind::LinkStateError(Box::new(e)).into()
+            // Delegate to the `LinkStateError` conversion so a remote close or
+            // detach that carries an AMQP error (for example `amqp:link:stolen`)
+            // becomes an `AmqpDescribedError`. Keeping the condition reachable
+            // lets callers classify the failure. The sender path already does
+            // this for `SendError::LinkStateError`.
+            fe2o3_amqp::link::RecvError::LinkStateError(link_state_error) => {
+                AmqpError::from(link_state_error)
             }
             fe2o3_amqp::link::RecvError::TransferLimitExceeded => {
                 AmqpErrorKind::TransferLimitExceeded(Box::new(e)).into()
@@ -316,6 +321,96 @@ mod tests {
             Some(&fe2o3_amqp_types::primitives::Value::String(
                 "test-receiver".into()
             ))
+        );
+    }
+
+    use crate::error::AmqpErrorCondition;
+
+    fn stolen_error() -> fe2o3_amqp_types::definitions::Error {
+        fe2o3_amqp_types::definitions::Error::new(
+            fe2o3_amqp_types::definitions::LinkError::Stolen,
+            Some("New receiver 'x' with higher epoch of '1' is created".to_string()),
+            None,
+        )
+    }
+
+    // A receive that fails because the broker closed the link with
+    // `amqp:link:stolen` must keep the described error. If it collapses to
+    // `LinkStateError`, the condition is only reachable through a fe2o3 type
+    // and no caller can classify the displacement.
+    #[test]
+    fn recv_link_state_remote_closed_with_error_keeps_described_error() {
+        let recv_error = fe2o3_amqp::link::RecvError::LinkStateError(
+            fe2o3_amqp::link::LinkStateError::RemoteClosedWithError(stolen_error()),
+        );
+        let amqp_error = AmqpError::from(recv_error);
+        match amqp_error.kind() {
+            AmqpErrorKind::AmqpDescribedError(described) => {
+                assert_eq!(described.condition, AmqpErrorCondition::LinkStolen);
+            }
+            _ => panic!("expected AmqpDescribedError, got {amqp_error:?}"),
+        }
+    }
+
+    #[test]
+    fn recv_link_state_remote_detached_with_error_keeps_described_error() {
+        let recv_error = fe2o3_amqp::link::RecvError::LinkStateError(
+            fe2o3_amqp::link::LinkStateError::RemoteDetachedWithError(stolen_error()),
+        );
+        let amqp_error = AmqpError::from(recv_error);
+        match amqp_error.kind() {
+            AmqpErrorKind::AmqpDescribedError(described) => {
+                assert_eq!(described.condition, AmqpErrorCondition::LinkStolen);
+            }
+            _ => panic!("expected AmqpDescribedError, got {amqp_error:?}"),
+        }
+    }
+
+    // A plain remote close with no error keeps its transport-level kind so the
+    // retry layer still classifies it as a link reattach.
+    #[test]
+    fn recv_link_state_remote_closed_maps_to_link_closed_by_remote() {
+        let recv_error = fe2o3_amqp::link::RecvError::LinkStateError(
+            fe2o3_amqp::link::LinkStateError::RemoteClosed,
+        );
+        let amqp_error = AmqpError::from(recv_error);
+        assert!(matches!(
+            amqp_error.kind(),
+            AmqpErrorKind::LinkClosedByRemote(_)
+        ));
+    }
+
+    // A plain remote detach with no error keeps its own kind, separate from a
+    // remote close. The two arms are distinct, so both need a test.
+    #[test]
+    fn recv_link_state_remote_detached_maps_to_link_detached_by_remote() {
+        let recv_error = fe2o3_amqp::link::RecvError::LinkStateError(
+            fe2o3_amqp::link::LinkStateError::RemoteDetached,
+        );
+        let amqp_error = AmqpError::from(recv_error);
+        assert!(matches!(
+            amqp_error.kind(),
+            AmqpErrorKind::LinkDetachedByRemote(_)
+        ));
+    }
+
+    // A link-state failure that is neither a close nor a detach still reports
+    // `LinkStateError`, and it now carries the `LinkStateError` itself. It
+    // carried the enclosing `RecvError` before the delegation.
+    #[test]
+    fn recv_link_state_other_carries_the_link_state_error() {
+        let recv_error = fe2o3_amqp::link::RecvError::LinkStateError(
+            fe2o3_amqp::link::LinkStateError::IllegalSessionState,
+        );
+        let amqp_error = AmqpError::from(recv_error);
+        let AmqpErrorKind::LinkStateError(source) = amqp_error.kind() else {
+            panic!("a link-state failure must report LinkStateError");
+        };
+        assert!(
+            source
+                .downcast_ref::<fe2o3_amqp::link::LinkStateError>()
+                .is_some(),
+            "the reported error must carry the LinkStateError, not the enclosing RecvError"
         );
     }
 }


### PR DESCRIPTION
## Summary

A receive that fails on a link-state error reported `AmqpErrorKind::LinkStateError` for every case. The AMQP condition, for example `amqp:link:stolen`, stayed inside a `fe2o3-amqp` type that callers cannot inspect.

## Motivation

`From<RecvError>` matched `RecvError::LinkStateError(_)` and built `AmqpErrorKind::LinkStateError` directly. It did not delegate to the `From<LinkStateError>` impl, which turns a remote close or detach into an `AmqpDescribedError`. The send path already delegates through `SendError::LinkStateError`, so the two paths disagreed.

A caller could not classify a failed receive. The condition was present in the error, but only behind a fe2o3 type, so no inspection at the `AmqpError` level reached it.

Event Hubs needs this. Its 0.15.0 changelog tells consumers to match on `ErrorKind::ConsumerDisconnected` to detect a partition that another consumer stole, and it can report that kind only when the condition is readable.

A live measurement shows why the in-flight path matters. `EventProcessor` opens every receiver at owner level 0, so two processor instances contest a partition at an equal epoch. At an equal epoch the broker accepts every attach and the later attacher wins, so it never refuses a re-attach. Across 86 seconds one run saw 15 accepted attaches, no refusals, and 13 Detach frames with condition `LinkStolen`. Event Hubs reads the refusal, so without this change it sees nothing, re-attaches, and steals the link back. Two receivers traded the partition about every 5 seconds and neither reported an error.

With this change the same contest reports `ConsumerDisconnected(Some(LinkStolen))` about 7 seconds after the second receiver attaches, from the in-flight receive, after exactly one Attach.

## Changes

`From<RecvError>` now delegates `LinkStateError` to `From<LinkStateError>`. The four observable results are: a remote close or detach that carries an AMQP error reports `AmqpDescribedError`; a plain remote close reports `LinkClosedByRemote`; a plain remote detach reports `LinkDetachedByRemote`; any other link-state failure still reports `LinkStateError`, and it now carries the `LinkStateError` rather than the enclosing `RecvError`.

The other `RecvError` arms are unchanged.

## Test plan

- [x] Five tests, one for each branch: `recv_link_state_remote_closed_with_error_keeps_described_error`, `recv_link_state_remote_detached_with_error_keeps_described_error`, `recv_link_state_remote_closed_maps_to_link_closed_by_remote`, `recv_link_state_remote_detached_maps_to_link_detached_by_remote`, and `recv_link_state_other_carries_the_link_state_error`.
- [x] All five fail when the delegation is removed. Restoring the old mapping gives `test result: FAILED. 0 passed; 5 failed`.
- [x] `cargo test -p azure_core_amqp --lib`: 117 passed, 0 failed.
- [x] Live run against a real namespace, two `EventProcessor` instances at owner level 0: every displaced partition reader reports `ConsumerDisconnected` with condition `LinkStolen`. Without this change the same run reports nothing, or one opaque `AmqpError`.
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and cspell with the repo config are clean.

## Related

Split out of #4807. That pull request needs this one for the `EventProcessor` scenario, which is an equal-epoch contest. #4807 covers a higher-epoch displacement on its own, through the refused re-attach.

#4805 puts the owner level on the wire and has merged. Without it no displacement happens at all.

The crate is unreleased at 1.2.0-beta.1, so this is filed under Bugs Fixed. It changes behavior for a caller that matches `AmqpErrorKind::LinkStateError` on a receive failure.