### PR TITLE
Enable continuous backup for AllVersionsAndDeletes tests

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/build.rs
+++ b/sdk/cosmos/azure_data_cosmos/build.rs
@@ -7,6 +7,6 @@
 fn main() {
     // Allow `#[cfg_attr(not(test_category = "..."), ignore)]` in `tests/*.rs`.
     println!(
-        "cargo:rustc-check-cfg=cfg(test_category, values(\"emulator\", \"emulator_vnext\", \"multi_write\", \"split\", \"binary_encoding\", \"gateway_v2\", \"gateway_v2_multi_region\"))"
+        "cargo:rustc-check-cfg=cfg(test_category, values(\"emulator\", \"emulator_vnext\", \"multi_write\", \"split\", \"binary_encoding\", \"gateway_v2\", \"gateway_v2_multi_region\", \"all_versions_and_deletes\"))"
     );
 }

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_change_feed.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_change_feed.rs
@@ -728,8 +728,8 @@ where
 /// supported by the vnext (Linux) emulator.
 #[tokio::test]
 #[cfg_attr(
-    not(test_category = "emulator"),
-    ignore = "requires test_category 'emulator' (the vnext emulator does not support full-fidelity change feed)"
+    not(test_category = "all_versions_and_deletes"),
+    ignore = "requires test_category 'all_versions_and_deletes' (requires live account with continuous backup enabled)"
 )]
 pub async fn all_versions_and_deletes_surfaces_create_replace_delete() -> Result<(), Box<dyn Error>>
 {
@@ -857,8 +857,8 @@ pub async fn all_versions_and_deletes_surfaces_create_replace_delete() -> Result
 /// supported by the vnext (Linux) emulator.
 #[tokio::test]
 #[cfg_attr(
-    not(test_category = "emulator"),
-    ignore = "requires test_category 'emulator' (the vnext emulator does not support full-fidelity change feed)"
+    not(test_category = "all_versions_and_deletes"),
+    ignore = "requires test_category 'all_versions_and_deletes' (requires live account with continuous backup enabled)"
 )]
 pub async fn all_versions_and_deletes_fans_out_creates_across_partitions(
 ) -> Result<(), Box<dyn Error>> {
@@ -958,8 +958,8 @@ pub async fn all_versions_and_deletes_fans_out_creates_across_partitions(
 /// supported by the vnext (Linux) emulator.
 #[tokio::test]
 #[cfg_attr(
-    not(test_category = "emulator"),
-    ignore = "requires test_category 'emulator' (the vnext emulator does not support full-fidelity change feed)"
+    not(test_category = "all_versions_and_deletes"),
+    ignore = "requires test_category 'all_versions_and_deletes' (requires live account with continuous backup enabled)"
 )]
 pub async fn all_versions_and_deletes_rejects_point_in_time_start() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_change_feed.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_change_feed.rs
@@ -660,6 +660,13 @@ impl AvadItem {
     }
 }
 
+/// The full-fidelity retention window used by the AllVersionsAndDeletes tests.
+///
+/// The service only accepts a `changeFeedPolicy.retentionDuration` between one
+/// hour and 30 days, so one hour is the cheapest window that live accounts will
+/// take.
+const AVAD_RETENTION: Duration = Duration::from_secs(60 * 60);
+
 /// Creates a container whose change feed policy enables full-fidelity
 /// (`AllVersionsAndDeletes`) reads with the given retention window.
 async fn create_avad_container(
@@ -724,8 +731,9 @@ where
 /// the create's LSN. The delete carries a delete `operationType` and metadata
 /// but a minimal `current`.
 ///
-/// Gated on `test_category = "emulator"` only: full-fidelity reads are not
-/// supported by the vnext (Linux) emulator.
+/// Gated on `test_category = "all_versions_and_deletes"`: full-fidelity reads
+/// need a live account with continuous backup and the account level all
+/// versions and deletes change feed mode turned on.
 #[tokio::test]
 #[cfg_attr(
     not(test_category = "all_versions_and_deletes"),
@@ -739,8 +747,7 @@ pub async fn all_versions_and_deletes_surfaces_create_replace_delete() -> Result
                 &run_context,
                 db_client,
                 "AvadCreateReplaceDelete",
-                // The emulator accepts a short (5 minute) full-fidelity retention.
-                Duration::from_secs(5 * 60),
+                AVAD_RETENTION,
                 None,
             )
             .await?;
