### PR TITLE
Fix Key Vault issues from sdk-reviewer agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,6 +835,8 @@ dependencies = [
 name = "azure_security_keyvault_test"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "azure_core 1.2.0-beta.1",
  "tokio",
 ]
 

--- a/sdk/keyvault/assets.json
+++ b/sdk/keyvault/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
   "TagPrefix": "rust/keyvault",
-  "Tag": "rust/keyvault_d0ee254014"
+  "Tag": "rust/keyvault_c9303ec620"
 }

--- a/sdk/keyvault/azure_security_keyvault_certificates/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_certificates/Cargo.toml
@@ -23,7 +23,6 @@ azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1" }
 futures = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-tokio = { workspace = true }
 
 [dev-dependencies]
 azure_core_test = { path = "../../core/azure_core_test", features = [

--- a/sdk/keyvault/azure_security_keyvault_keys/README.md
+++ b/sdk/keyvault/azure_security_keyvault_keys/README.md
@@ -167,12 +167,12 @@ println!(
 use azure_security_keyvault_keys::models::KeyClientGetKeyOptions;
 
 // Retrieve a public key as a JWK using the key client.
-let key_options = KeyClientGetKeyOptions {
+let get_options = KeyClientGetKeyOptions {
     key_version: Some("key-version".to_string()),
     ..Default::default()
 };
 let key = client
-    .get_key("key-name", None)
+    .get_key("key-name", Some(get_options))
     .await?
     .into_model()?;
 

--- a/sdk/keyvault/azure_security_keyvault_keys/tests/readme.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/tests/readme.rs
@@ -5,14 +5,24 @@ use azure_core::{error::Result, http::StatusCode};
 use azure_core_test::{recorded, TestContext, TestMode};
 use azure_security_keyvault_keys::{KeyClient, KeyClientOptions};
 use include_file::include_markdown;
+use std::sync::Arc;
 
 #[recorded::test]
 async fn readme(ctx: TestContext) -> Result<()> {
-    use azure_security_keyvault_test::Retry;
+    use azure_security_keyvault_test::{policies::GetLatestResource, Retry};
 
     let recording = ctx.recording();
 
     let mut options = KeyClientOptions::default();
+    // "key-version" is not detected as a valid version but as an unsupported operation.
+    options
+        .client_options
+        .per_try_policies
+        .push(Arc::new(GetLatestResource {
+            collection: "keys",
+            name: "key-name",
+            version: "key-version",
+        }));
     recording.instrument(&mut options.client_options);
 
     let client = KeyClient::new(

--- a/sdk/keyvault/azure_security_keyvault_secrets/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_secrets/Cargo.toml
@@ -25,7 +25,6 @@ futures = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 time = { workspace = true }
-tokio = { workspace = true }
 
 [dev-dependencies]
 azure_core_test = { path = "../../core/azure_core_test", features = [

--- a/sdk/keyvault/azure_security_keyvault_secrets/README.md
+++ b/sdk/keyvault/azure_security_keyvault_secrets/README.md
@@ -140,7 +140,7 @@ let get_options = SecretClientGetSecretOptions {
     ..Default::default()
 };
 let secret = client
-    .get_secret("secret-name", None)
+    .get_secret("secret-name", Some(get_options))
     .await?
     .into_model()?;
 

--- a/sdk/keyvault/azure_security_keyvault_secrets/tests/readme.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/tests/readme.rs
@@ -5,14 +5,24 @@ use azure_core::{error::Result, http::StatusCode};
 use azure_core_test::{recorded, TestContext, TestMode};
 use azure_security_keyvault_secrets::{SecretClient, SecretClientOptions};
 use include_file::include_markdown;
+use std::sync::Arc;
 
 #[recorded::test]
 async fn readme(ctx: TestContext) -> Result<()> {
-    use azure_security_keyvault_test::Retry;
+    use azure_security_keyvault_test::{policies::GetLatestResource, Retry};
 
     let recording = ctx.recording();
 
     let mut options = SecretClientOptions::default();
+    // "secret-version" is not detected as a valid version but as an unsupported operation.
+    options
+        .client_options
+        .per_try_policies
+        .push(Arc::new(GetLatestResource {
+            collection: "secrets",
+            name: "secret-name",
+            version: "secret-version",
+        }));
     recording.instrument(&mut options.client_options);
 
     let client = SecretClient::new(

--- a/sdk/keyvault/azure_security_keyvault_test/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_test/Cargo.toml
@@ -13,6 +13,8 @@ categories = ["development-tools"]
 publish = false
 
 [dependencies]
+async-trait = { workspace = true }
+azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1" }
 tokio = { workspace = true, features = ["rt"] }
 
 [lints]

--- a/sdk/keyvault/azure_security_keyvault_test/src/lib.rs
+++ b/sdk/keyvault/azure_security_keyvault_test/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+pub mod policies;
+
 use std::{ops::Mul, pin::Pin, time::Duration};
 use tokio::time::{sleep, Sleep};
 

--- a/sdk/keyvault/azure_security_keyvault_test/src/policies.rs
+++ b/sdk/keyvault/azure_security_keyvault_test/src/policies.rs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! HTTP client policies for use during testing Key Vault clients.
+
+use async_trait::async_trait;
+use azure_core::http::{
+    policies::{Policy, PolicyResult},
+    Context, Method, Request,
+};
+use std::sync::Arc;
+
+/// Get the latest version for a specific versioned resource.
+#[derive(Debug)]
+pub struct GetLatestResource {
+    pub collection: &'static str,
+    pub name: &'static str,
+    pub version: &'static str,
+}
+
+#[async_trait]
+impl Policy for GetLatestResource {
+    async fn send(
+        &self,
+        ctx: &Context,
+        request: &mut Request,
+        next: &[Arc<dyn Policy>],
+    ) -> PolicyResult {
+        rewrite_latest_resource_path(request, self.collection, self.name, self.version);
+        next[0].send(ctx, request, &next[1..]).await
+    }
+}
+
+fn rewrite_latest_resource_path(
+    request: &mut Request,
+    collection: &str,
+    name: &str,
+    version: &str,
+) {
+    if request.method() != Method::Get {
+        return;
+    }
+
+    let expected_path = format!("/{collection}/{name}/{version}");
+    if request.url().path() == expected_path {
+        request
+            .url_mut()
+            .set_path(&format!("/{collection}/{name}/"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use azure_core::http::Url;
+
+    #[test]
+    fn rewrites_matching_get_to_latest_version() {
+        let mut request = Request::new(
+            Url::parse("https://example.vault.azure.net/secrets/secret-name/secret-version")
+                .expect("valid URL"),
+            Method::Get,
+        );
+
+        rewrite_latest_resource_path(&mut request, "secrets", "secret-name", "secret-version");
+
+        assert_eq!(request.url().path(), "/secrets/secret-name/");
+    }
+
+    #[test]
+    fn leaves_non_matching_requests_unchanged() {
+        let mut list_request = Request::new(
+            Url::parse("https://example.vault.azure.net/secrets").expect("valid URL"),
+            Method::Get,
+        );
+        rewrite_latest_resource_path(
+            &mut list_request,
+            "secrets",
+            "secret-name",
+            "secret-version",
+        );
+        assert_eq!(list_request.url().path(), "/secrets");
+
+        let mut post_request = Request::new(
+            Url::parse("https://example.vault.azure.net/secrets/secret-name/secret-version")
+                .expect("valid URL"),
+            Method::Post,
+        );
+        rewrite_latest_resource_path(
+            &mut post_request,
+            "secrets",
+            "secret-name",
+            "secret-version",
+        );
+        assert_eq!(
+            post_request.url().path(),
+            "/secrets/secret-name/secret-version"
+        );
+    }
+}


### PR DESCRIPTION
Didn't need `tokio` in `[dependencies]` nor was I actually using the options bag for `get_secret` or `get_key`.

Turns out that the secrets and keys collection don't treat "arbitrary-string" as a valid version but detect it as an unsupported operation, unlike certificates. Added a test policy to work around that.
