### PR TITLE
Update instructions to aide in dependency versions changing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,7 @@ You are an expert Rust programmer. You write safe, efficient, maintainable, and 
 - Local dev-dependencies should generally be `path`-only so `cargo package` can validate publishable crates without requiring unpublished versions from crates.io.
 - In `sdk/core`, keep dependency versions managed from the root workspace and use local `path + version` only when the core stack (`typespec -> typespec_client_core -> azure_core`) must move together on unreleased changes.
 - Outside `sdk/core`, crates should usually inherit workspace dependencies that resolve to published versions; switch to local `path + version` on `sdk/core` crates only when they require unreleased core changes.
+- When a service crate switches to local `sdk/core` crates, check neighboring crates in the same build, test, or example graph for exchanged `sdk/core`-exposed types; they may also need matching local path dependencies to avoid mixed-graph type mismatches.
 
 ### General
 


### PR DESCRIPTION
This was based on some simulations of sdk/eventhubs needing a change in sdk/core.