### PR TITLE
Refine generate_api navigation links

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -272,7 +272,7 @@ function Get-rust-PackageInfoFromPackageFile([IO.FileInfo]$pkg, [string]$working
 }
 
 function Find-rust-Artifacts-For-Apireview([string]$ArtifactPath, [string]$packageName) {
-  [array]$files = Get-ChildItem -Path $ArtifactPath -Recurse -Filter "$packageName`_rust.json"
+  [array]$files = Get-ChildItem -Path $ArtifactPath -Recurse -Filter "$packageName.rust.json"
 
   if (!$files) {
     Write-Host "$($packageName) does not have api review json"

--- a/eng/scripts/Pack-Crates.ps1
+++ b/eng/scripts/Pack-Crates.ps1
@@ -217,7 +217,7 @@ try {
 
       $targetPath = [System.IO.Path]::Combine($OutputPath, $package.name)
       $targetContentsPath = [System.IO.Path]::Combine($targetPath, "contents")
-      $targetApiReviewFile = [System.IO.Path]::Combine($targetPath, "$($package.name)_rust.json")
+      $targetApiReviewFile = [System.IO.Path]::Combine($targetPath, "$($package.name).rust.json")
 
       if (Test-Path -Path $targetContentsPath) {
         Remove-Item -Path $targetContentsPath -Recurse -Force

--- a/eng/tools/generate_api/AGENTS.md
+++ b/eng/tools/generate_api/AGENTS.md
@@ -217,6 +217,7 @@ Important nested structures:
   - `HasSuffixSpace?`
   - `IsDocumentation?`
   - `NavigationDisplayName?`
+  - `NavigateToId?`
   - `RenderClasses?`
 
 Token kinds used:
@@ -236,9 +237,19 @@ Current APIView decisions:
   - item: `{module_line_id}.{item_name}_{index}`
   - member: `{item_line_id}.{member_name}_{index}`
 - reject duplicate `LineId`s
+- keep the crate root unwrapped and let APIView provide the root tree node
 - include `HasPrefixSpace` and `HasSuffixSpace`
 - doc comments use `Comment` with `IsDocumentation = true`
+- root/module inner attributes render at their scope with the original `#!` text preserved
 - represent nested modules through `ReviewLine.Children`
+- emit navigation metadata on modules and non-impl top-level items; impl blocks stay out of the tree
+- re-export tree nodes navigate by each imported item's leaf name rather than a generic `use` entry
+- APIView tree ordering within a module is:
+  - consts/statics
+  - type aliases/re-exports
+  - macros/proc macros
+  - free functions
+  - type-like items alphabetically
 - type all declaration tokens:
   - keywords use `Keyword`
   - item names use `TypeName` except functions use `MemberName`

--- a/eng/tools/generate_api/Cargo.toml
+++ b/eng/tools/generate_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generate_api"
-version = "2.0.0"
+version = "2.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/eng/tools/generate_api/README.md
+++ b/eng/tools/generate_api/README.md
@@ -39,7 +39,7 @@ From that path:
 
 - `Pack-Crates.ps1` runs `generate_api --format apiview` for each packed crate.
 - The staged package artifact keeps the existing downstream shape by renaming that output to
-  `<package>/<package>_rust.json`.
+  `<package>/<package>.rust.json`.
 - The shared `create-apireview` pipeline step consumes that staged JSON artifact.
 
 For local testing, `Pack-Crates.ps1 -APIReview` temporarily switches to markdown generation and

--- a/eng/tools/generate_api/src/extract.rs
+++ b/eng/tools/generate_api/src/extract.rs
@@ -27,6 +27,7 @@ fn find_item_entry<'a>(
     module: &'a ApiModule,
     segments: &[&str],
 ) -> Option<(&'a ApiModule, &'a ApiItem)> {
+    let segments = strip_duplicate_leading_module_segments(module, segments);
     let (head, tail) = segments.split_first()?;
     if tail.is_empty() {
         return module
@@ -36,11 +37,31 @@ fn find_item_entry<'a>(
             .map(|item| (module, item));
     }
 
-    let child = module
+    if let Some(child) = module
         .modules
         .iter()
-        .find(|candidate| candidate.local_name() == *head)?;
-    find_item_entry(child, tail)
+        .find(|candidate| candidate.local_name() == *head)
+    {
+        if let Some(found) = find_item_entry(child, tail) {
+            return Some(found);
+        }
+    }
+
+    if tail.is_empty() {
+        None
+    } else {
+        find_item_entry(module, tail)
+    }
+}
+
+fn strip_duplicate_leading_module_segments<'a>(
+    module: &ApiModule,
+    mut segments: &'a [&'a str],
+) -> &'a [&'a str] {
+    while segments.len() > 1 && segments[0] == module.local_name() {
+        segments = &segments[1..];
+    }
+    segments
 }
 
 pub(crate) fn extract_model(
@@ -96,7 +117,11 @@ fn extract_module(
                 let module = extract_module(krate, child, child_path, resolver)?;
                 insert_module(&mut result.modules, &mut seen_modules, module);
             }
-            ItemEnum::Impl(_) => {}
+            ItemEnum::Impl(impl_block) => {
+                if let Some(extracted) = extract_unassociated_trait_impl(krate, child, impl_block) {
+                    insert_item(&mut result, &mut seen_declarations, extracted);
+                }
+            }
             ItemEnum::Use(use_item) if should_include_item(child) => {
                 if let Some(expanded) =
                     expand_reexport(krate, child, use_item, &result.path, resolver)?
@@ -219,11 +244,10 @@ fn expand_reexport(
     let Some(model) = resolver.load_workspace_model(crate_name)? else {
         return Ok(None);
     };
-    let target_segments = summary
-        .path
-        .iter()
+    let normalized_target_path = normalize_use_path(&summary.path);
+    let target_segments = normalized_target_path
+        .split("::")
         .skip(1)
-        .map(String::as_str)
         .collect::<Vec<&str>>();
     Ok(expand_model_reexport(
         &model,
@@ -347,12 +371,33 @@ fn trait_impls_for_item(krate: &Crate, target: &Item) -> Vec<ApiItem> {
         .filter_map(|impl_id| krate.index.get(impl_id))
         .filter_map(|impl_item| match &impl_item.inner {
             ItemEnum::Impl(impl_block) if include_trait_impl_block(impl_block) => {
-                extract_trait_impl(krate, target, owner_kind, impl_item, impl_block)
+                extract_trait_impl(krate, impl_item, impl_block, Some(target), Some(owner_kind))
             }
             _ => None,
         })
         .map(rebase_trait_impl_item)
         .collect()
+}
+
+fn extract_unassociated_trait_impl(
+    krate: &Crate,
+    item: &Item,
+    impl_block: &Impl,
+) -> Option<ApiItem> {
+    if !include_trait_impl_block(impl_block) {
+        return None;
+    }
+
+    let owner = local_impl_owner(krate, &impl_block.for_);
+    let owner_kind = owner.map(item_kind);
+    extract_trait_impl(krate, item, impl_block, owner, owner_kind).map(rebase_trait_impl_item)
+}
+
+fn local_impl_owner<'a>(krate: &'a Crate, type_: &Type) -> Option<&'a Item> {
+    match type_ {
+        Type::ResolvedPath(path) => krate.index.get(&path.id),
+        _ => None,
+    }
 }
 
 fn rebase_trait_impl_item(mut item: ApiItem) -> ApiItem {
@@ -793,7 +838,12 @@ fn collect_item_declaration_path_references(krate: &Crate, item: &Item) -> Vec<A
             collect_function_declaration_path_references(krate, function, &mut references);
         }
         ItemEnum::Struct(struct_item) => {
-            collect_generics_path_references(krate, &struct_item.generics, &mut references);
+            collect_generic_params_path_references(krate, &struct_item.generics, &mut references);
+            collect_where_predicates_path_references(
+                krate,
+                &struct_item.generics.where_predicates,
+                &mut references,
+            );
             if let StructKind::Tuple(fields) = &struct_item.kind {
                 for field_id in fields.iter().flatten() {
                     let Some(field_item) = krate.index.get(field_id) else {
@@ -807,22 +857,47 @@ fn collect_item_declaration_path_references(krate: &Crate, item: &Item) -> Vec<A
             }
         }
         ItemEnum::Enum(enum_item) => {
-            collect_generics_path_references(krate, &enum_item.generics, &mut references);
+            collect_generic_params_path_references(krate, &enum_item.generics, &mut references);
+            collect_where_predicates_path_references(
+                krate,
+                &enum_item.generics.where_predicates,
+                &mut references,
+            );
         }
         ItemEnum::Trait(trait_item) => {
-            collect_generics_path_references(krate, &trait_item.generics, &mut references);
+            collect_generic_params_path_references(krate, &trait_item.generics, &mut references);
             collect_generic_bounds_path_references(krate, &trait_item.bounds, &mut references);
+            collect_where_predicates_path_references(
+                krate,
+                &trait_item.generics.where_predicates,
+                &mut references,
+            );
         }
         ItemEnum::TraitAlias(trait_alias) => {
-            collect_generics_path_references(krate, &trait_alias.generics, &mut references);
+            collect_generic_params_path_references(krate, &trait_alias.generics, &mut references);
             collect_generic_bounds_path_references(krate, &trait_alias.params, &mut references);
+            collect_where_predicates_path_references(
+                krate,
+                &trait_alias.generics.where_predicates,
+                &mut references,
+            );
         }
         ItemEnum::Union(union_item) => {
-            collect_generics_path_references(krate, &union_item.generics, &mut references);
+            collect_generic_params_path_references(krate, &union_item.generics, &mut references);
+            collect_where_predicates_path_references(
+                krate,
+                &union_item.generics.where_predicates,
+                &mut references,
+            );
         }
         ItemEnum::TypeAlias(type_alias) => {
+            collect_generic_params_path_references(krate, &type_alias.generics, &mut references);
             collect_type_path_references(krate, &type_alias.type_, &mut references);
-            collect_generics_path_references(krate, &type_alias.generics, &mut references);
+            collect_where_predicates_path_references(
+                krate,
+                &type_alias.generics.where_predicates,
+                &mut references,
+            );
         }
         ItemEnum::Constant { type_, .. } => {
             collect_type_path_references(krate, type_, &mut references);
@@ -841,7 +916,7 @@ fn collect_function_declaration_path_references(
     references: &mut Vec<ApiPathReference>,
 ) {
     let synthetic_lifetimes = synthetic_async_trait_lifetimes(function);
-    collect_generics_path_references_with_elision(
+    collect_generic_param_path_references_with_elision(
         krate,
         &function.generics,
         &synthetic_lifetimes,
@@ -858,17 +933,28 @@ fn collect_function_declaration_path_references(
     if let Some(output) = &function.sig.output {
         collect_type_path_references_with_elision(krate, output, &synthetic_lifetimes, references);
     }
+    collect_where_predicates_path_references_with_elision(
+        krate,
+        &function.generics.where_predicates,
+        &synthetic_lifetimes,
+        references,
+    );
 }
 
-fn collect_generics_path_references(
+fn collect_generic_params_path_references(
     krate: &Crate,
     generics: &rustdoc_types::Generics,
     references: &mut Vec<ApiPathReference>,
 ) {
-    collect_generics_path_references_with_elision(krate, generics, &HashSet::new(), references);
+    collect_generic_param_path_references_with_elision(
+        krate,
+        generics,
+        &HashSet::new(),
+        references,
+    );
 }
 
-fn collect_generics_path_references_with_elision(
+fn collect_generic_param_path_references_with_elision(
     krate: &Crate,
     generics: &rustdoc_types::Generics,
     synthetic_lifetimes: &HashSet<String>,
@@ -905,11 +991,17 @@ fn collect_generics_path_references_with_elision(
             GenericParamDefKind::Lifetime { .. } => {}
         }
     }
+}
 
+fn collect_where_predicates_path_references(
+    krate: &Crate,
+    predicates: &[WherePredicate],
+    references: &mut Vec<ApiPathReference>,
+) {
     collect_where_predicates_path_references_with_elision(
         krate,
-        &generics.where_predicates,
-        synthetic_lifetimes,
+        predicates,
+        &HashSet::new(),
         references,
     );
 }
@@ -1311,7 +1403,7 @@ fn collect_trait_impl_declaration_path_references(
     impl_block: &Impl,
 ) -> Vec<ApiPathReference> {
     let mut references = Vec::new();
-    collect_generics_path_references(krate, &impl_block.generics, &mut references);
+    collect_generic_params_path_references(krate, &impl_block.generics, &mut references);
     if let Some(trait_path) = &impl_block.trait_ {
         collect_path_reference(krate, trait_path, &mut references);
         if let Some(args) = &trait_path.args {
@@ -1324,6 +1416,11 @@ fn collect_trait_impl_declaration_path_references(
         }
     }
     collect_type_path_references(krate, &impl_block.for_, &mut references);
+    collect_where_predicates_path_references(
+        krate,
+        &impl_block.generics.where_predicates,
+        &mut references,
+    );
     references
 }
 
@@ -1332,8 +1429,13 @@ fn collect_inherent_impl_declaration_path_references(
     impl_block: &Impl,
 ) -> Vec<ApiPathReference> {
     let mut references = Vec::new();
-    collect_generics_path_references(krate, &impl_block.generics, &mut references);
+    collect_generic_params_path_references(krate, &impl_block.generics, &mut references);
     collect_type_path_references(krate, &impl_block.for_, &mut references);
+    collect_where_predicates_path_references(
+        krate,
+        &impl_block.generics.where_predicates,
+        &mut references,
+    );
     references
 }
 
@@ -1403,11 +1505,16 @@ fn collect_associated_member_declaration_path_references(
             type_,
             ..
         } => {
-            collect_generics_path_references(krate, generics, &mut references);
+            collect_generic_params_path_references(krate, generics, &mut references);
             collect_generic_bounds_path_references(krate, bounds, &mut references);
             if let Some(type_) = type_ {
                 collect_type_path_references(krate, type_, &mut references);
             }
+            collect_where_predicates_path_references(
+                krate,
+                &generics.where_predicates,
+                &mut references,
+            );
         }
         _ => {}
     }
@@ -1555,10 +1662,10 @@ fn known_derive_trait_name(path: &Path) -> Option<&'static str> {
 
 fn extract_trait_impl(
     krate: &Crate,
-    owner: &Item,
-    owner_kind: ApiItemKind,
     item: &Item,
     impl_block: &Impl,
+    owner: Option<&Item>,
+    owner_kind: Option<ApiItemKind>,
 ) -> Option<ApiItem> {
     if has_automatically_derived(item) {
         return None;
@@ -1566,10 +1673,6 @@ fn extract_trait_impl(
 
     let trait_path = impl_block.trait_.as_ref()?;
     let self_type = render_type(&impl_block.for_);
-    let owner_name = owner
-        .name
-        .clone()
-        .unwrap_or_else(|| fallback_item_name(owner).to_string());
     let declaration = render_trait_impl_declaration(impl_block, trait_path, &self_type);
 
     Some(ApiItem {
@@ -1577,9 +1680,14 @@ fn extract_trait_impl(
         kind: ApiItemKind::TraitImpl,
         source_id: Some(qualified_source_id(krate, item.id)),
         navigation_paths: Vec::new(),
-        owner_name: Some(owner_name),
-        owner_kind: Some(owner_kind),
-        owner_source_id: Some(qualified_source_id(krate, owner.id)),
+        owner_name: owner.map(|owner| {
+            owner
+                .name
+                .clone()
+                .unwrap_or_else(|| fallback_item_name(owner).to_string())
+        }),
+        owner_kind,
+        owner_source_id: owner.map(|owner| qualified_source_id(krate, owner.id)),
         inherent_impl_sort_key: None,
         doc_comments: extract_doc_comments(item),
         attributes: extract_attributes(item),
@@ -1898,26 +2006,17 @@ fn normalize_attribute(text: &str) -> String {
 
 fn normalize_module_attribute(text: &str, is_crate_root: bool) -> String {
     let normalized = normalize_attribute(text);
-    if should_render_as_inner_module_attribute(&normalized, is_crate_root) {
-        rewrite_attribute_prefix(&normalized, "#![")
+    if is_crate_root {
+        if normalized.starts_with("#![") || normalized.starts_with("#[") {
+            rewrite_attribute_prefix(&normalized, "#![")
+        } else {
+            normalized
+        }
+    } else if normalized.starts_with("#![") {
+        rewrite_attribute_prefix(&normalized, "#[")
     } else {
         normalized
     }
-}
-
-fn should_render_as_inner_module_attribute(attribute: &str, is_crate_root: bool) -> bool {
-    if attribute.starts_with("#![") {
-        return true;
-    }
-    if !attribute.starts_with("#[") {
-        return false;
-    }
-
-    is_crate_root
-        || matches!(
-            attribute_name(attribute),
-            Some("allow" | "deny" | "expect" | "forbid" | "warn")
-        )
 }
 
 fn rewrite_attribute_prefix(attribute: &str, prefix: &str) -> String {
@@ -1930,17 +2029,6 @@ fn rewrite_attribute_prefix(attribute: &str, prefix: &str) -> String {
     };
 
     format!("{prefix}{body}]")
-}
-
-fn attribute_name(attribute: &str) -> Option<&str> {
-    let body = attribute
-        .strip_prefix("#![")
-        .or_else(|| attribute.strip_prefix("#["))?
-        .strip_suffix(']')?;
-    let name_end = body
-        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
-        .unwrap_or(body.len());
-    (name_end > 0).then_some(&body[..name_end])
 }
 
 fn normalize_pin_attribute(attribute: &str) -> String {
@@ -2316,13 +2404,12 @@ fn split_macro_arms(body: &str) -> Vec<String> {
 }
 
 fn summarize_macro_arm(arm: &str) -> String {
-    let arm = collapse_whitespace(arm);
-    if let Some(fat_arrow_index) = find_top_level_fat_arrow(&arm) {
+    if let Some(fat_arrow_index) = find_top_level_fat_arrow(arm) {
         let matcher = arm[..fat_arrow_index].trim();
         let expansion = arm[fat_arrow_index + 2..].trim();
         format!("{matcher} => {};", summarize_macro_expansion(expansion))
     } else {
-        format!("{arm};")
+        format!("{};", arm.trim())
     }
 }
 
@@ -2384,26 +2471,6 @@ fn find_matching_delimiter(
     }
 
     None
-}
-
-fn collapse_whitespace(value: &str) -> String {
-    let mut collapsed = String::new();
-    let mut previous_was_whitespace = false;
-
-    for character in value.chars() {
-        if character.is_whitespace() {
-            previous_was_whitespace = true;
-            continue;
-        }
-
-        if previous_was_whitespace && !collapsed.is_empty() {
-            collapsed.push(' ');
-        }
-        previous_was_whitespace = false;
-        collapsed.push(character);
-    }
-
-    collapsed
 }
 
 fn render_function_declaration(name: &str, function: &Function, is_public: bool) -> String {
@@ -2790,12 +2857,11 @@ fn render_tuple_field(field_item: &Item) -> Option<String> {
 }
 
 fn join_rendered_fields(fields: Vec<Option<String>>) -> String {
-    let field_count = fields.len();
-    let mut rendered = fields.into_iter().flatten().collect::<Vec<_>>();
-    if rendered.len() < field_count {
-        rendered.push("/* private fields */".to_string());
-    }
-    rendered.join(", ")
+    fields
+        .into_iter()
+        .map(|field| field.unwrap_or_else(|| "/* private fields */".to_string()))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn render_named_field(field_item: &Item) -> Option<String> {

--- a/eng/tools/generate_api/src/extract.rs
+++ b/eng/tools/generate_api/src/extract.rs
@@ -4,7 +4,8 @@
 use crate::{
     driver::PackageMetadata,
     model::{
-        ApiAttribute, ApiItem, ApiItemKind, ApiMember, ApiModel, ApiModule, InherentImplSortKey,
+        ApiAttribute, ApiItem, ApiItemKind, ApiMember, ApiMemberKind, ApiModel, ApiModule,
+        ApiNavigationPath, ApiPathReference, InherentImplSortKey,
     },
 };
 use rustdoc_types::{
@@ -20,6 +21,26 @@ pub(crate) trait WorkspaceResolver {
     fn is_workspace_crate(&self, crate_name: &str) -> bool;
     fn load_workspace_model(&mut self, crate_name: &str) -> Result<Option<Arc<ApiModel>>, String>;
     fn load_workspace_crate(&mut self, crate_name: &str) -> Result<Option<Arc<Crate>>, String>;
+}
+
+fn find_item_entry<'a>(
+    module: &'a ApiModule,
+    segments: &[&str],
+) -> Option<(&'a ApiModule, &'a ApiItem)> {
+    let (head, tail) = segments.split_first()?;
+    if tail.is_empty() {
+        return module
+            .items
+            .iter()
+            .find(|candidate| candidate.name == *head)
+            .map(|item| (module, item));
+    }
+
+    let child = module
+        .modules
+        .iter()
+        .find(|candidate| candidate.local_name() == *head)?;
+    find_item_entry(child, tail)
 }
 
 pub(crate) fn extract_model(
@@ -53,7 +74,7 @@ fn extract_module(
     let mut result = ApiModule {
         path,
         doc_comments: extract_doc_comments(item),
-        attributes: extract_attributes(item),
+        attributes: extract_module_attributes(item, module.is_crate),
         items: Vec::new(),
         modules: Vec::new(),
     };
@@ -74,11 +95,6 @@ fn extract_module(
                 );
                 let module = extract_module(krate, child, child_path, resolver)?;
                 insert_module(&mut result.modules, &mut seen_modules, module);
-            }
-            ItemEnum::Impl(impl_block) if include_trait_impl_block(impl_block) => {
-                if let Some(extracted) = extract_trait_impl(krate, child, impl_block) {
-                    insert_item(&mut result, &mut seen_declarations, extracted);
-                }
             }
             ItemEnum::Impl(_) => {}
             ItemEnum::Use(use_item) if should_include_item(child) => {
@@ -102,6 +118,9 @@ fn extract_module(
                 for inherent_impl in inherent_impls_for_item(krate, child) {
                     insert_item(&mut result, &mut seen_declarations, inherent_impl);
                 }
+                for trait_impl in trait_impls_for_item(krate, child) {
+                    insert_item(&mut result, &mut seen_declarations, trait_impl);
+                }
             }
             _ => {}
         }
@@ -114,6 +133,33 @@ fn extract_module(
 struct ExpandedUse {
     items: Vec<ApiItem>,
     modules: Vec<ApiModule>,
+}
+
+fn apply_import_navigation_path(expanded: &mut ExpandedUse, path: &str) {
+    for item in expanded
+        .items
+        .iter_mut()
+        .filter(|item| item.owner_name.is_none())
+    {
+        let import_path = if last_path_segment(path) == item.name {
+            path.to_string()
+        } else {
+            format!("{path}::{}", item.name)
+        };
+
+        for path in reexport_navigation_paths(&import_path) {
+            if !item
+                .navigation_paths
+                .iter()
+                .any(|candidate| candidate.path == path)
+            {
+                item.navigation_paths.push(ApiNavigationPath {
+                    path,
+                    source_id: None,
+                });
+            }
+        }
+    }
 }
 
 fn expand_reexport(
@@ -235,6 +281,7 @@ fn expand_local_reexport(
         _ => return Ok(None),
     };
     apply_import_attributes(&mut expanded, import_attributes);
+    apply_import_navigation_path(&mut expanded, &import.source);
     Ok(Some(expanded))
 }
 
@@ -268,6 +315,7 @@ fn expand_model_reexport(
         expand_model_item_reexport(&model.root_module, target_segments)?
     };
     apply_import_attributes(&mut expanded, import_attributes);
+    apply_import_navigation_path(&mut expanded, &import.source);
     Some(expanded)
 }
 
@@ -292,13 +340,14 @@ fn trait_impls_for_item(krate: &Crate, target: &Item) -> Vec<ApiItem> {
     let Some(impl_ids) = item_impl_ids(target) else {
         return Vec::new();
     };
+    let owner_kind = item_kind(target);
 
     impl_ids
         .iter()
         .filter_map(|impl_id| krate.index.get(impl_id))
         .filter_map(|impl_item| match &impl_item.inner {
             ItemEnum::Impl(impl_block) if include_trait_impl_block(impl_block) => {
-                extract_trait_impl(krate, impl_item, impl_block)
+                extract_trait_impl(krate, target, owner_kind, impl_item, impl_block)
             }
             _ => None,
         })
@@ -317,21 +366,27 @@ fn rebase_trait_impl_item(mut item: ApiItem) -> ApiItem {
 }
 
 fn expand_model_item_reexport(module: &ApiModule, target_segments: &[&str]) -> Option<ExpandedUse> {
-    let target = find_item(module, target_segments)?.clone();
+    let (containing_module, target) = find_item_entry(module, target_segments)?;
+    let target = target.clone();
     let local_name = target_segments.last().copied()?;
-    let items = module
-        .items
-        .iter()
-        .filter(|candidate| {
-            candidate.name == local_name
-                || (candidate.kind == ApiItemKind::TraitImpl
-                    && candidate
-                        .declaration
-                        .contains(&format!(" for {local_name}")))
-        })
-        .cloned()
-        .map(rebase_trait_impl_item)
-        .collect::<Vec<_>>();
+    let target_source_id = target.source_id.clone();
+    let items =
+        containing_module
+            .items
+            .iter()
+            .filter(|candidate| {
+                target_source_id.as_ref().is_some_and(|source_id| {
+                    candidate.source_id.as_deref() == Some(source_id.as_str())
+                }) || target_source_id.as_ref().is_some_and(|source_id| {
+                    candidate.owner_source_id.as_deref() == Some(source_id.as_str())
+                }) || (candidate.owner_name.is_none()
+                    && candidate.kind == target.kind
+                    && candidate.name == local_name)
+                    || candidate.owner_name.as_deref() == Some(local_name)
+            })
+            .cloned()
+            .map(rebase_trait_impl_item)
+            .collect::<Vec<_>>();
 
     if items.is_empty() {
         Some(ExpandedUse {
@@ -504,28 +559,6 @@ fn find_module<'a>(module: &'a ApiModule, segments: &[&str]) -> Option<&'a ApiMo
     }
 }
 
-fn find_item<'a>(module: &'a ApiModule, segments: &[&str]) -> Option<&'a ApiItem> {
-    let (head, tail) = segments.split_first()?;
-    if tail.is_empty() {
-        module
-            .items
-            .iter()
-            .find(|candidate| candidate.name == *head)
-    } else {
-        if let Some(child) = module
-            .modules
-            .iter()
-            .find(|candidate| candidate.local_name() == *head)
-        {
-            if let Some(found) = find_item(child, tail) {
-                return Some(found);
-            }
-        }
-
-        find_item(module, tail)
-    }
-}
-
 fn rebase_module(mut module: ApiModule, new_path: String) -> ApiModule {
     let parent_path = new_path.clone();
     module.path = new_path;
@@ -649,6 +682,9 @@ fn extract_item(krate: &Crate, item: &Item) -> ApiItem {
     if let Some(attribute) = synthesize_derive_attribute(krate, item) {
         prepend_attributes(&mut attributes, &[attribute]);
     }
+    if let Some(attribute) = synthesize_pin_project_attribute(krate, item, &attributes) {
+        prepend_attributes(&mut attributes, &[attribute]);
+    }
     if matches!(item.inner, ItemEnum::Trait(_)) && trait_uses_async_trait(krate, item) {
         prepend_attributes(
             &mut attributes,
@@ -659,26 +695,723 @@ fn extract_item(krate: &Crate, item: &Item) -> ApiItem {
     }
 
     ApiItem {
-        name: item
-            .name
-            .clone()
-            .unwrap_or_else(|| fallback_item_name(item).to_string()),
+        name: item_name(krate, item),
         kind: item_kind(item),
-        source_id: Some(item.id.0.to_string()),
+        source_id: Some(qualified_source_id(krate, item.id)),
+        navigation_paths: item_navigation_paths(krate, item),
+        owner_name: None,
         owner_kind: None,
+        owner_source_id: None,
         inherent_impl_sort_key: None,
         doc_comments: extract_doc_comments(item),
         attributes,
         declaration: render_item_declaration(krate, item),
+        declaration_path_references: collect_item_declaration_path_references(krate, item),
         members: extract_members(krate, item),
+    }
+}
+
+fn item_name(krate: &Crate, item: &Item) -> String {
+    match &item.inner {
+        ItemEnum::Use(use_item) => {
+            if !use_item.name.is_empty() {
+                return use_item.name.clone();
+            }
+
+            let source = use_item
+                .id
+                .as_ref()
+                .and_then(|id| krate.paths.get(id))
+                .map(|summary| normalize_use_path(&summary.path))
+                .unwrap_or_else(|| use_item.source.clone());
+            last_path_segment(&source).to_string()
+        }
+        _ => item
+            .name
+            .clone()
+            .unwrap_or_else(|| fallback_item_name(item).to_string()),
     }
 }
 
 fn extract_members(krate: &Crate, item: &Item) -> Vec<ApiMember> {
     match &item.inner {
+        ItemEnum::Macro(source) => extract_macro_members(source),
+        ItemEnum::ProcMacro(proc_macro) => extract_proc_macro_members(proc_macro),
+        ItemEnum::Struct(struct_item) => extract_struct_members(krate, struct_item),
+        ItemEnum::Enum(enum_item) => extract_enum_members(krate, enum_item),
         ItemEnum::Trait(trait_item) => extract_trait_members(krate, trait_item),
+        ItemEnum::Union(union_item) => extract_union_members(krate, union_item),
         _ => Vec::new(),
     }
+}
+
+fn item_navigation_paths(krate: &Crate, item: &Item) -> Vec<ApiNavigationPath> {
+    match &item.inner {
+        ItemEnum::Use(use_item) => {
+            let source = use_item
+                .id
+                .as_ref()
+                .and_then(|id| krate.paths.get(id))
+                .map(|summary| normalize_use_path(&summary.path))
+                .unwrap_or_else(|| use_item.source.clone());
+            reexport_navigation_paths(&source)
+                .into_iter()
+                .map(|path| ApiNavigationPath {
+                    path,
+                    source_id: use_item
+                        .id
+                        .as_ref()
+                        .map(|id| qualified_source_id(krate, *id)),
+                })
+                .collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn qualified_source_id(krate: &Crate, id: Id) -> String {
+    krate
+        .paths
+        .get(&id)
+        .and_then(|summary| summary.path.first())
+        .map(|crate_name| format!("{crate_name}::{}", id.0))
+        .unwrap_or_else(|| id.0.to_string())
+}
+
+fn reexport_navigation_paths(path: &str) -> Vec<String> {
+    let mut paths = vec![path.to_string()];
+    if let Some(stripped) = path.strip_prefix("crate::") {
+        paths.push(stripped.to_string());
+    }
+    paths
+}
+
+fn collect_item_declaration_path_references(krate: &Crate, item: &Item) -> Vec<ApiPathReference> {
+    let mut references = Vec::new();
+    match &item.inner {
+        ItemEnum::Function(function) => {
+            collect_function_declaration_path_references(krate, function, &mut references);
+        }
+        ItemEnum::Struct(struct_item) => {
+            collect_generics_path_references(krate, &struct_item.generics, &mut references);
+            if let StructKind::Tuple(fields) = &struct_item.kind {
+                for field_id in fields.iter().flatten() {
+                    let Some(field_item) = krate.index.get(field_id) else {
+                        continue;
+                    };
+                    let ItemEnum::StructField(type_) = &field_item.inner else {
+                        continue;
+                    };
+                    collect_type_path_references(krate, type_, &mut references);
+                }
+            }
+        }
+        ItemEnum::Enum(enum_item) => {
+            collect_generics_path_references(krate, &enum_item.generics, &mut references);
+        }
+        ItemEnum::Trait(trait_item) => {
+            collect_generics_path_references(krate, &trait_item.generics, &mut references);
+            collect_generic_bounds_path_references(krate, &trait_item.bounds, &mut references);
+        }
+        ItemEnum::TraitAlias(trait_alias) => {
+            collect_generics_path_references(krate, &trait_alias.generics, &mut references);
+            collect_generic_bounds_path_references(krate, &trait_alias.params, &mut references);
+        }
+        ItemEnum::Union(union_item) => {
+            collect_generics_path_references(krate, &union_item.generics, &mut references);
+        }
+        ItemEnum::TypeAlias(type_alias) => {
+            collect_type_path_references(krate, &type_alias.type_, &mut references);
+            collect_generics_path_references(krate, &type_alias.generics, &mut references);
+        }
+        ItemEnum::Constant { type_, .. } => {
+            collect_type_path_references(krate, type_, &mut references);
+        }
+        ItemEnum::Static(static_item) => {
+            collect_type_path_references(krate, &static_item.type_, &mut references);
+        }
+        _ => {}
+    }
+    references
+}
+
+fn collect_function_declaration_path_references(
+    krate: &Crate,
+    function: &Function,
+    references: &mut Vec<ApiPathReference>,
+) {
+    let synthetic_lifetimes = synthetic_async_trait_lifetimes(function);
+    collect_generics_path_references_with_elision(
+        krate,
+        &function.generics,
+        &synthetic_lifetimes,
+        references,
+    );
+    for (_, argument_type) in &function.sig.inputs {
+        collect_type_path_references_with_elision(
+            krate,
+            argument_type,
+            &synthetic_lifetimes,
+            references,
+        );
+    }
+    if let Some(output) = &function.sig.output {
+        collect_type_path_references_with_elision(krate, output, &synthetic_lifetimes, references);
+    }
+}
+
+fn collect_generics_path_references(
+    krate: &Crate,
+    generics: &rustdoc_types::Generics,
+    references: &mut Vec<ApiPathReference>,
+) {
+    collect_generics_path_references_with_elision(krate, generics, &HashSet::new(), references);
+}
+
+fn collect_generics_path_references_with_elision(
+    krate: &Crate,
+    generics: &rustdoc_types::Generics,
+    synthetic_lifetimes: &HashSet<String>,
+    references: &mut Vec<ApiPathReference>,
+) {
+    for parameter in &generics.params {
+        match &parameter.kind {
+            GenericParamDefKind::Type {
+                bounds, default, ..
+            } => {
+                collect_generic_bounds_path_references_with_elision(
+                    krate,
+                    bounds,
+                    synthetic_lifetimes,
+                    references,
+                );
+                if let Some(default) = default {
+                    collect_type_path_references_with_elision(
+                        krate,
+                        default,
+                        synthetic_lifetimes,
+                        references,
+                    );
+                }
+            }
+            GenericParamDefKind::Const { type_, .. } => {
+                collect_type_path_references_with_elision(
+                    krate,
+                    type_,
+                    synthetic_lifetimes,
+                    references,
+                );
+            }
+            GenericParamDefKind::Lifetime { .. } => {}
+        }
+    }
+
+    collect_where_predicates_path_references_with_elision(
+        krate,
+        &generics.where_predicates,
+        synthetic_lifetimes,
+        references,
+    );
+}
+
+fn collect_generic_bounds_path_references(
+    krate: &Crate,
+    bounds: &[GenericBound],
+    references: &mut Vec<ApiPathReference>,
+) {
+    collect_generic_bounds_path_references_with_elision(krate, bounds, &HashSet::new(), references);
+}
+
+fn collect_generic_bounds_path_references_with_elision(
+    krate: &Crate,
+    bounds: &[GenericBound],
+    synthetic_lifetimes: &HashSet<String>,
+    references: &mut Vec<ApiPathReference>,
+) {
+    for bound in bounds {
+        match bound {
+            GenericBound::TraitBound {
+                trait_,
+                generic_params,
+                ..
+            } => {
+                for parameter in generic_params {
+                    if synthetic_lifetimes.contains(&parameter.name) {
+                        continue;
+                    }
+                    match &parameter.kind {
+                        GenericParamDefKind::Type {
+                            bounds, default, ..
+                        } => {
+                            collect_generic_bounds_path_references_with_elision(
+                                krate,
+                                bounds,
+                                synthetic_lifetimes,
+                                references,
+                            );
+                            if let Some(default) = default {
+                                collect_type_path_references_with_elision(
+                                    krate,
+                                    default,
+                                    synthetic_lifetimes,
+                                    references,
+                                );
+                            }
+                        }
+                        GenericParamDefKind::Const { type_, .. } => {
+                            collect_type_path_references_with_elision(
+                                krate,
+                                type_,
+                                synthetic_lifetimes,
+                                references,
+                            );
+                        }
+                        GenericParamDefKind::Lifetime { .. } => {}
+                    }
+                }
+                collect_path_reference(krate, trait_, references);
+            }
+            GenericBound::Use(_) => {}
+            GenericBound::Outlives(_) => {}
+        }
+    }
+}
+
+fn collect_where_predicates_path_references_with_elision(
+    krate: &Crate,
+    predicates: &[WherePredicate],
+    synthetic_lifetimes: &HashSet<String>,
+    references: &mut Vec<ApiPathReference>,
+) {
+    for predicate in predicates {
+        match predicate {
+            WherePredicate::BoundPredicate { type_, bounds, .. } => {
+                collect_type_path_references_with_elision(
+                    krate,
+                    type_,
+                    synthetic_lifetimes,
+                    references,
+                );
+                collect_generic_bounds_path_references_with_elision(
+                    krate,
+                    bounds,
+                    synthetic_lifetimes,
+                    references,
+                );
+            }
+            WherePredicate::LifetimePredicate { .. } => {}
+            WherePredicate::EqPredicate { lhs, rhs } => {
+                collect_type_path_references_with_elision(
+                    krate,
+                    lhs,
+                    synthetic_lifetimes,
+                    references,
+                );
+                collect_term_path_references_with_elision(
+                    krate,
+                    rhs,
+                    synthetic_lifetimes,
+                    references,
+                );
+            }
+        }
+    }
+}
+
+fn collect_term_path_references_with_elision(
+    krate: &Crate,
+    term: &Term,
+    synthetic_lifetimes: &HashSet<String>,
+    references: &mut Vec<ApiPathReference>,
+) {
+    if let Term::Type(type_) = term {
+        collect_type_path_references_with_elision(krate, type_, synthetic_lifetimes, references);
+    }
+}
+
+fn collect_type_path_references(
+    krate: &Crate,
+    type_: &Type,
+    references: &mut Vec<ApiPathReference>,
+) {
+    collect_type_path_references_with_elision(krate, type_, &HashSet::new(), references);
+}
+
+fn collect_type_path_references_with_elision(
+    krate: &Crate,
+    type_: &Type,
+    synthetic_lifetimes: &HashSet<String>,
+    references: &mut Vec<ApiPathReference>,
+) {
+    match type_ {
+        Type::ResolvedPath(path) => {
+            collect_path_reference(krate, path, references);
+            if let Some(args) = &path.args {
+                collect_generic_args_path_references_with_elision(
+                    krate,
+                    args,
+                    synthetic_lifetimes,
+                    references,
+                );
+            }
+        }
+        Type::DynTrait(dyn_trait) => {
+            for trait_ in &dyn_trait.traits {
+                for parameter in &trait_.generic_params {
+                    if synthetic_lifetimes.contains(&parameter.name) {
+                        continue;
+                    }
+                    match &parameter.kind {
+                        GenericParamDefKind::Type {
+                            bounds, default, ..
+                        } => {
+                            collect_generic_bounds_path_references_with_elision(
+                                krate,
+                                bounds,
+                                synthetic_lifetimes,
+                                references,
+                            );
+                            if let Some(default) = default {
+                                collect_type_path_references_with_elision(
+                                    krate,
+                                    default,
+                                    synthetic_lifetimes,
+                                    references,
+                                );
+                            }
+                        }
+                        GenericParamDefKind::Const { type_, .. } => {
+                            collect_type_path_references_with_elision(
+                                krate,
+                                type_,
+                                synthetic_lifetimes,
+                                references,
+                            );
+                        }
+                        GenericParamDefKind::Lifetime { .. } => {}
+                    }
+                }
+                collect_path_reference(krate, &trait_.trait_, references);
+                if let Some(args) = &trait_.trait_.args {
+                    collect_generic_args_path_references_with_elision(
+                        krate,
+                        args,
+                        synthetic_lifetimes,
+                        references,
+                    );
+                }
+            }
+        }
+        Type::FunctionPointer(pointer) => {
+            for parameter in &pointer.generic_params {
+                if synthetic_lifetimes.contains(&parameter.name) {
+                    continue;
+                }
+                match &parameter.kind {
+                    GenericParamDefKind::Type {
+                        bounds, default, ..
+                    } => {
+                        collect_generic_bounds_path_references_with_elision(
+                            krate,
+                            bounds,
+                            synthetic_lifetimes,
+                            references,
+                        );
+                        if let Some(default) = default {
+                            collect_type_path_references_with_elision(
+                                krate,
+                                default,
+                                synthetic_lifetimes,
+                                references,
+                            );
+                        }
+                    }
+                    GenericParamDefKind::Const { type_, .. } => {
+                        collect_type_path_references_with_elision(
+                            krate,
+                            type_,
+                            synthetic_lifetimes,
+                            references,
+                        );
+                    }
+                    GenericParamDefKind::Lifetime { .. } => {}
+                }
+            }
+            for (_, input) in &pointer.sig.inputs {
+                collect_type_path_references_with_elision(
+                    krate,
+                    input,
+                    synthetic_lifetimes,
+                    references,
+                );
+            }
+            if let Some(output) = &pointer.sig.output {
+                collect_type_path_references_with_elision(
+                    krate,
+                    output,
+                    synthetic_lifetimes,
+                    references,
+                );
+            }
+        }
+        Type::Tuple(types) => {
+            for type_ in types {
+                collect_type_path_references_with_elision(
+                    krate,
+                    type_,
+                    synthetic_lifetimes,
+                    references,
+                );
+            }
+        }
+        Type::Slice(type_)
+        | Type::Pat { type_, .. }
+        | Type::RawPointer { type_, .. }
+        | Type::BorrowedRef { type_, .. } => {
+            collect_type_path_references_with_elision(
+                krate,
+                type_,
+                synthetic_lifetimes,
+                references,
+            );
+        }
+        Type::Array { type_, .. } => {
+            collect_type_path_references_with_elision(
+                krate,
+                type_,
+                synthetic_lifetimes,
+                references,
+            );
+        }
+        Type::ImplTrait(bounds) => {
+            collect_generic_bounds_path_references_with_elision(
+                krate,
+                bounds,
+                synthetic_lifetimes,
+                references,
+            );
+        }
+        Type::QualifiedPath {
+            args,
+            self_type,
+            trait_,
+            ..
+        } => {
+            collect_type_path_references_with_elision(
+                krate,
+                self_type,
+                synthetic_lifetimes,
+                references,
+            );
+            if let Some(trait_) = trait_ {
+                collect_path_reference(krate, trait_, references);
+                if let Some(args) = &trait_.args {
+                    collect_generic_args_path_references_with_elision(
+                        krate,
+                        args,
+                        synthetic_lifetimes,
+                        references,
+                    );
+                }
+            }
+            collect_generic_args_path_references_with_elision(
+                krate,
+                args,
+                synthetic_lifetimes,
+                references,
+            );
+        }
+        Type::Generic(_) | Type::Primitive(_) | Type::Infer => {}
+    }
+}
+
+fn collect_generic_args_path_references_with_elision(
+    krate: &Crate,
+    args: &GenericArgs,
+    synthetic_lifetimes: &HashSet<String>,
+    references: &mut Vec<ApiPathReference>,
+) {
+    match args {
+        GenericArgs::AngleBracketed { args, constraints } => {
+            for argument in args {
+                match argument {
+                    GenericArg::Type(type_) => {
+                        collect_type_path_references_with_elision(
+                            krate,
+                            type_,
+                            synthetic_lifetimes,
+                            references,
+                        );
+                    }
+                    GenericArg::Const(_) | GenericArg::Lifetime(_) | GenericArg::Infer => {}
+                }
+            }
+            for constraint in constraints {
+                collect_generic_args_path_references_with_elision(
+                    krate,
+                    &constraint.args,
+                    synthetic_lifetimes,
+                    references,
+                );
+                match &constraint.binding {
+                    rustdoc_types::AssocItemConstraintKind::Equality(term) => {
+                        collect_term_path_references_with_elision(
+                            krate,
+                            term,
+                            synthetic_lifetimes,
+                            references,
+                        );
+                    }
+                    rustdoc_types::AssocItemConstraintKind::Constraint(bounds) => {
+                        collect_generic_bounds_path_references_with_elision(
+                            krate,
+                            bounds,
+                            synthetic_lifetimes,
+                            references,
+                        );
+                    }
+                }
+            }
+        }
+        GenericArgs::Parenthesized { inputs, output } => {
+            for input in inputs {
+                collect_type_path_references_with_elision(
+                    krate,
+                    input,
+                    synthetic_lifetimes,
+                    references,
+                );
+            }
+            if let Some(output) = output {
+                collect_type_path_references_with_elision(
+                    krate,
+                    output,
+                    synthetic_lifetimes,
+                    references,
+                );
+            }
+        }
+        GenericArgs::ReturnTypeNotation => {}
+    }
+}
+
+fn collect_path_reference(krate: &Crate, path: &Path, references: &mut Vec<ApiPathReference>) {
+    references.push(ApiPathReference {
+        path: path.path.clone(),
+        canonical_path: krate
+            .paths
+            .get(&path.id)
+            .map(|summary| normalize_use_path(&summary.path)),
+        target_source_id: Some(qualified_source_id(krate, path.id)),
+    });
+}
+
+fn collect_trait_impl_declaration_path_references(
+    krate: &Crate,
+    impl_block: &Impl,
+) -> Vec<ApiPathReference> {
+    let mut references = Vec::new();
+    collect_generics_path_references(krate, &impl_block.generics, &mut references);
+    if let Some(trait_path) = &impl_block.trait_ {
+        collect_path_reference(krate, trait_path, &mut references);
+        if let Some(args) = &trait_path.args {
+            collect_generic_args_path_references_with_elision(
+                krate,
+                args,
+                &HashSet::new(),
+                &mut references,
+            );
+        }
+    }
+    collect_type_path_references(krate, &impl_block.for_, &mut references);
+    references
+}
+
+fn collect_inherent_impl_declaration_path_references(
+    krate: &Crate,
+    impl_block: &Impl,
+) -> Vec<ApiPathReference> {
+    let mut references = Vec::new();
+    collect_generics_path_references(krate, &impl_block.generics, &mut references);
+    collect_type_path_references(krate, &impl_block.for_, &mut references);
+    references
+}
+
+fn collect_variant_declaration_path_references(
+    krate: &Crate,
+    variant_item: &Item,
+) -> Vec<ApiPathReference> {
+    let mut references = Vec::new();
+    let ItemEnum::Variant(Variant { kind, .. }) = &variant_item.inner else {
+        return references;
+    };
+    match kind {
+        VariantKind::Plain => {}
+        VariantKind::Tuple(fields) => {
+            for field_id in fields.iter().flatten() {
+                let Some(field_item) = krate.index.get(field_id) else {
+                    continue;
+                };
+                let ItemEnum::StructField(type_) = &field_item.inner else {
+                    continue;
+                };
+                collect_type_path_references(krate, type_, &mut references);
+            }
+        }
+        VariantKind::Struct { fields, .. } => {
+            for field_id in fields {
+                let Some(field_item) = krate.index.get(field_id) else {
+                    continue;
+                };
+                let ItemEnum::StructField(type_) = &field_item.inner else {
+                    continue;
+                };
+                collect_type_path_references(krate, type_, &mut references);
+            }
+        }
+    }
+    references
+}
+
+fn collect_field_declaration_path_references(
+    krate: &Crate,
+    field_item: &Item,
+) -> Vec<ApiPathReference> {
+    let mut references = Vec::new();
+    let ItemEnum::StructField(type_) = &field_item.inner else {
+        return references;
+    };
+    collect_type_path_references(krate, type_, &mut references);
+    references
+}
+
+fn collect_associated_member_declaration_path_references(
+    krate: &Crate,
+    item: &Item,
+) -> Vec<ApiPathReference> {
+    let mut references = Vec::new();
+    match &item.inner {
+        ItemEnum::Function(function) => {
+            collect_function_declaration_path_references(krate, function, &mut references);
+        }
+        ItemEnum::AssocConst { type_, .. } => {
+            collect_type_path_references(krate, type_, &mut references);
+        }
+        ItemEnum::AssocType {
+            generics,
+            bounds,
+            type_,
+            ..
+        } => {
+            collect_generics_path_references(krate, generics, &mut references);
+            collect_generic_bounds_path_references(krate, bounds, &mut references);
+            if let Some(type_) = type_ {
+                collect_type_path_references(krate, type_, &mut references);
+            }
+        }
+        _ => {}
+    }
+    references
 }
 
 fn synthesize_derive_attribute(krate: &Crate, item: &Item) -> Option<ApiAttribute> {
@@ -718,6 +1451,79 @@ fn synthesize_derive_attribute(krate: &Crate, item: &Item) -> Option<ApiAttribut
     }
 }
 
+fn synthesize_pin_project_attribute(
+    krate: &Crate,
+    item: &Item,
+    existing_attributes: &[ApiAttribute],
+) -> Option<ApiAttribute> {
+    if existing_attributes
+        .iter()
+        .any(|attribute| attribute.text.starts_with("#[pin_project"))
+    {
+        return None;
+    }
+
+    match &item.inner {
+        ItemEnum::Struct(struct_item) if struct_has_pin_fields(krate, struct_item) => {
+            Some(ApiAttribute {
+                text: "#[pin_project]".to_string(),
+            })
+        }
+        ItemEnum::Enum(enum_item) if enum_has_pin_fields(krate, enum_item) => Some(ApiAttribute {
+            text: "#[pin_project]".to_string(),
+        }),
+        _ => None,
+    }
+}
+
+fn struct_has_pin_fields(krate: &Crate, struct_item: &rustdoc_types::Struct) -> bool {
+    match &struct_item.kind {
+        StructKind::Unit => false,
+        StructKind::Tuple(fields) => fields
+            .iter()
+            .filter_map(|field_id| field_id.as_ref())
+            .filter_map(|field_id| krate.index.get(field_id))
+            .any(field_has_pin_attribute),
+        StructKind::Plain { fields, .. } => fields
+            .iter()
+            .filter_map(|field_id| krate.index.get(field_id))
+            .any(field_has_pin_attribute),
+    }
+}
+
+fn enum_has_pin_fields(krate: &Crate, enum_item: &rustdoc_types::Enum) -> bool {
+    enum_item
+        .variants
+        .iter()
+        .filter_map(|variant_id| krate.index.get(variant_id))
+        .any(|variant_item| variant_has_pin_fields(krate, variant_item))
+}
+
+fn variant_has_pin_fields(krate: &Crate, variant_item: &Item) -> bool {
+    let ItemEnum::Variant(Variant { kind, .. }) = &variant_item.inner else {
+        return false;
+    };
+
+    match kind {
+        VariantKind::Plain => false,
+        VariantKind::Tuple(fields) => fields
+            .iter()
+            .filter_map(|field_id| field_id.as_ref())
+            .filter_map(|field_id| krate.index.get(field_id))
+            .any(field_has_pin_attribute),
+        VariantKind::Struct { fields, .. } => fields
+            .iter()
+            .filter_map(|field_id| krate.index.get(field_id))
+            .any(field_has_pin_attribute),
+    }
+}
+
+fn field_has_pin_attribute(field_item: &Item) -> bool {
+    extract_attributes(field_item)
+        .iter()
+        .any(|attribute| attribute.text == "#[pin]")
+}
+
 fn has_automatically_derived(item: &Item) -> bool {
     item.attrs
         .iter()
@@ -747,24 +1553,40 @@ fn known_derive_trait_name(path: &Path) -> Option<&'static str> {
     }
 }
 
-fn extract_trait_impl(krate: &Crate, item: &Item, impl_block: &Impl) -> Option<ApiItem> {
+fn extract_trait_impl(
+    krate: &Crate,
+    owner: &Item,
+    owner_kind: ApiItemKind,
+    item: &Item,
+    impl_block: &Impl,
+) -> Option<ApiItem> {
     if has_automatically_derived(item) {
         return None;
     }
 
     let trait_path = impl_block.trait_.as_ref()?;
     let self_type = render_type(&impl_block.for_);
+    let owner_name = owner
+        .name
+        .clone()
+        .unwrap_or_else(|| fallback_item_name(owner).to_string());
     let declaration = render_trait_impl_declaration(impl_block, trait_path, &self_type);
 
     Some(ApiItem {
         name: self_type,
         kind: ApiItemKind::TraitImpl,
-        source_id: Some(item.id.0.to_string()),
-        owner_kind: None,
+        source_id: Some(qualified_source_id(krate, item.id)),
+        navigation_paths: Vec::new(),
+        owner_name: Some(owner_name),
+        owner_kind: Some(owner_kind),
+        owner_source_id: Some(qualified_source_id(krate, owner.id)),
         inherent_impl_sort_key: None,
         doc_comments: extract_doc_comments(item),
         attributes: extract_attributes(item),
         declaration,
+        declaration_path_references: collect_trait_impl_declaration_path_references(
+            krate, impl_block,
+        ),
         members: extract_impl_items(krate, &impl_block.items),
     })
 }
@@ -806,12 +1628,23 @@ fn extract_inherent_impl(
             .clone()
             .unwrap_or_else(|| fallback_item_name(target).to_string()),
         kind: ApiItemKind::InherentImpl,
-        source_id: Some(item.id.0.to_string()),
+        source_id: Some(qualified_source_id(krate, item.id)),
+        navigation_paths: Vec::new(),
+        owner_name: Some(
+            target
+                .name
+                .clone()
+                .unwrap_or_else(|| fallback_item_name(target).to_string()),
+        ),
         owner_kind: Some(owner_kind),
+        owner_source_id: Some(qualified_source_id(krate, target.id)),
         inherent_impl_sort_key: Some(inherent_impl_sort_key(&impl_block.for_)),
         doc_comments: extract_doc_comments(item),
         attributes: extract_attributes(item),
         declaration: render_inherent_impl_declaration(impl_block, &self_type),
+        declaration_path_references: collect_inherent_impl_declaration_path_references(
+            krate, impl_block,
+        ),
         members,
     })
 }
@@ -850,7 +1683,7 @@ fn extract_impl_items(krate: &Crate, item_ids: &[Id]) -> Vec<ApiMember> {
         .iter()
         .filter_map(|item_id| krate.index.get(item_id))
         .filter(|item| is_visible(item))
-        .filter_map(extract_associated_member)
+        .filter_map(|item| extract_associated_member(krate, item))
         .collect()
 }
 
@@ -859,23 +1692,117 @@ fn extract_trait_members(krate: &Crate, trait_item: &Trait) -> Vec<ApiMember> {
         .items
         .iter()
         .filter_map(|item_id| krate.index.get(item_id))
-        .filter_map(extract_associated_member)
+        .filter_map(|item| extract_associated_member(krate, item))
         .collect()
 }
 
-fn api_member(item: &Item, declaration: String) -> ApiMember {
+fn extract_macro_members(source: &str) -> Vec<ApiMember> {
+    parse_macro_definition(source)
+        .map(|(_, members)| members)
+        .unwrap_or_default()
+}
+
+fn extract_proc_macro_members(proc_macro: &rustdoc_types::ProcMacro) -> Vec<ApiMember> {
+    if !matches!(proc_macro.kind, MacroKind::Derive) || proc_macro.helpers.is_empty() {
+        return Vec::new();
+    }
+
+    let mut members = vec![text_member(
+        "available_attributes",
+        "// Attributes available to this derive:",
+    )];
+    members.extend(proc_macro.helpers.iter().map(|helper| ApiMember {
+        name: helper.clone(),
+        kind: ApiMemberKind::MacroInput,
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        declaration: format!("#[{helper}]"),
+        declaration_path_references: Vec::new(),
+    }));
+    members
+}
+
+fn extract_struct_members(krate: &Crate, struct_item: &rustdoc_types::Struct) -> Vec<ApiMember> {
+    let StructKind::Plain { fields, .. } = &struct_item.kind else {
+        return Vec::new();
+    };
+
+    fields
+        .iter()
+        .filter_map(|field_id| krate.index.get(field_id))
+        .filter_map(|field_item| extract_field_member(krate, field_item))
+        .collect()
+}
+
+fn extract_union_members(krate: &Crate, union_item: &Union) -> Vec<ApiMember> {
+    union_item
+        .fields
+        .iter()
+        .filter_map(|field_id| krate.index.get(field_id))
+        .filter_map(|field_item| extract_field_member(krate, field_item))
+        .collect()
+}
+
+fn extract_enum_members(krate: &Crate, enum_item: &rustdoc_types::Enum) -> Vec<ApiMember> {
+    enum_item
+        .variants
+        .iter()
+        .filter_map(|variant_id| krate.index.get(variant_id))
+        .map(|variant_item| ApiMember {
+            name: variant_item.name.clone().unwrap_or_default(),
+            kind: ApiMemberKind::Variant,
+            doc_comments: extract_doc_comments(variant_item),
+            attributes: extract_attributes(variant_item),
+            declaration: render_variant(krate, variant_item),
+            declaration_path_references: collect_variant_declaration_path_references(
+                krate,
+                variant_item,
+            ),
+        })
+        .collect()
+}
+
+fn extract_field_member(krate: &Crate, field_item: &Item) -> Option<ApiMember> {
+    render_named_field(field_item).map(|declaration| ApiMember {
+        name: field_item.name.clone().unwrap_or_default(),
+        kind: ApiMemberKind::Field,
+        doc_comments: extract_doc_comments(field_item),
+        attributes: extract_attributes(field_item),
+        declaration,
+        declaration_path_references: collect_field_declaration_path_references(krate, field_item),
+    })
+}
+
+fn api_member(krate: &Crate, item: &Item, kind: ApiMemberKind, declaration: String) -> ApiMember {
     ApiMember {
         name: item.name.clone().unwrap_or_default(),
+        kind,
         doc_comments: extract_doc_comments(item),
         attributes: extract_attributes(item),
         declaration,
+        declaration_path_references: collect_associated_member_declaration_path_references(
+            krate, item,
+        ),
     }
 }
 
-fn extract_associated_member(item: &Item) -> Option<ApiMember> {
+fn text_member(name: impl Into<String>, declaration: impl Into<String>) -> ApiMember {
+    ApiMember {
+        name: name.into(),
+        kind: ApiMemberKind::Text,
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        declaration: declaration.into(),
+        declaration_path_references: Vec::new(),
+    }
+}
+
+fn extract_associated_member(krate: &Crate, item: &Item) -> Option<ApiMember> {
     match &item.inner {
         ItemEnum::Function(function) => Some(api_member(
+            krate,
             item,
+            ApiMemberKind::Associated,
             render_function_declaration(
                 item.name.as_deref().unwrap_or("unknown_fn"),
                 function,
@@ -883,7 +1810,9 @@ fn extract_associated_member(item: &Item) -> Option<ApiMember> {
             ),
         )),
         ItemEnum::AssocConst { type_, value } => Some(api_member(
+            krate,
             item,
+            ApiMemberKind::Associated,
             render_assoc_const(
                 item.name.as_deref().unwrap_or("UNKNOWN_CONST"),
                 type_,
@@ -895,7 +1824,9 @@ fn extract_associated_member(item: &Item) -> Option<ApiMember> {
             bounds,
             type_,
         } => Some(api_member(
+            krate,
             item,
+            ApiMemberKind::Associated,
             render_assoc_type(
                 item.name.as_deref().unwrap_or("UnknownType"),
                 generics,
@@ -912,6 +1843,15 @@ fn extract_attributes(item: &Item) -> Vec<ApiAttribute> {
         .iter()
         .map(|text| ApiAttribute {
             text: normalize_attribute(text),
+        })
+        .collect()
+}
+
+fn extract_module_attributes(item: &Item, is_crate_root: bool) -> Vec<ApiAttribute> {
+    item.attrs
+        .iter()
+        .map(|text| ApiAttribute {
+            text: normalize_module_attribute(text, is_crate_root),
         })
         .collect()
 }
@@ -956,6 +1896,53 @@ fn normalize_attribute(text: &str) -> String {
     normalized
 }
 
+fn normalize_module_attribute(text: &str, is_crate_root: bool) -> String {
+    let normalized = normalize_attribute(text);
+    if should_render_as_inner_module_attribute(&normalized, is_crate_root) {
+        rewrite_attribute_prefix(&normalized, "#![")
+    } else {
+        normalized
+    }
+}
+
+fn should_render_as_inner_module_attribute(attribute: &str, is_crate_root: bool) -> bool {
+    if attribute.starts_with("#![") {
+        return true;
+    }
+    if !attribute.starts_with("#[") {
+        return false;
+    }
+
+    is_crate_root
+        || matches!(
+            attribute_name(attribute),
+            Some("allow" | "deny" | "expect" | "forbid" | "warn")
+        )
+}
+
+fn rewrite_attribute_prefix(attribute: &str, prefix: &str) -> String {
+    let Some(body) = attribute
+        .strip_prefix("#![")
+        .or_else(|| attribute.strip_prefix("#["))
+        .and_then(|body| body.strip_suffix(']'))
+    else {
+        return attribute.to_string();
+    };
+
+    format!("{prefix}{body}]")
+}
+
+fn attribute_name(attribute: &str) -> Option<&str> {
+    let body = attribute
+        .strip_prefix("#![")
+        .or_else(|| attribute.strip_prefix("#["))?
+        .strip_suffix(']')?;
+    let name_end = body
+        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+        .unwrap_or(body.len());
+    (name_end > 0).then_some(&body[..name_end])
+}
+
 fn normalize_pin_attribute(attribute: &str) -> String {
     normalize_pin_attribute_with_prefix(attribute, "#[")
         .or_else(|| normalize_pin_attribute_with_prefix(attribute, "#!["))
@@ -965,6 +1952,13 @@ fn normalize_pin_attribute(attribute: &str) -> String {
 fn normalize_pin_attribute_with_prefix(attribute: &str, prefix: &str) -> Option<String> {
     let body = attribute.strip_prefix(prefix)?;
     let body = body.strip_suffix(']')?;
+    if body == "pin_project::pin_project" {
+        return Some(format!("{prefix}pin_project]"));
+    }
+    if let Some(inner) = body.strip_prefix("pin_project::pin_project(") {
+        let inner = inner.strip_suffix(')')?;
+        return Some(format!("{prefix}pin_project({inner})]"));
+    }
     let inner = body.strip_prefix("pin(__private(")?;
     let inner = inner.strip_suffix("))")?;
     if inner.is_empty() {
@@ -1087,7 +2081,56 @@ fn include_inherent_impl_block(impl_block: &Impl) -> bool {
 }
 
 fn include_trait_impl_block(impl_block: &Impl) -> bool {
-    !impl_block.is_synthetic && impl_block.blanket_impl.is_none() && impl_block.trait_.is_some()
+    !impl_block.is_synthetic
+        && impl_block.blanket_impl.is_none()
+        && impl_block.trait_.is_some()
+        && !is_pin_project_generated_unpin_impl(impl_block)
+}
+
+fn is_pin_project_generated_unpin_impl(impl_block: &Impl) -> bool {
+    impl_block.trait_.as_ref().is_some_and(is_unpin_trait_path)
+        && impl_block
+            .generics
+            .where_predicates
+            .iter()
+            .any(is_pin_project_generated_unpin_predicate)
+}
+
+fn is_unpin_trait_path(path: &Path) -> bool {
+    matches!(
+        path.path.as_str(),
+        "Unpin" | "core::marker::Unpin" | "std::marker::Unpin"
+    )
+}
+
+fn is_pin_project_generated_unpin_predicate(predicate: &WherePredicate) -> bool {
+    match predicate {
+        WherePredicate::BoundPredicate { type_, bounds, .. } => {
+            is_pin_project_pinned_fields_type(type_)
+                && bounds.iter().any(is_pin_project_private_unpin_bound)
+        }
+        _ => false,
+    }
+}
+
+fn is_pin_project_pinned_fields_type(type_: &Type) -> bool {
+    match type_ {
+        Type::ResolvedPath(path) => matches!(
+            path.path.as_str(),
+            "_pin_project::__private::PinnedFieldsOf" | "pin_project::__private::PinnedFieldsOf"
+        ),
+        _ => false,
+    }
+}
+
+fn is_pin_project_private_unpin_bound(bound: &GenericBound) -> bool {
+    match bound {
+        GenericBound::TraitBound { trait_, .. } => matches!(
+            trait_.path.as_str(),
+            "_pin_project::__private::Unpin" | "pin_project::__private::Unpin"
+        ),
+        _ => false,
+    }
 }
 
 fn item_kind(item: &Item) -> ApiItemKind {
@@ -1129,7 +2172,7 @@ fn fallback_item_name(item: &Item) -> &'static str {
 fn render_item_declaration(krate: &Crate, item: &Item) -> String {
     match &item.inner {
         ItemEnum::Use(use_item) => render_use_declaration(krate, use_item),
-        ItemEnum::Macro(source) => source.clone(),
+        ItemEnum::Macro(source) => render_macro_declaration(source),
         ItemEnum::ProcMacro(proc_macro) => render_proc_macro_declaration(
             item.name.as_deref().unwrap_or("unknown_macro"),
             proc_macro,
@@ -1149,6 +2192,12 @@ fn render_item_declaration(krate: &Crate, item: &Item) -> String {
         ItemEnum::Static(static_item) => render_static_declaration(item, static_item),
         _ => format!("// Unsupported item: {}", fallback_item_name(item)),
     }
+}
+
+fn render_macro_declaration(source: &str) -> String {
+    parse_macro_definition(source)
+        .map(|(declaration, _)| declaration)
+        .unwrap_or_else(|| source.to_string())
 }
 
 fn render_use_declaration(krate: &Crate, use_item: &rustdoc_types::Use) -> String {
@@ -1184,18 +2233,177 @@ fn render_proc_macro_declaration(name: &str, proc_macro: &rustdoc_types::ProcMac
             if proc_macro.helpers.is_empty() {
                 format!("#[derive({name})]")
             } else {
-                let mut declaration = format!("#[derive({name})]\n{{\n");
-                declaration.push_str("    // Attributes available to this derive:\n");
-                for helper in &proc_macro.helpers {
-                    declaration.push_str("    #[");
-                    declaration.push_str(helper);
-                    declaration.push_str("]\n");
-                }
-                declaration.push('}');
-                declaration
+                format!("#[derive({name})] {{")
             }
         }
     }
+}
+
+fn parse_macro_definition(source: &str) -> Option<(String, Vec<ApiMember>)> {
+    let source = source.trim();
+    let open_index = source.find('{')?;
+    let close_index = find_matching_delimiter(source, open_index, '{', '}')?;
+    if !source[close_index + 1..].trim().is_empty() {
+        return None;
+    }
+
+    let declaration = source[..=open_index].trim().to_string();
+    let body = &source[open_index + 1..close_index];
+    let members = split_macro_arms(body)
+        .into_iter()
+        .enumerate()
+        .map(|(index, arm)| ApiMember {
+            name: format!("arm_{index}"),
+            kind: ApiMemberKind::MacroInput,
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            declaration: summarize_macro_arm(&arm),
+            declaration_path_references: Vec::new(),
+        })
+        .collect::<Vec<_>>();
+
+    (!members.is_empty()).then_some((declaration, members))
+}
+
+fn split_macro_arms(body: &str) -> Vec<String> {
+    let mut arms = Vec::new();
+    let mut start = None;
+    let mut paren_depth = 0usize;
+    let mut bracket_depth = 0usize;
+    let mut brace_depth = 0usize;
+
+    for (index, character) in body.char_indices() {
+        match character {
+            '(' => {
+                paren_depth += 1;
+                start.get_or_insert(index);
+            }
+            ')' => paren_depth = paren_depth.saturating_sub(1),
+            '[' => {
+                bracket_depth += 1;
+                start.get_or_insert(index);
+            }
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '{' => {
+                brace_depth += 1;
+                start.get_or_insert(index);
+            }
+            '}' => brace_depth = brace_depth.saturating_sub(1),
+            ';' if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 => {
+                if let Some(start_index) = start {
+                    let arm = body[start_index..index].trim();
+                    if !arm.is_empty() {
+                        arms.push(arm.to_string());
+                    }
+                }
+                start = None;
+            }
+            character if !character.is_whitespace() => {
+                start.get_or_insert(index);
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(start_index) = start {
+        let arm = body[start_index..].trim();
+        if !arm.is_empty() {
+            arms.push(arm.to_string());
+        }
+    }
+
+    arms
+}
+
+fn summarize_macro_arm(arm: &str) -> String {
+    let arm = collapse_whitespace(arm);
+    if let Some(fat_arrow_index) = find_top_level_fat_arrow(&arm) {
+        let matcher = arm[..fat_arrow_index].trim();
+        let expansion = arm[fat_arrow_index + 2..].trim();
+        format!("{matcher} => {};", summarize_macro_expansion(expansion))
+    } else {
+        format!("{arm};")
+    }
+}
+
+fn summarize_macro_expansion(expansion: &str) -> String {
+    let expansion = expansion.trim();
+    match expansion.chars().next() {
+        Some('{') if expansion.ends_with('}') => "{ ... }".to_string(),
+        Some('(') if expansion.ends_with(')') => "( ... )".to_string(),
+        Some('[') if expansion.ends_with(']') => "[ ... ]".to_string(),
+        _ => expansion.to_string(),
+    }
+}
+
+fn find_top_level_fat_arrow(value: &str) -> Option<usize> {
+    let mut paren_depth = 0usize;
+    let mut bracket_depth = 0usize;
+    let mut brace_depth = 0usize;
+    let mut chars = value.char_indices().peekable();
+
+    while let Some((index, character)) = chars.next() {
+        match character {
+            '(' => paren_depth += 1,
+            ')' => paren_depth = paren_depth.saturating_sub(1),
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '{' => brace_depth += 1,
+            '}' => brace_depth = brace_depth.saturating_sub(1),
+            '=' if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 => {
+                if let Some((_, '>')) = chars.peek() {
+                    return Some(index);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn find_matching_delimiter(
+    value: &str,
+    open_index: usize,
+    open_delimiter: char,
+    close_delimiter: char,
+) -> Option<usize> {
+    let mut depth = 0usize;
+    for (index, character) in value
+        .char_indices()
+        .skip_while(|(index, _)| *index < open_index)
+    {
+        if character == open_delimiter {
+            depth += 1;
+        } else if character == close_delimiter {
+            depth = depth.checked_sub(1)?;
+            if depth == 0 {
+                return Some(index);
+            }
+        }
+    }
+
+    None
+}
+
+fn collapse_whitespace(value: &str) -> String {
+    let mut collapsed = String::new();
+    let mut previous_was_whitespace = false;
+
+    for character in value.chars() {
+        if character.is_whitespace() {
+            previous_was_whitespace = true;
+            continue;
+        }
+
+        if previous_was_whitespace && !collapsed.is_empty() {
+            collapsed.push(' ');
+        }
+        previous_was_whitespace = false;
+        collapsed.push(character);
+    }
+
+    collapsed
 }
 
 fn render_function_declaration(name: &str, function: &Function, is_public: bool) -> String {
@@ -1336,75 +2544,44 @@ fn render_struct_declaration(
     match &struct_item.kind {
         StructKind::Unit => declaration.push(';'),
         StructKind::Tuple(fields) => {
-            let rendered_fields = fields
+            let tuple_fields = fields
                 .iter()
-                .filter_map(|field_id| field_id.as_ref())
-                .filter_map(|field_id| krate.index.get(field_id))
-                .filter_map(render_tuple_field)
-                .collect::<Vec<String>>()
-                .join(", ");
+                .map(|field_id| match field_id {
+                    Some(field_id) => krate.index.get(field_id).and_then(render_tuple_field),
+                    None => None,
+                })
+                .collect::<Vec<_>>();
             declaration.push('(');
-            declaration.push_str(&rendered_fields);
+            declaration.push_str(&join_rendered_fields(tuple_fields));
             declaration.push_str(");");
         }
-        StructKind::Plain { fields, .. } => {
-            declaration.push_str(" {\n");
-            for field in fields
-                .iter()
-                .filter_map(|field_id| krate.index.get(field_id))
-            {
-                if let Some(field_line) = render_named_field(field) {
-                    declaration.push_str("    ");
-                    declaration.push_str(&field_line);
-                    declaration.push('\n');
-                }
-            }
-            declaration.push('}');
+        StructKind::Plain { fields: _, .. } => {
+            declaration.push_str(" {");
         }
     }
 
     declaration
 }
 
-fn render_union_declaration(krate: &Crate, item: &Item, union_item: &Union) -> String {
+fn render_union_declaration(_krate: &Crate, item: &Item, union_item: &Union) -> String {
     let mut declaration = format!(
         "pub union {}{}",
         item.name.as_deref().unwrap_or("UnknownUnion"),
         render_generics_declaration(&union_item.generics)
     );
     declaration.push_str(&render_where_clause(&union_item.generics.where_predicates));
-    declaration.push_str(" {\n");
-    for field in union_item
-        .fields
-        .iter()
-        .filter_map(|field_id| krate.index.get(field_id))
-    {
-        if let Some(field_line) = render_named_field(field) {
-            declaration.push_str("    ");
-            declaration.push_str(&field_line);
-            declaration.push('\n');
-        }
-    }
-    declaration.push('}');
+    declaration.push_str(" {");
     declaration
 }
 
-fn render_enum_declaration(krate: &Crate, item: &Item, enum_item: &rustdoc_types::Enum) -> String {
+fn render_enum_declaration(_krate: &Crate, item: &Item, enum_item: &rustdoc_types::Enum) -> String {
     let mut declaration = format!(
         "pub enum {}{}",
         item.name.as_deref().unwrap_or("UnknownEnum"),
         render_generics_declaration(&enum_item.generics)
     );
     declaration.push_str(&render_where_clause(&enum_item.generics.where_predicates));
-    declaration.push_str(" {\n");
-    for variant_id in &enum_item.variants {
-        if let Some(variant_item) = krate.index.get(variant_id) {
-            declaration.push_str("    ");
-            declaration.push_str(&render_variant(krate, variant_item));
-            declaration.push('\n');
-        }
-    }
-    declaration.push('}');
+    declaration.push_str(" {");
     declaration
 }
 
@@ -1424,7 +2601,7 @@ fn render_variant(krate: &Crate, variant_item: &Item) -> String {
                     .iter()
                     .filter_map(|field_id| field_id.as_ref())
                     .filter_map(|field_id| krate.index.get(field_id))
-                    .filter_map(render_tuple_field)
+                    .filter_map(render_variant_tuple_field)
                     .collect::<Vec<String>>()
                     .join(", "),
             );
@@ -1436,7 +2613,7 @@ fn render_variant(krate: &Crate, variant_item: &Item) -> String {
                 &fields
                     .iter()
                     .filter_map(|field_id| krate.index.get(field_id))
-                    .filter_map(render_named_field)
+                    .filter_map(render_variant_named_field)
                     .collect::<Vec<String>>()
                     .join(", "),
             );
@@ -1601,11 +2778,24 @@ fn render_tuple_field(field_item: &Item) -> Option<String> {
     };
 
     let mut field = String::new();
+    for attribute in extract_attributes(field_item) {
+        field.push_str(&attribute.text);
+        field.push(' ');
+    }
     if matches!(field_item.visibility, Visibility::Public) {
         field.push_str("pub ");
     }
     field.push_str(&render_type(type_));
     Some(field)
+}
+
+fn join_rendered_fields(fields: Vec<Option<String>>) -> String {
+    let field_count = fields.len();
+    let mut rendered = fields.into_iter().flatten().collect::<Vec<_>>();
+    if rendered.len() < field_count {
+        rendered.push("/* private fields */".to_string());
+    }
+    rendered.join(", ")
 }
 
 fn render_named_field(field_item: &Item) -> Option<String> {
@@ -1622,6 +2812,26 @@ fn render_named_field(field_item: &Item) -> Option<String> {
     field.push_str(&render_type(type_));
     field.push(',');
     Some(field)
+}
+
+fn render_variant_tuple_field(field_item: &Item) -> Option<String> {
+    let ItemEnum::StructField(type_) = &field_item.inner else {
+        return None;
+    };
+
+    Some(render_type(type_))
+}
+
+fn render_variant_named_field(field_item: &Item) -> Option<String> {
+    let ItemEnum::StructField(type_) = &field_item.inner else {
+        return None;
+    };
+
+    Some(format!(
+        "{}: {}",
+        field_item.name.as_deref().unwrap_or("unknown_field"),
+        render_type(type_)
+    ))
 }
 
 fn render_generics_declaration(generics: &rustdoc_types::Generics) -> String {

--- a/eng/tools/generate_api/src/extract/tests.rs
+++ b/eng/tools/generate_api/src/extract/tests.rs
@@ -626,7 +626,7 @@ fn extracts_module_scope_lint_attrs_without_rewriting_item_attrs() {
             .iter()
             .map(|attribute| attribute.text.as_str())
             .collect::<Vec<_>>(),
-        vec!["#![deny(unsafe_code)]"]
+        vec!["#[deny(unsafe_code)]"]
     );
     assert_eq!(
         model.root_module.items[0]
@@ -635,6 +635,50 @@ fn extracts_module_scope_lint_attrs_without_rewriting_item_attrs() {
             .map(|attribute| attribute.text.as_str())
             .collect::<Vec<_>>(),
         vec!["#[deny(unsafe_code)]"]
+    );
+}
+
+#[test]
+fn extracts_unassociated_trait_impl_blocks() {
+    let trait_id = Id(1);
+    let impl_id = Id(2);
+
+    let model = extract_model(
+        &package_metadata("demo"),
+        &crate_with_items(vec![
+            item(
+                trait_id,
+                Some("LocalTrait"),
+                ItemEnum::Trait(Trait {
+                    is_auto: false,
+                    is_unsafe: false,
+                    is_dyn_compatible: true,
+                    items: Vec::new(),
+                    generics: empty_generics(),
+                    bounds: Vec::new(),
+                    implementations: Vec::new(),
+                }),
+            ),
+            trait_impl_item_for_type(
+                impl_id,
+                path("LocalTrait", trait_id.0),
+                Type::ResolvedPath(path("other_crate::ExternalType", 99)),
+                empty_generics(),
+            ),
+        ]),
+        &mut NoopResolver,
+    )
+    .expect("model extraction should succeed");
+
+    assert_eq!(
+        model
+            .root_module
+            .items
+            .iter()
+            .filter(|item| item.kind == ApiItemKind::TraitImpl)
+            .map(|item| item.declaration.as_str())
+            .collect::<Vec<_>>(),
+        vec!["impl LocalTrait for other_crate::ExternalType {"]
     );
 }
 
@@ -1095,6 +1139,44 @@ fn model_reexport_collects_nested_impls_by_owner_identity() {
             "impl fmt::Debug for Secret<T> {",
         ]
     );
+}
+
+#[test]
+fn model_reexport_resolves_duplicated_leading_module_segments() {
+    let expanded = expand_model_item_reexport(
+        &ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: Vec::new(),
+            modules: vec![ApiModule {
+                path: "demo::credentials".to_string(),
+                doc_comments: Vec::new(),
+                attributes: Vec::new(),
+                items: vec![ApiItem {
+                    name: "Secret".to_string(),
+                    kind: ApiItemKind::Struct,
+                    source_id: Some("secret".to_string()),
+                    navigation_paths: Vec::new(),
+                    owner_name: None,
+                    owner_kind: None,
+                    owner_source_id: None,
+                    inherent_impl_sort_key: None,
+                    doc_comments: Vec::new(),
+                    attributes: Vec::new(),
+                    declaration: "pub struct Secret;".to_string(),
+                    declaration_path_references: Vec::new(),
+                    members: Vec::new(),
+                }],
+                modules: Vec::new(),
+            }],
+        },
+        &["demo", "credentials", "Secret"],
+    )
+    .expect("duplicated leading root segment should still resolve");
+
+    assert_eq!(expanded.items.len(), 1);
+    assert_eq!(expanded.items[0].declaration, "pub struct Secret;");
 }
 
 #[test]
@@ -2070,6 +2152,126 @@ fn extracts_macro_matcher_arms_as_members() {
                 "($(#[$outer:meta])* $name:ident, $header:ident, $(($(#[$inner:meta])*$variant:ident, $value:expr)), *) => { ... };",
             ),
         ]
+    );
+}
+
+#[test]
+fn preserves_macro_arm_literal_whitespace() {
+    let macro_id = Id(1);
+    let krate = crate_with_items(vec![item(
+        macro_id,
+        Some("literal_spaces"),
+        ItemEnum::Macro(
+            r#"macro_rules! literal_spaces {
+    ("a  b") => "x  y";
+}"#
+            .to_string(),
+        ),
+    )]);
+
+    let macro_item = krate.index.get(&macro_id).expect("macro item present");
+    let extracted = extract_item(&krate, macro_item);
+
+    assert_eq!(extracted.members[0].declaration, r#"("a  b") => "x  y";"#);
+}
+
+#[test]
+fn collects_function_where_clause_references_after_signature_types() {
+    let function_id = Id(1);
+
+    let model = extract_model(
+        &package_metadata("demo"),
+        &crate_with_items(vec![item(
+            function_id,
+            Some("parse"),
+            ItemEnum::Function(Function {
+                sig: FunctionSignature {
+                    inputs: vec![("value".to_string(), Type::ResolvedPath(path("Input", 10)))],
+                    output: Some(Type::ResolvedPath(path("Output", 11))),
+                    is_c_variadic: false,
+                },
+                generics: Generics {
+                    params: vec![type_param("T")],
+                    where_predicates: vec![bound_predicate(
+                        Type::Generic("T".to_string()),
+                        vec![trait_bound("Bound", 12)],
+                    )],
+                },
+                header: FunctionHeader {
+                    is_const: false,
+                    is_unsafe: false,
+                    is_async: false,
+                    abi: Abi::Rust,
+                },
+                has_body: false,
+            }),
+        )]),
+        &mut NoopResolver,
+    )
+    .expect("model extraction should succeed");
+
+    let function = model
+        .root_module
+        .items
+        .iter()
+        .find(|item| item.name == "parse")
+        .expect("function should be extracted");
+
+    assert_eq!(
+        function
+            .declaration_path_references
+            .iter()
+            .map(|reference| reference.path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Input", "Output", "Bound"]
+    );
+}
+
+#[test]
+fn collects_trait_impl_where_clause_references_last() {
+    let impl_id = Id(2);
+    let struct_id = Id(3);
+
+    let trait_impl = trait_impl_item_for_type(
+        impl_id,
+        path("Service", 20).with_args(GenericArgs::AngleBracketed {
+            args: vec![GenericArg::Type(Type::ResolvedPath(path("Request", 21)))],
+            constraints: Vec::new(),
+        }),
+        Type::ResolvedPath(path("Client", struct_id.0)),
+        Generics {
+            params: vec![type_param("T")],
+            where_predicates: vec![bound_predicate(
+                Type::Generic("T".to_string()),
+                vec![trait_bound("Bound", 22)],
+            )],
+        },
+    );
+
+    let ItemEnum::Impl(impl_block) = &trait_impl.inner else {
+        panic!("expected impl item");
+    };
+
+    assert_eq!(
+        collect_trait_impl_declaration_path_references(
+            &crate_with_items(vec![
+                item(
+                    struct_id,
+                    Some("Client"),
+                    ItemEnum::Struct(Struct {
+                        kind: StructKind::Unit,
+                        generics: empty_generics(),
+                        impls: vec![impl_id],
+                    }),
+                ),
+                trait_impl.clone()
+            ]),
+            impl_block,
+        )
+        .iter()
+        .map(|reference| reference.path.as_str())
+        .collect::<Vec<_>>(),
+        vec!["Service", "Request", "Client", "Bound"]
     );
 }
 

--- a/eng/tools/generate_api/src/extract/tests.rs
+++ b/eng/tools/generate_api/src/extract/tests.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use super::*;
+use crate::model::{ApiMemberKind, ApiPathReference};
 use rustdoc_types::{
     Abi, Enum as RustdocEnum, FunctionSignature, Generics, ItemSummary, Module, Struct, Target,
     Type,
@@ -182,6 +183,102 @@ fn extracts_explicit_trait_impl_blocks_with_members() {
 }
 
 #[test]
+fn extracts_declaration_path_references_for_resolved_result_paths() {
+    let result_id = Id(1);
+    let function_id = Id(2);
+
+    let model = extract_model(
+        &package_metadata("demo"),
+        &crate_with_items(vec![
+            item(
+                result_id,
+                Some("Result"),
+                ItemEnum::Struct(Struct {
+                    kind: StructKind::Unit,
+                    generics: empty_generics(),
+                    impls: Vec::new(),
+                }),
+            ),
+            item(
+                function_id,
+                Some("parse"),
+                ItemEnum::Function(Function {
+                    sig: FunctionSignature {
+                        inputs: vec![
+                            (
+                                "std_result".to_string(),
+                                Type::ResolvedPath(path("std::result::Result", 10)),
+                            ),
+                            (
+                                "std_fmt".to_string(),
+                                Type::ResolvedPath(path("std::fmt::Result", 11)),
+                            ),
+                            (
+                                "fmt_result".to_string(),
+                                Type::ResolvedPath(path("fmt::Result", 12)),
+                            ),
+                        ],
+                        output: Some(Type::ResolvedPath(path("Result", result_id.0))),
+                        is_c_variadic: false,
+                    },
+                    generics: empty_generics(),
+                    header: FunctionHeader {
+                        is_const: false,
+                        is_unsafe: false,
+                        is_async: false,
+                        abi: Abi::Rust,
+                    },
+                    has_body: true,
+                }),
+            ),
+        ]),
+        &mut NoopResolver,
+    )
+    .expect("model extraction should succeed");
+
+    let parse = model
+        .root_module
+        .items
+        .iter()
+        .find(|item| item.name == "parse")
+        .expect("function should be extracted");
+
+    assert_eq!(
+        parse
+            .declaration_path_references
+            .iter()
+            .map(|reference| ApiPathReference {
+                path: reference.path.clone(),
+                canonical_path: reference.canonical_path.clone(),
+                target_source_id: reference.target_source_id.clone(),
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            ApiPathReference {
+                path: "std::result::Result".to_string(),
+                canonical_path: None,
+                target_source_id: Some("10".to_string()),
+            },
+            ApiPathReference {
+                path: "std::fmt::Result".to_string(),
+                canonical_path: None,
+                target_source_id: Some("11".to_string()),
+            },
+            ApiPathReference {
+                path: "fmt::Result".to_string(),
+                canonical_path: None,
+                target_source_id: Some("12".to_string()),
+            },
+            ApiPathReference {
+                path: "Result".to_string(),
+                canonical_path: None,
+                target_source_id: Some(result_id.0.to_string()),
+            },
+        ]
+    );
+}
+
+#[test]
 fn extract_item_synthesizes_async_trait_and_elides_synthetic_lifetimes() {
     let function_id = Id(2);
     let trait_id = Id(1);
@@ -246,6 +343,302 @@ fn extract_item_synthesizes_async_trait_and_elides_synthetic_lifetimes() {
 }
 
 #[test]
+fn suppresses_pin_project_generated_unpin_impls_for_bare_attributes() {
+    let struct_id = Id(1);
+    let impl_id = Id(2);
+
+    let model = extract_model(
+        &package_metadata("demo"),
+        &crate_with_items(vec![
+            item(
+                struct_id,
+                Some("AsyncResponseBody"),
+                ItemEnum::Struct(Struct {
+                    kind: StructKind::Tuple(vec![None]),
+                    generics: empty_generics(),
+                    impls: vec![impl_id],
+                }),
+            )
+            .with_attrs(vec!["#[pin(__private())]".to_string()]),
+            trait_impl_item_for_type(
+                impl_id,
+                path("Unpin", 10),
+                Type::ResolvedPath(path("AsyncResponseBody", struct_id.0)),
+                Generics {
+                    params: vec![lifetime_param("'pin")],
+                    where_predicates: vec![pin_project_generated_unpin_predicate(
+                        Type::ResolvedPath(path("__AsyncResponseBody", 11).with_args(
+                            GenericArgs::AngleBracketed {
+                                args: vec![GenericArg::Lifetime("'pin".to_string())],
+                                constraints: Vec::new(),
+                            },
+                        )),
+                    )],
+                },
+            ),
+        ]),
+        &mut NoopResolver,
+    )
+    .expect("model extraction should succeed");
+
+    assert_eq!(model.root_module.items.len(), 1);
+    assert_eq!(model.root_module.items[0].kind, ApiItemKind::Struct);
+    assert_eq!(
+        model.root_module.items[0]
+            .attributes
+            .iter()
+            .map(|attribute| attribute.text.as_str())
+            .collect::<Vec<_>>(),
+        vec!["#[pin_project]"]
+    );
+    assert!(
+        model
+            .root_module
+            .items
+            .iter()
+            .all(|item| item.kind != ApiItemKind::TraitImpl),
+        "pin-project generated Unpin impl should be suppressed"
+    );
+}
+
+#[test]
+fn suppresses_pin_project_generated_unpin_impls_for_argument_bearing_attributes() {
+    let struct_id = Id(1);
+    let field_id = Id(2);
+    let impl_id = Id(3);
+    let mut field = item(
+        field_id,
+        Some("iter"),
+        ItemEnum::StructField(Type::ResolvedPath(path("PageIterator<P>", 20))),
+    )
+    .with_attrs(vec!["#[pin]".to_string()]);
+    field.visibility = Visibility::Default;
+
+    let model = extract_model(
+        &package_metadata("demo"),
+        &crate_with_items(vec![
+            item(
+                struct_id,
+                Some("ItemIterator"),
+                ItemEnum::Struct(Struct {
+                    kind: StructKind::Plain {
+                        fields: vec![field_id],
+                        has_stripped_fields: false,
+                    },
+                    generics: Generics {
+                        params: vec![type_param("P")],
+                        where_predicates: Vec::new(),
+                    },
+                    impls: vec![impl_id],
+                }),
+            )
+            .with_attrs(vec![
+                "#[pin_project::pin_project(project = ItemIteratorProjection, project_replace = ItemIteratorProjectionOwned)]"
+                    .to_string(),
+            ]),
+            field,
+            trait_impl_item_for_type(
+                impl_id,
+                path("Unpin", 21),
+                Type::ResolvedPath(path("ItemIterator", struct_id.0).with_args(
+                    GenericArgs::AngleBracketed {
+                        args: vec![GenericArg::Type(Type::Generic("P".to_string()))],
+                        constraints: Vec::new(),
+                    },
+                )),
+                Generics {
+                    params: vec![lifetime_param("'pin"), type_param("P")],
+                    where_predicates: vec![
+                        bound_predicate(
+                            Type::Generic("P".to_string()),
+                            vec![trait_bound("Page", 22), trait_bound("Send", 23)],
+                        ),
+                        pin_project_generated_unpin_predicate(Type::ResolvedPath(
+                            path("__ItemIterator", 24).with_args(GenericArgs::AngleBracketed {
+                                args: vec![
+                                    GenericArg::Lifetime("'pin".to_string()),
+                                    GenericArg::Type(Type::Generic("P".to_string())),
+                                ],
+                                constraints: Vec::new(),
+                            }),
+                        )),
+                    ],
+                },
+            ),
+        ]),
+        &mut NoopResolver,
+    )
+    .expect("model extraction should succeed");
+
+    assert_eq!(model.root_module.items.len(), 1);
+    assert_eq!(model.root_module.items[0].kind, ApiItemKind::Struct);
+    assert_eq!(
+        model.root_module.items[0]
+            .attributes
+            .iter()
+            .map(|attribute| attribute.text.as_str())
+            .collect::<Vec<_>>(),
+        vec!["#[pin_project(project = ItemIteratorProjection, project_replace = ItemIteratorProjectionOwned)]"]
+    );
+    assert!(
+        model
+            .root_module
+            .items
+            .iter()
+            .all(|item| item.kind != ApiItemKind::TraitImpl),
+        "pin-project generated Unpin impl should be suppressed"
+    );
+}
+
+#[test]
+fn preserves_manual_unpin_impls() {
+    let struct_id = Id(1);
+    let impl_id = Id(2);
+
+    let model = extract_model(
+        &package_metadata("demo"),
+        &crate_with_items(vec![
+            item(
+                struct_id,
+                Some("ItemIterator"),
+                ItemEnum::Struct(Struct {
+                    kind: StructKind::Unit,
+                    generics: Generics {
+                        params: vec![type_param("P")],
+                        where_predicates: Vec::new(),
+                    },
+                    impls: vec![impl_id],
+                }),
+            ),
+            trait_impl_item_for_type(
+                impl_id,
+                path("Unpin", 30),
+                Type::ResolvedPath(path("ItemIterator", struct_id.0).with_args(
+                    GenericArgs::AngleBracketed {
+                        args: vec![GenericArg::Type(Type::Generic("P".to_string()))],
+                        constraints: Vec::new(),
+                    },
+                )),
+                Generics {
+                    params: vec![type_param("P")],
+                    where_predicates: vec![bound_predicate(
+                        Type::Generic("P".to_string()),
+                        vec![trait_bound("Send", 31)],
+                    )],
+                },
+            ),
+        ]),
+        &mut NoopResolver,
+    )
+    .expect("model extraction should succeed");
+
+    let trait_impls = model
+        .root_module
+        .items
+        .iter()
+        .filter(|item| item.kind == ApiItemKind::TraitImpl)
+        .collect::<Vec<_>>();
+
+    assert_eq!(trait_impls.len(), 1);
+    assert_eq!(
+        trait_impls[0].declaration,
+        "impl<P> Unpin for ItemIterator<P> where P: Send {"
+    );
+}
+
+#[test]
+fn extracts_root_module_attributes_as_inner_attrs() {
+    let mut krate = crate_with_items(vec![item(
+        Id(1),
+        Some("Foo"),
+        ItemEnum::Struct(Struct {
+            kind: StructKind::Unit,
+            generics: empty_generics(),
+            impls: Vec::new(),
+        }),
+    )]);
+    krate
+        .index
+        .get_mut(&Id(0))
+        .expect("crate root present")
+        .attrs = vec![
+        "#[warn(missing_docs)]".to_string(),
+        "#[doc = include_str!(\"../README.md\")]".to_string(),
+    ];
+
+    let model = extract_model(&package_metadata("demo"), &krate, &mut NoopResolver)
+        .expect("model extraction should succeed");
+
+    assert_eq!(
+        model
+            .root_module
+            .attributes
+            .iter()
+            .map(|attribute| attribute.text.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "#![warn(missing_docs)]",
+            "#![doc = include_str!(\"../README.md\")]",
+        ]
+    );
+}
+
+#[test]
+fn extracts_module_scope_lint_attrs_without_rewriting_item_attrs() {
+    let module_id = Id(1);
+    let module_item_id = Id(2);
+    let root_item_id = Id(3);
+    let model = extract_model(
+        &package_metadata("demo"),
+        &crate_with_root_items(
+            vec![module_id, root_item_id],
+            vec![
+                module_item(module_id, "inner", vec![module_item_id], false)
+                    .with_attrs(vec!["#[deny(unsafe_code)]".to_string()]),
+                item(
+                    module_item_id,
+                    Some("Nested"),
+                    ItemEnum::Struct(Struct {
+                        kind: StructKind::Unit,
+                        generics: empty_generics(),
+                        impls: Vec::new(),
+                    }),
+                ),
+                item(
+                    root_item_id,
+                    Some("Root"),
+                    ItemEnum::Struct(Struct {
+                        kind: StructKind::Unit,
+                        generics: empty_generics(),
+                        impls: Vec::new(),
+                    }),
+                )
+                .with_attrs(vec!["#[deny(unsafe_code)]".to_string()]),
+            ],
+        ),
+        &mut NoopResolver,
+    )
+    .expect("model extraction should succeed");
+
+    assert_eq!(
+        model.root_module.modules[0]
+            .attributes
+            .iter()
+            .map(|attribute| attribute.text.as_str())
+            .collect::<Vec<_>>(),
+        vec!["#![deny(unsafe_code)]"]
+    );
+    assert_eq!(
+        model.root_module.items[0]
+            .attributes
+            .iter()
+            .map(|attribute| attribute.text.as_str())
+            .collect::<Vec<_>>(),
+        vec!["#[deny(unsafe_code)]"]
+    );
+}
+
+#[test]
 fn renders_self_receivers_in_source_like_forms() {
     let function = Function {
         sig: FunctionSignature {
@@ -303,6 +696,50 @@ fn renders_self_receivers_in_source_like_forms() {
     assert_eq!(
         render_function_declaration("touch", &mut_ref_function, false),
         "fn touch(&mut self);"
+    );
+}
+
+#[test]
+fn extract_item_uses_reexport_leaf_name_when_rustdoc_item_name_is_missing() {
+    let bytes_id = Id(1);
+    let reexport_id = Id(2);
+    let krate = crate_with_items(vec![
+        item(
+            bytes_id,
+            Some("Bytes"),
+            ItemEnum::Struct(Struct {
+                kind: StructKind::Unit,
+                generics: empty_generics(),
+                impls: Vec::new(),
+            }),
+        ),
+        item(
+            reexport_id,
+            None,
+            ItemEnum::Use(rustdoc_types::Use {
+                source: "bytes::Bytes".to_string(),
+                name: "Bytes".to_string(),
+                id: Some(bytes_id),
+                is_glob: false,
+            }),
+        ),
+    ]);
+
+    let reexport = krate
+        .index
+        .get(&reexport_id)
+        .expect("reexport item present");
+    let extracted = extract_item(&krate, reexport);
+
+    assert_eq!(extracted.name, "Bytes");
+    assert_eq!(extracted.declaration, "pub use bytes::Bytes;");
+    assert_eq!(
+        extracted
+            .navigation_paths
+            .iter()
+            .map(|path| path.path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["bytes::Bytes"]
     );
 }
 
@@ -406,6 +843,103 @@ fn local_reexport_carries_explicit_trait_impls_for_reexported_items() {
 }
 
 #[test]
+fn local_types_are_followed_by_inherent_then_trait_impls() {
+    let secret_id = Id(1);
+    let debug_impl_id = Id(2);
+    let inherent_impl_id = Id(3);
+    let fmt_id = Id(4);
+    let new_id = Id(5);
+    let zebra_id = Id(6);
+
+    let model = extract_model(
+        &package_metadata("demo"),
+        &crate_with_root_items(
+            vec![debug_impl_id, zebra_id, secret_id, inherent_impl_id],
+            vec![
+                item(
+                    secret_id,
+                    Some("Secret"),
+                    ItemEnum::Struct(Struct {
+                        kind: StructKind::Unit,
+                        generics: empty_generics(),
+                        impls: vec![debug_impl_id, inherent_impl_id],
+                    }),
+                ),
+                impl_item_with_items(
+                    debug_impl_id,
+                    Some(path("fmt::Debug", 30)),
+                    "Secret",
+                    secret_id,
+                    false,
+                    vec![fmt_id],
+                ),
+                item(
+                    fmt_id,
+                    Some("fmt"),
+                    ItemEnum::Function(Function {
+                        sig: FunctionSignature {
+                            inputs: vec![(
+                                "self".to_string(),
+                                Type::BorrowedRef {
+                                    lifetime: None,
+                                    is_mutable: false,
+                                    type_: Box::new(Type::Generic("Self".to_string())),
+                                },
+                            )],
+                            output: Some(Type::ResolvedPath(path("fmt::Result", 31))),
+                            is_c_variadic: false,
+                        },
+                        generics: empty_generics(),
+                        header: FunctionHeader {
+                            is_const: false,
+                            is_unsafe: false,
+                            is_async: false,
+                            abi: Abi::Rust,
+                        },
+                        has_body: true,
+                    }),
+                ),
+                impl_item_for_type_with_items(
+                    inherent_impl_id,
+                    Type::ResolvedPath(path("Secret", secret_id.0)),
+                    empty_generics(),
+                    vec![new_id],
+                ),
+                inherent_method(new_id, "new"),
+                item(
+                    zebra_id,
+                    Some("Zebra"),
+                    ItemEnum::Struct(Struct {
+                        kind: StructKind::Unit,
+                        generics: empty_generics(),
+                        impls: Vec::new(),
+                    }),
+                ),
+            ],
+        ),
+        &mut NoopResolver,
+    )
+    .expect("model extraction should succeed");
+
+    let declarations = model
+        .root_module
+        .sorted_items()
+        .into_iter()
+        .map(|item| item.declaration.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        declarations,
+        vec![
+            "pub struct Secret;",
+            "impl Secret {",
+            "impl fmt::Debug for Secret {",
+            "pub struct Zebra;",
+        ]
+    );
+}
+
+#[test]
 fn local_reexport_preserves_synthesized_derives_for_reexported_items() {
     let hidden_module_id = Id(1);
     let struct_id = Id(2);
@@ -481,6 +1015,89 @@ fn local_reexport_preserves_synthesized_derives_for_reexported_items() {
 }
 
 #[test]
+fn model_reexport_collects_nested_impls_by_owner_identity() {
+    let expanded = expand_model_item_reexport(
+        &ApiModule {
+            path: "azure_core".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: Vec::new(),
+            modules: vec![ApiModule {
+                path: "azure_core::credentials".to_string(),
+                doc_comments: Vec::new(),
+                attributes: Vec::new(),
+                items: vec![
+                    ApiItem {
+                        name: "Secret".to_string(),
+                        kind: ApiItemKind::Struct,
+                        source_id: Some("secret".to_string()),
+                        navigation_paths: Vec::new(),
+                        owner_name: None,
+                        owner_kind: None,
+                        owner_source_id: None,
+                        inherent_impl_sort_key: None,
+                        doc_comments: Vec::new(),
+                        attributes: Vec::new(),
+                        declaration: "pub struct Secret<T>(T);".to_string(),
+                        declaration_path_references: Vec::new(),
+                        members: Vec::new(),
+                    },
+                    ApiItem {
+                        name: "Secret".to_string(),
+                        kind: ApiItemKind::InherentImpl,
+                        source_id: Some("secret-inherent".to_string()),
+                        navigation_paths: Vec::new(),
+                        owner_name: Some("Secret".to_string()),
+                        owner_kind: Some(ApiItemKind::Struct),
+                        owner_source_id: Some("secret".to_string()),
+                        inherent_impl_sort_key: Some(InherentImplSortKey {
+                            type_arg_classes: vec![0],
+                            rendered_self_type: "Secret<T>".to_string(),
+                        }),
+                        doc_comments: Vec::new(),
+                        attributes: Vec::new(),
+                        declaration: "impl<T> Secret<T> {".to_string(),
+                        declaration_path_references: Vec::new(),
+                        members: Vec::new(),
+                    },
+                    ApiItem {
+                        name: "Secret<T>".to_string(),
+                        kind: ApiItemKind::TraitImpl,
+                        source_id: Some("secret-debug".to_string()),
+                        navigation_paths: Vec::new(),
+                        owner_name: Some("Secret".to_string()),
+                        owner_kind: Some(ApiItemKind::Struct),
+                        owner_source_id: Some("secret".to_string()),
+                        inherent_impl_sort_key: None,
+                        doc_comments: Vec::new(),
+                        attributes: Vec::new(),
+                        declaration: "impl fmt::Debug for Secret<T> {".to_string(),
+                        declaration_path_references: Vec::new(),
+                        members: Vec::new(),
+                    },
+                ],
+                modules: Vec::new(),
+            }],
+        },
+        &["credentials", "Secret"],
+    )
+    .expect("model re-export should resolve nested item");
+
+    assert_eq!(
+        expanded
+            .items
+            .iter()
+            .map(|item| item.declaration.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "pub struct Secret<T>(T);",
+            "impl<T> Secret<T> {",
+            "impl fmt::Debug for Secret<T> {",
+        ]
+    );
+}
+
+#[test]
 fn normalize_attribute_flattens_multiline_reason_strings() {
     assert_eq!(
         normalize_attribute(
@@ -497,6 +1114,148 @@ fn normalize_attribute_flattens_multiline_pin_project_arguments() {
             "#[pin_project(project = ItemIteratorProjection, project_replace =\nItemIteratorProjectionOwned)]"
         ),
         "#[pin_project(project = ItemIteratorProjection, project_replace = ItemIteratorProjectionOwned)]"
+    );
+}
+
+#[test]
+fn normalize_attribute_rewrites_namespaced_pin_project_forms() {
+    assert_eq!(
+        normalize_attribute("#[pin_project::pin_project]"),
+        "#[pin_project]"
+    );
+    assert_eq!(
+        normalize_attribute("#[pin_project::pin_project(project = BodyProj)]"),
+        "#[pin_project(project = BodyProj)]"
+    );
+}
+
+#[test]
+fn extracts_pinned_tuple_struct_source_shape() {
+    let struct_id = Id(1);
+    let field_id = Id(2);
+    let mut field = item(
+        field_id,
+        None,
+        ItemEnum::StructField(Type::ResolvedPath(path("Body", 3))),
+    )
+    .with_attrs(vec!["#[pin]".to_string()]);
+    field.visibility = Visibility::Default;
+    let krate = crate_with_items(vec![
+        item(
+            struct_id,
+            Some("AsyncResponseBody"),
+            ItemEnum::Struct(Struct {
+                kind: StructKind::Tuple(vec![Some(field_id)]),
+                generics: empty_generics(),
+                impls: Vec::new(),
+            }),
+        ),
+        field,
+    ]);
+
+    let struct_item = krate.index.get(&struct_id).expect("struct item present");
+    let extracted = extract_item(&krate, struct_item);
+
+    assert_eq!(
+        extracted
+            .attributes
+            .iter()
+            .map(|attribute| attribute.text.as_str())
+            .collect::<Vec<_>>(),
+        vec!["#[pin_project]"]
+    );
+    assert_eq!(
+        extracted.declaration,
+        "pub struct AsyncResponseBody(#[pin] Body);"
+    );
+}
+
+#[test]
+fn renders_private_pinned_tuple_structs_as_opaque_fields() {
+    let struct_id = Id(1);
+    let krate = crate_with_items(vec![item(
+        struct_id,
+        Some("AsyncResponseBody"),
+        ItemEnum::Struct(Struct {
+            kind: StructKind::Tuple(vec![None]),
+            generics: empty_generics(),
+            impls: Vec::new(),
+        }),
+    )
+    .with_attrs(vec!["#[pin(__private())]".to_string()])]);
+
+    let struct_item = krate.index.get(&struct_id).expect("struct item present");
+    let extracted = extract_item(&krate, struct_item);
+
+    assert_eq!(
+        extracted
+            .attributes
+            .iter()
+            .map(|attribute| attribute.text.as_str())
+            .collect::<Vec<_>>(),
+        vec!["#[pin_project]"]
+    );
+    assert_eq!(
+        extracted.declaration,
+        "pub struct AsyncResponseBody(/* private fields */);"
+    );
+}
+
+#[test]
+fn preserves_argument_bearing_pin_project_attributes() {
+    let struct_id = Id(1);
+    let field_id = Id(2);
+    let mut field = item(
+        field_id,
+        Some("iter"),
+        ItemEnum::StructField(Type::ResolvedPath(path("PageIterator<P>", 3))),
+    )
+    .with_attrs(vec!["#[pin]".to_string()]);
+    field.visibility = Visibility::Default;
+    let krate = crate_with_items(vec![
+        item(
+            struct_id,
+            Some("ItemIterator"),
+            ItemEnum::Struct(Struct {
+                kind: StructKind::Plain {
+                    fields: vec![field_id],
+                    has_stripped_fields: false,
+                },
+                generics: Generics {
+                    params: vec![type_param("P")],
+                    where_predicates: Vec::new(),
+                },
+                impls: Vec::new(),
+            }),
+        )
+        .with_attrs(vec![
+            "#[pin_project::pin_project(project = ItemIteratorProjection, project_replace = ItemIteratorProjectionOwned)]"
+                .to_string(),
+        ]),
+        field,
+    ]);
+
+    let struct_item = krate.index.get(&struct_id).expect("struct item present");
+    let extracted = extract_item(&krate, struct_item);
+
+    assert_eq!(
+        extracted
+            .attributes
+            .iter()
+            .map(|attribute| attribute.text.as_str())
+            .collect::<Vec<_>>(),
+        vec!["#[pin_project(project = ItemIteratorProjection, project_replace = ItemIteratorProjectionOwned)]"]
+    );
+    assert_eq!(extracted.declaration, "pub struct ItemIterator<P> {");
+    assert_eq!(extracted.members.len(), 1);
+    assert_eq!(extracted.members[0].declaration, "iter: PageIterator<P>,");
+    assert_eq!(
+        extracted.members[0]
+            .attributes
+            .iter()
+            .map(|attribute| attribute.text.as_str())
+            .collect::<Vec<_>>(),
+        vec!["#[pin]"]
     );
 }
 
@@ -1167,6 +1926,153 @@ fn extracts_assoc_type_member_from_trait() {
     assert_eq!(extracted.members[0].declaration, "type Item;");
 }
 
+#[test]
+fn extracts_plain_struct_fields_as_members() {
+    let struct_id = Id(1);
+    let field_id = Id(2);
+    let krate = crate_with_items(vec![
+        item(
+            struct_id,
+            Some("Blob"),
+            ItemEnum::Struct(Struct {
+                kind: StructKind::Plain {
+                    fields: vec![field_id],
+                    has_stripped_fields: false,
+                },
+                generics: empty_generics(),
+                impls: Vec::new(),
+            }),
+        ),
+        item(
+            field_id,
+            Some("body"),
+            ItemEnum::StructField(Type::ResolvedPath(path("bytes::Bytes", 3))),
+        ),
+    ]);
+
+    let struct_item = krate.index.get(&struct_id).expect("struct item present");
+    let extracted = extract_item(&krate, struct_item);
+
+    assert_eq!(extracted.declaration, "pub struct Blob {");
+    assert_eq!(extracted.members.len(), 1);
+    assert_eq!(extracted.members[0].kind, ApiMemberKind::Field);
+    assert_eq!(extracted.members[0].declaration, "pub body: bytes::Bytes,");
+}
+
+#[test]
+fn extracts_enum_variants_as_members() {
+    let enum_id = Id(1);
+    let variant_id = Id(2);
+    let field_id = Id(3);
+    let krate = crate_with_items(vec![
+        item(
+            enum_id,
+            Some("Kind"),
+            ItemEnum::Enum(RustdocEnum {
+                variants: vec![variant_id],
+                generics: empty_generics(),
+                has_stripped_variants: false,
+                impls: Vec::new(),
+            }),
+        ),
+        item(
+            variant_id,
+            Some("Block"),
+            ItemEnum::Variant(Variant {
+                kind: VariantKind::Tuple(vec![Some(field_id)]),
+                discriminant: None,
+            }),
+        ),
+        item(
+            field_id,
+            None,
+            ItemEnum::StructField(Type::ResolvedPath(path("bytes::Bytes", 4))),
+        ),
+    ]);
+
+    let enum_item = krate.index.get(&enum_id).expect("enum item present");
+    let extracted = extract_item(&krate, enum_item);
+
+    assert_eq!(extracted.declaration, "pub enum Kind {");
+    assert_eq!(extracted.members.len(), 1);
+    assert_eq!(extracted.members[0].kind, ApiMemberKind::Variant);
+    assert_eq!(extracted.members[0].declaration, "Block(bytes::Bytes),");
+}
+
+#[test]
+fn extracts_derive_macro_helpers_as_members() {
+    let macro_id = Id(1);
+    let krate = crate_with_items(vec![item(
+        macro_id,
+        Some("BlobDerive"),
+        ItemEnum::ProcMacro(rustdoc_types::ProcMacro {
+            kind: rustdoc_types::MacroKind::Derive,
+            helpers: vec!["blob".to_string()],
+        }),
+    )]);
+
+    let macro_item = krate.index.get(&macro_id).expect("macro item present");
+    let extracted = extract_item(&krate, macro_item);
+
+    assert_eq!(extracted.declaration, "#[derive(BlobDerive)] {");
+    assert_eq!(
+        extracted
+            .members
+            .iter()
+            .map(|member| (member.kind, member.declaration.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                ApiMemberKind::Text,
+                "// Attributes available to this derive:"
+            ),
+            (ApiMemberKind::MacroInput, "#[blob]"),
+        ]
+    );
+}
+
+#[test]
+fn extracts_macro_matcher_arms_as_members() {
+    let macro_id = Id(1);
+    let krate = crate_with_items(vec![item(
+        macro_id,
+        Some("request_header"),
+        ItemEnum::Macro(
+            r#"macro_rules! request_header {
+    ($(#[$outer:meta])* $name:ident, $header:ident) => {
+        $crate::request_header!($name, $header,);
+    };
+    ($(#[$outer:meta])* $name:ident, $header:ident, $(($(#[$inner:meta])*$variant:ident, $value:expr)), *) => {
+        $crate::request_option!($(#[$outer])* $name);
+    };
+}"#
+            .to_string(),
+        ),
+    )]);
+
+    let macro_item = krate.index.get(&macro_id).expect("macro item present");
+    let extracted = extract_item(&krate, macro_item);
+
+    assert_eq!(extracted.declaration, "macro_rules! request_header {");
+    assert_eq!(
+        extracted
+            .members
+            .iter()
+            .map(|member| (member.kind, member.declaration.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                ApiMemberKind::MacroInput,
+                "($(#[$outer:meta])* $name:ident, $header:ident) => { ... };",
+            ),
+            (
+                ApiMemberKind::MacroInput,
+                "($(#[$outer:meta])* $name:ident, $header:ident, $(($(#[$inner:meta])*$variant:ident, $value:expr)), *) => { ... };",
+            ),
+        ]
+    );
+}
+
 fn crate_with_items(items: Vec<Item>) -> Crate {
     let module_items = items.iter().map(|item| item.id).collect::<Vec<_>>();
     crate_with_root_items(module_items, items)
@@ -1289,6 +2195,24 @@ fn impl_item_for_type_with_items(
     )
 }
 
+fn trait_impl_item_for_type(id: Id, trait_path: Path, for_type: Type, generics: Generics) -> Item {
+    item(
+        id,
+        None,
+        ItemEnum::Impl(Impl {
+            is_unsafe: false,
+            generics,
+            provided_trait_methods: Vec::new(),
+            trait_: Some(trait_path),
+            for_: for_type,
+            items: Vec::new(),
+            is_negative: false,
+            is_synthetic: false,
+            blanket_impl: None,
+        }),
+    )
+}
+
 fn inherent_method(id: Id, name: &str) -> Item {
     item(
         id,
@@ -1360,6 +2284,36 @@ fn type_param(name: &str) -> GenericParamDef {
             is_synthetic: false,
         },
     }
+}
+
+fn bound_predicate(type_: Type, bounds: Vec<GenericBound>) -> WherePredicate {
+    WherePredicate::BoundPredicate {
+        type_,
+        bounds,
+        generic_params: Vec::new(),
+    }
+}
+
+fn trait_bound(name: &str, id: u32) -> GenericBound {
+    GenericBound::TraitBound {
+        trait_: path(name, id),
+        generic_params: Vec::new(),
+        modifier: rustdoc_types::TraitBoundModifier::None,
+    }
+}
+
+fn pin_project_generated_unpin_predicate(projected_type: Type) -> WherePredicate {
+    bound_predicate(
+        Type::ResolvedPath(
+            path("_pin_project::__private::PinnedFieldsOf", 900).with_args(
+                GenericArgs::AngleBracketed {
+                    args: vec![GenericArg::Type(projected_type)],
+                    constraints: Vec::new(),
+                },
+            ),
+        ),
+        vec![trait_bound("_pin_project::__private::Unpin", 901)],
+    )
 }
 
 fn empty_generics() -> Generics {

--- a/eng/tools/generate_api/src/model.rs
+++ b/eng/tools/generate_api/src/model.rs
@@ -50,11 +50,15 @@ pub(crate) struct ApiItem {
     pub(crate) name: String,
     pub(crate) kind: ApiItemKind,
     pub(crate) source_id: Option<String>,
+    pub(crate) navigation_paths: Vec<ApiNavigationPath>,
+    pub(crate) owner_name: Option<String>,
     pub(crate) owner_kind: Option<ApiItemKind>,
+    pub(crate) owner_source_id: Option<String>,
     pub(crate) inherent_impl_sort_key: Option<InherentImplSortKey>,
     pub(crate) doc_comments: Vec<String>,
     pub(crate) attributes: Vec<ApiAttribute>,
     pub(crate) declaration: String,
+    pub(crate) declaration_path_references: Vec<ApiPathReference>,
     pub(crate) members: Vec<ApiMember>,
 }
 
@@ -72,9 +76,33 @@ pub(crate) struct ApiAttribute {
 #[derive(Debug, Clone)]
 pub(crate) struct ApiMember {
     pub(crate) name: String,
+    pub(crate) kind: ApiMemberKind,
     pub(crate) doc_comments: Vec<String>,
     pub(crate) attributes: Vec<ApiAttribute>,
     pub(crate) declaration: String,
+    pub(crate) declaration_path_references: Vec<ApiPathReference>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct ApiNavigationPath {
+    pub(crate) path: String,
+    pub(crate) source_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct ApiPathReference {
+    pub(crate) path: String,
+    pub(crate) canonical_path: Option<String>,
+    pub(crate) target_source_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum ApiMemberKind {
+    Associated,
+    Field,
+    Variant,
+    MacroInput,
+    Text,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -106,10 +134,9 @@ impl ApiItemKind {
             Self::Enum => 5,
             Self::Trait => 6,
             Self::TraitAlias => 7,
-            Self::InherentImpl => owner_kind
-                .expect("inherent impl items must carry an owning item kind")
-                .sort_rank(None),
-            Self::TraitImpl => 8,
+            Self::InherentImpl | Self::TraitImpl => {
+                owner_kind.map_or(8, |kind| kind.sort_rank(None))
+            }
             Self::Union => 9,
             Self::TypeAlias => 10,
             Self::Const => 11,
@@ -124,7 +151,15 @@ impl ApiItem {
     }
 
     fn sort_group_name(&self) -> &str {
-        &self.name
+        self.owner_name.as_deref().unwrap_or(&self.name)
+    }
+
+    fn kind_within_group(&self) -> usize {
+        match self.kind {
+            ApiItemKind::InherentImpl => 1,
+            ApiItemKind::TraitImpl if self.owner_kind.is_some() => 2,
+            _ => 0,
+        }
     }
 
     fn inherent_impl_sort_key(&self) -> Option<&InherentImplSortKey> {
@@ -139,13 +174,12 @@ impl ApiModule {
             left.sort_rank()
                 .cmp(&right.sort_rank())
                 .then_with(|| left.sort_group_name().cmp(right.sort_group_name()))
+                .then_with(|| left.kind_within_group().cmp(&right.kind_within_group()))
                 .then_with(|| match (left.kind, right.kind) {
                     (ApiItemKind::InherentImpl, ApiItemKind::InherentImpl) => left
                         .inherent_impl_sort_key()
                         .cmp(&right.inherent_impl_sort_key())
                         .then_with(|| left.declaration.cmp(&right.declaration)),
-                    (ApiItemKind::InherentImpl, _) => std::cmp::Ordering::Greater,
-                    (_, ApiItemKind::InherentImpl) => std::cmp::Ordering::Less,
                     _ => left.name.cmp(&right.name),
                 })
         });

--- a/eng/tools/generate_api/src/model/tests.rs
+++ b/eng/tools/generate_api/src/model/tests.rs
@@ -3,66 +3,63 @@
 
 use super::*;
 
+fn item(name: &str, kind: ApiItemKind, declaration: &str) -> ApiItem {
+    ApiItem {
+        name: name.to_string(),
+        kind,
+        source_id: None,
+        navigation_paths: Vec::new(),
+        owner_name: None,
+        owner_kind: None,
+        owner_source_id: None,
+        inherent_impl_sort_key: None,
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        declaration: declaration.to_string(),
+        declaration_path_references: Vec::new(),
+        members: Vec::new(),
+    }
+}
+
 #[test]
 fn sorts_inherent_impls_by_type_parameter_then_infer_then_explicit_type() {
+    let mut explicit = item(
+        "Builder",
+        ApiItemKind::InherentImpl,
+        "impl Builder<BlobState> {",
+    );
+    explicit.owner_name = Some("Builder".to_string());
+    explicit.owner_kind = Some(ApiItemKind::Struct);
+    explicit.inherent_impl_sort_key = Some(InherentImplSortKey {
+        type_arg_classes: vec![2],
+        rendered_self_type: "Builder<BlobState>".to_string(),
+    });
+
+    let mut generic = item("Builder", ApiItemKind::InherentImpl, "impl<S> Builder<S> {");
+    generic.owner_name = Some("Builder".to_string());
+    generic.owner_kind = Some(ApiItemKind::Struct);
+    generic.inherent_impl_sort_key = Some(InherentImplSortKey {
+        type_arg_classes: vec![0],
+        rendered_self_type: "Builder<S>".to_string(),
+    });
+
+    let mut inferred = item("Builder", ApiItemKind::InherentImpl, "impl Builder<_> {");
+    inferred.owner_name = Some("Builder".to_string());
+    inferred.owner_kind = Some(ApiItemKind::Struct);
+    inferred.inherent_impl_sort_key = Some(InherentImplSortKey {
+        type_arg_classes: vec![1],
+        rendered_self_type: "Builder<_>".to_string(),
+    });
+
     let module = ApiModule {
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
         items: vec![
-            ApiItem {
-                name: "Builder".to_string(),
-                kind: ApiItemKind::Struct,
-                source_id: None,
-                owner_kind: None,
-                inherent_impl_sort_key: None,
-                doc_comments: Vec::new(),
-                attributes: Vec::new(),
-                declaration: "pub struct Builder<S>(S);".to_string(),
-                members: Vec::new(),
-            },
-            ApiItem {
-                name: "Builder".to_string(),
-                kind: ApiItemKind::InherentImpl,
-                source_id: None,
-                owner_kind: Some(ApiItemKind::Struct),
-                inherent_impl_sort_key: Some(InherentImplSortKey {
-                    type_arg_classes: vec![2],
-                    rendered_self_type: "Builder<BlobState>".to_string(),
-                }),
-                doc_comments: Vec::new(),
-                attributes: Vec::new(),
-                declaration: "impl Builder<BlobState> {".to_string(),
-                members: Vec::new(),
-            },
-            ApiItem {
-                name: "Builder".to_string(),
-                kind: ApiItemKind::InherentImpl,
-                source_id: None,
-                owner_kind: Some(ApiItemKind::Struct),
-                inherent_impl_sort_key: Some(InherentImplSortKey {
-                    type_arg_classes: vec![0],
-                    rendered_self_type: "Builder<S>".to_string(),
-                }),
-                doc_comments: Vec::new(),
-                attributes: Vec::new(),
-                declaration: "impl<S> Builder<S> {".to_string(),
-                members: Vec::new(),
-            },
-            ApiItem {
-                name: "Builder".to_string(),
-                kind: ApiItemKind::InherentImpl,
-                source_id: None,
-                owner_kind: Some(ApiItemKind::Struct),
-                inherent_impl_sort_key: Some(InherentImplSortKey {
-                    type_arg_classes: vec![1],
-                    rendered_self_type: "Builder<_>".to_string(),
-                }),
-                doc_comments: Vec::new(),
-                attributes: Vec::new(),
-                declaration: "impl Builder<_> {".to_string(),
-                members: Vec::new(),
-            },
+            item("Builder", ApiItemKind::Struct, "pub struct Builder<S>(S);"),
+            explicit,
+            generic,
+            inferred,
         ],
         modules: Vec::new(),
     };

--- a/eng/tools/generate_api/src/render/apiview.rs
+++ b/eng/tools/generate_api/src/render/apiview.rs
@@ -1,13 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use crate::model::{ApiItem, ApiItemKind, ApiModel, ApiModule};
+use crate::model::{
+    ApiItem, ApiItemKind, ApiMember, ApiMemberKind, ApiModel, ApiModule, ApiPathReference,
+};
 use serde::Serialize;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RenderOptions {
     pub(crate) include_docs: bool,
+}
+
+fn prefers_navigation_target(existing: &NavigationTarget, candidate: &NavigationTarget) -> bool {
+    navigation_target_rank(candidate) > navigation_target_rank(existing)
+}
+
+fn navigation_target_rank(target: &NavigationTarget) -> (usize, usize) {
+    let declaration_rank = usize::from(!matches!(target.kind, Some(ApiItemKind::Use)));
+    (declaration_rank, target.path_depth)
+}
+
+fn path_depth(path: &str) -> usize {
+    path.split("::").count()
 }
 
 impl Default for RenderOptions {
@@ -67,17 +82,20 @@ struct ReviewToken {
         skip_serializing_if = "Option::is_none"
     )]
     navigation_display_name: Option<String>,
+    #[serde(rename = "NavigateToId", skip_serializing_if = "Option::is_none")]
+    navigate_to_id: Option<String>,
     #[serde(rename = "RenderClasses", skip_serializing_if = "Option::is_none")]
     render_classes: Option<Vec<String>>,
 }
 
 pub(crate) fn render(model: &ApiModel, options: &RenderOptions) -> Result<String, String> {
+    let navigation_lookup = NavigationLookup::new(model);
     let document = CodeFile {
         package_name: &model.package_name,
         package_version: &model.package_version,
         parser_version: &model.parser_version,
         language: "Rust",
-        review_lines: render_module_contents(&model.root_module, options),
+        review_lines: render_review_lines(model, options, &navigation_lookup),
     };
     validate_code_file(&document)?;
 
@@ -122,20 +140,71 @@ fn validate_review_lines(
     Ok(())
 }
 
-fn render_module_contents(module: &ApiModule, options: &RenderOptions) -> Vec<ReviewLine> {
-    let mut lines = render_items(module, options);
-    let mut child_modules = module.modules.clone();
-    child_modules.sort_by(|left, right| left.path.cmp(&right.path));
-    for child in &child_modules {
-        lines.extend(render_module(child, options));
+fn render_review_lines(
+    model: &ApiModel,
+    options: &RenderOptions,
+    navigation_lookup: &NavigationLookup,
+) -> Vec<ReviewLine> {
+    render_root_module(&model.root_module, options, navigation_lookup)
+}
+
+fn render_module_contents(
+    module: &ApiModule,
+    options: &RenderOptions,
+    navigation_lookup: &NavigationLookup,
+) -> Vec<ReviewLine> {
+    let mut lines = Vec::new();
+    let mut item_index = 0;
+    for entry in apiview_tree_entries(module) {
+        match entry {
+            ModuleTreeEntry::Item(item) => {
+                lines.extend(render_item(
+                    module,
+                    item,
+                    item_index,
+                    item_in_tree(item.kind),
+                    options,
+                    navigation_lookup,
+                ));
+                item_index += 1;
+            }
+            ModuleTreeEntry::Module(child) => {
+                lines.extend(render_module(child, options, navigation_lookup));
+            }
+        }
     }
     lines
 }
 
-fn render_module(module: &ApiModule, options: &RenderOptions) -> Vec<ReviewLine> {
+fn render_root_module(
+    module: &ApiModule,
+    options: &RenderOptions,
+    navigation_lookup: &NavigationLookup,
+) -> Vec<ReviewLine> {
+    let mut lines = Vec::new();
+    if options.include_docs {
+        lines.extend(render_doc_comment_lines(&module.doc_comments, None));
+    }
+    for attribute in &module.attributes {
+        lines.push(ReviewLine {
+            line_id: None,
+            tokens: tokenize_line(&attribute.text, "", token_kind::TYPE_NAME),
+            children: Vec::new(),
+            is_context_end_line: None,
+            related_to_line: None,
+        });
+    }
+    lines.extend(render_module_contents(module, options, navigation_lookup));
+    lines
+}
+
+fn render_module(
+    module: &ApiModule,
+    options: &RenderOptions,
+    navigation_lookup: &NavigationLookup,
+) -> Vec<ReviewLine> {
     let line_id = module_line_id(&module.path);
     let mut lines = Vec::new();
-
     if options.include_docs {
         lines.extend(render_doc_comment_lines(
             &module.doc_comments,
@@ -152,15 +221,25 @@ fn render_module(module: &ApiModule, options: &RenderOptions) -> Vec<ReviewLine>
             related_to_line: Some(line_id.clone()),
         });
     }
+    let mut tokens = tokenize_line(
+        &format!("pub mod {} {{", module.local_name()),
+        module.local_name(),
+        token_kind::TYPE_NAME,
+    );
+    annotate_navigation_token(
+        &mut tokens,
+        module.local_name(),
+        token_kind::TYPE_NAME,
+        module.local_name(),
+        &line_id,
+        "namespace",
+        NavigationMatch::First,
+    );
 
     lines.push(ReviewLine {
         line_id: Some(line_id.clone()),
-        tokens: tokenize_line(
-            &format!("pub mod {} {{", module.local_name()),
-            module.local_name(),
-            token_kind::TYPE_NAME,
-        ),
-        children: render_module_contents(module, options),
+        tokens,
+        children: render_module_contents(module, options, navigation_lookup),
         is_context_end_line: None,
         related_to_line: None,
     });
@@ -174,20 +253,18 @@ fn render_module(module: &ApiModule, options: &RenderOptions) -> Vec<ReviewLine>
     lines
 }
 
-fn render_items(module: &ApiModule, options: &RenderOptions) -> Vec<ReviewLine> {
-    let items = module.sorted_items();
-    let mut lines = Vec::new();
-    for (index, item) in items.into_iter().enumerate() {
-        lines.extend(render_item(module, item, index, options));
-    }
-    lines
+enum ModuleTreeEntry<'a> {
+    Item(&'a ApiItem),
+    Module(&'a ApiModule),
 }
 
 fn render_item(
     module: &ApiModule,
     item: &ApiItem,
     index: usize,
+    should_render_tree_node: bool,
     options: &RenderOptions,
+    navigation_lookup: &NavigationLookup,
 ) -> Vec<ReviewLine> {
     let line_id = format!("{}.{}_{index}", module_line_id(&module.path), item.name);
     let name_token_kind = item_name_token_kind(item.kind);
@@ -210,20 +287,49 @@ fn render_item(
         });
     }
 
-    let mut members = item.members.clone();
-    members.sort_by(|left, right| left.name.cmp(&right.name));
+    let members = sorted_members(&item.members);
     let declaration_owns_members = item.declaration.trim_end().ends_with('{');
     let member_related_line = if declaration_owns_members {
         line_id.clone()
     } else {
         format!("{line_id}.impl")
     };
-    let member_lines = render_member_lines(&members, &member_related_line, options);
+    let member_lines =
+        render_member_lines(&members, &member_related_line, options, navigation_lookup);
+    let tree_render_class = item_render_class(item.kind);
+    let mut tree_navigation_emitted = false;
+    let navigation_match = item_navigation_match(item.kind);
 
     for (declaration_index, declaration_line) in item.declaration.lines().enumerate() {
         if declaration_line.trim().is_empty() {
             continue;
         }
+
+        let mut tokens = tokenize_line(declaration_line, &item.name, name_token_kind);
+        if should_render_tree_node && !tree_navigation_emitted {
+            let navigate_target =
+                navigation_target_for_item(module, item, &line_id, navigation_lookup);
+            tree_navigation_emitted = annotate_navigation_token(
+                &mut tokens,
+                &item.name,
+                name_token_kind,
+                &item.name,
+                navigate_target.map_or(line_id.as_str(), |target| target.line_id.as_str()),
+                tree_render_class,
+                navigation_match,
+            );
+        }
+        annotate_path_references(
+            &mut tokens,
+            &item.declaration_path_references,
+            navigation_lookup,
+        );
+        annotate_trait_impl_owner_reference(&mut tokens, module, item, navigation_lookup);
+        annotate_reference_tokens(
+            &mut tokens,
+            navigation_lookup,
+            item.declaration_path_references.is_empty(),
+        );
 
         lines.push(ReviewLine {
             line_id: if declaration_index == 0 {
@@ -231,7 +337,7 @@ fn render_item(
             } else {
                 None
             },
-            tokens: tokenize_line(declaration_line, &item.name, name_token_kind),
+            tokens,
             children: if declaration_index == 0 && declaration_owns_members {
                 member_lines.clone()
             } else {
@@ -279,9 +385,10 @@ fn render_item(
 }
 
 fn render_member_lines(
-    members: &[crate::model::ApiMember],
+    members: &[&ApiMember],
     related_to_line: &str,
     options: &RenderOptions,
+    navigation_lookup: &NavigationLookup,
 ) -> Vec<ReviewLine> {
     let mut lines = Vec::new();
     for (member_index, member) in members.iter().enumerate() {
@@ -302,9 +409,24 @@ fn render_member_lines(
             });
         }
 
+        let mut tokens = tokenize_line(
+            &member.declaration,
+            &member.name,
+            member_name_token_kind(member.kind),
+        );
+        annotate_path_references(
+            &mut tokens,
+            &member.declaration_path_references,
+            navigation_lookup,
+        );
+        annotate_reference_tokens(
+            &mut tokens,
+            navigation_lookup,
+            member.declaration_path_references.is_empty(),
+        );
         lines.push(ReviewLine {
             line_id: Some(format!("{related_to_line}.{}_{member_index}", member.name)),
-            tokens: tokenize_line(&member.declaration, &member.name, token_kind::MEMBER_NAME),
+            tokens,
             children: Vec::new(),
             is_context_end_line: None,
             related_to_line: Some(related_to_line.to_string()),
@@ -369,6 +491,29 @@ fn item_name_token_kind(kind: ApiItemKind) -> u8 {
     }
 }
 
+fn member_name_token_kind(kind: ApiMemberKind) -> u8 {
+    match kind {
+        ApiMemberKind::Associated | ApiMemberKind::Field => token_kind::MEMBER_NAME,
+        ApiMemberKind::Variant | ApiMemberKind::MacroInput | ApiMemberKind::Text => {
+            token_kind::TYPE_NAME
+        }
+    }
+}
+
+fn sorted_members(members: &[ApiMember]) -> Vec<&ApiMember> {
+    let mut indexed = members.iter().enumerate().collect::<Vec<_>>();
+    indexed.sort_by(
+        |(left_index, left), (right_index, right)| match (left.kind, right.kind) {
+            (ApiMemberKind::Associated, ApiMemberKind::Associated) => left
+                .name
+                .cmp(&right.name)
+                .then_with(|| left.declaration.cmp(&right.declaration)),
+            _ => left_index.cmp(right_index),
+        },
+    );
+    indexed.into_iter().map(|(_, member)| member).collect()
+}
+
 fn tokenize_line(line: &str, item_name: &str, name_token_kind: u8) -> Vec<ReviewToken> {
     let mut tokens: Vec<ReviewToken> = Vec::new();
     let mut s = line.trim_start();
@@ -391,6 +536,7 @@ fn tokenize_line(line: &str, item_name: &str, name_token_kind: u8) -> Vec<Review
             has_suffix_space: false,
             is_documentation: false,
             navigation_display_name: None,
+            navigate_to_id: None,
             render_classes: None,
         });
         s = &s[len..];
@@ -405,6 +551,11 @@ fn next_token_kind(
     name_token_kind: u8,
     name_emitted: &mut bool,
 ) -> (u8, usize) {
+    if s.starts_with("/*") {
+        let len = s.find("*/").map_or(s.len(), |index| index + 2);
+        return (token_kind::COMMENT, len);
+    }
+
     // Multi-character punctuation sequences
     if s.starts_with("::") {
         return (token_kind::PUNCTUATION, 2);
@@ -493,7 +644,566 @@ fn doc_token(value: &str) -> ReviewToken {
         has_suffix_space: false,
         is_documentation: true,
         navigation_display_name: None,
+        navigate_to_id: None,
         render_classes: None,
+    }
+}
+
+fn apiview_sorted_items(module: &ApiModule) -> Vec<&ApiItem> {
+    let sorted_items = module.sorted_items();
+    let mut consts_and_statics = Vec::new();
+    let mut aliases_and_reexports = Vec::new();
+    let mut macros = Vec::new();
+    let mut functions = Vec::new();
+    let mut type_like_items = Vec::new();
+    let mut impls_by_owner = std::collections::BTreeMap::<&str, Vec<&ApiItem>>::new();
+    let mut trailing_impls = Vec::new();
+
+    for item in &sorted_items {
+        match item.kind {
+            ApiItemKind::Const | ApiItemKind::Static => consts_and_statics.push(*item),
+            ApiItemKind::TypeAlias | ApiItemKind::Use => aliases_and_reexports.push(*item),
+            ApiItemKind::Macro | ApiItemKind::ProcMacro => macros.push(*item),
+            ApiItemKind::Function => functions.push(*item),
+            ApiItemKind::InherentImpl | ApiItemKind::TraitImpl => {
+                impls_by_owner
+                    .entry(item.owner_name.as_deref().unwrap_or(item.name.as_str()))
+                    .or_default()
+                    .push(*item);
+            }
+            _ => type_like_items.push(*item),
+        }
+    }
+
+    sort_tree_bucket(&mut consts_and_statics);
+    sort_tree_bucket(&mut aliases_and_reexports);
+    sort_tree_bucket(&mut macros);
+    sort_tree_bucket(&mut functions);
+    sort_tree_bucket(&mut type_like_items);
+
+    let mut items = Vec::new();
+    items.extend(consts_and_statics);
+    items.extend(aliases_and_reexports);
+    items.extend(macros);
+    items.extend(functions);
+
+    for item in type_like_items {
+        items.push(item);
+        if let Some(impls) = impls_by_owner.remove(item.name.as_str()) {
+            items.extend(impls);
+        }
+    }
+
+    for item in sorted_items {
+        let owner_name = item.owner_name.as_deref().unwrap_or(item.name.as_str());
+        if matches!(
+            item.kind,
+            ApiItemKind::InherentImpl | ApiItemKind::TraitImpl
+        ) && impls_by_owner.contains_key(owner_name)
+        {
+            trailing_impls.push(item);
+            impls_by_owner.remove(owner_name);
+        }
+    }
+    items.extend(trailing_impls);
+
+    items
+}
+
+fn apiview_tree_entries(module: &ApiModule) -> Vec<ModuleTreeEntry<'_>> {
+    let mut entries = apiview_sorted_items(module)
+        .into_iter()
+        .map(ModuleTreeEntry::Item)
+        .collect::<Vec<_>>();
+    let mut child_modules = module.modules.iter().collect::<Vec<_>>();
+    child_modules.sort_by(|left, right| left.path.cmp(&right.path));
+    entries.extend(child_modules.into_iter().map(ModuleTreeEntry::Module));
+    entries
+}
+
+fn sort_tree_bucket(items: &mut Vec<&ApiItem>) {
+    items.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| {
+                left.kind
+                    .sort_rank(left.owner_kind)
+                    .cmp(&right.kind.sort_rank(right.owner_kind))
+            })
+            .then_with(|| left.declaration.cmp(&right.declaration))
+    });
+}
+
+fn item_in_tree(kind: ApiItemKind) -> bool {
+    !matches!(kind, ApiItemKind::InherentImpl | ApiItemKind::TraitImpl)
+}
+
+fn item_render_class(kind: ApiItemKind) -> &'static str {
+    match kind {
+        ApiItemKind::Function => "method",
+        ApiItemKind::Struct | ApiItemKind::Union => "class",
+        ApiItemKind::Enum => "enum",
+        ApiItemKind::Trait | ApiItemKind::TraitAlias => "interface",
+        ApiItemKind::Const
+        | ApiItemKind::Static
+        | ApiItemKind::TypeAlias
+        | ApiItemKind::Use
+        | ApiItemKind::Macro
+        | ApiItemKind::ProcMacro => "type",
+        ApiItemKind::InherentImpl | ApiItemKind::TraitImpl => "interface",
+    }
+}
+
+#[derive(Clone)]
+struct NavigationTarget {
+    line_id: String,
+    display_name: String,
+    render_class: &'static str,
+    kind: Option<ApiItemKind>,
+    path_depth: usize,
+}
+
+struct NavigationLookup {
+    root_path: String,
+    paths: BTreeMap<String, NavigationTarget>,
+    visible_source_ids: BTreeMap<String, NavigationTarget>,
+    simple_names: BTreeMap<String, Option<NavigationTarget>>,
+}
+
+impl NavigationLookup {
+    fn new(model: &ApiModel) -> Self {
+        let mut lookup = Self {
+            root_path: model.root_module.path.clone(),
+            paths: BTreeMap::new(),
+            visible_source_ids: BTreeMap::new(),
+            simple_names: BTreeMap::new(),
+        };
+        collect_navigation_targets(&mut lookup, &model.root_module);
+        lookup
+    }
+
+    fn insert_path(&mut self, path: impl Into<String>, target: &NavigationTarget) {
+        let path = path.into();
+        match self.paths.entry(path) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(target.clone());
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                if prefers_navigation_target(entry.get(), target) {
+                    entry.insert(target.clone());
+                }
+            }
+        }
+    }
+
+    fn insert_simple_name(&mut self, name: &str, target: &NavigationTarget) {
+        use std::collections::btree_map::Entry;
+
+        match self.simple_names.entry(name.to_string()) {
+            Entry::Vacant(entry) => {
+                entry.insert(Some(target.clone()));
+            }
+            Entry::Occupied(mut entry) => {
+                if entry
+                    .get()
+                    .as_ref()
+                    .is_some_and(|existing| existing.line_id == target.line_id)
+                {
+                    return;
+                }
+                entry.insert(None);
+            }
+        }
+    }
+
+    fn insert_visible_source_id(&mut self, source_id: &str, target: &NavigationTarget) {
+        match self.visible_source_ids.entry(source_id.to_string()) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(target.clone());
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                if prefers_navigation_target(entry.get(), target) {
+                    entry.insert(target.clone());
+                }
+            }
+        }
+    }
+
+    fn resolve_visible_source_id(&self, source_id: &str) -> Option<&NavigationTarget> {
+        self.visible_source_ids.get(source_id)
+    }
+
+    fn resolve_path(&self, path: &str, allow_simple_names: bool) -> Option<&NavigationTarget> {
+        let path = self.normalize_path(path);
+        self.paths.get(path.as_ref()).or_else(|| {
+            if path.contains("::") || !allow_simple_names {
+                None
+            } else {
+                self.simple_names
+                    .get(path.as_ref())
+                    .and_then(Option::as_ref)
+            }
+        })
+    }
+
+    fn resolve_reference_target(&self, reference: &ApiPathReference) -> Option<&NavigationTarget> {
+        if let Some(source_id) = reference.target_source_id.as_deref() {
+            if let Some(target) = self.resolve_visible_source_id(source_id) {
+                return Some(target);
+            }
+        }
+
+        reference
+            .canonical_path
+            .as_deref()
+            .and_then(|reference_path| self.resolve_path(reference_path, false))
+    }
+
+    fn normalize_path<'a>(&'a self, path: &'a str) -> std::borrow::Cow<'a, str> {
+        match path {
+            "crate" => std::borrow::Cow::Borrowed(self.root_path.as_str()),
+            _ => path
+                .strip_prefix("crate::")
+                .map(|suffix| std::borrow::Cow::Owned(format!("{}::{suffix}", self.root_path)))
+                .unwrap_or_else(|| std::borrow::Cow::Borrowed(path)),
+        }
+    }
+}
+
+fn collect_navigation_targets(lookup: &mut NavigationLookup, module: &ApiModule) {
+    let module_target = NavigationTarget {
+        line_id: module_line_id(&module.path),
+        display_name: module.local_name().to_string(),
+        render_class: "namespace",
+        kind: None,
+        path_depth: path_depth(&module.path),
+    };
+    lookup.insert_path(module.path.clone(), &module_target);
+    lookup.insert_simple_name(module.local_name(), &module_target);
+
+    for (index, item) in apiview_sorted_items(module).into_iter().enumerate() {
+        if !item_in_tree(item.kind) {
+            continue;
+        }
+
+        let target = NavigationTarget {
+            line_id: format!("{}.{}_{index}", module_line_id(&module.path), item.name),
+            display_name: item.name.clone(),
+            render_class: item_render_class(item.kind),
+            kind: Some(item.kind),
+            path_depth: path_depth(&format!("{}::{}", module.path, item.name)),
+        };
+        lookup.insert_path(format!("{}::{}", module.path, item.name), &target);
+        if let Some(source_id) = item.source_id.as_deref() {
+            lookup.insert_visible_source_id(source_id, &target);
+        }
+        lookup.insert_simple_name(&item.name, &target);
+        for path in &item.navigation_paths {
+            lookup.insert_path(path.path.clone(), &target);
+            if let Some(source_id) = path.source_id.as_deref() {
+                lookup.insert_visible_source_id(source_id, &target);
+            }
+        }
+    }
+
+    for entry in apiview_tree_entries(module) {
+        if let ModuleTreeEntry::Module(child) = entry {
+            collect_navigation_targets(lookup, child);
+        }
+    }
+}
+
+fn annotate_navigation_token(
+    tokens: &mut [ReviewToken],
+    item_name: &str,
+    name_token_kind: u8,
+    display_name: &str,
+    navigate_to_id: &str,
+    render_class: &'static str,
+    match_preference: NavigationMatch,
+) -> bool {
+    let token_index = match_preference
+        .find(tokens, item_name, Some(name_token_kind))
+        .or_else(|| match_preference.find(tokens, item_name, None));
+
+    if let Some(token) = token_index.and_then(|index| tokens.get_mut(index)) {
+        annotate_token_with_target(
+            token,
+            &NavigationTarget {
+                line_id: navigate_to_id.to_string(),
+                display_name: display_name.to_string(),
+                render_class,
+                kind: None,
+                path_depth: 0,
+            },
+            NavigationAnnotation::TreeNode,
+        );
+        true
+    } else {
+        false
+    }
+}
+
+fn navigation_target_for_item<'a>(
+    module: &ApiModule,
+    item: &ApiItem,
+    line_id: &'a str,
+    navigation_lookup: &'a NavigationLookup,
+) -> Option<&'a NavigationTarget> {
+    if item.kind != ApiItemKind::Use {
+        return None;
+    }
+
+    item.source_id
+        .as_deref()
+        .and_then(|source_id| navigation_lookup.resolve_visible_source_id(source_id))
+        .filter(|target| target.line_id != line_id)
+        .or_else(|| {
+            item.navigation_paths
+                .iter()
+                .filter_map(|path| {
+                    path.source_id.as_deref().and_then(|source_id| {
+                        navigation_lookup.resolve_visible_source_id(source_id)
+                    })
+                })
+                .find(|target| target.line_id != line_id)
+        })
+        .or_else(|| {
+            item.navigation_paths
+                .iter()
+                .find_map(|path| navigation_lookup.resolve_path(&path.path, false))
+                .filter(|target| target.line_id != line_id)
+        })
+        .or_else(|| {
+            let item_path = format!("{}::{}", module.path, item.name);
+            navigation_lookup
+                .resolve_path(&item_path, false)
+                .filter(|target| target.line_id != line_id)
+        })
+}
+
+fn annotate_path_references(
+    tokens: &mut [ReviewToken],
+    references: &[ApiPathReference],
+    navigation_lookup: &NavigationLookup,
+) {
+    let mut search_from = 0;
+    for reference in references {
+        let Some(target) = navigation_lookup.resolve_reference_target(reference) else {
+            continue;
+        };
+        let path_tokens = tokenize_line(&reference.path, "", token_kind::TYPE_NAME);
+        if path_tokens.is_empty() {
+            continue;
+        }
+        let Some(start) = find_token_sequence(tokens, &path_tokens, search_from) else {
+            continue;
+        };
+        let leaf_index = start + path_tokens.len().saturating_sub(1);
+        if let Some(token) = tokens.get_mut(leaf_index) {
+            if token.navigate_to_id.is_none() {
+                annotate_token_with_target(token, target, NavigationAnnotation::CodeOnly);
+            }
+        }
+        search_from = leaf_index.saturating_add(1);
+    }
+}
+
+fn find_token_sequence(
+    tokens: &[ReviewToken],
+    pattern: &[ReviewToken],
+    search_from: usize,
+) -> Option<usize> {
+    if pattern.is_empty() || pattern.len() > tokens.len() || search_from >= tokens.len() {
+        return None;
+    }
+
+    (search_from..=tokens.len().saturating_sub(pattern.len())).find(|start| {
+        pattern.iter().enumerate().all(|(offset, expected)| {
+            let actual = &tokens[start + offset];
+            actual.kind == expected.kind && actual.value == expected.value
+        })
+    })
+}
+
+fn annotate_reference_tokens(
+    tokens: &mut [ReviewToken],
+    navigation_lookup: &NavigationLookup,
+    allow_simple_names: bool,
+) {
+    let mut index = 0;
+    while index < tokens.len() {
+        let Some(token) = tokens.get(index) else {
+            break;
+        };
+        if !can_start_reference(token)
+            || token.value.starts_with('\'')
+            || index > 0 && tokens[index - 1].value == "::"
+        {
+            index += 1;
+            continue;
+        }
+
+        let start = index;
+        let mut end = index;
+        let mut segments = vec![token.value.clone()];
+        while end + 2 < tokens.len()
+            && tokens[end + 1].value == "::"
+            && tokens[end + 2].kind == token_kind::TYPE_NAME
+        {
+            end += 2;
+            segments.push(tokens[end].value.clone());
+        }
+
+        if is_reference_candidate(tokens, start, end) {
+            let path = segments.join("::");
+            if let Some(target) = navigation_lookup.resolve_path(&path, allow_simple_names) {
+                let token = &mut tokens[end];
+                if token.navigate_to_id.is_none() {
+                    annotate_token_with_target(token, target, NavigationAnnotation::CodeOnly);
+                }
+            }
+        }
+
+        index = end + 1;
+    }
+}
+
+fn annotate_trait_impl_owner_reference(
+    tokens: &mut [ReviewToken],
+    module: &ApiModule,
+    item: &ApiItem,
+    navigation_lookup: &NavigationLookup,
+) {
+    if item.kind != ApiItemKind::TraitImpl {
+        return;
+    }
+
+    let Some(owner_name) = item.owner_name.as_deref() else {
+        return;
+    };
+    let owner_path = format!("{}::{owner_name}", module.path);
+    let Some(target) = item
+        .owner_source_id
+        .as_deref()
+        .and_then(|owner_source_id| {
+            item.declaration_path_references
+                .iter()
+                .rev()
+                .find(|reference| reference.target_source_id.as_deref() == Some(owner_source_id))
+                .and_then(|reference| navigation_lookup.resolve_reference_target(reference))
+                .or_else(|| navigation_lookup.resolve_visible_source_id(owner_source_id))
+        })
+        .or_else(|| navigation_lookup.resolve_path(&owner_path, false))
+    else {
+        return;
+    };
+    let Some(for_index) = tokens.iter().position(|token| token.value == "for") else {
+        return;
+    };
+
+    let mut index = for_index + 1;
+    while index < tokens.len() && !can_start_reference(&tokens[index]) {
+        index += 1;
+    }
+    if index >= tokens.len() || tokens[index].value.starts_with('\'') {
+        return;
+    }
+
+    let mut leaf_index = index;
+    while leaf_index + 2 < tokens.len()
+        && tokens[leaf_index + 1].value == "::"
+        && tokens[leaf_index + 2].kind == token_kind::TYPE_NAME
+    {
+        leaf_index += 2;
+    }
+
+    let token = &mut tokens[leaf_index];
+    annotate_token_with_target(token, target, NavigationAnnotation::CodeOnly);
+}
+
+fn can_start_reference(token: &ReviewToken) -> bool {
+    token.kind == token_kind::TYPE_NAME
+        || token.kind == token_kind::KEYWORD && token.value == "crate"
+}
+
+fn is_reference_candidate(tokens: &[ReviewToken], start: usize, end: usize) -> bool {
+    if start == end {
+        if tokens.get(end + 1).is_some_and(|token| token.value == ":") {
+            return false;
+        }
+        if tokens.get(end + 1).is_some_and(|token| token.value == "!") {
+            return false;
+        }
+    }
+
+    let previous = start.checked_sub(1).and_then(|index| tokens.get(index));
+    !previous.is_some_and(|token| {
+        matches!(
+            token.value.as_str(),
+            "fn" | "struct"
+                | "enum"
+                | "trait"
+                | "type"
+                | "mod"
+                | "impl"
+                | "for"
+                | "use"
+                | "as"
+                | "const"
+                | "static"
+                | "derive"
+                | "macro"
+        )
+    })
+}
+
+#[derive(Clone, Copy)]
+enum NavigationAnnotation {
+    TreeNode,
+    CodeOnly,
+}
+
+fn annotate_token_with_target(
+    token: &mut ReviewToken,
+    target: &NavigationTarget,
+    annotation: NavigationAnnotation,
+) {
+    token.navigate_to_id = Some(target.line_id.clone());
+    match annotation {
+        NavigationAnnotation::TreeNode => {
+            token.navigation_display_name = Some(target.display_name.clone());
+            token.render_classes = Some(vec![target.render_class.to_string()]);
+        }
+        NavigationAnnotation::CodeOnly => {
+            token.navigation_display_name = None;
+            token.render_classes = None;
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum NavigationMatch {
+    First,
+    Last,
+}
+
+impl NavigationMatch {
+    fn find(self, tokens: &[ReviewToken], item_name: &str, kind: Option<u8>) -> Option<usize> {
+        let matches = |token: &ReviewToken| {
+            token.value == item_name && kind.is_none_or(|kind| token.kind == kind)
+        };
+        match self {
+            Self::First => tokens.iter().position(matches),
+            Self::Last => tokens.iter().rposition(matches),
+        }
+    }
+}
+
+fn item_navigation_match(kind: ApiItemKind) -> NavigationMatch {
+    match kind {
+        ApiItemKind::Use => NavigationMatch::Last,
+        _ => NavigationMatch::First,
     }
 }
 

--- a/eng/tools/generate_api/src/render/apiview/tests.rs
+++ b/eng/tools/generate_api/src/render/apiview/tests.rs
@@ -2,36 +2,125 @@
 // Licensed under the MIT License.
 
 use super::*;
-use crate::model::{ApiAttribute, ApiMember};
+use crate::model::{
+    ApiAttribute, ApiItem, ApiItemKind, ApiMember, ApiMemberKind, ApiModel, ApiModule,
+    ApiNavigationPath, ApiPathReference, InherentImplSortKey,
+};
+
+fn item(name: &str, kind: ApiItemKind, declaration: &str) -> ApiItem {
+    ApiItem {
+        name: name.to_string(),
+        kind,
+        source_id: None,
+        navigation_paths: Vec::new(),
+        owner_name: None,
+        owner_kind: None,
+        owner_source_id: None,
+        inherent_impl_sort_key: None,
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        declaration: declaration.to_string(),
+        declaration_path_references: Vec::new(),
+        members: Vec::new(),
+    }
+}
+
+fn member(name: &str, kind: ApiMemberKind, declaration: &str) -> ApiMember {
+    ApiMember {
+        name: name.to_string(),
+        kind,
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        declaration: declaration.to_string(),
+        declaration_path_references: Vec::new(),
+    }
+}
+
+fn path_reference(path: &str, target_source_id: &str) -> ApiPathReference {
+    path_reference_with_canonical(path, None, target_source_id)
+}
+
+fn path_reference_with_canonical(
+    path: &str,
+    canonical_path: Option<&str>,
+    target_source_id: &str,
+) -> ApiPathReference {
+    ApiPathReference {
+        path: path.to_string(),
+        canonical_path: canonical_path.map(str::to_string),
+        target_source_id: Some(target_source_id.to_string()),
+    }
+}
+
+fn navigation_path(path: &str, source_id: &str) -> ApiNavigationPath {
+    ApiNavigationPath {
+        path: path.to_string(),
+        source_id: Some(source_id.to_string()),
+    }
+}
+
+fn navigation_lookup(root_module: &ApiModule) -> NavigationLookup {
+    NavigationLookup::new(&ApiModel {
+        package_name: root_module.local_name().to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        root_module: root_module.clone(),
+    })
+}
+
+fn find_token<'a>(line: &'a ReviewLine, value: &str) -> &'a ReviewToken {
+    line.tokens
+        .iter()
+        .find(|token| token.value == value)
+        .unwrap_or_else(|| panic!("expected {value} token"))
+}
+
+fn find_child<'a>(line: &'a ReviewLine, line_id: &str) -> &'a ReviewLine {
+    line.children
+        .iter()
+        .find(|child| child.line_id.as_deref() == Some(line_id))
+        .unwrap_or_else(|| panic!("expected {line_id} child line"))
+}
+
+fn top_level_navigation_line_ids(lines: &[ReviewLine]) -> Vec<&str> {
+    lines
+        .iter()
+        .filter(|line| line.related_to_line.is_none())
+        .filter(|line| {
+            line.tokens
+                .iter()
+                .any(|token| token.navigation_display_name.is_some())
+        })
+        .filter_map(|line| line.line_id.as_deref())
+        .collect()
+}
 
 #[test]
 fn renders_trait_impl_tokens_with_typed_members() {
+    let mut impl_item = item(
+        "MyType",
+        ApiItemKind::TraitImpl,
+        "impl fmt::Debug for MyType {",
+    );
+    impl_item.attributes.push(ApiAttribute {
+        text: "#[cfg(feature = \"std\")]".to_string(),
+    });
+    impl_item.members.push(member(
+        "fmt",
+        ApiMemberKind::Associated,
+        "fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result;",
+    ));
+
     let module = ApiModule {
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
-        items: vec![ApiItem {
-            name: "MyType".to_string(),
-            kind: ApiItemKind::TraitImpl,
-            source_id: None,
-            owner_kind: None,
-            inherent_impl_sort_key: None,
-            doc_comments: Vec::new(),
-            attributes: vec![ApiAttribute {
-                text: "#[cfg(feature = \"std\")]".to_string(),
-            }],
-            declaration: "impl fmt::Debug for MyType {".to_string(),
-            members: vec![ApiMember {
-                name: "fmt".to_string(),
-                doc_comments: Vec::new(),
-                attributes: Vec::new(),
-                declaration: "fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result;".to_string(),
-            }],
-        }],
+        items: vec![impl_item],
         modules: Vec::new(),
     };
 
-    let lines = render_module_contents(&module, &RenderOptions::default());
+    let lookup = navigation_lookup(&module);
+    let lines = render_module_contents(&module, &RenderOptions::default(), &lookup);
 
     assert_eq!(lines.len(), 3);
     assert_eq!(
@@ -83,43 +172,28 @@ fn renders_trait_impl_tokens_with_typed_members() {
 
 #[test]
 fn renders_inherent_members_inside_impl_blocks() {
+    let mut inherent_impl = item("Foo", ApiItemKind::InherentImpl, "impl Foo {");
+    inherent_impl.owner_name = Some("Foo".to_string());
+    inherent_impl.owner_kind = Some(ApiItemKind::Struct);
+    inherent_impl.members.push(member(
+        "method",
+        ApiMemberKind::Associated,
+        "pub fn method(&self);",
+    ));
+
     let module = ApiModule {
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
         items: vec![
-            ApiItem {
-                name: "Foo".to_string(),
-                kind: ApiItemKind::Struct,
-                source_id: None,
-                owner_kind: None,
-                inherent_impl_sort_key: None,
-                doc_comments: Vec::new(),
-                attributes: Vec::new(),
-                declaration: "pub struct Foo;".to_string(),
-                members: Vec::new(),
-            },
-            ApiItem {
-                name: "Foo".to_string(),
-                kind: ApiItemKind::InherentImpl,
-                source_id: None,
-                owner_kind: Some(ApiItemKind::Struct),
-                inherent_impl_sort_key: None,
-                doc_comments: Vec::new(),
-                attributes: Vec::new(),
-                declaration: "impl Foo {".to_string(),
-                members: vec![ApiMember {
-                    name: "method".to_string(),
-                    doc_comments: Vec::new(),
-                    attributes: Vec::new(),
-                    declaration: "pub fn method(&self);".to_string(),
-                }],
-            },
+            item("Foo", ApiItemKind::Struct, "pub struct Foo;"),
+            inherent_impl,
         ],
         modules: Vec::new(),
     };
 
-    let lines = render_module_contents(&module, &RenderOptions::default());
+    let lookup = navigation_lookup(&module);
+    let lines = render_module_contents(&module, &RenderOptions::default(), &lookup);
 
     assert_eq!(lines.len(), 3);
     assert_eq!(
@@ -154,60 +228,78 @@ fn renders_inherent_members_inside_impl_blocks() {
 }
 
 #[test]
+fn tokenizes_private_fields_block_comment_as_a_comment() {
+    assert_eq!(
+        tokenize_line(
+            "pub struct AsyncResponseBody(/* private fields */);",
+            "AsyncResponseBody",
+            token_kind::TYPE_NAME,
+        )
+        .into_iter()
+        .map(|token| (token.kind, token.value))
+        .collect::<Vec<_>>(),
+        vec![
+            (token_kind::KEYWORD, "pub".to_string()),
+            (token_kind::KEYWORD, "struct".to_string()),
+            (token_kind::TYPE_NAME, "AsyncResponseBody".to_string()),
+            (token_kind::PUNCTUATION, "(".to_string()),
+            (token_kind::COMMENT, "/* private fields */".to_string()),
+            (token_kind::PUNCTUATION, ")".to_string()),
+            (token_kind::PUNCTUATION, ";".to_string()),
+        ]
+    );
+}
+
+#[test]
 fn keeps_duplicate_member_names_in_separate_inherent_impl_blocks() {
+    let mut blob_impl = item(
+        "Builder",
+        ApiItemKind::InherentImpl,
+        "impl Builder<BlobState> {",
+    );
+    blob_impl.owner_name = Some("Builder".to_string());
+    blob_impl.owner_kind = Some(ApiItemKind::Struct);
+    blob_impl.inherent_impl_sort_key = Some(InherentImplSortKey {
+        type_arg_classes: vec![2],
+        rendered_self_type: "Builder<BlobState>".to_string(),
+    });
+    blob_impl.members.push(member(
+        "read",
+        ApiMemberKind::Associated,
+        "pub fn read(self) -> Self;",
+    ));
+
+    let mut generic_impl = item(
+        "Builder",
+        ApiItemKind::InherentImpl,
+        "impl<S: QueueState> Builder<S> {",
+    );
+    generic_impl.owner_name = Some("Builder".to_string());
+    generic_impl.owner_kind = Some(ApiItemKind::Struct);
+    generic_impl.inherent_impl_sort_key = Some(InherentImplSortKey {
+        type_arg_classes: vec![0],
+        rendered_self_type: "Builder<S>".to_string(),
+    });
+    generic_impl.members.push(member(
+        "read",
+        ApiMemberKind::Associated,
+        "pub fn read(self) -> Self;",
+    ));
+
     let module = ApiModule {
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
         items: vec![
-            ApiItem {
-                name: "Builder".to_string(),
-                kind: ApiItemKind::Struct,
-                source_id: None,
-                owner_kind: None,
-                inherent_impl_sort_key: None,
-                doc_comments: Vec::new(),
-                attributes: Vec::new(),
-                declaration: "pub struct Builder<S>(S);".to_string(),
-                members: Vec::new(),
-            },
-            ApiItem {
-                name: "Builder".to_string(),
-                kind: ApiItemKind::InherentImpl,
-                source_id: None,
-                owner_kind: Some(ApiItemKind::Struct),
-                inherent_impl_sort_key: None,
-                doc_comments: Vec::new(),
-                attributes: Vec::new(),
-                declaration: "impl Builder<BlobState> {".to_string(),
-                members: vec![ApiMember {
-                    name: "read".to_string(),
-                    doc_comments: Vec::new(),
-                    attributes: Vec::new(),
-                    declaration: "pub fn read(self) -> Self;".to_string(),
-                }],
-            },
-            ApiItem {
-                name: "Builder".to_string(),
-                kind: ApiItemKind::InherentImpl,
-                source_id: None,
-                owner_kind: Some(ApiItemKind::Struct),
-                inherent_impl_sort_key: None,
-                doc_comments: Vec::new(),
-                attributes: Vec::new(),
-                declaration: "impl<S: QueueState> Builder<S> {".to_string(),
-                members: vec![ApiMember {
-                    name: "read".to_string(),
-                    doc_comments: Vec::new(),
-                    attributes: Vec::new(),
-                    declaration: "pub fn read(self) -> Self;".to_string(),
-                }],
-            },
+            item("Builder", ApiItemKind::Struct, "pub struct Builder<S>(S);"),
+            blob_impl,
+            generic_impl,
         ],
         modules: Vec::new(),
     };
 
-    let lines = render_module_contents(&module, &RenderOptions::default());
+    let lookup = navigation_lookup(&module);
+    let lines = render_module_contents(&module, &RenderOptions::default(), &lookup);
     let read_line_ids = lines
         .iter()
         .flat_map(|line| line.children.iter())
@@ -221,31 +313,28 @@ fn keeps_duplicate_member_names_in_separate_inherent_impl_blocks() {
 
 #[test]
 fn omits_doc_comment_lines_when_docs_are_disabled() {
+    let mut struct_item = item("Foo", ApiItemKind::Struct, "pub struct Foo;");
+    struct_item.doc_comments.push("/// item docs".to_string());
+    struct_item.members.push(member(
+        "method",
+        ApiMemberKind::Associated,
+        "pub fn method(&self);",
+    ));
+    struct_item.members[0]
+        .doc_comments
+        .push("/// member docs".to_string());
+
     let module = ApiModule {
         path: "demo".to_string(),
         doc_comments: vec!["/// module docs".to_string()],
         attributes: Vec::new(),
-        items: vec![ApiItem {
-            name: "Foo".to_string(),
-            kind: ApiItemKind::Struct,
-            source_id: None,
-            owner_kind: None,
-            inherent_impl_sort_key: None,
-            doc_comments: vec!["/// item docs".to_string()],
-            attributes: Vec::new(),
-            declaration: "pub struct Foo;".to_string(),
-            members: vec![ApiMember {
-                name: "method".to_string(),
-                doc_comments: vec!["/// member docs".to_string()],
-                attributes: Vec::new(),
-                declaration: "pub fn method(&self);".to_string(),
-            }],
-        }],
+        items: vec![struct_item],
         modules: Vec::new(),
     };
 
-    let with_docs = render_module(&module, &RenderOptions::default());
-    let without_docs = render_module(&module, &RenderOptions::new(false));
+    let lookup = navigation_lookup(&module);
+    let with_docs = render_module(&module, &RenderOptions::default(), &lookup);
+    let without_docs = render_module(&module, &RenderOptions::new(false), &lookup);
 
     assert!(with_docs.iter().any(|line| {
         line.tokens
@@ -254,5 +343,849 @@ fn omits_doc_comment_lines_when_docs_are_disabled() {
     }));
     assert!(!without_docs
         .iter()
-        .any(|line| { line.tokens.iter().any(|token| token.is_documentation) }));
+        .any(|line| line.tokens.iter().any(|token| token.is_documentation)));
+}
+
+#[test]
+fn links_trait_impl_owner_to_local_definition() {
+    let mut secret_bytes = item(
+        "SecretBytes",
+        ApiItemKind::Struct,
+        "pub struct SecretBytes;",
+    );
+    secret_bytes.source_id = Some("secret-bytes".to_string());
+
+    let mut trait_impl = item(
+        "SecretBytes",
+        ApiItemKind::TraitImpl,
+        "impl<T> From<T> for SecretBytes {",
+    );
+    trait_impl.owner_name = Some("SecretBytes".to_string());
+    trait_impl.owner_kind = Some(ApiItemKind::Struct);
+    trait_impl.owner_source_id = Some("secret-bytes".to_string());
+    trait_impl.declaration_path_references = vec![
+        path_reference("From", "from-trait"),
+        path_reference("crate::SecretBytes", "secret-bytes"),
+    ];
+
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![secret_bytes, trait_impl],
+            modules: Vec::new(),
+        },
+    };
+
+    let lookup = NavigationLookup::new(&model);
+    let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
+    let trait_impl = lines
+        .iter()
+        .find(|line| {
+            line.line_id.as_deref() == Some("module.demo.SecretBytes_1")
+                && line.tokens.iter().any(|token| token.value == "impl")
+        })
+        .expect("expected trait impl line");
+
+    assert_eq!(
+        find_token(trait_impl, "SecretBytes")
+            .navigate_to_id
+            .as_deref(),
+        Some("module.demo.SecretBytes_0")
+    );
+}
+
+#[test]
+fn links_trait_impl_owner_to_public_reexport() {
+    let mut secret_bytes = item(
+        "SecretBytes",
+        ApiItemKind::Use,
+        "pub use hidden::SecretBytes;",
+    );
+    secret_bytes.navigation_paths.push(navigation_path(
+        "hidden::SecretBytes",
+        "hidden-secret-bytes",
+    ));
+
+    let mut trait_impl = item(
+        "SecretBytes",
+        ApiItemKind::TraitImpl,
+        "impl<T> From<T> for SecretBytes {",
+    );
+    trait_impl.owner_name = Some("SecretBytes".to_string());
+    trait_impl.owner_kind = Some(ApiItemKind::Struct);
+    trait_impl.owner_source_id = Some("hidden-secret-bytes".to_string());
+    trait_impl.declaration_path_references = vec![
+        path_reference("From", "from-trait"),
+        path_reference("hidden::SecretBytes", "hidden-secret-bytes"),
+    ];
+
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![secret_bytes, trait_impl],
+            modules: Vec::new(),
+        },
+    };
+
+    let lookup = NavigationLookup::new(&model);
+    let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
+    let trait_impl = lines
+        .iter()
+        .find(|line| {
+            line.line_id.as_deref() == Some("module.demo.SecretBytes_1")
+                && line.tokens.iter().any(|token| token.value == "impl")
+        })
+        .expect("expected trait impl line");
+
+    assert_eq!(
+        find_token(trait_impl, "SecretBytes")
+            .navigate_to_id
+            .as_deref(),
+        Some("module.demo.SecretBytes_0")
+    );
+}
+
+#[test]
+fn links_trait_impl_owner_to_declaration_over_visible_reexport() {
+    let mut root_error = item("Error", ApiItemKind::Use, "pub use hidden::Error;");
+    root_error
+        .navigation_paths
+        .push(navigation_path("hidden::Error", "hidden-error"));
+
+    let mut hidden_error = item("Error", ApiItemKind::Struct, "pub struct Error;");
+    hidden_error.source_id = Some("hidden-error".to_string());
+    hidden_error.attributes.push(ApiAttribute {
+        text: "#[derive(SafeDebug)]".to_string(),
+    });
+
+    let mut trait_impl = item(
+        "Error",
+        ApiItemKind::TraitImpl,
+        "impl<T> From<T> for Error {",
+    );
+    trait_impl.owner_name = Some("Error".to_string());
+    trait_impl.owner_kind = Some(ApiItemKind::Struct);
+    trait_impl.owner_source_id = Some("hidden-error".to_string());
+    trait_impl.declaration_path_references = vec![
+        path_reference("From", "from-trait"),
+        path_reference_with_canonical("hidden::Error", Some("hidden::Error"), "hidden-error"),
+    ];
+
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![root_error, trait_impl],
+            modules: vec![ApiModule {
+                path: "demo::hidden".to_string(),
+                doc_comments: Vec::new(),
+                attributes: Vec::new(),
+                items: vec![hidden_error],
+                modules: Vec::new(),
+            }],
+        },
+    };
+
+    let lookup = NavigationLookup::new(&model);
+    let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
+    let trait_impl = lines
+        .iter()
+        .find(|line| {
+            line.line_id.as_deref() == Some("module.demo.Error_1")
+                && line.tokens.iter().any(|token| token.value == "impl")
+        })
+        .expect("expected trait impl line");
+
+    assert_eq!(
+        find_token(trait_impl, "Error").navigate_to_id.as_deref(),
+        Some("module.demo__hidden.Error_0")
+    );
+}
+
+#[test]
+fn keeps_trait_impl_owner_unlinked_without_visible_target() {
+    let mut trait_impl = item(
+        "Error",
+        ApiItemKind::TraitImpl,
+        "impl<T> From<T> for Error {",
+    );
+    trait_impl.owner_name = Some("Error".to_string());
+    trait_impl.owner_kind = Some(ApiItemKind::Struct);
+    trait_impl.owner_source_id = Some("external-error".to_string());
+    trait_impl
+        .declaration_path_references
+        .push(path_reference("From", "from-trait"));
+
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![trait_impl],
+            modules: Vec::new(),
+        },
+    };
+
+    let lookup = NavigationLookup::new(&model);
+    let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
+    let trait_impl = lines
+        .iter()
+        .find(|line| line.line_id.as_deref() == Some("module.demo.Error_0"))
+        .expect("expected trait impl line");
+
+    assert!(find_token(trait_impl, "Error").navigate_to_id.is_none());
+}
+
+#[test]
+fn links_associated_error_type_to_visible_error_target() {
+    let mut visible_error = item("Error", ApiItemKind::Use, "pub use hidden::Error;");
+    visible_error
+        .navigation_paths
+        .push(navigation_path("hidden::Error", "hidden-error"));
+
+    let response = item("Response", ApiItemKind::Struct, "pub struct Response;");
+
+    let mut try_from_impl = item(
+        "ErrorResponse",
+        ApiItemKind::TraitImpl,
+        "impl TryFrom<Error> for ErrorResponse {",
+    );
+    try_from_impl.owner_name = Some("ErrorResponse".to_string());
+    try_from_impl.owner_kind = Some(ApiItemKind::Struct);
+    try_from_impl.owner_source_id = Some("error-response".to_string());
+    try_from_impl.members.push(ApiMember {
+        name: "Error".to_string(),
+        kind: ApiMemberKind::Associated,
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        declaration: "type Error = Error;".to_string(),
+        declaration_path_references: vec![path_reference_with_canonical(
+            "Error",
+            Some("hidden::Error"),
+            "hidden-error",
+        )],
+    });
+
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![
+                visible_error,
+                response,
+                item(
+                    "ErrorResponse",
+                    ApiItemKind::Struct,
+                    "pub struct ErrorResponse;",
+                ),
+                try_from_impl,
+            ],
+            modules: Vec::new(),
+        },
+    };
+
+    let lookup = NavigationLookup::new(&model);
+    let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
+    let trait_impl = lines
+        .iter()
+        .find(|line| {
+            line.line_id
+                .as_deref()
+                .is_some_and(|line_id| line_id.starts_with("module.demo.ErrorResponse_"))
+                && line.tokens.iter().any(|token| token.value == "impl")
+        })
+        .expect("expected trait impl line");
+    let error_type = find_child(
+        trait_impl,
+        &format!(
+            "{}.Error_0",
+            trait_impl.line_id.as_deref().expect("trait impl line id")
+        ),
+    );
+    let error_tokens = error_type
+        .tokens
+        .iter()
+        .filter(|token| token.value == "Error")
+        .collect::<Vec<_>>();
+
+    assert_eq!(error_tokens.len(), 2);
+    assert!(error_tokens[0].navigate_to_id.is_none());
+    assert_eq!(
+        error_tokens[1].navigate_to_id.as_deref(),
+        Some("module.demo.Error_0")
+    );
+}
+
+#[test]
+fn links_bare_result_to_public_reexport_when_resolved_path_matches() {
+    let mut result = item("Result", ApiItemKind::Use, "pub use hidden::Result;");
+    result
+        .navigation_paths
+        .push(navigation_path("hidden::Result", "hidden-result"));
+
+    let mut parse = item(
+        "parse",
+        ApiItemKind::Function,
+        "pub fn parse() -> Result<u8>;",
+    );
+    parse
+        .declaration_path_references
+        .push(path_reference("Result", "hidden-result"));
+
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![result, parse],
+            modules: Vec::new(),
+        },
+    };
+
+    let lookup = NavigationLookup::new(&model);
+    let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
+    let parse = lines
+        .iter()
+        .find(|line| line.line_id.as_deref() == Some("module.demo.parse_1"))
+        .expect("expected parse line");
+
+    assert_eq!(
+        find_token(parse, "Result").navigate_to_id.as_deref(),
+        Some("module.demo.Result_0")
+    );
+}
+
+#[test]
+fn links_crate_result_with_resolved_path_metadata() {
+    let mut result = item("Result", ApiItemKind::Use, "pub use hidden::Result;");
+    result
+        .navigation_paths
+        .push(navigation_path("hidden::Result", "hidden-result"));
+
+    let mut parse = item(
+        "parse",
+        ApiItemKind::Function,
+        "pub fn parse() -> crate::Result<u8>;",
+    );
+    parse
+        .declaration_path_references
+        .push(path_reference("crate::Result", "hidden-result"));
+
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![result, parse],
+            modules: Vec::new(),
+        },
+    };
+
+    let lookup = NavigationLookup::new(&model);
+    let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
+    let parse = lines
+        .iter()
+        .find(|line| line.line_id.as_deref() == Some("module.demo.parse_1"))
+        .expect("expected parse line");
+
+    assert_eq!(
+        find_token(parse, "Result").navigate_to_id.as_deref(),
+        Some("module.demo.Result_0")
+    );
+}
+
+#[test]
+fn keeps_std_result_references_unlinked_without_current_crate_reexport() {
+    let mut parse = item(
+        "parse",
+        ApiItemKind::Function,
+        "pub fn parse(std_result: std::result::Result<u8, u8>, std_fmt: std::fmt::Result, fmt_result: fmt::Result) -> Result<u8>;",
+    );
+    parse.declaration_path_references = vec![
+        path_reference("std::result::Result", "std-result"),
+        path_reference("std::fmt::Result", "std-fmt-result"),
+        path_reference("fmt::Result", "fmt-result"),
+        path_reference("Result", "other-crate-result"),
+    ];
+
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![parse],
+            modules: Vec::new(),
+        },
+    };
+
+    let lookup = NavigationLookup::new(&model);
+    let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
+    let parse = lines
+        .iter()
+        .find(|line| line.line_id.as_deref() == Some("module.demo.parse_0"))
+        .expect("expected parse line");
+
+    let result_tokens = parse
+        .tokens
+        .iter()
+        .filter(|token| token.value == "Result")
+        .collect::<Vec<_>>();
+    assert_eq!(result_tokens.len(), 4);
+    assert!(result_tokens
+        .into_iter()
+        .all(|token| token.navigate_to_id.is_none()));
+}
+
+#[test]
+fn prefers_original_definition_over_public_reexport_for_bare_result_links() {
+    let mut root_reexport = item("Result", ApiItemKind::Use, "pub use errors::Result;");
+    root_reexport
+        .navigation_paths
+        .push(navigation_path("errors::Result", "errors-result"));
+
+    let mut original = item("Result", ApiItemKind::Struct, "pub struct Result;");
+    original.source_id = Some("errors-result".to_string());
+
+    let mut parse = item("parse", ApiItemKind::Function, "pub fn parse() -> Result;");
+    parse
+        .declaration_path_references
+        .push(path_reference("Result", "errors-result"));
+
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![root_reexport],
+            modules: vec![
+                ApiModule {
+                    path: "demo::client".to_string(),
+                    doc_comments: Vec::new(),
+                    attributes: Vec::new(),
+                    items: vec![parse],
+                    modules: Vec::new(),
+                },
+                ApiModule {
+                    path: "demo::errors".to_string(),
+                    doc_comments: Vec::new(),
+                    attributes: Vec::new(),
+                    items: vec![original],
+                    modules: Vec::new(),
+                },
+            ],
+        },
+    };
+
+    let lookup = NavigationLookup::new(&model);
+    let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
+    let client = lines
+        .iter()
+        .find(|line| line.line_id.as_deref() == Some("module.demo__client"))
+        .expect("expected client module");
+    let parse = client
+        .children
+        .iter()
+        .find(|line| line.line_id.as_deref() == Some("module.demo__client.parse_0"))
+        .expect("expected parse line");
+
+    assert_eq!(
+        find_token(parse, "Result").navigate_to_id.as_deref(),
+        Some("module.demo__errors.Result_0")
+    );
+}
+
+#[test]
+fn keeps_field_type_links_out_of_navigation_tree() {
+    let mut access_token = item(
+        "AccessToken",
+        ApiItemKind::Struct,
+        "pub struct AccessToken {",
+    );
+    access_token.members.push(member(
+        "secret",
+        ApiMemberKind::Field,
+        "pub secret: Secret,",
+    ));
+
+    let module = ApiModule {
+        path: "demo".to_string(),
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        items: vec![
+            access_token,
+            item("Secret", ApiItemKind::Struct, "pub struct Secret;"),
+        ],
+        modules: Vec::new(),
+    };
+
+    let lookup = navigation_lookup(&module);
+    let lines = render_module_contents(&module, &RenderOptions::default(), &lookup);
+    let access_token = lines
+        .iter()
+        .find(|line| line.line_id.as_deref() == Some("module.demo.AccessToken_0"))
+        .expect("expected AccessToken line");
+    let field = find_child(access_token, "module.demo.AccessToken_0.secret_0");
+    let secret = find_token(field, "Secret");
+
+    assert_eq!(
+        secret.navigate_to_id.as_deref(),
+        Some("module.demo.Secret_1")
+    );
+    assert_eq!(secret.navigation_display_name, None);
+    assert_eq!(secret.render_classes, None);
+
+    let declaration = find_token(
+        lines
+            .iter()
+            .find(|line| line.line_id.as_deref() == Some("module.demo.Secret_1"))
+            .expect("expected Secret line"),
+        "Secret",
+    );
+    assert_eq!(
+        declaration.navigation_display_name.as_deref(),
+        Some("Secret")
+    );
+    assert_eq!(declaration.render_classes, Some(vec!["class".to_string()]));
+}
+
+#[test]
+fn keeps_member_type_references_out_of_navigation_tree() {
+    let mut token_credential = item(
+        "TokenCredential",
+        ApiItemKind::Trait,
+        "pub trait TokenCredential {",
+    );
+    token_credential.members.push(member(
+        "get_token",
+        ApiMemberKind::Associated,
+        "fn get_token(&self, options: TokenRequestOptions) -> AccessToken;",
+    ));
+
+    let module = ApiModule {
+        path: "demo".to_string(),
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        items: vec![
+            item(
+                "AccessToken",
+                ApiItemKind::Struct,
+                "pub struct AccessToken;",
+            ),
+            item(
+                "TokenRequestOptions",
+                ApiItemKind::Struct,
+                "pub struct TokenRequestOptions;",
+            ),
+            token_credential,
+        ],
+        modules: Vec::new(),
+    };
+
+    let lookup = navigation_lookup(&module);
+    let lines = render_module_contents(&module, &RenderOptions::default(), &lookup);
+    let token_credential = lines
+        .iter()
+        .find(|line| line.line_id.as_deref() == Some("module.demo.TokenCredential_1"))
+        .expect("expected TokenCredential line");
+    let get_token = find_child(
+        token_credential,
+        "module.demo.TokenCredential_1.get_token_0",
+    );
+
+    for (value, expected) in [
+        ("TokenRequestOptions", "module.demo.TokenRequestOptions_2"),
+        ("AccessToken", "module.demo.AccessToken_0"),
+    ] {
+        let token = find_token(get_token, value);
+        assert_eq!(token.navigate_to_id.as_deref(), Some(expected));
+        assert_eq!(token.navigation_display_name, None);
+        assert_eq!(token.render_classes, None);
+    }
+}
+
+#[test]
+fn orders_modules_after_non_module_navigation_items() {
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![
+                item(
+                    "AccessToken",
+                    ApiItemKind::Struct,
+                    "pub struct AccessToken;",
+                ),
+                item("sleep", ApiItemKind::Function, "pub async fn sleep();"),
+                item("ANSWER", ApiItemKind::Const, "pub const ANSWER: u32 = 42;"),
+                item("Error", ApiItemKind::Use, "pub use hidden::Error;"),
+            ],
+            modules: vec![
+                ApiModule {
+                    path: "demo::zeta".to_string(),
+                    doc_comments: Vec::new(),
+                    attributes: Vec::new(),
+                    items: Vec::new(),
+                    modules: Vec::new(),
+                },
+                ApiModule {
+                    path: "demo::alpha".to_string(),
+                    doc_comments: Vec::new(),
+                    attributes: Vec::new(),
+                    items: Vec::new(),
+                    modules: Vec::new(),
+                },
+            ],
+        },
+    };
+
+    let lookup = NavigationLookup::new(&model);
+    let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
+
+    assert_eq!(
+        top_level_navigation_line_ids(&lines),
+        vec![
+            "module.demo.ANSWER_0",
+            "module.demo.Error_1",
+            "module.demo.sleep_2",
+            "module.demo.AccessToken_3",
+            "module.demo__alpha",
+            "module.demo__zeta",
+        ]
+    );
+}
+
+#[test]
+fn shares_module_last_tree_order_with_navigation_walk() {
+    let module = ApiModule {
+        path: "demo".to_string(),
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        items: vec![
+            item("Error", ApiItemKind::Use, "pub use hidden::Error;"),
+            item("sleep", ApiItemKind::Function, "pub async fn sleep();"),
+        ],
+        modules: vec![
+            ApiModule {
+                path: "demo::zeta".to_string(),
+                doc_comments: Vec::new(),
+                attributes: Vec::new(),
+                items: Vec::new(),
+                modules: Vec::new(),
+            },
+            ApiModule {
+                path: "demo::alpha".to_string(),
+                doc_comments: Vec::new(),
+                attributes: Vec::new(),
+                items: Vec::new(),
+                modules: Vec::new(),
+            },
+        ],
+    };
+
+    let labels = apiview_tree_entries(&module)
+        .into_iter()
+        .map(|entry| match entry {
+            ModuleTreeEntry::Item(item) => format!("item:{}", item.name),
+            ModuleTreeEntry::Module(module) => format!("module:{}", module.local_name()),
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        labels,
+        vec!["item:Error", "item:sleep", "module:alpha", "module:zeta",]
+    );
+}
+
+#[test]
+fn includes_same_crate_reexported_functions_in_tree() {
+    let mut top_level_sleep = item("sleep", ApiItemKind::Use, "pub use sleep::sleep;");
+    top_level_sleep.source_id = Some("sleep-reexport".to_string());
+    top_level_sleep
+        .navigation_paths
+        .push(navigation_path("sleep::sleep", "sleep-fn"));
+
+    let mut module_sleep = item("sleep", ApiItemKind::Function, "pub async fn sleep();");
+    module_sleep.source_id = Some("sleep-fn".to_string());
+
+    let module = ApiModule {
+        path: "demo".to_string(),
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        items: vec![
+            item("Error", ApiItemKind::Struct, "pub struct Error;"),
+            top_level_sleep,
+        ],
+        modules: vec![ApiModule {
+            path: "demo::sleep".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![module_sleep],
+            modules: Vec::new(),
+        }],
+    };
+
+    let lines = render_module_contents(
+        &module,
+        &RenderOptions::default(),
+        &navigation_lookup(&module),
+    );
+
+    assert_eq!(
+        top_level_navigation_line_ids(&lines),
+        vec![
+            "module.demo.sleep_0",
+            "module.demo.Error_1",
+            "module.demo__sleep"
+        ]
+    );
+
+    let top_level_sleep = lines
+        .iter()
+        .find(|line| line.line_id.as_deref() == Some("module.demo.sleep_0"))
+        .expect("expected root sleep reexport line");
+    let sleep_token = top_level_sleep
+        .tokens
+        .iter()
+        .rev()
+        .find(|token| token.value == "sleep")
+        .expect("expected reexported sleep token");
+    assert_eq!(
+        sleep_token.navigate_to_id.as_deref(),
+        Some("module.demo__sleep.sleep_0")
+    );
+}
+
+#[test]
+fn groups_same_crate_reexports_with_other_reexports() {
+    let mut top_level_reexport = item(
+        "ClientOptions",
+        ApiItemKind::Use,
+        "pub use options::ClientOptions;",
+    );
+    top_level_reexport
+        .navigation_paths
+        .push(navigation_path("options::ClientOptions", "client-options"));
+
+    let mut module_item = item(
+        "ClientOptions",
+        ApiItemKind::Struct,
+        "pub struct ClientOptions;",
+    );
+    module_item.source_id = Some("client-options".to_string());
+
+    let module = ApiModule {
+        path: "demo".to_string(),
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        items: vec![top_level_reexport],
+        modules: vec![ApiModule {
+            path: "demo::options".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![module_item],
+            modules: Vec::new(),
+        }],
+    };
+
+    let lines = render_module_contents(
+        &module,
+        &RenderOptions::default(),
+        &navigation_lookup(&module),
+    );
+
+    assert_eq!(
+        top_level_navigation_line_ids(&lines),
+        vec!["module.demo.ClientOptions_0", "module.demo__options"]
+    );
+}
+
+#[test]
+fn same_crate_reexport_links_to_nested_declaration() {
+    let mut root_client = item(
+        "CosmosClient",
+        ApiItemKind::Use,
+        "pub use clients::CosmosClient;",
+    );
+    root_client.source_id = Some("clients-cosmos-client".to_string());
+    root_client.navigation_paths.push(navigation_path(
+        "clients::CosmosClient",
+        "clients-cosmos-client",
+    ));
+
+    let mut nested_client = item(
+        "CosmosClient",
+        ApiItemKind::Struct,
+        "pub struct CosmosClient;",
+    );
+    nested_client.source_id = Some("clients-cosmos-client".to_string());
+
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![root_client],
+            modules: vec![ApiModule {
+                path: "demo::clients".to_string(),
+                doc_comments: Vec::new(),
+                attributes: Vec::new(),
+                items: vec![nested_client],
+                modules: Vec::new(),
+            }],
+        },
+    };
+
+    let lookup = NavigationLookup::new(&model);
+    let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
+    let reexport = lines
+        .iter()
+        .find(|line| line.line_id.as_deref() == Some("module.demo.CosmosClient_0"))
+        .expect("expected root CosmosClient reexport line");
+
+    assert_eq!(
+        find_token(reexport, "CosmosClient")
+            .navigate_to_id
+            .as_deref(),
+        Some("module.demo__clients.CosmosClient_0")
+    );
 }

--- a/eng/tools/generate_api/src/render/apiview/tests.rs
+++ b/eng/tools/generate_api/src/render/apiview/tests.rs
@@ -95,6 +95,13 @@ fn top_level_navigation_line_ids(lines: &[ReviewLine]) -> Vec<&str> {
         .collect()
 }
 
+fn line_text(line: &ReviewLine) -> String {
+    line.tokens
+        .iter()
+        .map(|token| token.value.as_str())
+        .collect()
+}
+
 #[test]
 fn renders_trait_impl_tokens_with_typed_members() {
     let mut impl_item = item(
@@ -168,6 +175,43 @@ fn renders_trait_impl_tokens_with_typed_members() {
             (token_kind::PUNCTUATION, ";"),
         ]
     );
+}
+
+#[test]
+fn renders_root_inner_attrs_and_child_module_outer_attrs() {
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: vec![ApiAttribute {
+                text: "#![warn(missing_docs)]".to_string(),
+            }],
+            items: Vec::new(),
+            modules: vec![ApiModule {
+                path: "demo::inner".to_string(),
+                doc_comments: Vec::new(),
+                attributes: vec![ApiAttribute {
+                    text: "#[deny(unsafe_code)]".to_string(),
+                }],
+                items: vec![item("Nested", ApiItemKind::Struct, "pub struct Nested;")],
+                modules: Vec::new(),
+            }],
+        },
+    };
+
+    let lookup = NavigationLookup::new(&model);
+    let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
+
+    assert_eq!(line_text(&lines[0]), "#![warn(missing_docs)]");
+    assert_eq!(line_text(&lines[1]), "#[deny(unsafe_code)]");
+    assert_eq!(
+        lines[1].related_to_line.as_deref(),
+        Some("module.demo__inner")
+    );
+    assert_eq!(lines[2].line_id.as_deref(), Some("module.demo__inner"));
 }
 
 #[test]
@@ -718,6 +762,91 @@ fn links_crate_result_with_resolved_path_metadata() {
     assert_eq!(
         find_token(parse, "Result").navigate_to_id.as_deref(),
         Some("module.demo.Result_0")
+    );
+}
+
+#[test]
+fn links_where_clause_references_after_signature_types() {
+    let input = item("Input", ApiItemKind::Struct, "pub struct Input<T>(T);");
+    let output = item("Output", ApiItemKind::Struct, "pub struct Output;");
+    let bound = item("Bound", ApiItemKind::Trait, "pub trait Bound {");
+
+    let mut parse = item(
+        "parse",
+        ApiItemKind::Function,
+        "pub fn parse<T>(value: Input<T>) -> Output where T: Bound;",
+    );
+    parse.declaration_path_references = vec![
+        path_reference("Input", "input"),
+        path_reference("Output", "output"),
+        path_reference("Bound", "bound"),
+    ];
+    let mut input = input;
+    input.source_id = Some("input".to_string());
+    let mut output = output;
+    output.source_id = Some("output".to_string());
+    let mut bound = bound;
+    bound.source_id = Some("bound".to_string());
+
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![input, output, bound, parse],
+            modules: Vec::new(),
+        },
+    };
+
+    let lookup = NavigationLookup::new(&model);
+    let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
+    let parse = lines
+        .iter()
+        .find(|line| {
+            line.line_id
+                .as_deref()
+                .is_some_and(|line_id| line_id.starts_with("module.demo.parse_"))
+        })
+        .expect("expected parse line");
+    let input_line_id = lines
+        .iter()
+        .find(|line| {
+            line.tokens.iter().any(|token| token.value == "struct")
+                && line.tokens.iter().any(|token| token.value == "Input")
+        })
+        .and_then(|line| line.line_id.as_deref())
+        .expect("expected input line");
+    let output_line_id = lines
+        .iter()
+        .find(|line| {
+            line.tokens.iter().any(|token| token.value == "struct")
+                && line.tokens.iter().any(|token| token.value == "Output")
+        })
+        .and_then(|line| line.line_id.as_deref())
+        .expect("expected output line");
+    let bound_line_id = lines
+        .iter()
+        .find(|line| {
+            line.tokens.iter().any(|token| token.value == "trait")
+                && line.tokens.iter().any(|token| token.value == "Bound")
+        })
+        .and_then(|line| line.line_id.as_deref())
+        .expect("expected bound line");
+
+    assert_eq!(
+        find_token(parse, "Input").navigate_to_id.as_deref(),
+        Some(input_line_id)
+    );
+    assert_eq!(
+        find_token(parse, "Output").navigate_to_id.as_deref(),
+        Some(output_line_id)
+    );
+    assert_eq!(
+        find_token(parse, "Bound").navigate_to_id.as_deref(),
+        Some(bound_line_id)
     );
 }
 

--- a/eng/tools/generate_api/src/render/markdown.rs
+++ b/eng/tools/generate_api/src/render/markdown.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use crate::model::{ApiItem, ApiMember, ApiModel, ApiModule};
+use crate::model::{ApiItem, ApiMember, ApiMemberKind, ApiModel, ApiModule};
 
 pub(crate) fn render(model: &ApiModel) -> String {
     let mut output = String::from("```rust\n");
@@ -17,10 +17,10 @@ fn render_module(output: &mut String, module: &ApiModule, is_root: bool, indent:
     modules.sort_by(|left, right| left.path.cmp(&right.path));
 
     let body_indent = if is_root { indent } else { indent + 1 };
+    for attribute in &module.attributes {
+        push_line(output, indent, &attribute.text);
+    }
     if !is_root {
-        for attribute in &module.attributes {
-            push_line(output, indent, &attribute.text);
-        }
         push_line(
             output,
             indent,
@@ -48,17 +48,16 @@ fn render_item(output: &mut String, item: &ApiItem, indent: usize) {
 
     push_multiline(output, indent, &item.declaration);
 
-    let mut members = item.members.clone();
-    members.sort_by(|left, right| left.name.cmp(&right.name));
+    let members = sorted_members(&item.members);
 
     if item.declaration.trim_end().ends_with('{') {
-        for member in &members {
+        for member in members {
             render_member(output, member, indent + 1);
         }
         push_line(output, indent, "}");
     } else if !members.is_empty() {
         push_line(output, indent, &format!("impl {} {{", item.name));
-        for member in &members {
+        for member in members {
             render_member(output, member, indent + 1);
         }
         push_line(output, indent, "}");
@@ -69,8 +68,21 @@ fn render_member(output: &mut String, function: &ApiMember, indent: usize) {
     for attribute in &function.attributes {
         push_line(output, indent, &attribute.text);
     }
-
     push_multiline(output, indent, &function.declaration);
+}
+
+fn sorted_members(members: &[ApiMember]) -> Vec<&ApiMember> {
+    let mut indexed = members.iter().enumerate().collect::<Vec<_>>();
+    indexed.sort_by(
+        |(left_index, left), (right_index, right)| match (left.kind, right.kind) {
+            (ApiMemberKind::Associated, ApiMemberKind::Associated) => left
+                .name
+                .cmp(&right.name)
+                .then_with(|| left.declaration.cmp(&right.declaration)),
+            _ => left_index.cmp(right_index),
+        },
+    );
+    indexed.into_iter().map(|(_, member)| member).collect()
 }
 
 fn push_multiline(output: &mut String, indent: usize, text: &str) {

--- a/eng/tools/generate_api/src/render/markdown/tests.rs
+++ b/eng/tools/generate_api/src/render/markdown/tests.rs
@@ -105,3 +105,35 @@ fn renders_inherent_members_inside_impl_blocks() {
     assert!(rendered.contains("impl Foo {\n    pub fn method(&self);\n}"));
     assert!(!rendered.contains("pub struct Foo;\n    pub fn method(&self);"));
 }
+
+#[test]
+fn renders_root_inner_attrs_and_child_module_outer_attrs() {
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: vec![ApiAttribute {
+                text: "#![warn(missing_docs)]".to_string(),
+            }],
+            items: Vec::new(),
+            modules: vec![ApiModule {
+                path: "demo::inner".to_string(),
+                doc_comments: Vec::new(),
+                attributes: vec![ApiAttribute {
+                    text: "#[deny(unsafe_code)]".to_string(),
+                }],
+                items: vec![item("Nested", ApiItemKind::Struct, "pub struct Nested;")],
+                modules: Vec::new(),
+            }],
+        },
+    };
+
+    let rendered = render(&model);
+
+    assert!(rendered.contains("#![warn(missing_docs)]"));
+    assert!(rendered.contains("#[deny(unsafe_code)]\npub mod inner {"));
+    assert!(!rendered.contains("#![deny(unsafe_code)]\npub mod inner {"));
+}

--- a/eng/tools/generate_api/src/render/markdown/tests.rs
+++ b/eng/tools/generate_api/src/render/markdown/tests.rs
@@ -2,10 +2,55 @@
 // Licensed under the MIT License.
 
 use super::*;
-use crate::model::{ApiAttribute, ApiItemKind};
+use crate::model::{
+    ApiAttribute, ApiItem, ApiItemKind, ApiMember, ApiMemberKind, ApiModel, ApiModule,
+};
+
+fn item(name: &str, kind: ApiItemKind, declaration: &str) -> ApiItem {
+    ApiItem {
+        name: name.to_string(),
+        kind,
+        source_id: None,
+        navigation_paths: Vec::new(),
+        owner_name: None,
+        owner_kind: None,
+        owner_source_id: None,
+        inherent_impl_sort_key: None,
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        declaration: declaration.to_string(),
+        declaration_path_references: Vec::new(),
+        members: Vec::new(),
+    }
+}
+
+fn member(name: &str, kind: ApiMemberKind, declaration: &str) -> ApiMember {
+    ApiMember {
+        name: name.to_string(),
+        kind,
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        declaration: declaration.to_string(),
+        declaration_path_references: Vec::new(),
+    }
+}
 
 #[test]
 fn renders_explicit_trait_impl_blocks() {
+    let mut item = item(
+        "MyType",
+        ApiItemKind::TraitImpl,
+        "impl fmt::Debug for MyType {",
+    );
+    item.attributes.push(ApiAttribute {
+        text: "#[cfg(feature = \"std\")]".to_string(),
+    });
+    item.members.push(member(
+        "fmt",
+        ApiMemberKind::Associated,
+        "fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result;",
+    ));
+
     let model = ApiModel {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
@@ -14,25 +59,7 @@ fn renders_explicit_trait_impl_blocks() {
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
-            items: vec![ApiItem {
-                name: "MyType".to_string(),
-                kind: ApiItemKind::TraitImpl,
-                source_id: None,
-                owner_kind: None,
-                inherent_impl_sort_key: None,
-                doc_comments: Vec::new(),
-                attributes: vec![ApiAttribute {
-                    text: "#[cfg(feature = \"std\")]".to_string(),
-                }],
-                declaration: "impl fmt::Debug for MyType {".to_string(),
-                members: vec![ApiMember {
-                    name: "fmt".to_string(),
-                    doc_comments: Vec::new(),
-                    attributes: Vec::new(),
-                    declaration: "fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result;"
-                        .to_string(),
-                }],
-            }],
+            items: vec![item],
             modules: Vec::new(),
         },
     };
@@ -47,6 +74,15 @@ fn renders_explicit_trait_impl_blocks() {
 
 #[test]
 fn renders_inherent_members_inside_impl_blocks() {
+    let mut inherent_impl = item("Foo", ApiItemKind::InherentImpl, "impl Foo {");
+    inherent_impl.owner_name = Some("Foo".to_string());
+    inherent_impl.owner_kind = Some(ApiItemKind::Struct);
+    inherent_impl.members.push(member(
+        "method",
+        ApiMemberKind::Associated,
+        "pub fn method(&self);",
+    ));
+
     let model = ApiModel {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
@@ -56,33 +92,8 @@ fn renders_inherent_members_inside_impl_blocks() {
             doc_comments: Vec::new(),
             attributes: Vec::new(),
             items: vec![
-                ApiItem {
-                    name: "Foo".to_string(),
-                    kind: ApiItemKind::Struct,
-                    source_id: None,
-                    owner_kind: None,
-                    inherent_impl_sort_key: None,
-                    doc_comments: Vec::new(),
-                    attributes: Vec::new(),
-                    declaration: "pub struct Foo;".to_string(),
-                    members: Vec::new(),
-                },
-                ApiItem {
-                    name: "Foo".to_string(),
-                    kind: ApiItemKind::InherentImpl,
-                    source_id: None,
-                    owner_kind: Some(ApiItemKind::Struct),
-                    inherent_impl_sort_key: None,
-                    doc_comments: Vec::new(),
-                    attributes: Vec::new(),
-                    declaration: "impl Foo {".to_string(),
-                    members: vec![ApiMember {
-                        name: "method".to_string(),
-                        doc_comments: Vec::new(),
-                        attributes: Vec::new(),
-                        declaration: "pub fn method(&self);".to_string(),
-                    }],
-                },
+                item("Foo", ApiItemKind::Struct, "pub struct Foo;"),
+                inherent_impl,
             ],
             modules: Vec::new(),
         },


### PR DESCRIPTION
Improve APIView navigation target selection so re-exports keep their
place in the tree but references prefer declaration-bearing targets.
This makes same-crate re-exports link to their nested declarations and
keeps cross-crate re-exports pointing at the deeper declaration path.
Update extraction, model, and renderer coverage to keep re-export
ordering, impl association, block comments, and navigation regressions
covered alongside the 2.1.0 parser bump.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: e18e52ce-ea7b-4afc-8589-73d7d69c95b0