@@ -853,8 +860,9 @@ pub async fn all_versions_and_deletes_surfaces_create_replace_delete() -> Result
 /// create envelope. The container is provisioned with enough throughput to force
 /// multiple physical partitions so the cross-partition merge path is exercised.
 ///
-/// Gated on `test_category = "emulator"` only: full-fidelity reads are not
-/// supported by the vnext (Linux) emulator.
+/// Gated on `test_category = "all_versions_and_deletes"`: full-fidelity reads
+/// need a live account with continuous backup and the account level all
+/// versions and deletes change feed mode turned on.
 #[tokio::test]
 #[cfg_attr(
     not(test_category = "all_versions_and_deletes"),
@@ -872,7 +880,7 @@ pub async fn all_versions_and_deletes_fans_out_creates_across_partitions(
                 &run_context,
                 db_client,
                 "AvadFanOut",
-                Duration::from_secs(5 * 60),
+                AVAD_RETENTION,
                 Some(ThroughputProperties::manual(11000)),
             )
             .await?;
@@ -954,8 +962,9 @@ pub async fn all_versions_and_deletes_fans_out_creates_across_partitions(
 /// `ChangeFeedStartFrom.Time` for all-versions-and-deletes. The client issues
 /// the request and the service returns a `BadRequest`.
 ///
-/// Gated on `test_category = "emulator"` only: full-fidelity reads are not
-/// supported by the vnext (Linux) emulator.
+/// Gated on `test_category = "all_versions_and_deletes"`: full-fidelity reads
+/// need a live account with continuous backup and the account level all
+/// versions and deletes change feed mode turned on.
 #[tokio::test]
 #[cfg_attr(
     not(test_category = "all_versions_and_deletes"),
@@ -968,7 +977,7 @@ pub async fn all_versions_and_deletes_rejects_point_in_time_start() -> Result<()
                 &run_context,
                 db_client,
                 "AvadRejectPointInTime",
-                Duration::from_secs(5 * 60),
+                AVAD_RETENTION,
                 None,
             )
             .await?;

--- a/sdk/cosmos/ci.yml
+++ b/sdk/cosmos/ci.yml
@@ -33,8 +33,11 @@ extends:
   parameters:
     ServiceDirectory: cosmos
     # macOS/Windows live-test legs need ~63-65 min; raise from the 60-min default
-    # so they finish instead of being cancelled at the agent cap.
-    TestTimeoutInMinutes: 90
+    # so they finish instead of being cancelled at the agent cap. The split and
+    # all_versions_and_deletes legs additionally wait on test-resources-post.ps1
+    # turning on the account level all versions and deletes change feed mode,
+    # which Azure Cosmos DB documents as taking up to 30 minutes.
+    TestTimeoutInMinutes: 150
     RunLiveTests: ${{ or(parameters.RunLiveTests, eq(variables['Build.Reason'], 'Schedule'), endsWith(variables['Build.DefinitionName'], '- weekly')) }}
     Artifacts:
     - name: azure_data_cosmos_macros

--- a/sdk/cosmos/live-platform-matrix.json
+++ b/sdk/cosmos/live-platform-matrix.json
@@ -52,6 +52,9 @@
         },
         "Session MultiRegion GatewayV2": {
           "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableMultipleRegions = $true; testCategory = 'gateway_v2_multi_region' }"
+        },
+        "Session SingleRegion ChangeFeed AllVersionsAndDeletes": {
+          "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableContinuousBackup = $true; testCategory = 'all_versions_and_deletes' }"
         }
       }
     }

