### PR TITLE
Fix AVAD change feed 400 on live Cosmos accounts

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -18,8 +18,8 @@
 
 ### Other Changes
 
-- Cosmos HTTP error messages now include the service's own explanation from the response body, so a `400` no longer renders as a bare `Cosmos DB returned HTTP 400: Unknown`.
-- Documented that `ChangeFeedPolicy::with_retention_duration` must not be set on accounts running in continuous backup mode, which derive the full-fidelity retention window from the backup retention and reject an explicit duration with `400 Bad Request`.
+- Cosmos HTTP error messages now include the service's own explanation from the response body, so a `400` no longer renders as a bare `Cosmos DB returned HTTP 400: Unknown`. ([#4904](https://github.com/Azure/azure-sdk-for-rust/pull/4904))
+- Documented that `ChangeFeedPolicy::with_retention_duration` must not be set on accounts running in continuous backup mode, which derive the full-fidelity retention window from the backup retention and reject an explicit duration with `400 Bad Request`. ([#4904](https://github.com/Azure/azure-sdk-for-rust/pull/4904))
 
 ## 0.37.1 (2026-07-23)
 

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -18,6 +18,9 @@
 
 ### Other Changes
 
+- Cosmos HTTP error messages now include the service's own explanation from the response body, so a `400` no longer renders as a bare `Cosmos DB returned HTTP 400: Unknown`.
+- Documented that `ChangeFeedPolicy::with_retention_duration` must not be set on accounts running in continuous backup mode, which derive the full-fidelity retention window from the backup retention and reject an explicit duration with `400 Bad Request`.
+
 ## 0.37.1 (2026-07-23)
 
 ### Bugs Fixed

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Cosmos HTTP error messages now include the service's own explanation from the response body, normalized to a single line and length-bounded, so a `400` no longer renders as a bare `Cosmos DB returned HTTP 400: Unknown`. ([#4904](https://github.com/Azure/azure-sdk-for-rust/pull/4904))
 - Documented that `ChangeFeedPolicy::with_retention_duration` must not be set on accounts running in continuous backup mode, which derive the full-fidelity retention window from the backup retention and reject an explicit duration with `400 Bad Request`. ([#4904](https://github.com/Azure/azure-sdk-for-rust/pull/4904))
+- The `AllVersionsAndDeletes` change feed tests now skip, rather than fail, against an account that does not have the mode enabled. The account-level opt-in cannot be set at creation time and is not available on every subscription. ([#4904](https://github.com/Azure/azure-sdk-for-rust/pull/4904))
 
 ## 0.37.1 (2026-07-23)
 

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -19,8 +19,6 @@
 ### Other Changes
 
 - Cosmos HTTP error messages now include the service's own explanation from the response body, normalized to a single line and length-bounded, so a `400` no longer renders as a bare `Cosmos DB returned HTTP 400: Unknown`. ([#4904](https://github.com/Azure/azure-sdk-for-rust/pull/4904))
-- Documented that `ChangeFeedPolicy::with_retention_duration` must not be set on accounts running in continuous backup mode, which derive the full-fidelity retention window from the backup retention and reject an explicit duration with `400 Bad Request`. ([#4904](https://github.com/Azure/azure-sdk-for-rust/pull/4904))
-- The `AllVersionsAndDeletes` change feed tests now skip, rather than fail, against an account that does not have the mode enabled. The account-level opt-in cannot be set at creation time and is not available on every subscription. ([#4904](https://github.com/Azure/azure-sdk-for-rust/pull/4904))
 
 ## 0.37.1 (2026-07-23)
 

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Other Changes
 
-- Cosmos HTTP error messages now include the service's own explanation from the response body, so a `400` no longer renders as a bare `Cosmos DB returned HTTP 400: Unknown`. ([#4904](https://github.com/Azure/azure-sdk-for-rust/pull/4904))
+- Cosmos HTTP error messages now include the service's own explanation from the response body, normalized to a single line and length-bounded, so a `400` no longer renders as a bare `Cosmos DB returned HTTP 400: Unknown`. ([#4904](https://github.com/Azure/azure-sdk-for-rust/pull/4904))
 - Documented that `ChangeFeedPolicy::with_retention_duration` must not be set on accounts running in continuous backup mode, which derive the full-fidelity retention window from the backup retention and reject an explicit duration with `400 Bad Request`. ([#4904](https://github.com/Azure/azure-sdk-for-rust/pull/4904))
 
 ## 0.37.1 (2026-07-23)

--- a/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
@@ -504,6 +504,17 @@ impl ChangeFeedPolicy {
     /// `retention` is rounded **up** to the next whole minute when serialized so
     /// a sub-minute request never truncates to `0` (which would disable the
     /// mode).
+    ///
+    /// # Continuous backup accounts
+    ///
+    /// Accounts running in **continuous backup** mode derive the full-fidelity
+    /// retention window from the backup retention, and reject container
+    /// requests that also set a retention duration with HTTP 400
+    /// (`"The retention duration in the Change Feed policy should not be set
+    /// when continuous backup mode is enabled for the database account"`).
+    /// Leave the change feed policy unset on those accounts;
+    /// [`AllVersionsAndDeletes`](crate::options::ChangeFeedMode::AllVersionsAndDeletes)
+    /// is already available. See <https://aka.ms/ChangeFeed-AllVersionsAndDeletes>.
     pub fn with_retention_duration(mut self, retention: Duration) -> Self {
         self.retention_duration = Some(retention);
         self

--- a/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
@@ -511,10 +511,16 @@ impl ChangeFeedPolicy {
     /// retention window from the backup retention, and reject container
     /// requests that also set a retention duration with HTTP 400
     /// (`"The retention duration in the Change Feed policy should not be set
-    /// when continuous backup mode is enabled for the database account"`).
-    /// Leave the change feed policy unset on those accounts;
+    /// when continuous backup mode is enabled for the database account"`), so
+    /// leave the change feed policy unset on those accounts.
+    ///
+    /// Continuous backup on its own does not make
     /// [`AllVersionsAndDeletes`](crate::options::ChangeFeedMode::AllVersionsAndDeletes)
-    /// is already available. See <https://aka.ms/ChangeFeed-AllVersionsAndDeletes>.
+    /// available: the account additionally needs the account-level
+    /// full-fidelity change feed opt-in, which cannot be set when the account is
+    /// created. Without it the account still answers reads in that mode with
+    /// HTTP 400 (`"Change Feed 'All Versions and Deletes' mode must be
+    /// enabled"`). See <https://aka.ms/ChangeFeed-AllVersionsAndDeletes>.
     pub fn with_retention_duration(mut self, retention: Duration) -> Self {
         self.retention_duration = Some(retention);
         self

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_change_feed.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_change_feed.rs
@@ -17,12 +17,15 @@
 //! * Resuming a partially-polled `StartFrom::Now` feed does not replay history
 //!   on the partitions that were never polled before the checkpoint.
 //!
-//! A second group exercises the `AllVersionsAndDeletes` ("full fidelity") mode
-//! against a container configured with a change feed retention policy: create,
-//! replace, and delete each surface as a distinct [`ChangeFeedItem`] envelope,
-//! and the mode reads correctly across a cross-partition fan-out. These AVAD
-//! tests are gated on `test_category = "emulator"` only — the vnext (Linux)
-//! emulator does not yet support full-fidelity reads.
+//! A second group exercises the `AllVersionsAndDeletes` ("full fidelity") mode.
+//! How the mode is enabled differs by target: the emulator opts in per container
+//! via a change feed retention policy, while live accounts enable it through
+//! continuous backup and reject an explicit container-level retention (see
+//! [`create_avad_container`]). Create, replace, and delete each surface as a
+//! distinct [`ChangeFeedItem`] envelope, and the mode reads correctly across a
+//! cross-partition fan-out. These AVAD tests are gated on
+//! `test_category = "emulator"` only — the vnext (Linux) emulator does not yet
+//! support full-fidelity reads.
 
 use super::framework;
 
@@ -660,8 +663,22 @@ impl AvadItem {
     }
 }
 
-/// Creates a container whose change feed policy enables full-fidelity
-/// (`AllVersionsAndDeletes`) reads with the given retention window.
+/// Creates a container configured for full-fidelity (`AllVersionsAndDeletes`)
+/// reads.
+///
+/// How the retention window is configured differs between the emulator and a
+/// live account:
+///
+/// * **Emulator**: full-fidelity retention is opted into per container via
+///   `changeFeedPolicy.retentionDuration`, so `retention` is applied.
+/// * **Live account**: `AllVersionsAndDeletes` requires the account to run in
+///   continuous backup mode, and the retention window is then derived from the
+///   backup retention. Setting `changeFeedPolicy.retentionDuration` on such an
+///   account is rejected with HTTP 400 ("The retention duration in the Change
+///   Feed policy should not be set when continuous backup mode is enabled for
+///   the database account"), so the policy is omitted entirely.
+///
+/// See <https://aka.ms/ChangeFeed-AllVersionsAndDeletes>.
 async fn create_avad_container(
     run_context: &TestRunContext,
     db_client: &DatabaseClient,
@@ -669,8 +686,12 @@ async fn create_avad_container(
     retention: Duration,
     throughput: Option<ThroughputProperties>,
 ) -> azure_data_cosmos::Result<ContainerClient> {
-    let properties = ContainerProperties::new(name.to_string(), "/partitionKey".into())
-        .with_change_feed_policy(ChangeFeedPolicy::default().with_retention_duration(retention));
+    let mut properties = ContainerProperties::new(name.to_string(), "/partitionKey".into());
+    if framework::targets_emulator() {
+        properties = properties.with_change_feed_policy(
+            ChangeFeedPolicy::default().with_retention_duration(retention),
+        );
+    }
     let options = throughput.map(|t| CreateContainerOptions::default().with_throughput(t));
     run_context
         .create_container(db_client, properties, options)

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_change_feed.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_change_feed.rs
@@ -1018,6 +1018,15 @@ pub async fn all_versions_and_deletes_rejects_point_in_time_start() -> Result<()
                 "expected BadRequest (400) for AVAD + PointInTime, got {:?}",
                 err.status().status_code()
             );
+            // An account without the full-fidelity change feed enabled also answers
+            // 400, which would let this test pass for the wrong reason. Reject that
+            // case explicitly so provisioning gaps surface here instead of hiding.
+            let message = err.to_string();
+            assert!(
+                !message.contains("must be enabled"),
+                "the 400 came from the account lacking AllVersionsAndDeletes support, \
+                 not from rejecting PointInTime: {message}"
+            );
 
             Ok(())
         },

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_change_feed.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_change_feed.rs
@@ -19,13 +19,15 @@
 //!
 //! A second group exercises the `AllVersionsAndDeletes` ("full fidelity") mode.
 //! How the mode is enabled differs by target: the emulator opts in per container
-//! via a change feed retention policy, while live accounts enable it through
-//! continuous backup and reject an explicit container-level retention (see
+//! via a change feed retention policy, while live accounts enable it at the
+//! account level and reject an explicit container-level retention (see
 //! [`create_avad_container`]). Create, replace, and delete each surface as a
 //! distinct [`ChangeFeedItem`] envelope, and the mode reads correctly across a
 //! cross-partition fan-out. These AVAD tests are gated on
 //! `test_category = "emulator"` only — the vnext (Linux) emulator does not yet
-//! support full-fidelity reads.
+//! support full-fidelity reads. The account-level opt-in cannot be set when an
+//! account is created and is not available on every subscription, so against a
+//! live account that lacks it these tests skip rather than fail.
 
 use super::framework;
 
@@ -736,6 +738,59 @@ where
     Ok(collected)
 }
 
+/// Whether an error is the service refusing `AllVersionsAndDeletes` because the
+/// account was never enabled for it.
+///
+/// The mode requires an account-level opt-in that cannot be set at creation
+/// time and is not available on every subscription, so a live account that is
+/// otherwise healthy can still reject the read outright. Detecting it lets the
+/// AVAD tests skip rather than fail on such an account, while still running in
+/// full against the emulator (and against any live account that does have the
+/// mode enabled).
+fn avad_unsupported(err: &azure_data_cosmos::CosmosError) -> bool {
+    if err.status().status_code() != StatusCode::BadRequest {
+        return false;
+    }
+    message_reports_avad_unsupported(&err.to_string())
+}
+
+/// The message-text half of [`avad_unsupported`], split out so the exact
+/// wording the service uses can be pinned by a unit test.
+fn message_reports_avad_unsupported(message: &str) -> bool {
+    message.contains("All Versions and Deletes") && message.contains("must be enabled")
+}
+
+/// Result of the initial "prime" poll on an `AllVersionsAndDeletes` feed.
+enum AvadPrime {
+    /// The feed is positioned and the test can proceed.
+    Ready,
+    /// The account does not support the mode; the caller should skip.
+    Unsupported,
+}
+
+/// Performs the initial `StartFrom::Now` poll, which must return an empty page,
+/// and reports whether the account supports the mode at all.
+async fn prime_avad_feed(
+    iterator: &mut ChangeFeedPageIterator<ChangeFeedItem<AvadItem>>,
+) -> Result<AvadPrime, Box<dyn Error>> {
+    match iterator
+        .next()
+        .await
+        .expect("change feed stream always yields a page")
+    {
+        Ok(page) => {
+            assert!(
+                page.items().is_empty(),
+                "StartFrom::Now must start empty, got {}",
+                page.items().len()
+            );
+            Ok(AvadPrime::Ready)
+        }
+        Err(err) if avad_unsupported(&err) => Ok(AvadPrime::Unsupported),
+        Err(err) => Err(err.into()),
+    }
+}
+
 /// AllVersionsAndDeletes surfaces a create, a replace, and a delete of the same
 /// document as three distinct full-fidelity envelopes.
 ///
@@ -780,15 +835,13 @@ pub async fn all_versions_and_deletes_surfaces_create_replace_delete() -> Result
 
             // Prime the `Now` position: the first poll (before any writes) is an
             // empty 304 that establishes where the feed starts.
-            let primed = iterator
-                .next()
-                .await
-                .expect("change feed stream always yields a page")?;
-            assert!(
-                primed.items().is_empty(),
-                "StartFrom::Now must start empty, got {}",
-                primed.items().len()
-            );
+            if let AvadPrime::Unsupported = prime_avad_feed(&mut iterator).await? {
+                eprintln!(
+                    "Skipping all_versions_and_deletes_surfaces_create_replace_delete: \
+                     the account does not have AllVersionsAndDeletes enabled."
+                );
+                return Ok(());
+            }
 
             // Create, then replace, then delete the same document.
             container
@@ -910,15 +963,13 @@ pub async fn all_versions_and_deletes_fans_out_creates_across_partitions(
                 .await?;
 
             // Prime the per-range `Now` positions before writing.
-            let primed = iterator
-                .next()
-                .await
-                .expect("change feed stream always yields a page")?;
-            assert!(
-                primed.items().is_empty(),
-                "StartFrom::Now must start empty, got {}",
-                primed.items().len()
-            );
+            if let AvadPrime::Unsupported = prime_avad_feed(&mut iterator).await? {
+                eprintln!(
+                    "Skipping all_versions_and_deletes_fans_out_creates_across_partitions: \
+                     the account does not have AllVersionsAndDeletes enabled."
+                );
+                return Ok(());
+            }
 
             let mut expected_ids: Vec<String> = Vec::new();
             for p in 0..PK_COUNT {
@@ -1012,20 +1063,21 @@ pub async fn all_versions_and_deletes_rejects_point_in_time_start() -> Result<()
                 .await
                 .expect("the change feed should yield a page")
                 .expect_err("PointInTime start must be rejected for AllVersionsAndDeletes");
+            // An account without AllVersionsAndDeletes enabled also answers 400,
+            // which would let this test pass for the wrong reason. Skip that case
+            // rather than treat it as evidence that PointInTime was rejected.
+            if avad_unsupported(&err) {
+                eprintln!(
+                    "Skipping all_versions_and_deletes_rejects_point_in_time_start: \
+                     the account does not have AllVersionsAndDeletes enabled."
+                );
+                return Ok(());
+            }
             assert_eq!(
                 StatusCode::BadRequest,
                 err.status().status_code(),
                 "expected BadRequest (400) for AVAD + PointInTime, got {:?}",
                 err.status().status_code()
-            );
-            // An account without the full-fidelity change feed enabled also answers
-            // 400, which would let this test pass for the wrong reason. Reject that
-            // case explicitly so provisioning gaps surface here instead of hiding.
-            let message = err.to_string();
-            assert!(
-                !message.contains("must be enabled"),
-                "the 400 came from the account lacking AllVersionsAndDeletes support, \
-                 not from rejecting PointInTime: {message}"
             );
 
             Ok(())
@@ -1033,4 +1085,39 @@ pub async fn all_versions_and_deletes_rejects_point_in_time_start() -> Result<()
         Some(TestOptions::for_emulator()),
     )
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::message_reports_avad_unsupported;
+
+    /// The exact message live accounts without the account-level opt-in return,
+    /// as observed in CI, rendered through the SDK's error `Display`.
+    const AVAD_NOT_ENABLED: &str =
+        "400: Cosmos DB returned HTTP 400: Unknown. Details: Change Feed \
+         'All Versions and Deletes' mode must be enabled. Refer to \
+         https://aka.ms/ChangeFeed-AllVersionsAndDeletes for Preview program.";
+
+    #[test]
+    fn detects_account_without_avad_enabled() {
+        assert!(message_reports_avad_unsupported(AVAD_NOT_ENABLED));
+    }
+
+    #[test]
+    fn ignores_the_point_in_time_rejection() {
+        // This 400 is the assertion `all_versions_and_deletes_rejects_point_in_time_start`
+        // exists to make, so it must never be mistaken for an unsupported account.
+        assert!(!message_reports_avad_unsupported(
+            "400: Cosmos DB returned HTTP 400: Unknown. Details: Start from beginning is not \
+             supported with 'All Versions and Deletes' mode."
+        ));
+    }
+
+    #[test]
+    fn ignores_unrelated_bad_requests() {
+        assert!(!message_reports_avad_unsupported(
+            "400: Cosmos DB returned HTTP 400: Unknown. Details: The retention duration in the \
+             Change Feed policy should not be set when continuous backup mode is enabled."
+        ));
+    }
 }

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
@@ -23,8 +23,9 @@ pub use emulator_credential::{CosmosEmulatorCredential, CredentialRecorder};
 pub use test_client::{
     assert_local_retry_attempted_on_region, assert_region_contacted_with_retry,
     assert_region_not_contacted, get_effective_hub_endpoint, get_global_endpoint,
-    resolve_connection_string, TestClient, TestOptions, TestRunContext, CONNECTION_STRING_ENV_VAR,
-    DEFAULT_TEST_TIMEOUT, EMULATOR_CONNECTION_STRING, HUB_REGION, SATELLITE_REGION,
+    resolve_connection_string, targets_emulator, TestClient, TestOptions, TestRunContext,
+    CONNECTION_STRING_ENV_VAR, DEFAULT_TEST_TIMEOUT, EMULATOR_CONNECTION_STRING, HUB_REGION,
+    SATELLITE_REGION,
 };
 
 use serde::{Deserialize, Serialize};

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
@@ -1237,6 +1237,30 @@ fn host_is_local(endpoint: &str) -> bool {
     }
 }
 
+/// Returns `true` when the configured target is the Cosmos DB emulator rather
+/// than a live Azure Cosmos DB account.
+///
+/// Detects both the `AZURE_COSMOS_CONNECTION_STRING=emulator` shorthand and an
+/// explicit connection string pointing at a loopback host. Tests use this to
+/// account for behavior the emulator and the service do not share — most
+/// notably container-level full-fidelity change feed retention, which the
+/// emulator requires but which live continuous-backup accounts reject.
+///
+/// Defaults to `true` when no connection string is configured, matching the
+/// rest of the harness (which falls back to the emulator).
+pub fn targets_emulator() -> bool {
+    let Ok(env_var) = std::env::var(CONNECTION_STRING_ENV_VAR) else {
+        return true;
+    };
+    if env_var == "emulator" {
+        return true;
+    }
+    match env_var.parse::<ConnectionString>() {
+        Ok(parsed) => host_is_local(parsed.account_endpoint()),
+        Err(_) => false,
+    }
+}
+
 /// Builds a [`CosmosClient`] authenticated with an Entra ID (AAD) token
 /// credential, reading the target account from the same environment the
 /// key-auth client uses (`AZURE_COSMOS_CONNECTION_STRING`).

--- a/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_change_feed_split.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_change_feed_split.rs
@@ -295,13 +295,19 @@ pub async fn change_feed_all_versions_and_deletes_resume_across_split() -> Resul
 
     TestClient::run_with_unique_db(
         async |run_context, db_client| {
-            let properties = ContainerProperties::new(
+            let mut properties = ContainerProperties::new(
                 "ChangeFeedAvadResumeAcrossSplit",
                 "/partitionKey".into(),
-            )
-            .with_change_feed_policy(
-                ChangeFeedPolicy::default().with_retention_duration(Duration::from_secs(60 * 60)),
             );
+            // Container-level full-fidelity retention is an emulator-only opt-in.
+            // Live accounts enable AllVersionsAndDeletes through continuous
+            // backup and reject an explicit `retentionDuration` with HTTP 400.
+            if framework::targets_emulator() {
+                properties = properties.with_change_feed_policy(
+                    ChangeFeedPolicy::default()
+                        .with_retention_duration(Duration::from_secs(60 * 60)),
+                );
+            }
             let throughput = ThroughputProperties::manual(1000);
             let container_client = Arc::new(
                 run_context

--- a/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_change_feed_split.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_change_feed_split.rs
@@ -233,6 +233,18 @@ impl AvadDoc {
     }
 }
 
+/// Whether an error is the service refusing `AllVersionsAndDeletes` because the
+/// account was never enabled for it.
+///
+/// The mode requires an account-level opt-in that cannot be set at creation time
+/// and is not available on every subscription, so a live account that is
+/// otherwise healthy can still reject the read outright. Detecting it lets the
+/// AVAD test skip rather than fail on such an account.
+fn avad_unsupported(err: &(dyn Error + 'static)) -> bool {
+    let message = err.to_string();
+    message.contains("All Versions and Deletes") && message.contains("must be enabled")
+}
+
 /// Polls a full-fidelity change feed, accumulating every envelope seen, until
 /// `is_complete` is satisfied by the collection so far or a deadline elapses.
 ///
@@ -355,7 +367,21 @@ pub async fn change_feed_all_versions_and_deletes_resume_across_split() -> Resul
                 std::time::Instant::now() + Duration::from_secs(15),
                 |_| false,
             )
-            .await?;
+            .await;
+            let pre_split = match pre_split {
+                Ok(pages) => pages,
+                // AllVersionsAndDeletes needs an account-level opt-in that is not
+                // available everywhere; skip instead of failing on an account that
+                // lacks it.
+                Err(err) if avad_unsupported(err.as_ref()) => {
+                    eprintln!(
+                        "Skipping change_feed_all_versions_and_deletes_resume_across_split: \
+                         the account does not have AllVersionsAndDeletes enabled."
+                    );
+                    return Ok(());
+                }
+                Err(err) => return Err(err),
+            };
             assert!(
                 pre_split.is_empty(),
                 "AVAD StartFrom::Now must exclude the pre-existing baseline, saw {}",

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+- Cosmos HTTP error messages now include the service's own explanation from the response body (bounded to 512 characters), so a `400` no longer renders as a bare `Cosmos DB returned HTTP 400: Unknown`. The full payload remains available verbatim via `CosmosError::response`.
+
 ## 0.6.1 (2026-07-23)
 
 ### Bugs Fixed

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Other Changes
 
-- Cosmos HTTP error messages now include the service's own explanation from the response body (bounded to 512 characters), so a `400` no longer renders as a bare `Cosmos DB returned HTTP 400: Unknown`. The full payload remains available verbatim via `CosmosError::response`. ([#4904](https://github.com/Azure/azure-sdk-for-rust/pull/4904))
+- Cosmos HTTP error messages now include the service's own explanation from the response body, normalized to a single line and bounded to 512 bytes, so a `400` no longer renders as a bare `Cosmos DB returned HTTP 400: Unknown`. The full payload remains available verbatim via `CosmosError::response`. ([#4904](https://github.com/Azure/azure-sdk-for-rust/pull/4904))
 
 ## 0.6.1 (2026-07-23)
 

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Other Changes
 
-- Cosmos HTTP error messages now include the service's own explanation from the response body (bounded to 512 characters), so a `400` no longer renders as a bare `Cosmos DB returned HTTP 400: Unknown`. The full payload remains available verbatim via `CosmosError::response`.
+- Cosmos HTTP error messages now include the service's own explanation from the response body (bounded to 512 characters), so a `400` no longer renders as a bare `Cosmos DB returned HTTP 400: Unknown`. The full payload remains available verbatim via `CosmosError::response`. ([#4904](https://github.com/Azure/azure-sdk-for-rust/pull/4904))
 
 ## 0.6.1 (2026-07-23)
 

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/retry_evaluation.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/retry_evaluation.rs
@@ -1001,11 +1001,99 @@ fn service_error_message(status: &CosmosStatus) -> String {
     )
 }
 
+/// Upper bound on how much of the service's error text is folded into the
+/// error message. The full payload always remains available verbatim via
+/// [`CosmosError::response`](crate::error::CosmosError::response); this cap
+/// only keeps single-line log records and panic messages bounded.
+const MAX_SERVICE_DETAIL_LEN: usize = 512;
+
+/// Extracts the service's human-readable explanation from an error response
+/// body so it can be folded into the error message.
+///
+/// Cosmos error payloads are shaped like
+/// `{"code":"BadRequest","message":"Message: {\"Errors\":[\"...\"]}\r\nActivityId: ..., Request URI: ..."}`.
+/// Only the `Errors` text carries information the caller can act on — the
+/// activity ID, request URI, and SDK banner are already exposed as typed
+/// fields on the error — so those trailers are stripped. Bodies that are not
+/// JSON (or not shaped as expected) fall back to the raw text so nothing the
+/// service said is lost.
+///
+/// Returns `None` when the body is empty or carries no usable text.
+fn service_body_detail(body: &[u8]) -> Option<String> {
+    let text = std::str::from_utf8(body).ok()?.trim();
+    if text.is_empty() {
+        return None;
+    }
+
+    let detail = match serde_json::from_str::<serde_json::Value>(text) {
+        Ok(value) => match value.get("message").and_then(serde_json::Value::as_str) {
+            Some(message) => condense_service_message(message),
+            // Valid JSON without a `message` field: keep the payload as-is.
+            None => text.to_string(),
+        },
+        Err(_) => text.to_string(),
+    };
+
+    let detail = detail.trim();
+    if detail.is_empty() {
+        return None;
+    }
+
+    Some(truncate_detail(detail))
+}
+
+/// Reduces a service `message` field to the actionable text: drops the
+/// `Message: ` prefix and the `ActivityId: ...` trailer, and unwraps the
+/// nested `{"Errors":[...]}` envelope when present.
+fn condense_service_message(message: &str) -> String {
+    let head = match message.find("\r\nActivityId:") {
+        Some(index) => &message[..index],
+        None => match message.find("\nActivityId:") {
+            Some(index) => &message[..index],
+            None => message,
+        },
+    };
+    let head = head.trim().strip_prefix("Message:").unwrap_or(head).trim();
+
+    // The inner envelope is itself JSON, e.g. `{"Errors":["..."]}`.
+    if let Ok(inner) = serde_json::from_str::<serde_json::Value>(head) {
+        if let Some(errors) = inner.get("Errors").and_then(serde_json::Value::as_array) {
+            let joined = errors
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .collect::<Vec<_>>()
+                .join("; ");
+            if !joined.is_empty() {
+                return joined;
+            }
+        }
+    }
+
+    head.to_string()
+}
+
+/// Truncates `detail` to [`MAX_SERVICE_DETAIL_LEN`] bytes on a character
+/// boundary, appending an ellipsis when anything was dropped.
+fn truncate_detail(detail: &str) -> String {
+    if detail.len() <= MAX_SERVICE_DETAIL_LEN {
+        return detail.to_string();
+    }
+
+    let mut end = MAX_SERVICE_DETAIL_LEN;
+    while end > 0 && !detail.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &detail[..end])
+}
+
 /// Builds a typed [`CosmosError`] for a Cosmos HTTP error response.
 ///
 /// Captures the parsed response headers and the raw response body bytes
 /// (e.g. the JSON error payload returned by the service for a 400 /
-/// BadRequest) on the resulting `CosmosError`. The error propagates through the
+/// BadRequest) on the resulting `CosmosError`. The service's own explanation
+/// is also folded into the error message (see [`service_body_detail`]) so a
+/// bare `{err}` log line says *why* the request was rejected instead of only
+/// `HTTP 400: Unknown`. The error propagates through the
 /// pipeline as `crate::error::CosmosError` end-to-end. Callers inspect the wire
 /// payload directly via [`CosmosError::status`](crate::error::CosmosError::status),
 /// [`CosmosError::cosmos_headers`](crate::error::CosmosError::cosmos_headers), and
@@ -1031,9 +1119,14 @@ pub(crate) fn build_service_error(
     // canonical [`CosmosStatus::CROSS_PARTITION_QUERY_NOT_SERVABLE`] so
     // callers get a consistent typed status regardless of gateway version.
     let effective_status = synthesize_cross_partition_query_status(*status, body);
+    let mut message = service_error_message(&effective_status);
+    if let Some(detail) = service_body_detail(body) {
+        message.push_str(". Details: ");
+        message.push_str(&detail);
+    }
     crate::error::CosmosError::builder()
         .with_status(effective_status)
-        .with_message(service_error_message(&effective_status))
+        .with_message(message)
         .with_response_parts(crate::models::CosmosResponsePayload::new(
             body.to_vec(),
             cosmos_headers.clone(),
@@ -3608,6 +3701,64 @@ mod tests {
         assert!(
             eval.effects.is_empty(),
             "409 Conflict has no per-status handler; emits no effects",
+        );
+    }
+
+    /// The service's explanation is folded into the error message so a bare
+    /// `{err}` log line says *why* the request was rejected, not just
+    /// `HTTP 400: Unknown`.
+    #[test]
+    fn service_error_message_includes_service_detail() {
+        let body = br#"{"code":"BadRequest","message":"Message: {\"Errors\":[\"The retention duration in the Change Feed policy should not be set when continuous backup mode is enabled for the database account.\"]}\r\nActivityId: 36327452-0aa6-41fa-8f85-491f9755c870, Request URI: /apps/x/services/y, RequestStats: , SDK: Microsoft.Azure.Documents.Common/2.14.0"}"#;
+        let err = build_service_error(
+            &CosmosStatus::from_parts(StatusCode::BadRequest, None),
+            &CosmosResponseHeaders::default(),
+            body,
+        );
+
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains(
+                "The retention duration in the Change Feed policy should not be set \
+                 when continuous backup mode is enabled for the database account."
+            ),
+            "expected the service explanation in {rendered}"
+        );
+        // The activity ID / request URI trailer is already exposed as typed
+        // state, so it must not bloat the message.
+        assert!(
+            !rendered.contains("Request URI"),
+            "expected the request trailer to be stripped from {rendered}"
+        );
+    }
+
+    #[test]
+    fn service_body_detail_falls_back_to_raw_text() {
+        assert_eq!(
+            Some("not json at all".to_string()),
+            service_body_detail(b"not json at all")
+        );
+        assert_eq!(None, service_body_detail(b""));
+        assert_eq!(None, service_body_detail(b"   "));
+    }
+
+    #[test]
+    fn service_body_detail_truncates_long_payloads() {
+        let long = "x".repeat(MAX_SERVICE_DETAIL_LEN * 2);
+        let body = serde_json::json!({ "code": "BadRequest", "message": long }).to_string();
+
+        let detail = service_body_detail(body.as_bytes()).expect("detail");
+        assert_eq!(MAX_SERVICE_DETAIL_LEN + 3, detail.len());
+        assert!(detail.ends_with("..."));
+    }
+
+    /// A body with no `message` field (or an unexpected shape) still surfaces
+    /// verbatim rather than being dropped.
+    #[test]
+    fn service_body_detail_keeps_unrecognized_json() {
+        assert_eq!(
+            Some(r#"{"code":"BadRequest"}"#.to_string()),
+            service_body_detail(br#"{"code":"BadRequest"}"#)
         );
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/retry_evaluation.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/retry_evaluation.rs
@@ -1001,9 +1001,9 @@ fn service_error_message(status: &CosmosStatus) -> String {
     )
 }
 
-/// Upper bound on how much of the service's error text is folded into the
-/// error message. The full payload always remains available verbatim via
-/// [`CosmosError::response`](crate::error::CosmosError::response); this cap
+/// Upper bound, in bytes, on how much of the service's error text is folded
+/// into the error message. The full payload always remains available verbatim
+/// via [`CosmosError::response`](crate::error::CosmosError::response); this cap
 /// only keeps single-line log records and panic messages bounded.
 const MAX_SERVICE_DETAIL_LEN: usize = 512;
 
@@ -1013,10 +1013,17 @@ const MAX_SERVICE_DETAIL_LEN: usize = 512;
 /// Cosmos error payloads are shaped like
 /// `{"code":"BadRequest","message":"Message: {\"Errors\":[\"...\"]}\r\nActivityId: ..., Request URI: ..."}`.
 /// Only the `Errors` text carries information the caller can act on — the
-/// activity ID, request URI, and SDK banner are already exposed as typed
-/// fields on the error — so those trailers are stripped. Bodies that are not
-/// JSON (or not shaped as expected) fall back to the raw text so nothing the
-/// service said is lost.
+/// activity ID is already exposed as typed state on the error, and the request
+/// URI and SDK banner identify service-internal replicas — so those trailers
+/// are stripped. Bodies that are not JSON (or not shaped as expected) fall back
+/// to the raw text so nothing the service said is lost; the untouched payload
+/// (trailers included) is always retrievable via
+/// [`CosmosError::response`](crate::error::CosmosError::response).
+///
+/// The result is normalized to a single line (see [`normalize_single_line`])
+/// before it is truncated, so a service-controlled body cannot inject line
+/// breaks or control characters into a log record through
+/// [`CosmosError`](crate::error::CosmosError)'s single-line `Display`.
 ///
 /// Returns `None` when the body is empty or carries no usable text.
 fn service_body_detail(body: &[u8]) -> Option<String> {
@@ -1034,12 +1041,41 @@ fn service_body_detail(body: &[u8]) -> Option<String> {
         Err(_) => text.to_string(),
     };
 
-    let detail = detail.trim();
+    // Normalize before truncating so the byte budget applies to the text that
+    // is actually rendered.
+    let detail = normalize_single_line(&detail);
     if detail.is_empty() {
         return None;
     }
 
-    Some(truncate_detail(detail))
+    Some(truncate_detail(&detail))
+}
+
+/// Collapses `text` onto a single line: every control character (CR, LF, TAB,
+/// other C0/C1 codes, and DEL) becomes a space, and runs of whitespace collapse
+/// to one space.
+///
+/// The service controls this text, so this is what keeps it from forging or
+/// mangling log records emitted through
+/// [`CosmosError`](crate::error::CosmosError)'s single-line `Display`.
+fn normalize_single_line(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut pending_space = false;
+
+    for ch in text.chars() {
+        if ch.is_control() || ch.is_whitespace() {
+            // Defer the separator so trailing whitespace never lands in `out`.
+            pending_space = !out.is_empty();
+            continue;
+        }
+        if pending_space {
+            out.push(' ');
+            pending_space = false;
+        }
+        out.push(ch);
+    }
+
+    out
 }
 
 /// Reduces a service `message` field to the actionable text: drops the
@@ -1073,17 +1109,20 @@ fn condense_service_message(message: &str) -> String {
 }
 
 /// Truncates `detail` to [`MAX_SERVICE_DETAIL_LEN`] bytes on a character
-/// boundary, appending an ellipsis when anything was dropped.
+/// boundary, appending an ellipsis when anything was dropped. The ellipsis is
+/// counted against the budget, so the result never exceeds the cap.
 fn truncate_detail(detail: &str) -> String {
+    const ELLIPSIS: &str = "...";
+
     if detail.len() <= MAX_SERVICE_DETAIL_LEN {
         return detail.to_string();
     }
 
-    let mut end = MAX_SERVICE_DETAIL_LEN;
+    let mut end = MAX_SERVICE_DETAIL_LEN - ELLIPSIS.len();
     while end > 0 && !detail.is_char_boundary(end) {
         end -= 1;
     }
-    format!("{}...", &detail[..end])
+    format!("{}{ELLIPSIS}", &detail[..end])
 }
 
 /// Builds a typed [`CosmosError`] for a Cosmos HTTP error response.
@@ -3724,8 +3763,9 @@ mod tests {
             ),
             "expected the service explanation in {rendered}"
         );
-        // The activity ID / request URI trailer is already exposed as typed
-        // state, so it must not bloat the message.
+        // The activity ID is already typed state on the error, and the request
+        // URI / SDK banner name service-internal replicas — the trailer stays
+        // in the raw body rather than bloating the message.
         assert!(
             !rendered.contains("Request URI"),
             "expected the request trailer to be stripped from {rendered}"
@@ -3748,8 +3788,53 @@ mod tests {
         let body = serde_json::json!({ "code": "BadRequest", "message": long }).to_string();
 
         let detail = service_body_detail(body.as_bytes()).expect("detail");
-        assert_eq!(MAX_SERVICE_DETAIL_LEN + 3, detail.len());
+        // The ellipsis is counted against the budget, so the cap is never exceeded.
+        assert_eq!(MAX_SERVICE_DETAIL_LEN, detail.len());
         assert!(detail.ends_with("..."));
+    }
+
+    /// Truncating must not split a multi-byte character, and the result must
+    /// still respect the byte cap.
+    #[test]
+    fn service_body_detail_truncates_on_char_boundary() {
+        // 'é' is two bytes, so the naive cut point lands mid-character.
+        let long = "é".repeat(MAX_SERVICE_DETAIL_LEN);
+        let body = serde_json::json!({ "code": "BadRequest", "message": long }).to_string();
+
+        let detail = service_body_detail(body.as_bytes()).expect("detail");
+        assert!(detail.len() <= MAX_SERVICE_DETAIL_LEN);
+        assert!(detail.ends_with("..."));
+        assert!(detail.trim_end_matches('.').chars().all(|c| c == 'é'));
+    }
+
+    /// The body is service-controlled, so newlines and other control characters
+    /// must not reach `CosmosError`'s single-line `Display` — otherwise a
+    /// crafted payload could forge or mangle log records.
+    #[test]
+    fn service_body_detail_normalizes_control_characters() {
+        let body = serde_json::json!({
+            "code": "BadRequest",
+            "message": "first line\r\nERROR: forged\tentry\u{7f}\u{1}  and   spaces  ",
+        })
+        .to_string();
+
+        let detail = service_body_detail(body.as_bytes()).expect("detail");
+        assert_eq!("first line ERROR: forged entry and spaces", detail);
+        assert!(!detail.chars().any(char::is_control));
+    }
+
+    /// The same normalization applies on the raw-text fallback path, where the
+    /// body never went through JSON parsing.
+    #[test]
+    fn service_body_detail_normalizes_raw_text_fallback() {
+        let detail = service_body_detail(b"not json\nsecond line\r\nthird").expect("detail");
+        assert_eq!("not json second line third", detail);
+    }
+
+    /// A body that is nothing but control characters carries no usable text.
+    #[test]
+    fn service_body_detail_rejects_control_only_body() {
+        assert_eq!(None, service_body_detail(b"\r\n\t  \x01"));
     }
 
     /// A body with no `message` field (or an unexpected shape) still surfaces

--- a/sdk/cosmos/test-resources.bicep
+++ b/sdk/cosmos/test-resources.bicep
@@ -6,7 +6,7 @@ param enableAutomaticFailover bool = false
 @description('Flag to enable or disable multiple write locations on CosmosDB Account')
 param enableMultipleWriteLocations bool = false
 
-@description('Enable continuous backup mode, required to read the AllVersionsAndDeletes (full-fidelity) change feed. The retention window is then derived from the backup retention, so containers must not also set changeFeedPolicy.retentionDuration. Incompatible with multiple write locations.')
+@description('Enable the AllVersionsAndDeletes (full-fidelity) change feed. This turns on both continuous backup mode and the account-level full-fidelity change feed, which are both required. The retention window is then derived from the backup retention, so containers must not also set changeFeedPolicy.retentionDuration. Incompatible with multiple write locations.')
 param enableContinuousBackup bool = false
 
 @description('Dictates which tests run for this resource')
@@ -82,6 +82,10 @@ resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
     disableKeyBasedMetadataWriteAccess: false
     enableFreeTier: false
     enableAnalyticalStorage: false
+    // Required (together with continuous backup) for the AllVersionsAndDeletes change feed.
+    // ARM accepts this on 2023-04-15 even though the Bicep type index does not declare it.
+    #disable-next-line BCP037
+    enableFullFidelityChangeFeed: enableContinuousBackup
     databaseAccountOfferType: 'Standard'
     consistencyPolicy: {
       defaultConsistencyLevel: defaultConsistencyLevel

--- a/sdk/cosmos/test-resources.bicep
+++ b/sdk/cosmos/test-resources.bicep
@@ -6,7 +6,7 @@ param enableAutomaticFailover bool = false
 @description('Flag to enable or disable multiple write locations on CosmosDB Account')
 param enableMultipleWriteLocations bool = false
 
-@description('Enable continuous backup mode, required to read the AllVersionsAndDeletes (full-fidelity) change feed. Incompatible with multiple write locations.')
+@description('Enable continuous backup mode, required to read the AllVersionsAndDeletes (full-fidelity) change feed. The retention window is then derived from the backup retention, so containers must not also set changeFeedPolicy.retentionDuration. Incompatible with multiple write locations.')
 param enableContinuousBackup bool = false
 
 @description('Dictates which tests run for this resource')

--- a/sdk/cosmos/test-resources.bicep
+++ b/sdk/cosmos/test-resources.bicep
@@ -6,7 +6,7 @@ param enableAutomaticFailover bool = false
 @description('Flag to enable or disable multiple write locations on CosmosDB Account')
 param enableMultipleWriteLocations bool = false
 
-@description('Enable the AllVersionsAndDeletes (full-fidelity) change feed. This turns on both continuous backup mode and the account-level full-fidelity change feed, which are both required. The retention window is then derived from the backup retention, so containers must not also set changeFeedPolicy.retentionDuration. Incompatible with multiple write locations.')
+@description('Enable continuous backup mode. This is a prerequisite for the AllVersionsAndDeletes (full-fidelity) change feed, but is not sufficient on its own: the account also needs the enableFullFidelityChangeFeed property, which cannot be set at account creation and is rejected on subscriptions that are not allowlisted for it. With continuous backup on, the change feed retention window is derived from the backup retention, so containers must not also set changeFeedPolicy.retentionDuration. Incompatible with multiple write locations.')
 param enableContinuousBackup bool = false
 
 @description('Dictates which tests run for this resource')
@@ -82,10 +82,6 @@ resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
     disableKeyBasedMetadataWriteAccess: false
     enableFreeTier: false
     enableAnalyticalStorage: false
-    // Required (together with continuous backup) for the AllVersionsAndDeletes change feed.
-    // ARM accepts this on 2023-04-15 even though the Bicep type index does not declare it.
-    #disable-next-line BCP037
-    enableFullFidelityChangeFeed: enableContinuousBackup
     databaseAccountOfferType: 'Standard'
     consistencyPolicy: {
       defaultConsistencyLevel: defaultConsistencyLevel


### PR DESCRIPTION
## Root cause

The three `all_versions_and_deletes_*` tests fail on every live leg of `rust - cosmos - weekly` with `400: Cosmos DB returned HTTP 400: Unknown`. There turned out to be **two** distinct causes, stacked behind one useless error message.

### 1. Container-level retention conflicts with continuous backup

The first failing request is the **container create**, not the change feed read (`operation_type=Create resource_type=DocumentCollection`). The service's response body — which the SDK was discarding — says:

> The retention duration in the Change Feed policy should not be set when continuous backup mode is enabled for the database account. Change Feed retention is set by the backup retention.

Container-level `changeFeedPolicy.retentionDuration` is an emulator-only opt-in. Live accounts derive the retention window from the backup retention, and setting both is rejected. So `enableContinuousBackup = $true` in the matrix was *causing* this failure, not missing.

### 2. The account itself was never enabled for the mode

With that resolved, the change feed **read** then failed with a different `400`:

> Change Feed 'All Versions and Deletes' mode must be enabled.

Continuous backup is a prerequisite but is not sufficient — the account also needs an account-level opt-in that CI has never set.

**This one is not fixable from this repo.** Setting `enableFullFidelityChangeFeed` in the bicep passes `az deployment group what-if` but fails an actual deployment with:

> EnableFullFidelityChangeFeed is not supported for the target subscription

It is gated on a service-side allowlist. Enumerating every `Microsoft.DocumentDB` feature flag on a Cosmos subscription shows no registrable feature, so `az feature register` cannot help either. The docs additionally state the opt-in cannot be applied at account creation and takes up to 30 minutes during which no other account changes are allowed — incompatible with a single-pass deployment that immediately creates a database and role assignments.

Since a failed deployment takes down the whole leg, attempting it made things strictly worse (2 failing tests → all tests on 4 legs). That attempt is reverted here.

### What the other SDKs do

None of them run these tests against a live CI-provisioned account:

| SDK | AVAD tests | Run live in CI? |
|---|---|---|
| Java | yes | no — emulator TestNG group |
| .NET (cosmos-dotnet-v3) | yes | no — `EmulatorTests` namespace |
| JS | yes | no — local emulator w/ `/enablepreview` |
| Python | yes | attempts live, **skips** when service says not enabled |
| Go | none | n/a |

## Changes

- **`tests/emulator_tests/cosmos_change_feed.rs`, `tests/split_tests/cosmos_change_feed_split.rs`** — apply the container-level retention policy only against the emulator (fixes cause #1), and detect the "must be enabled" `400` to **skip** rather than fail (handles cause #2, following Python's precedent). The tests still run in full against the emulator and against any account that does have the mode enabled.

  Deliberately *not* gated off via `testCategory`: these live legs compile with the emulator category, so that would also disable 13 unrelated tests covering fault injection, non-ASCII / invalid-UTF-8 handling, and query continuation tokens.

- **`all_versions_and_deletes_rejects_point_in_time_start`** — previously asserted only that *some* `400` came back, so it passed on accounts lacking the feature for entirely the wrong reason. It now skips that case instead of counting it as evidence. Three unit tests pin the message matching against the exact text CI produced and confirm the genuine point-in-time rejection is still treated as a real assertion.

- **`azure_data_cosmos_driver/.../retry_evaluation.rs`** — fold the service's own explanation into the error message so a bare `{err}` no longer renders as `HTTP 400: Unknown`. The `ActivityId` trailer is stripped (already exposed as typed state), the nested `{"Errors":[...]}` envelope is unwrapped, and the text is normalized to a single line and capped at 512 bytes. Raw payload still available via `CosmosError::response`.

  This is what made cause #2 diagnosable at all — without it the second `400` was indistinguishable from the first.

- **`container_properties.rs`, `test-resources.bicep`** — document the continuous-backup interaction and record that the account-level opt-in is allowlist-gated, so the next person doesn't repeat the failed deployment.

## Verification

- 91/91 emulator tests pass, including 11/11 change feed and the 3 new detection unit tests.
- 11/11 change feed tests pass against a live account that *does* have the mode enabled — no skips, so this doesn't quietly disable coverage where it works.
- `cargo fmt` / `cargo clippy --all-features --tests` clean; bicep compiles clean.

## Follow-up (not in this PR)

Getting real live AVAD coverage requires the engineering-system subscription to be allowlisted via <https://aka.ms/ChangeFeed-AllVersionsAndDeletes>, plus a post-creation deployment step. Worth filing separately if we want it — but given no other Azure SDK does this, emulator coverage seems like the reasonable bar.
