### PR TITLE
[Cosmos] Release patch versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "azure_data_cosmos"
-version = "0.38.0"
+version = "0.37.1"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "azure_data_cosmos_driver"
-version = "0.7.0"
+version = "0.6.1"
 dependencies = [
  "arc-swap",
  "async-lock",

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 0.38.0 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 0.37.1 (2026-07-23)
 
 ### Bugs Fixed
 
 - Fixed `ContainerClient::read_feed_ranges` failing on containers with large partition counts by fully draining routing metadata and retrying missing cache results with a forced refresh. ([#4845](https://github.com/Azure/azure-sdk-for-rust/pull/4845))
-
-### Other Changes
 
 ## 0.37.0 (2026-07-20)
 

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["api-bindings"]
 async-lock.workspace = true
 async-trait.workspace = true
 azure_core = { workspace = true, default-features = false }
-azure_data_cosmos_driver = { version = "0.7.0", path = "../azure_data_cosmos_driver", default-features = false }
+azure_data_cosmos_driver = { version = "0.6.1", path = "../azure_data_cosmos_driver", default-features = false }
 base64.workspace = true
 futures.workspace = true
 pin-project.workspace = true

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_data_cosmos"
-version = "0.38.0"
+version = "0.37.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Azure Cosmos DB"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/cosmos/azure_data_cosmos_benchmarks/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_benchmarks/Cargo.toml
@@ -20,7 +20,7 @@ harness = false
 [dependencies]
 async-trait.workspace = true
 azure_core.workspace = true
-azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", version = "0.7.0", features = [
+azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", version = "0.6.1", features = [
   "__internal_mocking",
   "__internal_backtrace_bench",
 ] }

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 0.7.0 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 0.6.1 (2026-07-23)
 
 ### Bugs Fixed
 
 - Fixed partition-range discovery for containers whose routing metadata spans more than ten pages, added full-refresh recovery for invalid incremental maps, and prevented empty routing maps from remaining cached. ([#4845](https://github.com/Azure/azure-sdk-for-rust/pull/4845))
-
-### Other Changes
 
 ## 0.6.0 (2026-07-20)
 

--- a/sdk/cosmos/azure_data_cosmos_driver/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_data_cosmos_driver"
-version = "0.7.0"
+version = "0.6.1"
 description = "Core implementation layer for Azure Cosmos DB - provides transport, routing, and protocol handling for cross-language SDK reuse"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/cosmos/azure_data_cosmos_driver_native/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib", "staticlib"]
 # HTTP client (the driver's default factory needs either `rustls` or
 # `native_tls` — `rustls` matches the driver's own default and avoids the
 # OpenSSL-on-Windows breakage that bites `native_tls`).
-azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", version = "0.7.0", default-features = false, features = ["tokio", "rustls"] }
+azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", version = "0.6.1", default-features = false, features = ["tokio", "rustls"] }
 # Required at runtime for master-key auth — `Secret` lives in
 # `azure_core::credentials` and `Url::parse` is the gate for the account
 # endpoint. Both are zero-cost wrappers around existing driver deps so

--- a/sdk/cosmos/azure_data_cosmos_perf/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_perf/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 azure_core = { workspace = true, features = ["reqwest"] }
-azure_data_cosmos = { path = "../azure_data_cosmos", version = "0.38.0", features = ["key_auth"] }
+azure_data_cosmos = { path = "../azure_data_cosmos", version = "0.37.1", features = ["key_auth"] }
 azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", version = "0.6.1" }
 azure_identity = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }

--- a/sdk/cosmos/azure_data_cosmos_perf/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_perf/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 async-trait.workspace = true
 azure_core = { workspace = true, features = ["reqwest"] }
 azure_data_cosmos = { path = "../azure_data_cosmos", version = "0.38.0", features = ["key_auth"] }
-azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", version = "0.7.0" }
+azure_data_cosmos_driver = { path = "../azure_data_cosmos_driver", version = "0.6.1" }
 azure_identity = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 console-subscriber = { workspace = true, optional = true }


### PR DESCRIPTION
## Cosmos DB Rust patch releases

### Version changes

- `azure_data_cosmos_driver`: 0.7.0 (unreleased) → 0.6.1
- `azure_data_cosmos`: 0.38.0 (unreleased) → 0.37.1
- Updated local workspace dependency pins to the release versions.

### Bugs fixed

- Fixed partition-range discovery for containers whose routing metadata spans more than ten pages, added full-refresh recovery for invalid incremental maps, and prevented empty routing maps from remaining cached. (#4845)
- Fixed `ContainerClient::read_feed_ranges` failing on containers with large partition counts by fully draining routing metadata and retrying missing cache results with a forced refresh. (#4845)

### Release order

Publish `azure_data_cosmos_driver` 0.6.1 first. After it is visible on crates.io, publish `azure_data_cosmos` 0.37.1.