--- a/sdk/cosmos/live-platform-matrix.json
+++ b/sdk/cosmos/live-platform-matrix.json
@@ -18,19 +18,19 @@
     "RustToolchainName": ["stable"],
     "Account Settings": {
       "Eventual SingleWrite": {
-        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Eventual'; enableAutomaticFailover = $false; enableContinuousBackup = $true }"
+        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Eventual'; enableAutomaticFailover = $false }"
       },
       "Session SingleWrite": {
-        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableAutomaticFailover = $false; enableContinuousBackup = $true }"
+        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableAutomaticFailover = $false }"
       },
       "Strong SingleWrite": {
-        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Strong'; enableAutomaticFailover = $false; enableContinuousBackup = $true }"
+        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Strong'; enableAutomaticFailover = $false }"
       },
       "Session MultiWrite": {
         "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableMultipleWriteLocations = $true; enableAutomaticFailover = $false; testCategory = 'multi_write'; enableMultipleRegions = $true }"
       },
       "Session Split": {
-        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableAutomaticFailover = $false; testCategory = 'split'; enableContinuousBackup = $true }"
+        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableAutomaticFailover = $false; testCategory = 'split'; enableAllVersionsAndDeletesChangeFeed = $true }"
       },
       "Session SingleWrite MultiRegion PartitionFailover": {
         "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableAutomaticFailover = $true; enableMultipleRegions = $true; testCategory = 'multi_region' }"
@@ -54,7 +54,7 @@
           "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableMultipleRegions = $true; testCategory = 'gateway_v2_multi_region' }"
         },
         "Session SingleRegion ChangeFeed AllVersionsAndDeletes": {
-          "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableContinuousBackup = $true; testCategory = 'all_versions_and_deletes' }"
+          "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableAllVersionsAndDeletesChangeFeed = $true; testCategory = 'all_versions_and_deletes' }"
         }
       }
     }

--- a/sdk/cosmos/test-resources-post.ps1
+++ b/sdk/cosmos/test-resources-post.ps1
@@ -83,8 +83,30 @@ if ($response.StatusCode -notin 200, 201, 202) {
     throw "PATCH $accountUri returned HTTP $($response.StatusCode): $($response.Content)"
 }
 
+# ARM silently drops properties an API version doesn't know about, so an unsupported
+# api-version would leave us polling for the full timeout. Give up early once the
+# account has been idle at 'Succeeded' for a while with the flag still off.
+$idleSucceededPolls = 0
+$idleSucceededLimit = 6
+
 Wait-CosmosDbAccount 'all versions and deletes change feed mode to be enabled' {
-    param($a) ($a.properties.provisioningState -eq 'Succeeded') -and $a.properties.enableAllVersionsAndDeletesChangeFeed
+    param($a)
+
+    if ($a.properties.enableAllVersionsAndDeletesChangeFeed) {
+        return ($a.properties.provisioningState -eq 'Succeeded')
+    }
+
+    if ($a.properties.provisioningState -eq 'Succeeded') {
+        $script:idleSucceededPolls++
+        if ($script:idleSucceededPolls -ge $script:idleSucceededLimit) {
+            throw "The account stayed at 'Succeeded' without picking up 'enableAllVersionsAndDeletesChangeFeed'. The PATCH was accepted but had no effect, which usually means API version '$apiVersion' no longer exposes the property."
+        }
+    }
+    else {
+        $script:idleSucceededPolls = 0
+    }
+
+    return $false
 } | Out-Null
 
 Write-Host 'All versions and deletes change feed mode is enabled.'

