### PR TITLE
chore: add @meetamitbhatia to CODEOWNERS alongside @j7nw4r

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -74,14 +74,14 @@
 # AzureSDKOwners: @vincenttran-msft @jalauzon-msft @jaschrep-msft
 
 # PRLabel: %Event Hubs
-/sdk/eventhubs/          @j7nw4r @SwayGom @sagar0207
+/sdk/eventhubs/          @j7nw4r @meetamitbhatia @SwayGom @sagar0207
 
 # PRLabel: %Event Hubs %Storage
-/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/    @j7nw4r @SwayGom @sagar0207 @jalauzon-msft @vincenttran-msft @jaschrep-msft
+/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/    @j7nw4r @meetamitbhatia @SwayGom @sagar0207 @jalauzon-msft @vincenttran-msft @jaschrep-msft
 
 # ServiceLabel: %Event Hubs
 # AzureSDKOwners: @LarryOsterman
-# ServiceOwners: @j7nw4r @SwayGom @sagar0207
+# ServiceOwners: @j7nw4r @meetamitbhatia @SwayGom @sagar0207
 
 ####################
 # Management Libraries


### PR DESCRIPTION
## Summary

@meetamitbhatia (Amit Bhatia) is not in the CODEOWNERS file. He works on the messaging libraries and must get review requests on the same paths as @j7nw4r.

## Motivation

@meetamitbhatia joined the messaging team. Without a CODEOWNERS entry, GitHub does not add him to pull requests that touch the messaging paths. The team then loses a reviewer, and review latency goes up.

## Changes

This change adds `@meetamitbhatia` next to `@j7nw4r` on every line that already lists `@j7nw4r`. It changes 2 owner paths and 1 `ServiceOwners` comment. It removes no owner and adds no new path.

Owner paths:

- `/sdk/eventhubs/`
- `/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/`

## Validation

@meetamitbhatia is a member of the `Azure` organization, so the CODEOWNERS linter can resolve the handle.
