### PR TITLE
[Storage] Fix Blob upload perf test partition size

### DIFF
--- a/sdk/storage/azure_storage_blob/perf/clap_parsers.rs
+++ b/sdk/storage/azure_storage_blob/perf/clap_parsers.rs
@@ -12,3 +12,13 @@ pub fn non_zero_usize(s: &str) -> Result<NonZero<usize>, String> {
             })
         })
 }
+
+pub fn non_zero_u64(s: &str) -> Result<NonZero<u64>, String> {
+    s.parse::<u64>()
+        .map_err(|e| format!("Failed to parse '{}' as u64: {}", s, e))
+        .and_then(|n| {
+            NonZero::new(n).ok_or_else(|| {
+                format!("Value must be a non-zero positive integer, but got '{}'", s)
+            })
+        })
+}

--- a/sdk/storage/azure_storage_blob/perf/upload_blob_test.rs
+++ b/sdk/storage/azure_storage_blob/perf/upload_blob_test.rs
@@ -16,7 +16,7 @@ use clap::Args;
 use futures::FutureExt;
 
 use crate::{
-    clap_parsers::non_zero_usize,
+    clap_parsers::{non_zero_u64, non_zero_usize},
     extensions::{OnceLockExt, RecordingExt},
 };
 
@@ -31,7 +31,7 @@ pub struct UploadBlobTestOptions {
     concurrency: Option<NonZero<usize>>,
 
     // Size in bytes to partition data into for each transfer.
-    #[arg(long, value_parser = non_zero_usize)]
+    #[arg(long, value_parser = non_zero_u64)]
     partition_size: Option<NonZero<u64>>,
 
     #[arg(long)]


### PR DESCRIPTION
`--partition-size` was being parsed as a `usize` when it is in fact a `u64` for upload.