### PR TITLE
Fix partition range metadata drain

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed `ContainerClient::read_feed_ranges` failing on containers with large partition counts by fully draining routing metadata and retrying missing cache results with a forced refresh.
+
 ### Other Changes
 
 ## 0.37.0 (2026-07-20)

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed `ContainerClient::read_feed_ranges` failing on containers with large partition counts by fully draining routing metadata and retrying missing cache results with a forced refresh.
+- Fixed `ContainerClient::read_feed_ranges` failing on containers with large partition counts by fully draining routing metadata and retrying missing cache results with a forced refresh. ([#14](https://github.com/tvaron3/azure-sdk-for-rust/pull/14))
 
 ### Other Changes
 

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed `ContainerClient::read_feed_ranges` failing on containers with large partition counts by fully draining routing metadata and retrying missing cache results with a forced refresh. ([#14](https://github.com/tvaron3/azure-sdk-for-rust/pull/14))
+- Fixed `ContainerClient::read_feed_ranges` failing on containers with large partition counts by fully draining routing metadata and retrying missing cache results with a forced refresh. ([#4845](https://github.com/Azure/azure-sdk-for-rust/pull/4845))
 
 ### Other Changes
 

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -1029,52 +1029,29 @@ impl ContainerClient {
             .context
             .driver
             .resolve_all_partition_key_ranges(&self.container_ref, options.force_refresh())
-            .await
-            .ok_or_else(|| {
-                // Service was reachable but didn't return a usable routing
-                // map — a service-side invariant violation, surfaced as a
-                // 500 with the client-generated
-                // `SERIALIZATION_RESPONSE_BODY_INVALID` sub-status so
-                // callers can distinguish it from caller misuse.
-                crate::DriverCosmosError::builder()
-                    .with_status(crate::error::CosmosStatus::SERIALIZATION_RESPONSE_BODY_INVALID)
-                    .with_message("failed to resolve routing map for container")
-                    .build()
-            })?;
+            .await;
 
-        if ranges.is_empty() && !options.force_refresh() {
+        if should_force_refresh_feed_ranges(ranges.as_deref(), options.force_refresh()) {
             // A valid container always has at least one partition key range.
-            // Empty result likely means a stale/failed cache — retry with forced refresh.
+            // Missing or empty results likely mean a stale/failed cache.
             ranges = self
                 .context
                 .driver
                 .resolve_all_partition_key_ranges(&self.container_ref, true)
-                .await
-                .ok_or_else(|| {
-                    crate::DriverCosmosError::builder()
-                        .with_status(
-                            crate::error::CosmosStatus::SERIALIZATION_RESPONSE_BODY_INVALID,
-                        )
-                        .with_message("failed to resolve routing map for container")
-                        .build()
-                })?;
+                .await;
         }
 
-        if ranges.is_empty() {
-            // Forced refresh produced an empty routing map — either the
-            // container truly does not exist or the service is
-            // unreachable. Map to 503 with the transport-generated
-            // sub-status so the caller treats this as a service-side
-            // availability issue (not their bug).
-            return Err(crate::DriverCosmosError::builder()
-                .with_status(crate::error::CosmosStatus::TRANSPORT_GENERATED_503)
-                .with_message(
-                    "resolved routing map contains no partition key ranges; \
-                     the container may not exist or the service may be unreachable",
-                )
+        let ranges = ranges.ok_or_else(|| {
+            // Service was reachable but didn't return a usable routing
+            // map — a service-side invariant violation, surfaced as a
+            // 500 with the client-generated
+            // `SERIALIZATION_RESPONSE_BODY_INVALID` sub-status so
+            // callers can distinguish it from caller misuse.
+            crate::DriverCosmosError::builder()
+                .with_status(crate::error::CosmosStatus::SERIALIZATION_RESPONSE_BODY_INVALID)
+                .with_message("failed to resolve routing map for container")
                 .build()
-                .into());
-        }
+        })?;
 
         ranges
             .iter()
@@ -1262,6 +1239,10 @@ fn apply_batch_options(mut operation: CosmosOperation, options: &BatchOptions) -
     operation
 }
 
+fn should_force_refresh_feed_ranges<T>(ranges: Option<&[T]>, force_refresh: bool) -> bool {
+    !force_refresh && ranges.is_none_or(<[T]>::is_empty)
+}
+
 /// Compile-time guarantee that the futures returned by [`ContainerClient`]
 /// helpers are `Send`.
 ///
@@ -1278,4 +1259,17 @@ fn _assert_futures_are_send() {
     let patch: PatchInstructions = todo!();
     let options: Option<PatchItemOptions> = todo!();
     assert_send(client.patch_item(partition_key, item_id, patch, options));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_force_refresh_feed_ranges;
+
+    #[test]
+    fn feed_ranges_refreshes_missing_or_empty_initial_resolution() {
+        assert!(should_force_refresh_feed_ranges::<()>(None, false));
+        assert!(should_force_refresh_feed_ranges::<()>(Some(&[]), false));
+        assert!(!should_force_refresh_feed_ranges(Some(&[()]), false));
+        assert!(!should_force_refresh_feed_ranges::<()>(None, true));
+    }
 }

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
@@ -113,6 +113,7 @@ pub fn assert_region_not_contacted(
 pub const DEFAULT_TEST_TIMEOUT: Duration = Duration::from_secs(80);
 const CONTAINER_READINESS_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(5);
 const CONTAINER_READINESS_RETRY_DELAY: Duration = Duration::from_secs(1);
+const FAULT_INJECTION_READINESS_MAX_ATTEMPTS: usize = 20;
 
 async fn retry_container_readiness<T, E, F, Fut, TimeoutError>(
     region: &str,
@@ -930,6 +931,76 @@ impl TestRunContext {
                 Err(e) => return Err(e),
             }
         }
+    }
+
+    /// Creates a container and waits until both the normal and fault-injection
+    /// clients can read it in their configured region.
+    pub fn create_container_for_fault_injection<'a>(
+        &'a self,
+        db_client: &'a DatabaseClient,
+        properties: azure_data_cosmos::models::ContainerProperties,
+        throughput: ThroughputProperties,
+    ) -> Pin<Box<dyn Future<Output = azure_data_cosmos::Result<ContainerClient>> + Send + 'a>> {
+        let fault_client = self
+            .fault_client
+            .clone()
+            .expect("fault-injection client must be configured");
+
+        Box::pin(async move {
+            let created = db_client
+                .create_container(
+                    properties,
+                    Some(CreateContainerOptions::default().with_throughput(throughput)),
+                )
+                .await?
+                .into_model()?;
+            let container_id = created.id;
+
+            let original_db_client = db_client;
+            let original_container_id = container_id.clone();
+            let original_readiness = retry_container_readiness(
+                "original client",
+                CONTAINER_READINESS_ATTEMPT_TIMEOUT,
+                CONTAINER_READINESS_RETRY_DELAY,
+                Some(FAULT_INJECTION_READINESS_MAX_ATTEMPTS),
+                container_readiness_timeout_error,
+                move || {
+                    let db_client = original_db_client;
+                    let container_id = original_container_id.clone();
+                    async move {
+                        let container = db_client.container_client(&container_id).await?;
+                        container.read(None).await?;
+                        Ok::<_, azure_data_cosmos::CosmosError>(container)
+                    }
+                },
+            );
+
+            let fault_db_id = db_client.id().to_owned();
+            let fault_container_id = container_id;
+            let fault_readiness = retry_container_readiness(
+                "fault-injection client",
+                CONTAINER_READINESS_ATTEMPT_TIMEOUT,
+                CONTAINER_READINESS_RETRY_DELAY,
+                Some(FAULT_INJECTION_READINESS_MAX_ATTEMPTS),
+                container_readiness_timeout_error,
+                move || {
+                    let fault_client = fault_client.clone();
+                    let db_id = fault_db_id.clone();
+                    let container_id = fault_container_id.clone();
+                    async move {
+                        let container = fault_client
+                            .database_client(&db_id)
+                            .container_client(&container_id)
+                            .await?;
+                        container.read(None).await?;
+                        Ok::<_, azure_data_cosmos::CosmosError>(container)
+                    }
+                },
+            );
+
+            let (container, _) = tokio::try_join!(original_readiness, fault_readiness)?;
+            Ok(container)
+        })
     }
 
     /// Creates a container with specified throughput and waits for it to be fully created.

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
@@ -111,6 +111,7 @@ pub fn assert_region_not_contacted(
 
 /// Default timeout for tests (80 seconds).
 pub const DEFAULT_TEST_TIMEOUT: Duration = Duration::from_secs(80);
+const CONTAINER_READINESS_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Options for configuring test execution.
 #[derive(Default)]
@@ -918,50 +919,58 @@ impl TestRunContext {
             // Both `container_client()` (which resolves metadata via the driver) and
             // `read()` can fail with 404 while the container replicates.
             loop {
-                let result = async {
+                let result = tokio::time::timeout(CONTAINER_READINESS_ATTEMPT_TIMEOUT, async {
                     hub_client
                         .database_client(db_client.id())
                         .container_client(container_id)
                         .await?
                         .read(None)
                         .await
-                }
+                })
                 .await;
                 match result {
-                    Ok(_) => break,
-                    Err(e) => {
+                    Ok(Ok(_)) => break,
+                    Ok(Err(e)) => {
                         println!(
                             "waiting for container to be created in hub region ({}): {}",
                             HUB_REGION.as_str(),
                             e
                         );
-                        tokio::time::sleep(Duration::from_secs(1)).await;
                     }
+                    Err(_) => println!(
+                        "container readiness probe timed out in hub region ({})",
+                        HUB_REGION.as_str()
+                    ),
                 }
+                tokio::time::sleep(Duration::from_secs(1)).await;
             }
 
             // Wait for satellite region client to successfully resolve and read the container.
             loop {
-                let result = async {
+                let result = tokio::time::timeout(CONTAINER_READINESS_ATTEMPT_TIMEOUT, async {
                     satellite_client
                         .database_client(db_client.id())
                         .container_client(container_id)
                         .await?
                         .read(None)
                         .await
-                }
+                })
                 .await;
                 match result {
-                    Ok(_) => break,
-                    Err(e) => {
+                    Ok(Ok(_)) => break,
+                    Ok(Err(e)) => {
                         println!(
                             "waiting for container to be created in satellite region ({}): {}",
                             SATELLITE_REGION.as_str(),
                             e
                         );
-                        tokio::time::sleep(Duration::from_secs(1)).await;
                     }
+                    Err(_) => println!(
+                        "container readiness probe timed out in satellite region ({})",
+                        SATELLITE_REGION.as_str()
+                    ),
                 }
+                tokio::time::sleep(Duration::from_secs(1)).await;
             }
 
             db_client.container_client(container_id).await

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
@@ -13,7 +13,7 @@ use azure_data_cosmos::{
         ConnectionPoolOptions, CreateContainerOptions, ItemReadOptions, Region,
         ServerCertificateValidation,
     },
-    CosmosClient, CosmosRuntime, PartitionKey, Query, RoutingStrategy,
+    CosmosClient, CosmosError, CosmosRuntime, CosmosStatus, PartitionKey, Query, RoutingStrategy,
 };
 use azure_data_cosmos_driver::models::ConnectionString;
 use futures::TryStreamExt;
@@ -112,6 +112,55 @@ pub fn assert_region_not_contacted(
 /// Default timeout for tests (80 seconds).
 pub const DEFAULT_TEST_TIMEOUT: Duration = Duration::from_secs(80);
 const CONTAINER_READINESS_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(5);
+const CONTAINER_READINESS_RETRY_DELAY: Duration = Duration::from_secs(1);
+
+async fn retry_container_readiness<T, E, F, Fut, TimeoutError>(
+    region: &str,
+    attempt_timeout: Duration,
+    retry_delay: Duration,
+    max_attempts: Option<usize>,
+    timeout_error: TimeoutError,
+    mut probe: F,
+) -> Result<T, E>
+where
+    E: std::fmt::Display,
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    TimeoutError: Fn(&str, usize) -> E,
+{
+    let mut attempts = 0;
+    let mut last_error = None;
+    loop {
+        attempts += 1;
+        match tokio::time::timeout(attempt_timeout, probe()).await {
+            Ok(Ok(value)) => return Ok(value),
+            Ok(Err(error)) => {
+                if max_attempts.is_some_and(|limit| attempts >= limit) {
+                    return Err(error);
+                }
+                println!("waiting for container to be ready in {region}: {error}");
+                last_error = Some(error);
+            }
+            Err(_) => {
+                if max_attempts.is_some_and(|limit| attempts >= limit) {
+                    return Err(last_error.unwrap_or_else(|| timeout_error(region, attempts)));
+                }
+                println!("container readiness probe timed out in {region}");
+            }
+        }
+        tokio::time::sleep(retry_delay).await;
+    }
+}
+
+fn container_readiness_timeout_error(region: &str, attempts: usize) -> CosmosError {
+    azure_data_cosmos_driver::error::CosmosError::builder()
+        .with_status(CosmosStatus::new(StatusCode::RequestTimeout))
+        .with_message(format!(
+            "container readiness probe timed out in {region} after {attempts} attempts"
+        ))
+        .build()
+        .into()
+}
 
 /// Options for configuring test execution.
 #[derive(Default)]
@@ -915,65 +964,77 @@ impl TestRunContext {
 
             let container_id = &created_properties.id;
 
-            // Wait for hub region client to successfully resolve and read the container.
-            // Both `container_client()` (which resolves metadata via the driver) and
-            // `read()` can fail with 404 while the container replicates.
-            loop {
-                let result = tokio::time::timeout(CONTAINER_READINESS_ATTEMPT_TIMEOUT, async {
-                    hub_client
-                        .database_client(db_client.id())
-                        .container_client(container_id)
-                        .await?
-                        .read(None)
-                        .await
-                })
-                .await;
-                match result {
-                    Ok(Ok(_)) => break,
-                    Ok(Err(e)) => {
-                        println!(
-                            "waiting for container to be created in hub region ({}): {}",
-                            HUB_REGION.as_str(),
-                            e
-                        );
-                    }
-                    Err(_) => println!(
-                        "container readiness probe timed out in hub region ({})",
-                        HUB_REGION.as_str()
-                    ),
-                }
-                tokio::time::sleep(Duration::from_secs(1)).await;
-            }
+            let db_id = db_client.id().to_owned();
 
-            // Wait for satellite region client to successfully resolve and read the container.
-            loop {
-                let result = tokio::time::timeout(CONTAINER_READINESS_ATTEMPT_TIMEOUT, async {
-                    satellite_client
-                        .database_client(db_client.id())
-                        .container_client(container_id)
-                        .await?
-                        .read(None)
-                        .await
-                })
-                .await;
-                match result {
-                    Ok(Ok(_)) => break,
-                    Ok(Err(e)) => {
-                        println!(
-                            "waiting for container to be created in satellite region ({}): {}",
-                            SATELLITE_REGION.as_str(),
-                            e
-                        );
+            let hub_probe_client = hub_client.clone();
+            let hub_db_id = db_id.clone();
+            let hub_container_id = container_id.clone();
+            retry_container_readiness(
+                HUB_REGION.as_str(),
+                CONTAINER_READINESS_ATTEMPT_TIMEOUT,
+                CONTAINER_READINESS_RETRY_DELAY,
+                None,
+                container_readiness_timeout_error,
+                move || {
+                    let client = hub_probe_client.clone();
+                    let db_id = hub_db_id.clone();
+                    let container_id = hub_container_id.clone();
+                    async move {
+                        let container = client
+                            .database_client(&db_id)
+                            .container_client(&container_id)
+                            .await?;
+                        container.read(None).await?;
+                        Ok::<_, azure_data_cosmos::CosmosError>(container)
                     }
-                    Err(_) => println!(
-                        "container readiness probe timed out in satellite region ({})",
-                        SATELLITE_REGION.as_str()
-                    ),
-                }
-                tokio::time::sleep(Duration::from_secs(1)).await;
-            }
+                },
+            )
+            .await?;
 
-            db_client.container_client(container_id).await
+            let satellite_probe_client = satellite_client.clone();
+            let satellite_db_id = db_id.clone();
+            let satellite_container_id = container_id.clone();
+            retry_container_readiness(
+                SATELLITE_REGION.as_str(),
+                CONTAINER_READINESS_ATTEMPT_TIMEOUT,
+                CONTAINER_READINESS_RETRY_DELAY,
+                None,
+                container_readiness_timeout_error,
+                move || {
+                    let client = satellite_probe_client.clone();
+                    let db_id = satellite_db_id.clone();
+                    let container_id = satellite_container_id.clone();
+                    async move {
+                        let container = client
+                            .database_client(&db_id)
+                            .container_client(&container_id)
+                            .await?;
+                        container.read(None).await?;
+                        Ok::<_, azure_data_cosmos::CosmosError>(container)
+                    }
+                },
+            )
+            .await?;
+
+            let original_db_client = db_client;
+            let original_container_id = container_id.clone();
+            retry_container_readiness(
+                "original client",
+                CONTAINER_READINESS_ATTEMPT_TIMEOUT,
+                CONTAINER_READINESS_RETRY_DELAY,
+                Some(30),
+                container_readiness_timeout_error,
+                move || {
+                    let db_client = original_db_client;
+                    let container_id = original_container_id.clone();
+                    async move {
+                        let container = db_client.container_client(&container_id).await?;
+                        container.read(None).await?;
+                        Ok::<_, azure_data_cosmos::CosmosError>(container)
+                    }
+                },
+            )
+            .await
         })
     }
 
@@ -1139,4 +1200,101 @@ pub async fn build_aad_client_from_env(
     let account = azure_data_cosmos::AccountReference::with_credential(endpoint, credential);
     let client = builder.build(account, strategy).await?;
     Ok((client, recorder))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::retry_container_readiness;
+    use std::{
+        future::pending,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
+
+    #[tokio::test]
+    async fn container_readiness_retries_timeout_and_error() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let count = attempts.clone();
+
+        let result = retry_container_readiness(
+            "test-region",
+            Duration::from_millis(10),
+            Duration::ZERO,
+            None,
+            |_, _| "timed out",
+            move || {
+                let count = count.clone();
+                async move {
+                    match count.fetch_add(1, Ordering::SeqCst) {
+                        0 => pending::<Result<usize, &'static str>>().await,
+                        1 => Err("not ready"),
+                        _ => Ok(42),
+                    }
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn container_readiness_returns_last_error_after_attempt_limit() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let count = attempts.clone();
+
+        let error = retry_container_readiness(
+            "test-region",
+            Duration::from_millis(10),
+            Duration::ZERO,
+            Some(2),
+            |_, _| "timed out",
+            move || {
+                let count = count.clone();
+                async move {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    Err::<(), _>("permanent failure")
+                }
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error, "permanent failure");
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn container_readiness_bounds_timeout_only_failures() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let count = attempts.clone();
+
+        let error = retry_container_readiness(
+            "test-region",
+            Duration::from_millis(10),
+            Duration::ZERO,
+            Some(2),
+            |_, attempts| match attempts {
+                2 => "timed out after two attempts",
+                _ => unreachable!(),
+            },
+            move || {
+                let count = count.clone();
+                async move {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    pending::<Result<(), &'static str>>().await
+                }
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error, "timed out after two attempts");
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
 }

--- a/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/mod.rs
@@ -17,6 +17,7 @@ pub mod dual_backend;
 pub mod end_to_end;
 pub mod hpk;
 pub mod partition_key_equality;
+pub mod partition_range_drain;
 pub mod query_comparison;
 pub mod session_token;
 pub mod user_agent;

--- a/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/partition_range_drain.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/partition_range_drain.rs
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Large partition-range metadata drains through the public SDK.
+
+use std::sync::{Arc, Mutex};
+
+use azure_core::{
+    credentials::Secret,
+    http::{headers::HeaderName, Request, Url},
+};
+use azure_data_cosmos::{
+    options::Region, AccountEndpoint, AccountReference, CosmosClientBuilder, CosmosRuntimeBuilder,
+    RoutingStrategy,
+};
+use azure_data_cosmos_driver::in_memory_emulator::{
+    ConsistencyLevel, ContainerConfig, InMemoryEmulatorHttpClient, RequestObserver,
+    VirtualAccountConfig, VirtualRegion,
+};
+
+const EMULATOR_GATEWAY_URL: &str = "https://eastus.emulator.local";
+const PARTITION_COUNT: usize = 25_000;
+const PKRANGE_PAGE_SIZE: usize = 1_000;
+const IF_NONE_MATCH: HeaderName = HeaderName::from_static("if-none-match");
+const A_IM: HeaderName = HeaderName::from_static("a-im");
+
+#[derive(Clone, Debug)]
+struct PartitionRangeRequest {
+    if_none_match: Option<String>,
+    a_im: Option<String>,
+}
+
+#[derive(Debug, Default)]
+struct PartitionRangeObserver {
+    requests: Mutex<Vec<PartitionRangeRequest>>,
+}
+
+impl RequestObserver for PartitionRangeObserver {
+    fn on_request(&self, request: &Request) {
+        if !request.url().path().ends_with("/pkranges") {
+            return;
+        }
+
+        self.requests.lock().unwrap().push(PartitionRangeRequest {
+            if_none_match: request
+                .headers()
+                .get_optional_str(&IF_NONE_MATCH)
+                .map(str::to_owned),
+            a_im: request.headers().get_optional_str(&A_IM).map(str::to_owned),
+        });
+    }
+}
+
+#[tokio::test]
+async fn read_feed_ranges_drains_25k_partition_container() {
+    let config = VirtualAccountConfig::new(vec![VirtualRegion::new(
+        "East US",
+        Url::parse(EMULATOR_GATEWAY_URL).unwrap(),
+    )])
+    .unwrap()
+    .with_consistency(ConsistencyLevel::Session);
+    let observer = Arc::new(PartitionRangeObserver::default());
+    let emulator =
+        Arc::new(InMemoryEmulatorHttpClient::new(config).with_request_observer(observer.clone()));
+    let store = emulator.store();
+
+    store.create_database("large-db");
+    store.create_container_with_config(
+        "large-db",
+        "large-container",
+        serde_json::from_value(serde_json::json!({
+            "paths": ["/pk"],
+            "kind": "Hash",
+            "version": 2,
+        }))
+        .unwrap(),
+        ContainerConfig::new()
+            .with_partition_count(PARTITION_COUNT as u32)
+            .with_partition_key_range_page_size(PKRANGE_PAGE_SIZE as u32)
+            .build()
+            .unwrap(),
+    );
+
+    let account = AccountReference::with_authentication_key(
+        EMULATOR_GATEWAY_URL.parse::<AccountEndpoint>().unwrap(),
+        Secret::new("dGVzdGtleQ=="),
+    );
+    let client = CosmosClientBuilder::new()
+        .with_runtime(
+            CosmosRuntimeBuilder::from(emulator.runtime_builder())
+                .build()
+                .await
+                .unwrap(),
+        )
+        .build(account, RoutingStrategy::ProximityTo(Region::EAST_US))
+        .await
+        .unwrap();
+    let container = client
+        .database_client("large-db")
+        .container_client("large-container")
+        .await
+        .unwrap();
+
+    let ranges = container.read_feed_ranges(None).await.unwrap();
+
+    assert_eq!(ranges.len(), PARTITION_COUNT);
+    let requests = observer.requests.lock().unwrap();
+    assert_eq!(requests.len(), PARTITION_COUNT / PKRANGE_PAGE_SIZE + 1);
+    assert!(requests[0].if_none_match.is_none());
+    assert!(requests[1..]
+        .iter()
+        .all(|request| request.if_none_match.is_some()));
+    assert!(requests
+        .iter()
+        .all(|request| request.a_im.as_deref() == Some("Incremental Feed")));
+}

--- a/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write_fault_injection.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write_fault_injection.rs
@@ -16,7 +16,7 @@ use framework::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use std::{borrow::Cow, error::Error};
+use std::{borrow::Cow, error::Error, time::Duration};
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
 struct NestedItem {
@@ -107,7 +107,11 @@ async fn verify_read_fails_with_injected_error(
 
             Ok(())
         },
-        Some(TestOptions::new().with_fault_injection_rules(fault_builder)),
+        Some(
+            TestOptions::new()
+                .with_fault_injection_rules(fault_builder)
+                .with_timeout(Duration::from_secs(180)),
+        ),
     )
     .await
 }

--- a/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write_fault_injection.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write_fault_injection.rs
@@ -9,7 +9,9 @@ use azure_data_cosmos::fault_injection::{
     FaultInjectionRuleBuilder, FaultOperationType,
 };
 use azure_data_cosmos::models::{ContainerProperties, ThroughputProperties};
-use azure_data_cosmos::options::{ExcludedRegions, ItemReadOptions, OperationOptions};
+use azure_data_cosmos::options::{
+    ExcludedRegions, ItemReadOptions, OperationOptions, ThrottlingRetryOptionsBuilder,
+};
 use framework::{
     assert_local_retry_attempted_on_region, assert_region_contacted_with_retry,
     assert_region_not_contacted, TestClient, TestOptions, HUB_REGION, SATELLITE_REGION,
@@ -30,6 +32,20 @@ struct TestItem {
     value: usize,
     nested: NestedItem,
     bool_value: bool,
+}
+
+fn read_options_for_expected_status(expected_status: StatusCode) -> Option<ItemReadOptions> {
+    if expected_status != StatusCode::TooManyRequests {
+        return None;
+    }
+
+    let mut operation = OperationOptions::default();
+    operation.throttling_retry_options = Some(
+        ThrottlingRetryOptionsBuilder::new()
+            .with_max_retry_count(0)
+            .build(),
+    );
+    Some(ItemReadOptions::default().with_operation_options(operation))
 }
 
 /// Shared implementation for fault injection read failure tests.
@@ -89,8 +105,10 @@ async fn verify_read_fails_with_injected_error(
             let fault_db_client = fault_client.database_client(db_client.id());
             let fault_container_client = fault_db_client.container_client(&container_id).await?;
 
+            let options = read_options_for_expected_status(expected_status);
+
             let result = run_context
-                .read_item(&fault_container_client, &pk, &item_id, None)
+                .read_item(&fault_container_client, &pk, &item_id, options)
                 .await;
 
             let err = result.expect_err(&format!(
@@ -114,6 +132,15 @@ async fn verify_read_fails_with_injected_error(
         ),
     )
     .await
+}
+
+#[test]
+fn too_many_requests_test_disables_throttling_retries() {
+    let options = read_options_for_expected_status(StatusCode::TooManyRequests).unwrap();
+    let throttling = options.operation.throttling_retry_options.unwrap();
+
+    assert_eq!(throttling.max_retry_count, Some(0));
+    assert!(read_options_for_expected_status(StatusCode::ServiceUnavailable).is_none());
 }
 
 #[tokio::test]

--- a/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write_fault_injection.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/multi_write_tests/cosmos_multi_write_fault_injection.rs
@@ -57,7 +57,7 @@ async fn verify_read_fails_with_injected_error(
         async |run_context, db_client| {
             let container_id = format!("Container-{}", Uuid::new_v4());
             let container_client = run_context
-                .create_container_with_throughput(
+                .create_container_for_fault_injection(
                     db_client,
                     ContainerProperties::new(container_id.clone(), "/partition_key".into()),
                     ThroughputProperties::manual(400),
@@ -213,7 +213,7 @@ pub async fn item_read_succeeds_when_fault_targets_create_item() -> Result<(), B
             // Create a container using the normal client
             let container_id = format!("Container-{}", Uuid::new_v4());
             let container_client = run_context
-                .create_container_with_throughput(
+                .create_container_for_fault_injection(
                     db_client,
                     ContainerProperties::new(container_id.clone(), "/partition_key".into()),
                     ThroughputProperties::manual(400),
@@ -263,7 +263,11 @@ pub async fn item_read_succeeds_when_fault_targets_create_item() -> Result<(), B
 
             Ok(())
         },
-        Some(TestOptions::new().with_fault_injection_rules(fault_builder)),
+        Some(
+            TestOptions::new()
+                .with_fault_injection_rules(fault_builder)
+                .with_timeout(Duration::from_secs(180)),
+        ),
     )
     .await
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed partition-range discovery for containers whose routing metadata spans more than ten pages, added full-refresh recovery for invalid incremental maps, and prevented empty routing maps from remaining cached.
+
 ### Other Changes
 
 ## 0.6.0 (2026-07-20)

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed partition-range discovery for containers whose routing metadata spans more than ten pages, added full-refresh recovery for invalid incremental maps, and prevented empty routing maps from remaining cached. ([#14](https://github.com/tvaron3/azure-sdk-for-rust/pull/14))
+- Fixed partition-range discovery for containers whose routing metadata spans more than ten pages, added full-refresh recovery for invalid incremental maps, and prevented empty routing maps from remaining cached. ([#4845](https://github.com/Azure/azure-sdk-for-rust/pull/4845))
 
 ### Other Changes
 

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed partition-range discovery for containers whose routing metadata spans more than ten pages, added full-refresh recovery for invalid incremental maps, and prevented empty routing maps from remaining cached.
+- Fixed partition-range discovery for containers whose routing metadata spans more than ten pages, added full-refresh recovery for invalid incremental maps, and prevented empty routing maps from remaining cached. ([#14](https://github.com/tvaron3/azure-sdk-for-rust/pull/14))
 
 ### Other Changes
 

--- a/sdk/cosmos/azure_data_cosmos_driver/docs/PARTITION_KEY_RANGE_CACHE_SPEC.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/docs/PARTITION_KEY_RANGE_CACHE_SPEC.md
@@ -350,11 +350,10 @@ On the first request for a container:
    a. Calls `fetch_pk_ranges(container, None)` (no continuation for first fetch).
    b. Parses the response: accumulates ranges and captures the `etag` continuation token.
    c. Loops, passing the continuation token to subsequent calls, until the service
-      returns HTTP 304 Not Modified (signaling no more pages), or `MAX_FETCH_ITERATIONS`
-      (10) is reached.
+      returns HTTP 304 Not Modified (signaling no more pages).
 3. The accumulated ranges are passed to `ContainerRoutingMap::try_create`
    to build the routing map, preserving the final continuation token.
-4. The resulting map is stored in the cache.
+4. A valid map is stored in the cache; an empty fallback is evicted.
 5. Concurrent requests for the same container that arrive while the fetch is
    in-flight share the same pending future (single-pending-I/O).
 
@@ -368,12 +367,12 @@ flowchart TD
     NM{"result.not_modified?"}
     Break["trace! + break"]
     Extend["trace!(range_count) + all_ranges.extend(result.ranges)"]
-    Done["debug!(iterations, total_ranges, not_modified)<br/>ContainerRoutingMap::try_create(all_ranges, None, continuation) → map"]
+    Done["debug!(iterations, total_ranges)<br/>ContainerRoutingMap::try_create(all_ranges, None, continuation) → map"]
     Start --> Init --> Trace1
     Trace1 --> Fetch --> Update --> NM
     NM -- yes --> Break --> Done
     NM -- no --> Extend --> Trace1
-    Extend -. "loop bounded by<br/>MAX_FETCH_ITERATIONS = 10" .-> Trace1
+    Extend -. "continue until<br/>HTTP 304" .-> Trace1
 ```
 
 Note: `fetch_and_build_routing_map` is a bare free function (not an associated
@@ -448,12 +447,12 @@ sequenceDiagram
 
 If `fetch_fn` returns `None` (service unreachable or unexpected response):
 
-- **During initial population:** The cache stores an empty routing map via
-  `ContainerRoutingMap::empty()`. All EPK lookups return `None`.
+- **During initial population:** The empty fallback is evicted and the lookup
+  returns `None`.
 - **During incremental refresh:** The previous routing map is preserved. A
   `tracing::warn!` is emitted for diagnostics.
-- **During `try_combine`:** If the merge is incomplete or overlapping, the previous
-  map is preserved as fallback with a warning logged.
+- **During `try_combine`:** If the merge is incomplete or overlapping, the cache
+  performs a full metadata refresh. If recovery fails, the previous map is preserved.
 
 ---
 
@@ -681,17 +680,17 @@ obtain:
 | Scenario | Behavior |
 |----------|----------|
 | Empty partition key (`PartitionKey::EMPTY`) | Returns `None` immediately — cross-partition request, no range resolution needed. |
-| `fetch_fn` returns `None` (initial fetch) | Caches an empty routing map. Lookups return `None`. Warning logged. |
+| `fetch_fn` returns `None` (initial fetch) | Returns `None`; the empty fallback is evicted. Warning logged. |
 | `fetch_fn` returns `None` (incremental refresh) | Falls back to previous routing map. Warning logged. |
 | Incomplete range set (gaps in coverage) | `try_create` returns `Err(IncompleteRanges)`. Falls back to empty map + warning. |
 | Overlapping ranges (data corruption) | `try_create` returns `Err(OverlappingRanges)`. Falls back to empty map + warning. |
 | Partition split (gone parent ranges) | Parent ranges filtered out by `try_create`. Only child ranges kept. |
-| `try_combine` fails (incomplete merge) | Falls back to previous routing map. Warning logged. |
+| `try_combine` fails (incomplete merge) | Performs a full refresh; preserves the previous map if recovery fails. |
 | EPK not found in routing map | `get_range_by_effective_partition_key` returns `None` (should not happen for a valid map). |
 | Concurrent requests for same container | Single-pending-I/O: one fetch, others await. |
 | Concurrent `force_refresh` requests | ETag-based `should_force_refresh` ensures only one refresh runs; others reuse the result. |
 | `invalidate` during in-flight resolve | New requests after invalidation trigger a refetch. In-flight requests finish with the old map. |
-| `Change feed loop exceeds MAX_FETCH_ITERATIONS` | Loop terminates, warning logged, builds map from accumulated ranges so far. |
+| Change feed has more pages | Continues fetching until the service returns HTTP 304. |
 
 ---
 
@@ -922,10 +921,9 @@ principle.
 
 ### 13.4 Change-Feed Loop Safety
 
-The change-feed loop in `fetch_and_build_routing_map` is bounded by
-`MAX_FETCH_ITERATIONS = 10`. This prevents infinite loops if the server never returns
-304 Not Modified. On exceeding the limit, the loop terminates and builds the routing
-map from whatever ranges have been accumulated so far.
+The change-feed loop in `fetch_and_build_routing_map` has no client-side
+iteration cap. It continues until the service returns HTTP 304 Not Modified;
+transport failures terminate the fetch through the normal request error path.
 
 ### 13.5 ETag-Based `should_force_refresh`
 

--- a/sdk/cosmos/azure_data_cosmos_driver/docs/PARTITION_KEY_RANGE_CACHE_SPEC.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/docs/PARTITION_KEY_RANGE_CACHE_SPEC.md
@@ -360,14 +360,14 @@ On the first request for a container:
 ```mermaid
 flowchart TD
     Start["fetch_and_build_routing_map(container, previous=None, fetch_fn)"]
-    Init["continuation = None"]
+    Init["continuation = None<br/>all_ranges = HashMap&lt;id, range&gt;"]
     Trace1["trace!(iteration, has_continuation)"]
     Fetch["result = fetch_fn(container, continuation)?"]
     Update["continuation = result.continuation"]
     NM{"result.not_modified?"}
     Break["trace! + break"]
-    Extend["trace!(range_count) + all_ranges.extend(result.ranges)"]
-    Done["debug!(iterations, total_ranges)<br/>ContainerRoutingMap::try_create(all_ranges, None, continuation) → map"]
+    Extend["trace!(range_count) + insert ranges by ID"]
+    Done["debug!(iterations, total_ranges)<br/>try_create(all_ranges.into_values(), continuation) → map"]
     Start --> Init --> Trace1
     Trace1 --> Fetch --> Update --> NM
     NM -- yes --> Break --> Done

--- a/sdk/cosmos/azure_data_cosmos_driver/docs/PARTITION_KEY_RANGE_CACHE_SPEC.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/docs/PARTITION_KEY_RANGE_CACHE_SPEC.md
@@ -363,7 +363,7 @@ flowchart TD
     Init["continuation = None<br/>all_ranges = HashMap&lt;id, range&gt;"]
     Trace1["trace!(iteration, has_continuation)"]
     Fetch["result = fetch_fn(container, continuation)?"]
-    Update["continuation = result.continuation"]
+    Update["continuation = result.continuation.or(continuation)"]
     NM{"result.not_modified?"}
     Break["trace! + break"]
     Extend["trace!(range_count) + insert ranges by ID"]

--- a/sdk/cosmos/azure_data_cosmos_driver/docs/PARTITION_KEY_RANGE_CACHE_SPEC.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/docs/PARTITION_KEY_RANGE_CACHE_SPEC.md
@@ -682,8 +682,8 @@ obtain:
 | Empty partition key (`PartitionKey::EMPTY`) | Returns `None` immediately — cross-partition request, no range resolution needed. |
 | `fetch_fn` returns `None` (initial fetch) | Returns `None`; the empty fallback is evicted. Warning logged. |
 | `fetch_fn` returns `None` (incremental refresh) | Falls back to previous routing map. Warning logged. |
-| Incomplete range set (gaps in coverage) | `try_create` returns `Err(IncompleteRanges)`. Falls back to empty map + warning. |
-| Overlapping ranges (data corruption) | `try_create` returns `Err(OverlappingRanges)`. Falls back to empty map + warning. |
+| Incomplete range set (gaps in coverage) | `try_create` returns `Err(IncompleteRanges)`; the empty fallback is evicted and the lookup returns `None`. Warning logged. |
+| Overlapping ranges (data corruption) | `try_create` returns `Err(OverlappingRanges)`; the empty fallback is evicted and the lookup returns `None`. Warning logged. |
 | Partition split (gone parent ranges) | Parent ranges filtered out by `try_create`. Only child ranges kept. |
 | `try_combine` fails (incomplete merge) | Performs a full refresh; preserves the previous map if recovery fails. |
 | EPK not found in routing map | `get_range_by_effective_partition_key` returns `None` (should not happen for a valid map). |

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/async_cache.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/async_cache.rs
@@ -97,6 +97,21 @@ where
         write_guard.remove(key).and_then(|lazy| lazy.try_get())
     }
 
+    /// Removes an entry only if it still contains the observed value.
+    pub(crate) async fn invalidate_if_same(&self, key: &K, observed: &Arc<V>) -> bool {
+        let mut write_guard = self.map.write().await;
+        let should_remove = write_guard
+            .get(key)
+            .and_then(|lazy| lazy.try_get())
+            .is_some_and(|current| Arc::ptr_eq(&current, observed));
+
+        if should_remove {
+            write_guard.remove(key);
+        }
+
+        should_remove
+    }
+
     /// Clears all entries from the cache.
     #[cfg(test)]
     pub(crate) async fn clear(&self) {
@@ -319,13 +334,58 @@ mod tests {
             }));
         }
 
+        let mut results = Vec::new();
         for handle in handles {
             let result = handle.await.unwrap();
             assert_eq!(*result, "result");
+            results.push(result);
         }
 
         // Only ONE initialization should have occurred - this is the key invariant!
         assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert!(results[1..]
+            .iter()
+            .all(|result| Arc::ptr_eq(&results[0], result)));
+    }
+
+    #[tokio::test]
+    async fn concurrent_different_keys_do_not_serialize() {
+        let cache = Arc::new(AsyncCache::<String, i32>::new());
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+
+        let first = {
+            let cache = cache.clone();
+            let barrier = barrier.clone();
+            async move {
+                cache
+                    .get_or_insert_with("first".to_string(), || async move {
+                        barrier.wait().await;
+                        1
+                    })
+                    .await
+            }
+        };
+        let second = {
+            let cache = cache.clone();
+            let barrier = barrier.clone();
+            async move {
+                cache
+                    .get_or_insert_with("second".to_string(), || async move {
+                        barrier.wait().await;
+                        2
+                    })
+                    .await
+            }
+        };
+
+        let (first, second) = tokio::time::timeout(Duration::from_secs(1), async {
+            tokio::join!(first, second)
+        })
+        .await
+        .expect("different cache keys should initialize concurrently");
+
+        assert_eq!(*first, 1);
+        assert_eq!(*second, 2);
     }
 
     #[tokio::test]
@@ -355,6 +415,20 @@ mod tests {
         assert_eq!(*removed.unwrap(), 42);
         assert!(cache.get(&"key".to_string()).await.is_none());
         assert!(cache_is_empty(&cache).await);
+    }
+
+    #[tokio::test]
+    async fn conditional_invalidation_preserves_replacement() {
+        let cache: AsyncCache<String, i32> = AsyncCache::new();
+        let key = "key".to_string();
+        let observed = cache.get_or_insert_with(key.clone(), || async { 42 }).await;
+
+        cache
+            .get_or_refresh_with(key.clone(), |_| true, || async { 100 })
+            .await;
+
+        assert!(!cache.invalidate_if_same(&key, &observed).await);
+        assert_eq!(*cache.get(&key).await.unwrap(), 100);
     }
 
     #[tokio::test]

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/container_routing_map.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/container_routing_map.rs
@@ -660,6 +660,35 @@ mod tests {
     }
 
     #[test]
+    fn try_combine_resolves_cascading_splits_from_one_page() {
+        let map = ContainerRoutingMap::try_create(single_range(), None, None)
+            .unwrap()
+            .unwrap();
+
+        // 0 -> B + C, then B -> D + E. Children of B intentionally precede B.
+        let new_ranges = vec![
+            make_range("D", "", "33", Some(vec!["B".into()])),
+            make_range("E", "33", "55", Some(vec!["B".into()])),
+            make_range("B", "", "55", Some(vec!["0".into()])),
+            make_range("C", "55", "FF", Some(vec!["0".into()])),
+        ];
+
+        let merged = map
+            .try_combine(new_ranges, Some("new-etag".into()))
+            .unwrap()
+            .unwrap();
+
+        let ids = merged
+            .ranges()
+            .iter()
+            .map(|range| range.id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(ids, ["D", "E", "C"]);
+        assert!(merged.is_gone("0"));
+        assert!(merged.is_gone("B"));
+    }
+
+    #[test]
     fn try_combine_incomplete_returns_none() {
         let map = ContainerRoutingMap::try_create(single_range(), None, None)
             .unwrap()

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/partition_key_range_cache.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/partition_key_range_cache.rs
@@ -308,8 +308,8 @@ impl PartitionKeyRangeCache {
 /// This mirrors the SDK's routing-map-for-container pattern:
 ///
 /// 1. Start from the previous map's continuation token (or `None` for fresh fetch).
-/// 2. Loop calling `fetch_pk_ranges(container, continuation)` until the
-///    service returns 304 Not Modified.
+/// 2. Continue fetching without a client-side iteration cap until the service
+///    returns 304 Not Modified.
 /// 3. Accumulate all fetched ranges.
 /// 4. If a previous map exists, merge via [`ContainerRoutingMap::try_combine`];
 ///    otherwise create a fresh routing map.

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/partition_key_range_cache.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/partition_key_range_cache.rs
@@ -6,12 +6,7 @@
 //! Uses the driver's operation pipeline to fetch `/pkranges` from the service
 //! and caches the resulting [`ContainerRoutingMap`] per container RID.
 
-use std::{
-    collections::{HashMap, HashSet},
-    hash::{DefaultHasher, Hash, Hasher},
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{collections::HashMap, sync::Arc};
 
 use crate::models::{
     effective_partition_key::EffectivePartitionKey, partition_key_range::PkRangesResponse,
@@ -19,8 +14,6 @@ use crate::models::{
 };
 
 use super::{container_routing_map::ContainerRoutingMap, AsyncCache};
-
-const MAX_FETCH_DURATION: Duration = Duration::from_secs(5 * 60);
 
 /// Result of a single partition key range fetch from the service.
 ///
@@ -333,22 +326,10 @@ where
     let mut continuation = previous_routing_map
         .as_ref()
         .and_then(|m| m.change_feed_next_if_none_match.clone());
-    let mut seen_pages = HashSet::new();
-    let started = Instant::now();
-
     let mut iterations_completed = 0;
     loop {
         let iteration = iterations_completed;
         iterations_completed += 1;
-        if started.elapsed() >= MAX_FETCH_DURATION {
-            tracing::warn!(
-                iterations = iterations_completed,
-                "Partition key range fetch exceeded its overall deadline"
-            );
-            return previous_routing_map
-                .map(|p| (*p).clone())
-                .unwrap_or_else(ContainerRoutingMap::empty);
-        }
 
         tracing::trace!(
             iteration,
@@ -379,23 +360,6 @@ where
             break;
         }
 
-        let mut page_hasher = DefaultHasher::new();
-        for range in &result.ranges {
-            range.id.hash(&mut page_hasher);
-            range.min_inclusive.hash(&mut page_hasher);
-            range.max_exclusive.hash(&mut page_hasher);
-            range.parents.hash(&mut page_hasher);
-        }
-        let page_key = (result.continuation.clone(), page_hasher.finish());
-        if !seen_pages.insert(page_key) {
-            tracing::warn!(
-                iteration,
-                "Partition key range fetch repeated the same page"
-            );
-            return previous_routing_map
-                .map(|p| (*p).clone())
-                .unwrap_or_else(ContainerRoutingMap::empty);
-        }
         continuation = result.continuation.or(continuation);
 
         tracing::trace!(
@@ -1525,36 +1489,6 @@ mod tests {
             .is_none());
         assert!(cache
             .try_lookup(&container, false, empty_fetch)
-            .await
-            .is_none());
-        assert_eq!(call_count.load(Ordering::SeqCst), 2);
-    }
-
-    #[tokio::test]
-    async fn repeated_continuation_terminates_without_caching_partial_map() {
-        use std::sync::{
-            atomic::{AtomicUsize, Ordering},
-            Arc,
-        };
-
-        let cache = PartitionKeyRangeCache::new();
-        let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
-        let call_count = Arc::new(AtomicUsize::new(0));
-        let count = call_count.clone();
-        let stalled_fetch = move |_container: ContainerReference, _continuation: Option<String>| {
-            let count = count.clone();
-            async move {
-                count.fetch_add(1, Ordering::SeqCst);
-                Some(PkRangeFetchResult {
-                    ranges: vec![PkRange::new("same-page".into(), "", "80")],
-                    continuation: Some("unchanged-etag".to_string()),
-                    not_modified: false,
-                })
-            }
-        };
-
-        assert!(cache
-            .try_lookup(&container, false, stalled_fetch)
             .await
             .is_none());
         assert_eq!(call_count.load(Ordering::SeqCst), 2);

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/partition_key_range_cache.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cache/partition_key_range_cache.rs
@@ -6,7 +6,12 @@
 //! Uses the driver's operation pipeline to fetch `/pkranges` from the service
 //! and caches the resulting [`ContainerRoutingMap`] per container RID.
 
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    hash::{DefaultHasher, Hash, Hasher},
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use crate::models::{
     effective_partition_key::EffectivePartitionKey, partition_key_range::PkRangesResponse,
@@ -15,12 +20,7 @@ use crate::models::{
 
 use super::{container_routing_map::ContainerRoutingMap, AsyncCache};
 
-/// Maximum number of change feed iterations to prevent infinite loops.
-///
-/// In practice the loop completes in 1–2 iterations: the service returns all
-/// partition key ranges in a single unbounded page, then 304 Not Modified on the
-/// next call. This cap is a safety net, not an expected limit.
-const MAX_FETCH_ITERATIONS: usize = 10;
+const MAX_FETCH_DURATION: Duration = Duration::from_secs(5 * 60);
 
 /// Result of a single partition key range fetch from the service.
 ///
@@ -250,8 +250,7 @@ impl PartitionKeyRangeCache {
     ///
     /// Returns a routing map for the container. If the initial fetch fails or
     /// returns invalid ranges, the previously cached routing map is preserved
-    /// when one exists; only when there is no previous map to fall back to is
-    /// an empty routing map cached and returned.
+    /// when one exists. Empty routing maps are evicted and returned as `None`.
     pub(crate) async fn try_lookup<F, Fut>(
         &self,
         container: &ContainerReference,
@@ -264,7 +263,7 @@ impl PartitionKeyRangeCache {
     {
         let key = container.clone();
 
-        if force_refresh {
+        let routing_map = if force_refresh {
             // Retrieve the existing routing map for incremental refresh.
             let previous = self.cache.get(&key).await;
             let prev_continuation = previous
@@ -286,16 +285,21 @@ impl PartitionKeyRangeCache {
                     },
                     || fetch_and_build_routing_map(key.clone(), previous, fetch_pk_ranges),
                 )
-                .await
+                .await?
         } else {
-            Some(
-                self.cache
-                    .get_or_insert_with(key.clone(), || {
-                        fetch_and_build_routing_map(key.clone(), None, fetch_pk_ranges)
-                    })
-                    .await,
-            )
+            self.cache
+                .get_or_insert_with(key.clone(), || {
+                    fetch_and_build_routing_map(key.clone(), None, fetch_pk_ranges)
+                })
+                .await
+        };
+
+        if routing_map.ranges().is_empty() {
+            self.cache.invalidate_if_same(&key, &routing_map).await;
+            return None;
         }
+
+        Some(routing_map)
     }
 
     /// Invalidates the cached routing map for a container.
@@ -312,7 +316,7 @@ impl PartitionKeyRangeCache {
 ///
 /// 1. Start from the previous map's continuation token (or `None` for fresh fetch).
 /// 2. Loop calling `fetch_pk_ranges(container, continuation)` until the
-///    service returns 304 Not Modified or `MAX_FETCH_ITERATIONS` is reached.
+///    service returns 304 Not Modified.
 /// 3. Accumulate all fetched ranges.
 /// 4. If a previous map exists, merge via [`ContainerRoutingMap::try_combine`];
 ///    otherwise create a fresh routing map.
@@ -325,15 +329,26 @@ where
     F: Fn(ContainerReference, Option<String>) -> Fut,
     Fut: std::future::Future<Output = Option<PkRangeFetchResult>>,
 {
-    let mut all_ranges = Vec::new();
+    let mut all_ranges = HashMap::new();
     let mut continuation = previous_routing_map
         .as_ref()
         .and_then(|m| m.change_feed_next_if_none_match.clone());
+    let mut seen_pages = HashSet::new();
+    let started = Instant::now();
 
-    let mut received_not_modified = false;
     let mut iterations_completed = 0;
-    for iteration in 0..MAX_FETCH_ITERATIONS {
-        iterations_completed = iteration + 1;
+    loop {
+        let iteration = iterations_completed;
+        iterations_completed += 1;
+        if started.elapsed() >= MAX_FETCH_DURATION {
+            tracing::warn!(
+                iterations = iterations_completed,
+                "Partition key range fetch exceeded its overall deadline"
+            );
+            return previous_routing_map
+                .map(|p| (*p).clone())
+                .unwrap_or_else(ContainerRoutingMap::empty);
+        }
 
         tracing::trace!(
             iteration,
@@ -358,63 +373,97 @@ where
             }
         };
 
-        continuation = result.continuation;
-
         if result.not_modified {
+            continuation = result.continuation.or(continuation);
             tracing::trace!(iteration, "Service returned 304 Not Modified");
-            received_not_modified = true;
             break;
         }
+
+        let mut page_hasher = DefaultHasher::new();
+        for range in &result.ranges {
+            range.id.hash(&mut page_hasher);
+            range.min_inclusive.hash(&mut page_hasher);
+            range.max_exclusive.hash(&mut page_hasher);
+            range.parents.hash(&mut page_hasher);
+        }
+        let page_key = (result.continuation.clone(), page_hasher.finish());
+        if !seen_pages.insert(page_key) {
+            tracing::warn!(
+                iteration,
+                "Partition key range fetch repeated the same page"
+            );
+            return previous_routing_map
+                .map(|p| (*p).clone())
+                .unwrap_or_else(ContainerRoutingMap::empty);
+        }
+        continuation = result.continuation.or(continuation);
 
         tracing::trace!(
             iteration,
             range_count = result.ranges.len(),
             "Received partition key ranges"
         );
-        all_ranges.extend(result.ranges);
+        all_ranges.extend(
+            result
+                .ranges
+                .into_iter()
+                .map(|range| (range.id.clone(), range)),
+        );
     }
 
     tracing::debug!(
         iterations = iterations_completed,
         total_ranges = all_ranges.len(),
-        not_modified = received_not_modified,
         "Partition key range fetch loop completed"
     );
-
-    if !received_not_modified && !all_ranges.is_empty() {
-        tracing::warn!(
-            "Partition key range fetch loop reached MAX_FETCH_ITERATIONS ({}) without \
-             receiving Not Modified; routing map may be built from partial data",
-            MAX_FETCH_ITERATIONS
-        );
-    }
 
     // Incremental refresh: merge new ranges into the previous routing map.
     if let Some(prev) = previous_routing_map {
         if all_ranges.is_empty() {
-            // No changes since last fetch (304 on first iteration).
-            return (*prev).clone();
+            let mut unchanged = (*prev).clone();
+            unchanged.change_feed_next_if_none_match = continuation;
+            return unchanged;
         }
-        return match prev.try_combine(all_ranges, continuation) {
+        return match prev.try_combine(all_ranges.into_values().collect(), continuation) {
             Ok(Some(map)) => map,
             Ok(None) => {
                 tracing::warn!(
-                    "Incremental routing map merge incomplete; falling back to previous map"
+                    "Incremental routing map merge incomplete; falling back to full refresh"
                 );
-                (*prev).clone()
+                let refreshed = Box::pin(fetch_and_build_routing_map(
+                    container,
+                    None,
+                    fetch_pk_ranges,
+                ))
+                .await;
+                if refreshed.ranges().is_empty() {
+                    (*prev).clone()
+                } else {
+                    refreshed
+                }
             }
             Err(e) => {
                 tracing::warn!(
-                    "Incremental routing map merge failed: {}; falling back to previous map",
+                    "Incremental routing map merge failed: {}; falling back to full refresh",
                     e
                 );
-                (*prev).clone()
+                let refreshed = Box::pin(fetch_and_build_routing_map(
+                    container,
+                    None,
+                    fetch_pk_ranges,
+                ))
+                .await;
+                if refreshed.ranges().is_empty() {
+                    (*prev).clone()
+                } else {
+                    refreshed
+                }
             }
         };
     }
 
     // Full (non-incremental) creation.
-    match ContainerRoutingMap::try_create(all_ranges, None, continuation) {
+    match ContainerRoutingMap::try_create(all_ranges.into_values().collect(), None, continuation) {
         Ok(Some(map)) => map,
         Ok(None) => {
             tracing::warn!("Partition key range fetch returned empty set");
@@ -597,6 +646,14 @@ mod tests {
         )
     }
 
+    fn routing_map(ranges: Vec<PkRange>, continuation: &str) -> Arc<ContainerRoutingMap> {
+        Arc::new(
+            ContainerRoutingMap::try_create(ranges, None, Some(continuation.to_string()))
+                .unwrap()
+                .unwrap(),
+        )
+    }
+
     /// A fetch function returning two partition key ranges split at the midpoint "80".
     /// Range "0": ["", "80"), Range "1": ["80", "FF")
     async fn two_range_fetch(
@@ -730,7 +787,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn try_lookup_empty_routing_map_returns_empty_ranges() {
+    async fn try_lookup_empty_routing_map_returns_none() {
         let cache = PartitionKeyRangeCache::new();
         let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
 
@@ -742,16 +799,13 @@ mod tests {
             Some(PkRangeFetchResult {
                 ranges: vec![],
                 continuation: None,
-                not_modified: false,
+                not_modified: true,
             })
         }
 
         let routing_map = cache.try_lookup(&container, false, empty_fetch).await;
 
-        // Cache returns an empty routing map (not None) — the CosmosDriver public
-        // methods check for empty ranges and convert to None.
-        assert!(routing_map.is_some());
-        assert!(routing_map.unwrap().ranges().is_empty());
+        assert!(routing_map.is_none());
     }
 
     #[tokio::test]
@@ -769,8 +823,7 @@ mod tests {
 
         let routing_map = cache.try_lookup(&container, false, failing_fetch).await;
 
-        // Complete fetch failure returns None from try_lookup.
-        assert!(routing_map.is_some()); // empty map is cached as fallback
+        assert!(routing_map.is_none());
     }
 
     #[tokio::test]
@@ -862,7 +915,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_overlapping_ranges_empty_map_returns_empty_vec() {
+    async fn resolve_overlapping_ranges_empty_map_returns_none() {
         let cache = PartitionKeyRangeCache::new();
         let container = make_container(
             r#"{"paths":["/tenantId","/userId","/sessionId"],"kind":"MultiHash","version":2}"#,
@@ -880,7 +933,7 @@ mod tests {
             Some(PkRangeFetchResult {
                 ranges: vec![],
                 continuation: None,
-                not_modified: false,
+                not_modified: true,
             })
         }
 
@@ -893,10 +946,7 @@ mod tests {
             )
             .await;
 
-        // Empty routing map → resolve_overlapping_ranges returns Some(vec![])
-        // (CosmosDriver public method normalizes this to None)
-        assert!(ranges.is_some());
-        assert!(ranges.unwrap().is_empty());
+        assert!(ranges.is_none());
     }
 
     #[tokio::test]
@@ -920,24 +970,30 @@ mod tests {
                 Some(PkRangeFetchResult {
                     ranges: vec![],
                     continuation: None,
-                    not_modified: false,
+                    not_modified: true,
                 })
             }
         };
 
-        // First lookup: gets empty routing map
-        let map1 = cache
+        // First lookup rejects the empty routing map and evicts it.
+        assert!(cache
             .try_lookup(&container, false, empty_fetch)
             .await
-            .unwrap();
-        assert!(map1.ranges().is_empty());
+            .is_none());
 
         // Force refresh with a fetch that returns valid ranges
-        let recovering_fetch = |_container: ContainerReference, _continuation: Option<String>| async {
-            Some(PkRangeFetchResult {
-                ranges: vec![PkRange::new("0".into(), "", "FF")],
-                continuation: Some("etag-2".to_string()),
-                not_modified: false,
+        let recovering_fetch = |_container: ContainerReference, continuation: Option<String>| async move {
+            Some(match continuation {
+                Some(continuation) => PkRangeFetchResult {
+                    ranges: vec![],
+                    continuation: Some(continuation),
+                    not_modified: true,
+                },
+                None => PkRangeFetchResult {
+                    ranges: vec![PkRange::new("0".into(), "", "FF")],
+                    continuation: Some("etag-2".to_string()),
+                    not_modified: false,
+                },
             })
         };
 
@@ -947,6 +1003,561 @@ mod tests {
             .unwrap();
         assert_eq!(map2.ranges().len(), 1);
         assert_eq!(map2.ranges()[0].id, "0");
+    }
+
+    #[tokio::test]
+    async fn drains_more_than_ten_partition_range_pages() {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+
+        const BOUNDARIES: [&str; 12] = [
+            "", "10", "20", "30", "40", "50", "60", "70", "80", "90", "A0", "FF",
+        ];
+
+        let cache = PartitionKeyRangeCache::new();
+        let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let continuations_seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let count = call_count.clone();
+        let seen = continuations_seen.clone();
+        let paged_fetch = move |_container: ContainerReference, continuation: Option<String>| {
+            let count = count.clone();
+            let seen = seen.clone();
+            async move {
+                seen.lock().unwrap().push(continuation.clone());
+                let page = count.fetch_add(1, Ordering::SeqCst);
+                if page == BOUNDARIES.len() - 1 {
+                    return Some(PkRangeFetchResult {
+                        ranges: vec![],
+                        continuation,
+                        not_modified: true,
+                    });
+                }
+
+                Some(PkRangeFetchResult {
+                    ranges: vec![PkRange::new(
+                        page.to_string(),
+                        BOUNDARIES[page],
+                        BOUNDARIES[page + 1],
+                    )],
+                    continuation: Some(format!("etag-{page}")),
+                    not_modified: false,
+                })
+            }
+        };
+
+        let routing_map = cache
+            .try_lookup(&container, false, paged_fetch)
+            .await
+            .unwrap();
+
+        assert_eq!(routing_map.ranges().len(), BOUNDARIES.len() - 1);
+        assert_eq!(call_count.load(Ordering::SeqCst), BOUNDARIES.len());
+        let expected = std::iter::once(None)
+            .chain((0..BOUNDARIES.len() - 1).map(|page| Some(format!("etag-{page}"))))
+            .collect::<Vec<_>>();
+        assert_eq!(*continuations_seen.lock().unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn redelivered_ranges_are_deduplicated_by_id() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let result =
+            fetch_and_build_routing_map(container, None, move |_container, continuation| {
+                let count = count.clone();
+                async move {
+                    Some(match count.fetch_add(1, Ordering::SeqCst) {
+                        0 => PkRangeFetchResult {
+                            ranges: vec![PkRange::new("0".into(), "", "80")],
+                            continuation: Some("etag-before-split".to_string()),
+                            not_modified: false,
+                        },
+                        1 => PkRangeFetchResult {
+                            ranges: vec![
+                                PkRange::new("0".into(), "", "80"),
+                                PkRange::new("1".into(), "80", "FF"),
+                            ],
+                            continuation: Some("etag-after-split".to_string()),
+                            not_modified: false,
+                        },
+                        2 => PkRangeFetchResult {
+                            ranges: vec![],
+                            continuation,
+                            not_modified: true,
+                        },
+                        call => panic!("unexpected fetch call: {call}"),
+                    })
+                }
+            })
+            .await;
+
+        assert_eq!(result.ranges().len(), 2);
+        assert_eq!(result.ranges()[0].id, "0");
+        assert_eq!(result.ranges()[1].id, "1");
+    }
+
+    #[tokio::test]
+    async fn immediate_not_modified_preserves_previous_ranges() {
+        let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
+        let previous = routing_map(test_ranges(), "etag-previous");
+
+        let result = fetch_and_build_routing_map(
+            container,
+            Some(previous),
+            |_container, continuation| async move {
+                Some(PkRangeFetchResult {
+                    ranges: vec![],
+                    continuation,
+                    not_modified: true,
+                })
+            },
+        )
+        .await;
+
+        assert_eq!(result.ranges().len(), 1);
+        assert_eq!(
+            result.change_feed_next_if_none_match.as_deref(),
+            Some("etag-previous")
+        );
+    }
+
+    #[tokio::test]
+    async fn not_modified_wins_over_non_empty_payload() {
+        let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
+        let previous = routing_map(test_ranges(), "etag-previous");
+
+        let result = fetch_and_build_routing_map(
+            container,
+            Some(previous),
+            |_container, _continuation| async {
+                Some(PkRangeFetchResult {
+                    ranges: vec![PkRange::new("ignored".into(), "", "80")],
+                    continuation: Some("etag-advanced".to_string()),
+                    not_modified: true,
+                })
+            },
+        )
+        .await;
+
+        assert_eq!(result.ranges().len(), 1);
+        assert_eq!(result.ranges()[0].id, "0");
+        assert_eq!(
+            result.change_feed_next_if_none_match.as_deref(),
+            Some("etag-advanced")
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_page_advances_continuation_without_range_changes() {
+        let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
+        let previous = routing_map(test_ranges(), "etag-previous");
+
+        let result = fetch_and_build_routing_map(
+            container,
+            Some(previous),
+            |_container, _continuation| async {
+                Some(PkRangeFetchResult {
+                    ranges: vec![],
+                    continuation: Some("etag-advanced".to_string()),
+                    not_modified: true,
+                })
+            },
+        )
+        .await;
+
+        assert_eq!(result.ranges().len(), 1);
+        assert_eq!(
+            result.change_feed_next_if_none_match.as_deref(),
+            Some("etag-advanced")
+        );
+    }
+
+    #[tokio::test]
+    async fn real_wire_not_modified_preserves_last_data_etag() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let result =
+            fetch_and_build_routing_map(container, None, move |_container, _continuation| {
+                let count = count.clone();
+                async move {
+                    Some(if count.fetch_add(1, Ordering::SeqCst) == 0 {
+                        PkRangeFetchResult {
+                            ranges: test_ranges(),
+                            continuation: Some("etag-data".to_string()),
+                            not_modified: false,
+                        }
+                    } else {
+                        PkRangeFetchResult {
+                            ranges: vec![],
+                            continuation: None,
+                            not_modified: true,
+                        }
+                    })
+                }
+            })
+            .await;
+
+        assert_eq!(result.ranges().len(), 1);
+        assert_eq!(
+            result.change_feed_next_if_none_match.as_deref(),
+            Some("etag-data")
+        );
+        assert_eq!(call_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn mid_drain_failure_does_not_cache_partial_map() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let cache = PartitionKeyRangeCache::new();
+        let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let count = call_count.clone();
+        let failing_fetch = move |_container: ContainerReference, _continuation: Option<String>| {
+            let count = count.clone();
+            async move {
+                (count.fetch_add(1, Ordering::SeqCst) & 1 == 0).then(|| PkRangeFetchResult {
+                    ranges: vec![PkRange::new("0".into(), "", "80")],
+                    continuation: Some("etag-partial".to_string()),
+                    not_modified: false,
+                })
+            }
+        };
+
+        assert!(cache
+            .try_lookup(&container, false, failing_fetch.clone())
+            .await
+            .is_none());
+        assert!(cache
+            .try_lookup(&container, false, failing_fetch)
+            .await
+            .is_none());
+        assert_eq!(call_count.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn missing_continuation_preserves_previous_map() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
+        let previous = routing_map(test_ranges(), "etag-previous");
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let result = fetch_and_build_routing_map(
+            container,
+            Some(previous),
+            move |_container, continuation| {
+                let count = count.clone();
+                async move {
+                    Some(if count.fetch_add(1, Ordering::SeqCst) == 0 {
+                        let mut updated = PkRange::new("0".into(), "", "FF");
+                        updated.throughput_fraction = 0.5;
+                        PkRangeFetchResult {
+                            ranges: vec![updated],
+                            continuation: None,
+                            not_modified: false,
+                        }
+                    } else {
+                        PkRangeFetchResult {
+                            ranges: vec![],
+                            continuation,
+                            not_modified: true,
+                        }
+                    })
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(result.ranges()[0].id, "0");
+        assert_eq!(result.ranges()[0].throughput_fraction, 0.5);
+        assert_eq!(
+            result.change_feed_next_if_none_match.as_deref(),
+            Some("etag-previous")
+        );
+        assert_eq!(call_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn unknown_incremental_parent_falls_back_to_full_refresh() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
+        let previous = routing_map(test_ranges(), "etag-previous");
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let result = fetch_and_build_routing_map(
+            container,
+            Some(previous),
+            move |_container, continuation| {
+                let count = count.clone();
+                async move {
+                    Some(match count.fetch_add(1, Ordering::SeqCst) {
+                        0 => {
+                            let mut child = PkRange::new("child".into(), "", "FF");
+                            child.parents = Some(vec!["ghost-parent".to_string()]);
+                            PkRangeFetchResult {
+                                ranges: vec![child],
+                                continuation: Some("etag-child".to_string()),
+                                not_modified: false,
+                            }
+                        }
+                        1 | 3 => PkRangeFetchResult {
+                            ranges: vec![],
+                            continuation,
+                            not_modified: true,
+                        },
+                        2 => PkRangeFetchResult {
+                            ranges: vec![
+                                PkRange::new("full-left".into(), "", "80"),
+                                PkRange::new("full-right".into(), "80", "FF"),
+                            ],
+                            continuation: Some("etag-full".to_string()),
+                            not_modified: false,
+                        },
+                        call => panic!("unexpected fetch call: {call}"),
+                    })
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(result.ranges()[0].id, "full-left");
+        assert_eq!(result.ranges()[1].id, "full-right");
+        assert_eq!(
+            result.change_feed_next_if_none_match.as_deref(),
+            Some("etag-full")
+        );
+        assert_eq!(call_count.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn failed_full_refresh_after_merge_failure_preserves_previous_map() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
+        let previous = routing_map(test_ranges(), "etag-previous");
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let result = fetch_and_build_routing_map(
+            container,
+            Some(previous),
+            move |_container, continuation| {
+                let count = count.clone();
+                async move {
+                    match count.fetch_add(1, Ordering::SeqCst) {
+                        0 => {
+                            let mut child = PkRange::new("child".into(), "", "FF");
+                            child.parents = Some(vec!["ghost-parent".to_string()]);
+                            Some(PkRangeFetchResult {
+                                ranges: vec![child],
+                                continuation: Some("etag-child".to_string()),
+                                not_modified: false,
+                            })
+                        }
+                        1 => Some(PkRangeFetchResult {
+                            ranges: vec![],
+                            continuation,
+                            not_modified: true,
+                        }),
+                        2 => None,
+                        call => panic!("unexpected fetch call: {call}"),
+                    }
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(result.ranges()[0].id, "0");
+        assert_eq!(
+            result.change_feed_next_if_none_match.as_deref(),
+            Some("etag-previous")
+        );
+        assert_eq!(call_count.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn overlapping_incremental_page_falls_back_to_full_refresh() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
+        let previous = routing_map(test_ranges(), "etag-previous");
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let result = fetch_and_build_routing_map(
+            container,
+            Some(previous),
+            move |_container, continuation| {
+                let count = count.clone();
+                async move {
+                    Some(match count.fetch_add(1, Ordering::SeqCst) {
+                        0 => {
+                            let mut left = PkRange::new("left".into(), "", "AA");
+                            left.parents = Some(vec!["0".to_string()]);
+                            let mut right = PkRange::new("right".into(), "80", "FF");
+                            right.parents = Some(vec!["0".to_string()]);
+                            PkRangeFetchResult {
+                                ranges: vec![left, right],
+                                continuation: Some("etag-overlap".to_string()),
+                                not_modified: false,
+                            }
+                        }
+                        1 | 3 => PkRangeFetchResult {
+                            ranges: vec![],
+                            continuation,
+                            not_modified: true,
+                        },
+                        2 => PkRangeFetchResult {
+                            ranges: vec![
+                                PkRange::new("full-left".into(), "", "80"),
+                                PkRange::new("full-right".into(), "80", "FF"),
+                            ],
+                            continuation: Some("etag-full".to_string()),
+                            not_modified: false,
+                        },
+                        call => panic!("unexpected fetch call: {call}"),
+                    })
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(result.ranges()[0].id, "full-left");
+        assert_eq!(result.ranges()[1].id, "full-right");
+        assert_eq!(
+            result.change_feed_next_if_none_match.as_deref(),
+            Some("etag-full")
+        );
+        assert_eq!(call_count.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn per_page_retry_does_not_restart_completed_pages() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
+        let first_page_attempts = Arc::new(AtomicUsize::new(0));
+        let second_page_attempts = Arc::new(AtomicUsize::new(0));
+        let first = first_page_attempts.clone();
+        let second = second_page_attempts.clone();
+
+        let result =
+            fetch_and_build_routing_map(container, None, move |_container, continuation| {
+                let first = first.clone();
+                let second = second.clone();
+                async move {
+                    Some(match continuation.as_deref() {
+                        None => {
+                            first.fetch_add(1, Ordering::SeqCst);
+                            PkRangeFetchResult {
+                                ranges: vec![PkRange::new("0".into(), "", "80")],
+                                continuation: Some("etag-1".to_string()),
+                                not_modified: false,
+                            }
+                        }
+                        Some("etag-1") => {
+                            // The request pipeline retries internally; the drain sees
+                            // only the successful page result.
+                            second.fetch_add(2, Ordering::SeqCst);
+                            PkRangeFetchResult {
+                                ranges: vec![PkRange::new("1".into(), "80", "FF")],
+                                continuation: Some("etag-2".to_string()),
+                                not_modified: false,
+                            }
+                        }
+                        Some("etag-2") => PkRangeFetchResult {
+                            ranges: vec![],
+                            continuation,
+                            not_modified: true,
+                        },
+                        other => panic!("unexpected continuation: {other:?}"),
+                    })
+                }
+            })
+            .await;
+
+        assert_eq!(result.ranges().len(), 2);
+        assert_eq!(first_page_attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(second_page_attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn empty_routing_map_is_not_cached() {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+
+        let cache = PartitionKeyRangeCache::new();
+        let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let count = call_count.clone();
+        let empty_fetch = move |_container: ContainerReference, _continuation: Option<String>| {
+            let count = count.clone();
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                Some(PkRangeFetchResult {
+                    ranges: vec![],
+                    continuation: None,
+                    not_modified: true,
+                })
+            }
+        };
+
+        assert!(cache
+            .try_lookup(&container, false, empty_fetch.clone())
+            .await
+            .is_none());
+        assert!(cache
+            .try_lookup(&container, false, empty_fetch)
+            .await
+            .is_none());
+        assert_eq!(call_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn repeated_continuation_terminates_without_caching_partial_map() {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+
+        let cache = PartitionKeyRangeCache::new();
+        let container = make_container(r#"{"paths":["/pk"],"version":2}"#);
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let count = call_count.clone();
+        let stalled_fetch = move |_container: ContainerReference, _continuation: Option<String>| {
+            let count = count.clone();
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                Some(PkRangeFetchResult {
+                    ranges: vec![PkRange::new("same-page".into(), "", "80")],
+                    continuation: Some("unchanged-etag".to_string()),
+                    not_modified: false,
+                })
+            }
+        };
+
+        assert!(cache
+            .try_lookup(&container, false, stalled_fetch)
+            .await
+            .is_none());
+        assert_eq!(call_count.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]

--- a/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/config.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/config.rs
@@ -555,6 +555,7 @@ fn rand_fraction() -> f64 {
 #[derive(Clone, Debug)]
 pub struct ContainerConfig {
     partition_count: u32,
+    partition_key_range_page_size: Option<u32>,
     provisioned_throughput_ru: Option<u32>,
 }
 
@@ -577,6 +578,14 @@ impl ContainerConfig {
         self
     }
 
+    /// Sets the number of partition key ranges returned per `/pkranges` page.
+    ///
+    /// When unset, the emulator returns all ranges in one page.
+    pub fn with_partition_key_range_page_size(mut self, page_size: u32) -> Self {
+        self.partition_key_range_page_size = Some(page_size);
+        self
+    }
+
     /// Sets the provisioned throughput in RU/s. Validation is deferred to
     /// [`Self::build`].
     pub fn with_throughput(mut self, ru_per_second: u32) -> Self {
@@ -589,6 +598,7 @@ impl ContainerConfig {
     ///
     /// Validation rules:
     /// - `partition_count` must be in `1..=MAX_PARTITION_COUNT`.
+    /// - `partition_key_range_page_size`, when set, must be greater than zero.
     /// - `provisioned_throughput_ru`, when set, must be `>= 400` RU/s.
     ///
     /// Returns a `Client` error on the first violation.
@@ -609,6 +619,14 @@ impl ContainerConfig {
                 .with_message(format!("partition count must be <= {MAX_PARTITION_COUNT}"))
                 .build());
         }
+        if self.partition_key_range_page_size == Some(0) {
+            return Err(crate::error::CosmosError::builder()
+                .with_status(crate::error::CosmosStatus::new(
+                    azure_core::http::StatusCode::BadRequest,
+                ))
+                .with_message("partition key range page size must be > 0")
+                .build());
+        }
         if let Some(ru) = self.provisioned_throughput_ru {
             if ru < 400 {
                 return Err(crate::error::CosmosError::builder()
@@ -626,20 +644,40 @@ impl ContainerConfig {
         self.partition_count
     }
 
+    pub fn partition_key_range_page_size(&self) -> Option<u32> {
+        self.partition_key_range_page_size
+    }
+
     pub fn provisioned_throughput_ru(&self) -> Option<u32> {
         self.provisioned_throughput_ru
     }
 }
 
 impl Default for ContainerConfig {
-    /// Defaults: **4 physical partitions** and no provisioned throughput
-    /// (throttling disabled even if the account-level `with_throttling_enabled`
-    /// is `true`). Override with [`ContainerConfig::with_partition_count`] and
-    /// [`ContainerConfig::with_throughput`].
+    /// Defaults to 4 physical partitions, unpaged partition metadata, and no
+    /// provisioned throughput.
     fn default() -> Self {
         Self {
             partition_count: 4,
+            partition_key_range_page_size: None,
             provisioned_throughput_ru: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ContainerConfig;
+
+    #[test]
+    fn partition_key_range_page_size_must_be_positive() {
+        let error = ContainerConfig::new()
+            .with_partition_key_range_page_size(0)
+            .build()
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("partition key range page size must be > 0"));
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/operations.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/operations.rs
@@ -2080,14 +2080,6 @@ fn handle_read_pkranges(
 
     region_ref
         .with_container(db_id, coll_id, |state| {
-            // Honor If-None-Match for change-feed-style routing-map refreshes.
-            // The driver's `fetch_and_build_routing_map` loops calling
-            // `fetch_pk_ranges` with the previous etag as `If-None-Match` until
-            // the service returns 304 (or hits `MAX_FETCH_ITERATIONS`).
-            // Without 304 support the loop runs the maximum number of iterations,
-            // accumulates duplicate ranges, and `ContainerRoutingMap::try_create`
-            // produces an empty map — defeating PK-range pre-resolution and
-            // any feature that depends on it (PPCB, PPAF).
             if let Some(client_etag) = if_none_match {
                 if client_etag == state.metadata.etag {
                     return ResponseBuilder::new(StatusCode::NotModified, start)
@@ -2096,10 +2088,27 @@ fn handle_read_pkranges(
                         .build();
                 }
             }
-            let body = pkranges_to_json(state);
+
+            let total = state.physical_partitions.len();
+            let page_start = if_none_match
+                .and_then(|token| parse_pkrange_page_token(token, &state.metadata.etag))
+                .unwrap_or(0)
+                .min(total);
+            let page_size = state
+                .metadata
+                .partition_key_range_page_size
+                .map(|size| size as usize)
+                .unwrap_or(total.max(1));
+            let page_end = page_start.saturating_add(page_size).min(total);
+            let next_etag = if page_end < total {
+                pkrange_page_token(page_end, &state.metadata.etag)
+            } else {
+                state.metadata.etag.clone()
+            };
+            let body = pkranges_to_json(state, page_start, page_end);
             success_response(StatusCode::Ok, &body, 1.0, "", start)
-                .with_etag(&state.metadata.etag)
-                .with_item_count(state.physical_partitions.len() as u32)
+                .with_etag(&next_etag)
+                .with_item_count((page_end - page_start) as u32)
                 .build()
         })
         .unwrap_or_else(|| {
@@ -2114,6 +2123,18 @@ fn handle_read_pkranges(
             )
             .build()
         })
+}
+
+fn pkrange_page_token(offset: usize, etag: &str) -> String {
+    format!("pkranges/{offset}/{etag}")
+}
+
+fn parse_pkrange_page_token(token: &str, expected_etag: &str) -> Option<usize> {
+    let token = token.strip_prefix("pkranges/")?;
+    let (offset, etag) = token.split_once('/')?;
+    (etag == expected_etag)
+        .then(|| offset.parse::<usize>().ok())
+        .flatten()
 }
 
 fn paginate_values(
@@ -5469,6 +5490,17 @@ fn container_not_found(db_id: &str, coll_id: &str, start: Instant) -> AsyncRawRe
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pkrange_page_token_round_trips_offset_and_etag() {
+        let token = pkrange_page_token(1_000, "\"etag/with/slashes\"");
+
+        assert_eq!(
+            parse_pkrange_page_token(&token, "\"etag/with/slashes\""),
+            Some(1_000)
+        );
+        assert_eq!(parse_pkrange_page_token(&token, "\"other-etag\""), None);
+    }
 
     fn document_item(epk: &str, id: &str) -> DocumentFeedItem {
         DocumentFeedItem {

--- a/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/store.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/store.rs
@@ -580,6 +580,7 @@ impl EmulatorStore {
             etag: new_etag(),
             partition_key: pk_def,
             partition_count: config.partition_count(),
+            partition_key_range_page_size: config.partition_key_range_page_size(),
             provisioned_throughput_ru: config.provisioned_throughput_ru(),
             // Shared counter — first id allocated by split/merge will be
             // `partition_count` (one past the last initial partition id).
@@ -1339,6 +1340,7 @@ pub(crate) struct ContainerMetadata {
     pub etag: String,
     pub partition_key: PartitionKeyDefinition,
     pub partition_count: u32,
+    pub partition_key_range_page_size: Option<u32>,
     pub provisioned_throughput_ru: Option<u32>,
     /// Shared atomic counter for allocating new partition IDs (split/merge).
     /// Authoritative across *all* regions so partition IDs cannot diverge —

--- a/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/system_properties.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/system_properties.rs
@@ -122,10 +122,16 @@ pub(crate) fn offer_to_json(meta: &super::store::OfferMetadata) -> serde_json::V
     })
 }
 
-/// Returns a JSON representation of partition key ranges for a container.
-pub(crate) fn pkranges_to_json(container: &super::store::ContainerState) -> serde_json::Value {
+/// Returns a JSON representation of a page of partition key ranges.
+pub(crate) fn pkranges_to_json(
+    container: &super::store::ContainerState,
+    start: usize,
+    end: usize,
+) -> serde_json::Value {
     let ranges: Vec<serde_json::Value> = container
         .physical_partitions
+        .get(start..end)
+        .unwrap_or_default()
         .iter()
         .map(|p| {
             let parents: Vec<String> = p.parents.iter().map(|id| id.to_string()).collect();


### PR DESCRIPTION
Fix partition-range discovery for large Cosmos DB containers whose routing metadata requires more than ten `/pkranges` responses.

- Drain partition-range metadata until the service signals completion with HTTP 304, without a client-side page, range-count, time, or replay limit.
- Deduplicate ranges by ID when metadata paging restarts, recover invalid incremental maps with a full refresh, and avoid caching empty routing maps.
- Retry `ContainerClient::read_feed_ranges` once with forced refresh when initial metadata resolution fails.
- Add Rust coverage corresponding to the scenarios in Azure/azure-sdk-for-python#47245.
- Extend the in-memory emulator with configurable `/pkranges` paging and verify a 25,000-partition container through the public SDK.

Validation includes the complete driver library tests, SDK library tests, the 25,000-partition emulator integration test, formatting, and clippy.