### PR TITLE
Add an AAD emulator leg to the Cosmos CI matrix

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -50,6 +50,7 @@
     "dotenv",
     "downcasted",
     "downcasting",
+    "enableaadauthentication",
     "entra",
     "etag",
     "eventhub",

--- a/sdk/cosmos/AGENTS.md
+++ b/sdk/cosmos/AGENTS.md
@@ -493,7 +493,7 @@ Before considering any task complete, run the following checks **in order** on a
          cargo test -p azure_data_cosmos --test emulator -- --test-threads=1
      ```
 
-     Database create/delete and throughput (offer) operations stay on a key-authenticated management client even in this mode, mirroring live accounts where they are not data-plane RBAC actions. CI runs this as the `windows_stable_aad_emulator` leg (`sdk/cosmos/aad-emulator-matrix.json`); the live counterpart is `sdk/cosmos/live-aad-platform-matrix.json`.
+     Database create/delete and throughput (offer) operations stay on a key-authenticated management client even in this mode, mirroring live accounts where they are not data-plane RBAC actions. CI runs this as the `windows_stable_aad_emulator` Build-stage leg of the `rust - cosmos` pipeline (`sdk/cosmos/aad-emulator-matrix.json`); the live counterpart is `sdk/cosmos/live-aad-platform-matrix.json`. Note that the shared `rust - pullrequest` pipeline uses a fixed repo-wide matrix (`eng/pipelines/templates/stages/pr-platform-matrix.json`) and ignores service `ci.yml` matrix configs, so per-service legs never appear there.
 
 **Common documentation link errors to avoid**:
 

--- a/sdk/cosmos/AGENTS.md
+++ b/sdk/cosmos/AGENTS.md
@@ -486,6 +486,15 @@ Before considering any task complete, run the following checks **in order** on a
 
      A subset of emulator tests (backup-endpoint fallback, partition failover) are intentionally not gated on `"emulator_vnext"` because they rely on multi-endpoint topology the vnext gateway does not model. See the per-file module headers for the exclusion rationale.
 
+   - To run the emulator suite with the data-plane client authenticated via **Entra ID (AAD)** instead of the account key, set `AZURE_COSMOS_AUTH_MODE=aad`. This requires the Windows emulator started with `/enableaadauthentication`; the framework then mints the emulator's fake JWT via `CosmosEmulatorCredential`.
+
+     ```bash
+     AZURE_COSMOS_AUTH_MODE=aad RUSTFLAGS='--cfg test_category="emulator"' \
+         cargo test -p azure_data_cosmos --test emulator -- --test-threads=1
+     ```
+
+     Database create/delete and throughput (offer) operations stay on a key-authenticated management client even in this mode, mirroring live accounts where they are not data-plane RBAC actions. CI runs this as the `windows_stable_aad_emulator` leg (`sdk/cosmos/aad-emulator-matrix.json`); the live counterpart is `sdk/cosmos/live-aad-platform-matrix.json`.
+
 **Common documentation link errors to avoid**:
 
 - When documenting factory methods or APIs, ensure the linked method names match the actual implementation

--- a/sdk/cosmos/aad-emulator-matrix.json
+++ b/sdk/cosmos/aad-emulator-matrix.json
@@ -1,0 +1,15 @@
+{
+  "displayNames": {
+    "aad": "aad_emulator"
+  },
+  "matrix": {
+    "Agent": {
+      "windows": {
+        "OSVmImage": "env:WINDOWSVMIMAGE",
+        "Pool": "env:WINDOWSPOOL"
+      }
+    },
+    "RustToolchainName": ["stable"],
+    "AZURE_COSMOS_AUTH_MODE": ["aad"]
+  }
+}

--- a/sdk/cosmos/ci.yml
+++ b/sdk/cosmos/ci.yml
@@ -61,6 +61,25 @@ extends:
         Selection: sparse
         NonSparseParameters: RustToolchainName
         GenerateVMJobs: true
+      # Runs the emulator integration suite with the primary (data-plane) client
+      # authenticated via Entra ID instead of the account key, so AAD-path
+      # regressions surface on every cosmos CI run rather than waiting for the
+      # weekly live AAD legs (Cosmos_live_test_aad below).
+      #
+      # Registered under MatrixConfigs, not AdditionalMatrixConfigs, because the
+      # archetype feeds MatrixConfigs to the Build stage only, while
+      # AdditionalMatrixConfigs is appended to *both* Build and Live Test. This
+      # leg provisions no account and needs no live counterpart.
+      #
+      # Windows-only: Invoke-CosmosTestSetup.ps1 skips emulator setup on
+      # non-Windows Azure DevOps agents, and it launches the Windows emulator
+      # with /enableaadauthentication. On the emulator any valid token maps to
+      # a root identity, so the data-plane RBAC limits that force the dual
+      # key/AAD client split on live accounts do not apply here.
+      - Name: Cosmos_aad_emulator
+        Path: sdk/cosmos/aad-emulator-matrix.json
+        Selection: all
+        GenerateVMJobs: true
     LiveTestMatrixConfigs:
       - Name: Cosmos_live_test
         Path: sdk/cosmos/live-platform-matrix.json
@@ -87,19 +106,5 @@ extends:
     AdditionalMatrixConfigs:
       - Name: Cosmos_vnext_emulator
         Path: sdk/cosmos/vnext-emulator-matrix.json
-        Selection: all
-        GenerateVMJobs: true
-      # Runs the full emulator integration suite on every PR with the primary
-      # (data-plane) client authenticated via Entra ID instead of the account
-      # key, so AAD regressions are caught at PR time rather than waiting for
-      # the weekly live AAD legs (Cosmos_live_test_aad above).
-      #
-      # Windows-only: Invoke-CosmosTestSetup.ps1 skips emulator setup on
-      # non-Windows Azure DevOps agents, and it launches the Windows emulator
-      # with /enableaadauthentication. On the emulator any valid token maps to
-      # a root identity, so the data-plane RBAC limits that force the dual
-      # key/AAD client split on live accounts do not apply here.
-      - Name: Cosmos_aad_emulator
-        Path: sdk/cosmos/aad-emulator-matrix.json
         Selection: all
         GenerateVMJobs: true

--- a/sdk/cosmos/ci.yml
+++ b/sdk/cosmos/ci.yml
@@ -89,3 +89,17 @@ extends:
         Path: sdk/cosmos/vnext-emulator-matrix.json
         Selection: all
         GenerateVMJobs: true
+      # Runs the full emulator integration suite on every PR with the primary
+      # (data-plane) client authenticated via Entra ID instead of the account
+      # key, so AAD regressions are caught at PR time rather than waiting for
+      # the weekly live AAD legs (Cosmos_live_test_aad above).
+      #
+      # Windows-only: Invoke-CosmosTestSetup.ps1 skips emulator setup on
+      # non-Windows Azure DevOps agents, and it launches the Windows emulator
+      # with /enableaadauthentication. On the emulator any valid token maps to
+      # a root identity, so the data-plane RBAC limits that force the dual
+      # key/AAD client split on live accounts do not apply here.
+      - Name: Cosmos_aad_emulator
+        Path: sdk/cosmos/aad-emulator-matrix.json
+        Selection: all
+        GenerateVMJobs: true


### PR DESCRIPTION
## Summary

Completes **Phase 1** of #4715, which was left undone when #4730 landed.

#4730 introduced `AZURE_COSMOS_AUTH_MODE` and wired `=aad` into the **live** test matrix (`live-aad-platform-matrix.json`), delivering Phase 2. Phase 1 — running the *entire emulator suite* under AAD — never shipped. A code search on `main` confirms it:

```
sdk/cosmos/ci.yml
sdk/cosmos/live-aad-platform-matrix.json
sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
```

`AZURE_COSMOS_AUTH_MODE=aad` is set on **no** Build-stage leg, so the emulator suite runs key-only everywhere except the weekly live legs. The consequence: an AAD-path regression only surfaces on the next `rust - cosmos - weekly` run, up to a week later. This leg moves that signal to every `rust - cosmos` run.

## What changed

**`sdk/cosmos/aad-emulator-matrix.json`** (new) — a single-job matrix: Windows agent, `stable` toolchain, `AZURE_COSMOS_AUTH_MODE=aad`.

**`sdk/cosmos/ci.yml`** — registers it as `Cosmos_aad_emulator` under `MatrixConfigs`.

**No framework changes.** `AuthMode` and `build_aad_client_from_env` from #4730 already do host-based credential selection, picking `CosmosEmulatorCredential` (the emulator's fake JWT, signed with the master key) for emulator hosts. This is purely CI registration.

Verified the matrix expands as intended using the repo's own generator (`job-matrix-functions.ps1`):

```
NAME: windows_stable_aad_emulator
{"OSVmImage":"windows-2022","Pool":"winpool","RustToolchainName":"stable","AZURE_COSMOS_AUTH_MODE":"aad"}
```

One job, no collision with the release matrix's `windows_stable`.

## Why `MatrixConfigs` and not `AdditionalMatrixConfigs`

#4715 proposed `AdditionalMatrixConfigs`, mirroring the existing vnext leg. That turns out to be the wrong home. `archetype-sdk-client.yml` feeds it to **both** stages:

```yaml
# Build stage                    # Live Test stage
MatrixConfigs:                   MatrixConfigs:
- ${{ parameters.MatrixConfigs }}          - ${{ parameters.LiveTestMatrixConfigs }}
- ${{ parameters.AdditionalMatrixConfigs }}    - ${{ parameters.AdditionalMatrixConfigs }}
```

So registering there would have provisioned a live account and run an unintended `windows_stable_aad_emulator` **live** leg, duplicating `live-aad-platform-matrix.json` at extra cost. This isn't hypothetical — #4730's checks show the vnext leg landing in both places, as `Build Test vnext_emulator_stable_vnext_emulator_true` *and* `Live Test Public Test vnext_emulator_stable_vnext_emulator_true`.

`MatrixConfigs` feeds the Build stage only, which is what an emulator leg wants.

## Correction: this does not add a leg to shared PR builds

My first push claimed it did. The build disagreed — no `aad_emulator` job appeared. The AzDO timeline for build `6640325` shows why: `rust - pullrequest` runs `Create-JobMatrix.ps1` against a fixed repo-wide config and never reads service `ci.yml` matrix configs.

```
-ConfigPath eng/pipelines/templates/stages/pr-platform-matrix.json -Selection all ...
```

The pre-existing vnext leg is absent from PR builds for the same reason. Per-service legs only materialize in the service pipelines. Adding a Cosmos-specific leg to `pr-platform-matrix.json` isn't an option either — that file is shared by every service.

Worth noting the gap is narrower than it first looks: PR builds *do* already run the full Cosmos emulator suite on `Test windows_stable`, because `Invoke-CosmosTestSetup.ps1` starts the emulator on Windows agents regardless of matrix config. It just runs key-authenticated. This PR adds the AAD counterpart at the `rust - cosmos` level.

## Why Windows-only

Two constraints force it:

1. `Invoke-CosmosTestSetup.ps1` sets `AZURE_COSMOS_TEST_MODE=skipped` and returns early on non-Windows Azure DevOps agents, so a Linux/macOS leg would run no emulator tests at all.
2. That same script already launches the Windows emulator with `/enableaadauthentication`, which is what makes the AAD path work.

(The Linux `vnext` leg sidesteps the Windows gate only because its branch returns before that check — and the vnext container isn't started with AAD enabled, so it isn't a candidate.)

## Why this leg is blocking rather than `ContinueOnError`

The vnext leg is non-blocking because it targets a preview emulator. This one is deliberately blocking, since a non-blocking leg reproduces the gap being closed — failures nobody acts on. Risk is low: on the emulator, `/enableaadauthentication` maps any valid token to a **root identity**, so the data-plane RBAC limits that force the dual key/AAD client split on live accounts don't apply. The main known AAD-specific failure mode, the `cosmos_proxy` tests, is already handled — they skip under `AZURE_COSMOS_AUTH_MODE=aad`, and on the emulator the fake JWT is minted locally with no HTTP call, so the `HTTPS_PROXY` hijack that motivated that skip can't occur anyway.

## Scope note

Database create/delete and throughput (offer) operations stay on the key-authenticated management client even in `aad` mode, matching live behavior. #4715 observed that the emulator's root identity *could* do those over AAD too, but keeping one code path for both keeps the emulator leg an honest rehearsal of the live legs.

## Also

- `sdk/cosmos/AGENTS.md` — documents the local invocation next to the existing vnext emulator instructions, plus the PR-pipeline caveat above.
- `.vscode/cspell.json` — adds `enableaadauthentication`, now referenced outside the setup script that inline-ignored it.

Refs #4715
