### PR TITLE
chore: add Eric Lam, SJ, and Amit Bhatia to Event Hubs CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,14 +83,14 @@
 # AzureSDKOwners: @vincenttran-msft @jalauzon-msft @jaschrep-msft
 
 # PRLabel: %Event Hubs
-/sdk/eventhubs/          @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak
+/sdk/eventhubs/          @hmlam @j7nw4r @meetamitbhatia @SwayGom @sagar0207 @sjkwak
 
 # PRLabel: %Event Hubs %Storage
-/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/    @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak @jalauzon-msft @vincenttran-msft @jaschrep-msft
+/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/    @hmlam @j7nw4r @meetamitbhatia @SwayGom @sagar0207 @sjkwak @jalauzon-msft @vincenttran-msft @jaschrep-msft
 
 # ServiceLabel: %Event Hubs
 # AzureSDKOwners: @LarryOsterman
-# ServiceOwners: @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak
+# ServiceOwners: @hmlam @j7nw4r @meetamitbhatia @SwayGom @sagar0207 @sjkwak
 
 ####################
 # Management Libraries

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,14 +83,14 @@
 # AzureSDKOwners: @vincenttran-msft @jalauzon-msft @jaschrep-msft
 
 # PRLabel: %Event Hubs
-/sdk/eventhubs/          @j7nw4r @SwayGom @sagar0207
+/sdk/eventhubs/          @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak
 
 # PRLabel: %Event Hubs %Storage
-/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/    @j7nw4r @SwayGom @sagar0207 @jalauzon-msft @vincenttran-msft @jaschrep-msft
+/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/    @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak @jalauzon-msft @vincenttran-msft @jaschrep-msft
 
 # ServiceLabel: %Event Hubs
 # AzureSDKOwners: @LarryOsterman
-# ServiceOwners: @j7nw4r @SwayGom @sagar0207
+# ServiceOwners: @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak
 
 ####################
 # Management Libraries

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -74,14 +74,14 @@
 # AzureSDKOwners: @vincenttran-msft @jalauzon-msft @jaschrep-msft
 
 # PRLabel: %Event Hubs
-/sdk/eventhubs/          @j7nw4r @SwayGom @sagar0207
+/sdk/eventhubs/          @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak
 
 # PRLabel: %Event Hubs %Storage
-/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/    @j7nw4r @SwayGom @sagar0207 @jalauzon-msft @vincenttran-msft @jaschrep-msft
+/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/    @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak @jalauzon-msft @vincenttran-msft @jaschrep-msft
 
 # ServiceLabel: %Event Hubs
 # AzureSDKOwners: @LarryOsterman
-# ServiceOwners: @j7nw4r @SwayGom @sagar0207
+# ServiceOwners: @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak
 
 ####################
 # Management Libraries

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -74,14 +74,14 @@
 # AzureSDKOwners: @vincenttran-msft @jalauzon-msft @jaschrep-msft
 
 # PRLabel: %Event Hubs
-/sdk/eventhubs/          @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak
+/sdk/eventhubs/          @hmlam @j7nw4r @meetamitbhatia @SwayGom @sagar0207 @sjkwak
 
 # PRLabel: %Event Hubs %Storage
-/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/    @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak @jalauzon-msft @vincenttran-msft @jaschrep-msft
+/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/    @hmlam @j7nw4r @meetamitbhatia @SwayGom @sagar0207 @sjkwak @jalauzon-msft @vincenttran-msft @jaschrep-msft
 
 # ServiceLabel: %Event Hubs
 # AzureSDKOwners: @LarryOsterman
-# ServiceOwners: @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak
+# ServiceOwners: @hmlam @j7nw4r @meetamitbhatia @SwayGom @sagar0207 @sjkwak
 
 ####################
 # Management Libraries


### PR DESCRIPTION
## Summary

The Event Hubs entries in `.github/CODEOWNERS` do not list @hmlam, @sjkwak, or @meetamitbhatia. This pull request adds all three.

## Motivation

@hmlam and @sjkwak own the Event Hubs paths in the .NET, Java, JS, Python, and C++ repos. They get no review request and no service notification for Event Hubs changes in this repo. The owner list must agree across the language repos.

@meetamitbhatia joined the messaging team. GitHub does not add him to pull requests on these paths until a CODEOWNERS entry names him.

## Changes

Adds @hmlam, @sjkwak, and @meetamitbhatia to three places:

- The `/sdk/eventhubs/` owner line.
- The `/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/` owner line.
- The Event Hubs `ServiceOwners` list.

The change removes no owner and adds no new path.

## Validation

The CODEOWNERS linter needs each handle to be a public member of the `Azure` organization. @meetamitbhatia is a private member today, so the linter reports an error on each of the three lines. @meetamitbhatia must make the membership public before this pull request can merge.