--- a/sdk/cosmos/test-resources-post.ps1
+++ b/sdk/cosmos/test-resources-post.ps1
@@ -1,0 +1,94 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Azure Cosmos DB refuses `enableAllVersionsAndDeletesChangeFeed` while an account is
+# being created, so test-resources.bicep can only provision the continuous backup
+# prerequisite. This script turns the account level feature on afterwards and waits for
+# the account to settle. Without it, creating a container with a full fidelity
+# `changeFeedPolicy` fails with HTTP 400 and the AllVersionsAndDeletes change feed tests
+# cannot pass.
+#
+# See https://learn.microsoft.com/azure/cosmos-db/change-feed-modes
+#
+# Deliberately declared as a simple (non-advanced) script: New-TestResources.ps1 splats
+# its own bound parameters onto this script, and unknown named arguments only land
+# harmlessly in $args when the script has no [Parameter()] attributes.
+
+param (
+    [hashtable] $DeploymentOutputs
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($DeploymentOutputs['ENABLE_ALL_VERSIONS_AND_DELETES_CHANGE_FEED'] -ne 'true') {
+    Write-Host 'All versions and deletes change feed mode was not requested for this account. Nothing to do.'
+    return
+}
+
+$accountId = $DeploymentOutputs['COSMOS_ACCOUNT_RESOURCE_ID']
+if (!$accountId) {
+    throw "Deployment output 'COSMOS_ACCOUNT_RESOURCE_ID' is missing. Make sure sdk/cosmos/test-resources.bicep still emits it."
+}
+
+# `enableAllVersionsAndDeletesChangeFeed` is only exposed by preview API versions.
+$apiVersion = '2025-05-01-preview'
+$accountUri = "${accountId}?api-version=$apiVersion"
+$pollIntervalSeconds = 30
+# Enabling the feature can take up to 30 minutes, during which no other account changes
+# are accepted. Leave headroom, but still fail well inside the live test job timeout.
+$timeout = [timespan]::FromMinutes(40)
+
+function Get-CosmosDbAccount {
+    $response = Invoke-AzRestMethod -Method GET -Path $accountUri
+    if ($response.StatusCode -ne 200) {
+        throw "GET $accountUri returned HTTP $($response.StatusCode): $($response.Content)"
+    }
+
+    return $response.Content | ConvertFrom-Json
+}
+
+function Wait-CosmosDbAccount([string] $activity, [scriptblock] $isDone) {
+    $deadline = (Get-Date).Add($timeout)
+    while ($true) {
+        $account = Get-CosmosDbAccount
+        if (& $isDone $account) {
+            return $account
+        }
+
+        if ((Get-Date) -gt $deadline) {
+            throw "Timed out after $($timeout.TotalMinutes) minutes waiting for $activity. Last provisioning state: '$($account.properties.provisioningState)'."
+        }
+
+        Write-Host "  Waiting for $activity. Provisioning state is '$($account.properties.provisioningState)'; checking again in $pollIntervalSeconds seconds."
+        Start-Sleep -Seconds $pollIntervalSeconds
+    }
+}
+
+Write-Host "Preparing '$accountId' for all versions and deletes change feed mode."
+
+$account = Wait-CosmosDbAccount 'the account to finish provisioning' {
+    param($a) $a.properties.provisioningState -eq 'Succeeded'
+}
+
+if ($account.properties.enableAllVersionsAndDeletesChangeFeed) {
+    Write-Host 'All versions and deletes change feed mode is already enabled.'
+    return
+}
+
+$payload = @{ properties = @{ enableAllVersionsAndDeletesChangeFeed = $true } } | ConvertTo-Json -Depth 3 -Compress
+Write-Host 'Enabling all versions and deletes change feed mode. This can take up to 30 minutes.'
+
+$response = Invoke-AzRestMethod -Method PATCH -Path $accountUri -Payload $payload
+if ($response.StatusCode -notin 200, 201, 202) {
+    throw "PATCH $accountUri returned HTTP $($response.StatusCode): $($response.Content)"
+}
+
+Wait-CosmosDbAccount 'all versions and deletes change feed mode to be enabled' {
+    param($a) ($a.properties.provisioningState -eq 'Succeeded') -and $a.properties.enableAllVersionsAndDeletesChangeFeed
+} | Out-Null
+
+Write-Host 'All versions and deletes change feed mode is enabled.'
+
+# The feature lights up in the control plane slightly ahead of the data plane, so give
+# the account a moment before the tests start creating full fidelity containers.
+Start-Sleep -Seconds 60

--- a/sdk/cosmos/test-resources.bicep
+++ b/sdk/cosmos/test-resources.bicep
@@ -9,6 +9,9 @@ param enableMultipleWriteLocations bool = false
 @description('Enable continuous backup mode, required to read the AllVersionsAndDeletes (full-fidelity) change feed. Incompatible with multiple write locations.')
 param enableContinuousBackup bool = false
 
+@description('Request the account level "All versions and deletes change feed mode" feature. Azure Cosmos DB does not accept this flag while the account is being created, so test-resources-post.ps1 turns it on after deployment. Implies continuous backup.')
+param enableAllVersionsAndDeletesChangeFeed bool = false
+
 @description('Dictates which tests run for this resource')
 param testCategory string = 'emulator'
 
@@ -53,7 +56,10 @@ var multiRegionConfiguration = [
   }
 ]
 var locationsConfiguration = (enableMultipleRegions ? multiRegionConfiguration : singleRegionConfiguration)
