### PR TITLE
Cosmos: Shrink driver async state machines

### DIFF
--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
@@ -2337,11 +2337,12 @@ impl CosmosDriver {
 
         let transcode_response_to_text = binary.enabled && binary.request_text_response;
 
-        // TODO: This boxing is a temporary fix to avoid a large future.
-        // We need to do some refactoring here to shrink the future size and avoid this heap allocation if possible.
+        // Boxed: this is the top-level entry point that callers (feed
+        // iterators, user code) compose and nest, so keeping its frame small
+        // matters more than avoiding one allocation per operation.
         let response = Box::pin(async {
             let container = operation.container().cloned();
-            let mut plan = Box::pin(self.plan_operation(operation, &options, None)).await?;
+            let mut plan = self.plan_operation(operation, &options, None).await?;
             self.execute_plan(&mut plan, container, options).await
         })
         .await?;
@@ -2645,7 +2646,11 @@ impl CosmosDriver {
 
         let mut topology = container.map(|c| {
             CachedTopologyProvider::new(&self.pk_range_cache, c, |container, continuation| {
-                self.fetch_pk_ranges_from_service(container, continuation)
+                // Box the fetch future: the cache layer is generic over the
+                // returned future, so leaving it unboxed inlines the whole
+                // `execute_operation_direct` state machine into every cache
+                // frame.
+                Box::pin(self.fetch_pk_ranges_from_service(container, continuation))
             })
         });
 
@@ -2962,7 +2967,8 @@ impl CosmosDriver {
                 &self.pk_range_cache,
                 container_ref,
                 |container, continuation| {
-                    self.fetch_pk_ranges_from_service(container, continuation)
+                    // Box the fetch future — see the note in `execute_plan`.
+                    Box::pin(self.fetch_pk_ranges_from_service(container, continuation))
                 },
             );
             let pipeline = planner::build_unordered_merge(
@@ -2987,16 +2993,22 @@ impl CosmosDriver {
                 .build()
         })?;
 
-        let query_plan = self
-            .resolve_query_plan(container, &operation, options)
-            .await?;
+        // Box the query-plan resolution: unboxed it pulls the entire
+        // `execute_operation_direct` -> `execute_operation_pipeline` state
+        // machine into this function's frame. One allocation per
+        // cross-partition query plan is negligible against the gateway
+        // round-trip it performs.
+        let query_plan = Box::pin(self.resolve_query_plan(container, &operation, options)).await?;
 
         // Build the fan-out pipeline using the query plan.
         let container_ref = container.clone();
         let mut topology = CachedTopologyProvider::new(
             &self.pk_range_cache,
             container_ref,
-            |container, continuation| self.fetch_pk_ranges_from_service(container, continuation),
+            |container, continuation| {
+                // Box the fetch future — see the note in `execute_plan`.
+                Box::pin(self.fetch_pk_ranges_from_service(container, continuation))
+            },
         );
 
         let pipeline =

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/operation_pipeline.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/operation_pipeline.rs
@@ -470,7 +470,10 @@ pub(crate) async fn execute_operation_pipeline(
                 // `failover_retry_count`, and `location` on
                 // `retry_state` — see [`OperationRetryState`].
                 retry_state.hedge_already_fired = true;
-                match execute_hedged(
+                // Box the hedge race: it is a cold path (hedge-eligible reads
+                // only) and its state machine otherwise dominates this retry
+                // loop's frame.
+                match Box::pin(execute_hedged(
                     &attempt_ctx,
                     &routing,
                     &upgrade.secondary_routing,
@@ -478,7 +481,7 @@ pub(crate) async fn execute_operation_pipeline(
                     upgrade.strategy_config,
                     diagnostics,
                     &retry_state,
-                )
+                ))
                 .await
                 {
                     HedgedRaceResult::Terminal(result) => return result,
@@ -721,7 +724,9 @@ pub(crate) async fn execute_operation_pipeline(
             effects,
         );
         retry_state.pending_write_effects.extend(deferred_effects);
-        location_state_store.apply(&immediate_effects).await;
+        // Boxed: a cold, side-effect-only await whose frame would otherwise be
+        // combined into every variant of this loop's state machine.
+        Box::pin(location_state_store.apply(&immediate_effects)).await;
 
         // ── STAGE 7: Act on the control-flow decision ──────────────────
         match action {
@@ -731,7 +736,12 @@ pub(crate) async fn execute_operation_pipeline(
                 // healthy, so the previously-failed regions can be safely
                 // marked unavailable for this partition (and endpoint, when
                 // PPAF is active).
-                flush_pending_write_effects(&mut retry_state, location_state_store).await;
+                // Boxed: cold, side-effect-only await.
+                Box::pin(flush_pending_write_effects(
+                    &mut retry_state,
+                    location_state_store,
+                ))
+                .await;
 
                 // If a PPCB probe request succeeded, remove the ProbeCandidate entry.
                 try_cleanup_probe_candidate(&retry_state, location_state_store);
@@ -845,7 +855,12 @@ pub(crate) async fn execute_operation_pipeline(
                 let cosmos_status = error.status();
                 let confirming = is_region_confirming_status(&cosmos_status);
                 if confirming {
-                    flush_pending_write_effects(&mut retry_state, location_state_store).await;
+                    // Boxed: cold, side-effect-only await.
+                    Box::pin(flush_pending_write_effects(
+                        &mut retry_state,
+                        location_state_store,
+                    ))
+                    .await;
                 } else {
                     retry_state.pending_write_effects.clear();
                 }
@@ -975,7 +990,8 @@ pub(crate) async fn execute_operation_pipeline(
                 // replaces `retry_state` from `new_state` (which carries
                 // `hedge_already_fired = false`).
                 retry_state.hedge_already_fired = true;
-                match execute_hedged(
+                // Box the hedge race — cold path; see the note above.
+                match Box::pin(execute_hedged(
                     &attempt_ctx,
                     &primary_routing,
                     &secondary_routing,
@@ -983,7 +999,7 @@ pub(crate) async fn execute_operation_pipeline(
                     strategy_config,
                     diagnostics,
                     &retry_state,
-                )
+                ))
                 .await
                 {
                     HedgedRaceResult::Terminal(result) => return result,


### PR DESCRIPTION
Several hot async fns inlined large sub-futures into their own state machines, producing multi-kilobyte frames that risk overflowing the default 1 MiB stack on Windows x64 and forced repeated large_futures suppressions.

Box the sub-futures that dominate each frame:

- the pk-range fetch closures passed to the partition key range cache, which is generic over the fetch future and otherwise inlines the whole execute_operation_direct state machine into every cache frame
- the query plan resolution awaited by plan_operation
- the hedge race and the cold, side-effect-only location-state awaits in the operation pipeline retry loop

plan_operation drops from 15456 to 3336 bytes and the topology resolution chain from 15704 to 2184 bytes. Behavior is unchanged; the added allocations sit on paths that already perform a network round trip.

Closes #4794 