### PR TITLE
[Storage] Idempotent tracing init in `azure_core_test`

### DIFF
--- a/sdk/core/azure_core_test/CHANGELOG.md
+++ b/sdk/core/azure_core_test/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed test-proxy startup failures cascading into misleading "a global default trace dispatcher has already been set" panics across recorded tests. Tracing initialization is now idempotent.
+
 ### Other Changes
 
 ## 0.1.0 (2026-06-04)

--- a/sdk/core/azure_core_test/src/recorded.rs
+++ b/sdk/core/azure_core_test/src/recorded.rs
@@ -96,11 +96,11 @@ fn init_tracing() {
     #[cfg(feature = "tracing")]
     {
         use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
-        tracing_subscriber::fmt()
+        let _ = tracing_subscriber::fmt()
             .with_env_filter(EnvFilter::from_default_env())
             .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
             .with_ansi(std::env::var("NO_COLOR").map_or(true, |v| v.is_empty()))
             .with_writer(std::io::stderr)
-            .init();
+            .try_init();
     }
 }


### PR DESCRIPTION
Resolves #4530

### Testing

- **Root-caused via static analysis.** Traced the call flow: `init_tracing()` installs the global subscriber before the fallible proxy startup in `TEST_PROXY.get_or_init` (`recorded.rs`), and `proxy.endpoint()` panics when the test-proxy spawns but never prints "Now listening on:" (`bootstrap.rs`).
- **Confirmed the mechanism against tokio docs.** `OnceCell::get_or_init` re-runs its initializer after a panic, so the first failure re-invokes `init_tracing()` on every waiting test → repeated `.init()` panics.
- **Built a deterministic repro** (throwaway `tests/subscriber_cascade_repro.rs`) modeling the once-guard: initializer installs the subscriber via `.init()` then panics. Deleted once verified.

### Fix

In `sdk/core/azure_core_test/src/recorded.rs`, `init_tracing()` now calls `.try_init()` (result ignored) instead of `.init()`:

```rust
let _ = tracing_subscriber::fmt()
    .with_env_filter(EnvFilter::from_default_env())
    .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
    .with_ansi(std::env::var("NO_COLOR").map_or(true, |v| v.is_empty()))
    .with_writer(std::io::stderr)
    .try_init();
```

`try_init()` returns a `Result` instead of panicking when a subscriber already exists, making tracing setup idempotent. A failed test-proxy startup can no longer poison the shared once-guard and cascade into misleading subscriber panics across every other test.