-var backupPolicy = (enableContinuousBackup ? {
+// All versions and deletes mode cannot be turned on unless the account already has
+// continuous backups, so asking for the change feed feature implies the backup policy.
+var useContinuousBackup = (enableContinuousBackup || enableAllVersionsAndDeletesChangeFeed)
+var backupPolicy = (useContinuousBackup ? {
   type: 'Continuous'
   continuousModeProperties: {
     tier: 'Continuous7Days'
@@ -140,3 +146,7 @@ output DATABASE_NAME string = databaseName
 output AZURE_COSMOS_CONNECTION_STRING string = 'AccountEndpoint=${reference(resourceId, apiVersion).documentEndpoint};AccountKey=${listKeys(resourceId, apiVersion).primaryMasterKey};'
 output ACCOUNT_HOST string = reference(resourceId, apiVersion).documentEndpoint
 output AZURE_COSMOS_DEFAULT_CONSISTENCY string = defaultConsistencyLevel
+// Consumed by test-resources-post.ps1 so it can finish enabling the all versions
+// and deletes change feed mode once the account exists.
+output COSMOS_ACCOUNT_RESOURCE_ID string = resourceId
+output ENABLE_ALL_VERSIONS_AND_DELETES_CHANGE_FEED string = (enableAllVersionsAndDeletesChangeFeed ? 'true' : 'false')

--- a/sdk/cosmos/test-resources.bicep
+++ b/sdk/cosmos/test-resources.bicep
@@ -55,8 +55,8 @@ var multiRegionConfiguration = [
 var locationsConfiguration = (enableMultipleRegions ? multiRegionConfiguration : singleRegionConfiguration)
 var backupPolicy = (enableContinuousBackup ? {
   type: 'Continuous'
-  continuousModeProperties: {
-    tier: 'Continuous7Days'
+  continuousTierPolicy: {
+    state: 'On'
   }
 } : {
   type: 'Periodic'

--- a/sdk/cosmos/test-resources.bicep
+++ b/sdk/cosmos/test-resources.bicep
@@ -55,8 +55,8 @@ var multiRegionConfiguration = [
 var locationsConfiguration = (enableMultipleRegions ? multiRegionConfiguration : singleRegionConfiguration)
 var backupPolicy = (enableContinuousBackup ? {
   type: 'Continuous'
-  continuousTierPolicy: {
-    state: 'On'
+  continuousModeProperties: {
+    tier: 'Continuous7Days'
   }
 } : {
   type: 'Periodic'


### PR DESCRIPTION
Add support for enabling continuous backup on Cosmos DB test accounts to support the AllVersionsAndDeletes change feed mode added in PR #4706.

## Changes

- Add nableContinuousBackup parameter to 	est-resources.bicep that configures continuous backup policy when enabled
- Update cosmosAccount resource to conditionally use continuous backup when the parameter is set
- Add a new account configuration in live-platform-matrix.json for Session SingleRegion ChangeFeed AllVersionsAndDeletes tests that enables continuous backup

## Related Issue

Fixes #4706 - The live tests for AllVersionsAndDeletes change feed mode require continuous backup to be enabled on the test account