### PR TITLE
Align sample local deps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,6 +276,7 @@ Additional specialized instructions for specific workflows can be found in:
   - `create-perf-test` - Generate a new performance test
   - `create-recorded-test` - Generate a new recorded integration test
   - `lint-markdown` - Check and fix formatting in markdown files using markdownlint-cli2
+- Keep local AGENTS terse: add only deltas, use short imperative bullets, and link instead of repeating detail.
 
 ## Cross-References
 

--- a/samples/AGENTS.md
+++ b/samples/AGENTS.md
@@ -7,3 +7,4 @@ Follow [../AGENTS.md](../AGENTS.md).
 - Use the latest stable published versions of repo crates.
 - Use path dependencies only to show unpublished functionality that cannot live in a crate's `examples/` directory.
 - Never use path dependencies for convenience or to track unreleased versions.
+- If a sample uses a local `path` crate, mirror its direct Azure SDK `path + version` dependencies for any public types that cross the boundary; do not mix published and local crate instances there.

--- a/samples/storage_blob_logging/Cargo.toml
+++ b/samples/storage_blob_logging/Cargo.toml
@@ -8,12 +8,12 @@ repository = "https://github.com/azure/azure-sdk-for-rust"
 publish = false
 
 [dependencies]
-azure_core = { version = "1.1.0", default-features = false }
-azure_core_opentelemetry = "1.0.0"
-azure_identity = { version = "1.0.0", default-features = false }
-azure_storage_blob = { path = "../../sdk/storage/azure_storage_blob" }
+azure_core = { path = "../../sdk/core/azure_core", version = "1.2.0-beta.1", default-features = false }
+azure_core_opentelemetry = { path = "../../sdk/core/azure_core_opentelemetry", version = "1.1.0-beta.1" }
+azure_identity = { path = "../../sdk/identity/azure_identity", version = "1.1.0-beta.1", default-features = false }
+azure_storage_blob = { path = "../../sdk/storage/azure_storage_blob", version = "1.1.0-beta.2" }
 clap = { version = "4.6.0", features = ["derive", "env"] }
-opentelemetry-stdout = "0.31.0"
-opentelemetry_sdk = "0.31.0"
+opentelemetry-stdout = "0.32"
+opentelemetry_sdk = "0.32.1"
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }


### PR DESCRIPTION

This pull request makes several documentation and dependency updates to improve guidance for local agent workflows and ensure consistency in sample usage of local and published crates. The most important changes are grouped below.

**Documentation improvements:**

* Updated `AGENTS.md` to clarify that local agent instructions should be concise, only list deltas, use short imperative bullets, and link to details instead of repeating them.
* Added guidance in `samples/AGENTS.md` to ensure that when a sample uses a local `path` crate, any public types crossing the boundary must use matching `path + version` dependencies for Azure SDK crates, avoiding mixing published and local instances.

**Dependency management:**

* Updated dependencies in `samples/storage_blob_logging/Cargo.toml` to use local `path` references with explicit versions for Azure SDK crates, and upgraded OpenTelemetry dependencies to newer versions. This aligns with the new guidance for local crate usage.
