### PR TITLE
Stabilize APIView line IDs

### DIFF
--- a/eng/tools/generate_api/src/driver.rs
+++ b/eng/tools/generate_api/src/driver.rs
@@ -49,6 +49,7 @@ fn generate_rustdoc_json(package: &PackageMetadata) -> Result<PathBuf, String> {
     command
         .arg(format!("+{channel}"))
         .arg("rustdoc")
+        .args(package.rustdoc_selector_args())
         .arg("-Z")
         .arg("unstable-options")
         .arg("--output-format")
@@ -83,6 +84,21 @@ struct CargoPackage {
 struct CargoTarget {
     name: String,
     kind: Vec<String>,
+}
+
+fn is_library_target_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "lib" | "rlib" | "dylib" | "cdylib" | "staticlib" | "proc-macro"
+    )
+}
+
+fn crate_target_name(package_name: &str, targets: &[CargoTarget]) -> String {
+    targets
+        .iter()
+        .find(|target| target.kind.iter().any(|kind| is_library_target_kind(kind)))
+        .map(|target| target.name.clone())
+        .unwrap_or_else(|| package_name.replace('-', "_"))
 }
 
 fn load_workspace_metadata(request: &Request) -> Result<WorkspaceMetadata, String> {
@@ -120,16 +136,16 @@ fn load_workspace_metadata(request: &Request) -> Result<WorkspaceMetadata, Strin
                 package.manifest_path
             )
         })?;
-        let name = package
-            .targets
-            .iter()
-            .find(|target| target.kind.iter().any(|k| k == "lib"))
-            .map(|target| target.name.clone())
-            .unwrap_or_else(|| package.name.replace('-', "_"));
+        let name = crate_target_name(&package.name, &package.targets);
 
         if manifest_path == requested_manifest {
             current_package = Some(name.clone());
         }
+
+        let has_library_target = package
+            .targets
+            .iter()
+            .any(|target| target.kind.iter().any(|kind| is_library_target_kind(kind)));
 
         workspace_packages.insert(
             name.clone(),
@@ -137,6 +153,7 @@ fn load_workspace_metadata(request: &Request) -> Result<WorkspaceMetadata, Strin
                 name,
                 version: package.version,
                 manifest_path,
+                has_library_target,
             },
         );
     }
@@ -250,4 +267,83 @@ pub(crate) struct PackageMetadata {
     pub(crate) name: String,
     pub(crate) version: String,
     pub(crate) manifest_path: PathBuf,
+    pub(crate) has_library_target: bool,
+}
+
+impl PackageMetadata {
+    fn rustdoc_selector_args(&self) -> &[&str] {
+        if self.has_library_target {
+            &["--lib"]
+        } else {
+            &[]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{crate_target_name, CargoTarget};
+    use std::path::PathBuf;
+
+    #[test]
+    fn prefers_library_like_target_names() {
+        assert_eq!(
+            crate_target_name(
+                "azure_data_cosmos_driver_native",
+                &[CargoTarget {
+                    name: "azurecosmosdriver".to_string(),
+                    kind: vec!["cdylib".to_string(), "staticlib".to_string()],
+                }],
+            ),
+            "azurecosmosdriver"
+        );
+        assert_eq!(
+            crate_target_name(
+                "typespec_macros",
+                &[CargoTarget {
+                    name: "typespec_macros".to_string(),
+                    kind: vec!["proc-macro".to_string()],
+                }],
+            ),
+            "typespec_macros"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_package_name_when_no_library_like_target_exists() {
+        assert_eq!(
+            crate_target_name(
+                "azure-data-cosmos-benchmarks",
+                &[CargoTarget {
+                    name: "smoke".to_string(),
+                    kind: vec!["bin".to_string()],
+                }],
+            ),
+            "azure_data_cosmos_benchmarks"
+        );
+    }
+
+    #[test]
+    fn adds_lib_selector_for_library_like_packages() {
+        let package = super::PackageMetadata {
+            name: "azurecosmosdriver".to_string(),
+            version: "0.1.0".to_string(),
+            manifest_path: PathBuf::from("sdk/cosmos/azure_data_cosmos_driver_native/Cargo.toml"),
+            has_library_target: true,
+        };
+
+        assert_eq!(package.rustdoc_selector_args(), ["--lib"]);
+    }
+
+    #[test]
+    fn omits_lib_selector_for_non_library_packages() {
+        let package = super::PackageMetadata {
+            name: "azure_data_cosmos_benchmarks".to_string(),
+            version: "0.1.0".to_string(),
+            manifest_path: PathBuf::from("sdk/cosmos/azure_data_cosmos_benchmarks/Cargo.toml"),
+            has_library_target: false,
+        };
+
+        assert!(package.rustdoc_selector_args().is_empty());
+    }
 }

--- a/eng/tools/generate_api/src/extract/tests.rs
+++ b/eng/tools/generate_api/src/extract/tests.rs
@@ -2530,6 +2530,7 @@ fn package_metadata(name: &str) -> PackageMetadata {
         name: name.to_string(),
         version: "1.0.0".to_string(),
         manifest_path: std::path::PathBuf::from("Cargo.toml"),
+        has_library_target: true,
     }
 }
 

--- a/eng/tools/generate_api/src/render/apiview.rs
+++ b/eng/tools/generate_api/src/render/apiview.rs
@@ -154,19 +154,22 @@ fn render_module_contents(
     navigation_lookup: &NavigationLookup,
 ) -> Vec<ReviewLine> {
     let mut lines = Vec::new();
-    let mut item_index = 0;
+    let mut item_line_id_counts = BTreeMap::new();
     for entry in apiview_tree_entries(module) {
         match entry {
             ModuleTreeEntry::Item(item) => {
+                let line_id = allocate_unique_line_id(
+                    item_line_id_base(module, item),
+                    &mut item_line_id_counts,
+                );
                 lines.extend(render_item(
                     module,
                     item,
-                    item_index,
+                    line_id,
                     item_in_tree(item.kind),
                     options,
                     navigation_lookup,
                 ));
-                item_index += 1;
             }
             ModuleTreeEntry::Module(child) => {
                 lines.extend(render_module(child, options, navigation_lookup));
@@ -261,12 +264,11 @@ enum ModuleTreeEntry<'a> {
 fn render_item(
     module: &ApiModule,
     item: &ApiItem,
-    index: usize,
+    line_id: String,
     should_render_tree_node: bool,
     options: &RenderOptions,
     navigation_lookup: &NavigationLookup,
 ) -> Vec<ReviewLine> {
-    let line_id = format!("{}.{}_{index}", module_line_id(&module.path), item.name);
     let name_token_kind = item_name_token_kind(item.kind);
     let mut lines = Vec::new();
 
@@ -391,7 +393,8 @@ fn render_member_lines(
     navigation_lookup: &NavigationLookup,
 ) -> Vec<ReviewLine> {
     let mut lines = Vec::new();
-    for (member_index, member) in members.iter().enumerate() {
+    let mut member_line_id_counts = BTreeMap::new();
+    for member in members.iter() {
         if options.include_docs {
             lines.extend(render_doc_comment_lines(
                 &member.doc_comments,
@@ -424,8 +427,12 @@ fn render_member_lines(
             navigation_lookup,
             member.declaration_path_references.is_empty(),
         );
+        let line_id = allocate_unique_line_id(
+            member_line_id_base(related_to_line, member),
+            &mut member_line_id_counts,
+        );
         lines.push(ReviewLine {
-            line_id: Some(format!("{related_to_line}.{}_{member_index}", member.name)),
+            line_id: Some(line_id),
             tokens,
             children: Vec::new(),
             is_context_end_line: None,
@@ -453,6 +460,111 @@ fn render_doc_comment_lines(
 
 fn module_line_id(path: &str) -> String {
     format!("module.{}", sanitize(path))
+}
+
+fn item_line_id_base(module: &ApiModule, item: &ApiItem) -> String {
+    let module_line_id = module_line_id(&module.path);
+    match item.kind {
+        ApiItemKind::Use => {
+            format!("{module_line_id}.reexport.{}", sanitize_segment(&item.name))
+        }
+        ApiItemKind::InherentImpl | ApiItemKind::TraitImpl => format!(
+            "{module_line_id}.{}.{}",
+            item_kind_slug(item.kind),
+            sanitize_segment(&normalized_declaration_identity(&item.declaration)),
+        ),
+        _ => format!(
+            "{module_line_id}.{}.{}",
+            item_kind_slug(item.kind),
+            sanitize_segment(&item.name),
+        ),
+    }
+}
+
+fn member_line_id_base(related_to_line: &str, member: &ApiMember) -> String {
+    let identity = match member.kind {
+        ApiMemberKind::Field | ApiMemberKind::Variant | ApiMemberKind::Associated => {
+            sanitize_segment(&member.name)
+        }
+        ApiMemberKind::MacroInput | ApiMemberKind::Text => {
+            sanitize_segment(&normalized_declaration_identity(&member.declaration))
+        }
+    };
+    format!(
+        "{related_to_line}.{}.{}",
+        member_kind_slug(member.kind),
+        identity
+    )
+}
+
+fn allocate_unique_line_id(base: String, counts: &mut BTreeMap<String, usize>) -> String {
+    let count = counts.entry(base.clone()).or_default();
+    let line_id = if *count == 0 {
+        base
+    } else {
+        format!("{base}.alt{count}")
+    };
+    *count += 1;
+    line_id
+}
+
+fn item_kind_slug(kind: ApiItemKind) -> &'static str {
+    match kind {
+        ApiItemKind::Use => "reexport",
+        ApiItemKind::Macro => "macro",
+        ApiItemKind::ProcMacro => "proc_macro",
+        ApiItemKind::Function => "function",
+        ApiItemKind::Struct => "struct",
+        ApiItemKind::Enum => "enum",
+        ApiItemKind::Trait => "trait",
+        ApiItemKind::TraitAlias => "trait_alias",
+        ApiItemKind::InherentImpl => "inherent_impl",
+        ApiItemKind::TraitImpl => "trait_impl",
+        ApiItemKind::Union => "union",
+        ApiItemKind::TypeAlias => "type_alias",
+        ApiItemKind::Const => "const",
+        ApiItemKind::Static => "static",
+    }
+}
+
+fn member_kind_slug(kind: ApiMemberKind) -> &'static str {
+    match kind {
+        ApiMemberKind::Associated => "associated",
+        ApiMemberKind::Field => "field",
+        ApiMemberKind::Variant => "variant",
+        ApiMemberKind::MacroInput => "macro_input",
+        ApiMemberKind::Text => "text",
+    }
+}
+
+fn normalized_declaration_identity(declaration: &str) -> String {
+    let declaration = declaration
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    declaration
+        .trim_end_matches('{')
+        .trim_end_matches(';')
+        .trim()
+        .to_string()
+}
+
+fn sanitize_segment(value: &str) -> String {
+    let mut segment = String::new();
+    let mut previous_was_separator = false;
+    for character in value.chars() {
+        if character.is_ascii_alphanumeric() {
+            segment.push(character);
+            previous_was_separator = false;
+        } else if !previous_was_separator && !segment.is_empty() {
+            segment.push('_');
+            previous_was_separator = true;
+        }
+    }
+
+    segment.trim_matches('_').to_string()
 }
 
 fn sanitize(value: &str) -> String {
@@ -881,13 +993,16 @@ fn collect_navigation_targets(lookup: &mut NavigationLookup, module: &ApiModule)
     lookup.insert_path(module.path.clone(), &module_target);
     lookup.insert_simple_name(module.local_name(), &module_target);
 
-    for (index, item) in apiview_sorted_items(module).into_iter().enumerate() {
+    let mut item_line_id_counts = BTreeMap::new();
+    for item in apiview_sorted_items(module) {
+        let line_id =
+            allocate_unique_line_id(item_line_id_base(module, item), &mut item_line_id_counts);
         if !item_in_tree(item.kind) {
             continue;
         }
 
         let target = NavigationTarget {
-            line_id: format!("{}.{}_{index}", module_line_id(&module.path), item.name),
+            line_id,
             display_name: item.name.clone(),
             render_class: item_render_class(item.kind),
             kind: Some(item.kind),

--- a/eng/tools/generate_api/src/render/apiview/tests.rs
+++ b/eng/tools/generate_api/src/render/apiview/tests.rs
@@ -267,7 +267,7 @@ fn renders_inherent_members_inside_impl_blocks() {
     );
     assert_eq!(
         lines[2].related_to_line.as_deref(),
-        Some("module.demo.Foo_1")
+        Some("module.demo.inherent_impl.impl_Foo")
     );
 }
 
@@ -348,7 +348,7 @@ fn keeps_duplicate_member_names_in_separate_inherent_impl_blocks() {
         .iter()
         .flat_map(|line| line.children.iter())
         .filter_map(|line| line.line_id.as_deref())
-        .filter(|line_id| line_id.ends_with(".read_0"))
+        .filter(|line_id| line_id.ends_with(".associated.read"))
         .collect::<Vec<_>>();
 
     assert_eq!(read_line_ids.len(), 2);
@@ -430,7 +430,7 @@ fn links_trait_impl_owner_to_local_definition() {
     let trait_impl = lines
         .iter()
         .find(|line| {
-            line.line_id.as_deref() == Some("module.demo.SecretBytes_1")
+            line.line_id.as_deref() == Some("module.demo.trait_impl.impl_T_From_T_for_SecretBytes")
                 && line.tokens.iter().any(|token| token.value == "impl")
         })
         .expect("expected trait impl line");
@@ -439,7 +439,7 @@ fn links_trait_impl_owner_to_local_definition() {
         find_token(trait_impl, "SecretBytes")
             .navigate_to_id
             .as_deref(),
-        Some("module.demo.SecretBytes_0")
+        Some("module.demo.struct.SecretBytes")
     );
 }
 
@@ -486,7 +486,7 @@ fn links_trait_impl_owner_to_public_reexport() {
     let trait_impl = lines
         .iter()
         .find(|line| {
-            line.line_id.as_deref() == Some("module.demo.SecretBytes_1")
+            line.line_id.as_deref() == Some("module.demo.trait_impl.impl_T_From_T_for_SecretBytes")
                 && line.tokens.iter().any(|token| token.value == "impl")
         })
         .expect("expected trait impl line");
@@ -495,7 +495,7 @@ fn links_trait_impl_owner_to_public_reexport() {
         find_token(trait_impl, "SecretBytes")
             .navigate_to_id
             .as_deref(),
-        Some("module.demo.SecretBytes_0")
+        Some("module.demo.reexport.SecretBytes")
     );
 }
 
@@ -549,14 +549,14 @@ fn links_trait_impl_owner_to_declaration_over_visible_reexport() {
     let trait_impl = lines
         .iter()
         .find(|line| {
-            line.line_id.as_deref() == Some("module.demo.Error_1")
+            line.line_id.as_deref() == Some("module.demo.trait_impl.impl_T_From_T_for_Error")
                 && line.tokens.iter().any(|token| token.value == "impl")
         })
         .expect("expected trait impl line");
 
     assert_eq!(
         find_token(trait_impl, "Error").navigate_to_id.as_deref(),
-        Some("module.demo__hidden.Error_0")
+        Some("module.demo__hidden.struct.Error")
     );
 }
 
@@ -591,7 +591,9 @@ fn keeps_trait_impl_owner_unlinked_without_visible_target() {
     let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
     let trait_impl = lines
         .iter()
-        .find(|line| line.line_id.as_deref() == Some("module.demo.Error_0"))
+        .find(|line| {
+            line.line_id.as_deref() == Some("module.demo.trait_impl.impl_T_From_T_for_Error")
+        })
         .expect("expected trait impl line");
 
     assert!(find_token(trait_impl, "Error").navigate_to_id.is_none());
@@ -656,14 +658,14 @@ fn links_associated_error_type_to_visible_error_target() {
         .find(|line| {
             line.line_id
                 .as_deref()
-                .is_some_and(|line_id| line_id.starts_with("module.demo.ErrorResponse_"))
+                .is_some_and(|line_id| line_id.starts_with("module.demo.trait_impl."))
                 && line.tokens.iter().any(|token| token.value == "impl")
         })
         .expect("expected trait impl line");
     let error_type = find_child(
         trait_impl,
         &format!(
-            "{}.Error_0",
+            "{}.associated.Error",
             trait_impl.line_id.as_deref().expect("trait impl line id")
         ),
     );
@@ -677,7 +679,7 @@ fn links_associated_error_type_to_visible_error_target() {
     assert!(error_tokens[0].navigate_to_id.is_none());
     assert_eq!(
         error_tokens[1].navigate_to_id.as_deref(),
-        Some("module.demo.Error_0")
+        Some("module.demo.reexport.Error")
     );
 }
 
@@ -714,12 +716,12 @@ fn links_bare_result_to_public_reexport_when_resolved_path_matches() {
     let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
     let parse = lines
         .iter()
-        .find(|line| line.line_id.as_deref() == Some("module.demo.parse_1"))
+        .find(|line| line.line_id.as_deref() == Some("module.demo.function.parse"))
         .expect("expected parse line");
 
     assert_eq!(
         find_token(parse, "Result").navigate_to_id.as_deref(),
-        Some("module.demo.Result_0")
+        Some("module.demo.reexport.Result")
     );
 }
 
@@ -756,12 +758,12 @@ fn links_crate_result_with_resolved_path_metadata() {
     let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
     let parse = lines
         .iter()
-        .find(|line| line.line_id.as_deref() == Some("module.demo.parse_1"))
+        .find(|line| line.line_id.as_deref() == Some("module.demo.function.parse"))
         .expect("expected parse line");
 
     assert_eq!(
         find_token(parse, "Result").navigate_to_id.as_deref(),
-        Some("module.demo.Result_0")
+        Some("module.demo.reexport.Result")
     );
 }
 
@@ -805,11 +807,7 @@ fn links_where_clause_references_after_signature_types() {
     let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
     let parse = lines
         .iter()
-        .find(|line| {
-            line.line_id
-                .as_deref()
-                .is_some_and(|line_id| line_id.starts_with("module.demo.parse_"))
-        })
+        .find(|line| line.line_id.as_deref() == Some("module.demo.function.parse"))
         .expect("expected parse line");
     let input_line_id = lines
         .iter()
@@ -881,7 +879,7 @@ fn keeps_std_result_references_unlinked_without_current_crate_reexport() {
     let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
     let parse = lines
         .iter()
-        .find(|line| line.line_id.as_deref() == Some("module.demo.parse_0"))
+        .find(|line| line.line_id.as_deref() == Some("module.demo.function.parse"))
         .expect("expected parse line");
 
     let result_tokens = parse
@@ -947,12 +945,12 @@ fn prefers_original_definition_over_public_reexport_for_bare_result_links() {
     let parse = client
         .children
         .iter()
-        .find(|line| line.line_id.as_deref() == Some("module.demo__client.parse_0"))
+        .find(|line| line.line_id.as_deref() == Some("module.demo__client.function.parse"))
         .expect("expected parse line");
 
     assert_eq!(
         find_token(parse, "Result").navigate_to_id.as_deref(),
-        Some("module.demo__errors.Result_0")
+        Some("module.demo__errors.struct.Result")
     );
 }
 
@@ -984,14 +982,14 @@ fn keeps_field_type_links_out_of_navigation_tree() {
     let lines = render_module_contents(&module, &RenderOptions::default(), &lookup);
     let access_token = lines
         .iter()
-        .find(|line| line.line_id.as_deref() == Some("module.demo.AccessToken_0"))
+        .find(|line| line.line_id.as_deref() == Some("module.demo.struct.AccessToken"))
         .expect("expected AccessToken line");
-    let field = find_child(access_token, "module.demo.AccessToken_0.secret_0");
+    let field = find_child(access_token, "module.demo.struct.AccessToken.field.secret");
     let secret = find_token(field, "Secret");
 
     assert_eq!(
         secret.navigate_to_id.as_deref(),
-        Some("module.demo.Secret_1")
+        Some("module.demo.struct.Secret")
     );
     assert_eq!(secret.navigation_display_name, None);
     assert_eq!(secret.render_classes, None);
@@ -999,7 +997,7 @@ fn keeps_field_type_links_out_of_navigation_tree() {
     let declaration = find_token(
         lines
             .iter()
-            .find(|line| line.line_id.as_deref() == Some("module.demo.Secret_1"))
+            .find(|line| line.line_id.as_deref() == Some("module.demo.struct.Secret"))
             .expect("expected Secret line"),
         "Secret",
     );
@@ -1047,16 +1045,19 @@ fn keeps_member_type_references_out_of_navigation_tree() {
     let lines = render_module_contents(&module, &RenderOptions::default(), &lookup);
     let token_credential = lines
         .iter()
-        .find(|line| line.line_id.as_deref() == Some("module.demo.TokenCredential_1"))
+        .find(|line| line.line_id.as_deref() == Some("module.demo.trait.TokenCredential"))
         .expect("expected TokenCredential line");
     let get_token = find_child(
         token_credential,
-        "module.demo.TokenCredential_1.get_token_0",
+        "module.demo.trait.TokenCredential.associated.get_token",
     );
 
     for (value, expected) in [
-        ("TokenRequestOptions", "module.demo.TokenRequestOptions_2"),
-        ("AccessToken", "module.demo.AccessToken_0"),
+        (
+            "TokenRequestOptions",
+            "module.demo.struct.TokenRequestOptions",
+        ),
+        ("AccessToken", "module.demo.struct.AccessToken"),
     ] {
         let token = find_token(get_token, value);
         assert_eq!(token.navigate_to_id.as_deref(), Some(expected));
@@ -1110,10 +1111,10 @@ fn orders_modules_after_non_module_navigation_items() {
     assert_eq!(
         top_level_navigation_line_ids(&lines),
         vec![
-            "module.demo.ANSWER_0",
-            "module.demo.Error_1",
-            "module.demo.sleep_2",
-            "module.demo.AccessToken_3",
+            "module.demo.const.ANSWER",
+            "module.demo.reexport.Error",
+            "module.demo.function.sleep",
+            "module.demo.struct.AccessToken",
             "module.demo__alpha",
             "module.demo__zeta",
         ]
@@ -1199,15 +1200,15 @@ fn includes_same_crate_reexported_functions_in_tree() {
     assert_eq!(
         top_level_navigation_line_ids(&lines),
         vec![
-            "module.demo.sleep_0",
-            "module.demo.Error_1",
+            "module.demo.reexport.sleep",
+            "module.demo.struct.Error",
             "module.demo__sleep"
         ]
     );
 
     let top_level_sleep = lines
         .iter()
-        .find(|line| line.line_id.as_deref() == Some("module.demo.sleep_0"))
+        .find(|line| line.line_id.as_deref() == Some("module.demo.reexport.sleep"))
         .expect("expected root sleep reexport line");
     let sleep_token = top_level_sleep
         .tokens
@@ -1217,7 +1218,7 @@ fn includes_same_crate_reexported_functions_in_tree() {
         .expect("expected reexported sleep token");
     assert_eq!(
         sleep_token.navigate_to_id.as_deref(),
-        Some("module.demo__sleep.sleep_0")
+        Some("module.demo__sleep.function.sleep")
     );
 }
 
@@ -1261,7 +1262,7 @@ fn groups_same_crate_reexports_with_other_reexports() {
 
     assert_eq!(
         top_level_navigation_line_ids(&lines),
-        vec!["module.demo.ClientOptions_0", "module.demo__options"]
+        vec!["module.demo.reexport.ClientOptions", "module.demo__options"]
     );
 }
 
@@ -1308,13 +1309,190 @@ fn same_crate_reexport_links_to_nested_declaration() {
     let lines = render_review_lines(&model, &RenderOptions::default(), &lookup);
     let reexport = lines
         .iter()
-        .find(|line| line.line_id.as_deref() == Some("module.demo.CosmosClient_0"))
+        .find(|line| line.line_id.as_deref() == Some("module.demo.reexport.CosmosClient"))
         .expect("expected root CosmosClient reexport line");
 
     assert_eq!(
         find_token(reexport, "CosmosClient")
             .navigate_to_id
             .as_deref(),
-        Some("module.demo__clients.CosmosClient_0")
+        Some("module.demo__clients.struct.CosmosClient")
+    );
+}
+
+#[test]
+fn keeps_item_line_ids_stable_when_unrelated_siblings_are_inserted() {
+    let base_module = ApiModule {
+        path: "demo".to_string(),
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        items: vec![item("Error", ApiItemKind::Struct, "pub struct Error;")],
+        modules: Vec::new(),
+    };
+    let expanded_module = ApiModule {
+        path: "demo".to_string(),
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        items: vec![
+            item("ANSWER", ApiItemKind::Const, "pub const ANSWER: u32 = 42;"),
+            item("sleep", ApiItemKind::Function, "pub async fn sleep();"),
+            item("Error", ApiItemKind::Struct, "pub struct Error;"),
+        ],
+        modules: Vec::new(),
+    };
+
+    let base_lines = render_module_contents(
+        &base_module,
+        &RenderOptions::default(),
+        &navigation_lookup(&base_module),
+    );
+    let expanded_lines = render_module_contents(
+        &expanded_module,
+        &RenderOptions::default(),
+        &navigation_lookup(&expanded_module),
+    );
+
+    let base_error = base_lines
+        .iter()
+        .find(|line| line.line_id.as_deref() == Some("module.demo.struct.Error"))
+        .expect("expected base Error line");
+    let expanded_error = expanded_lines
+        .iter()
+        .find(|line| line.line_id.as_deref() == Some("module.demo.struct.Error"))
+        .expect("expected expanded Error line");
+
+    assert_eq!(
+        base_error.line_id.as_deref(),
+        expanded_error.line_id.as_deref()
+    );
+}
+
+#[test]
+fn keeps_member_line_ids_stable_when_unrelated_siblings_are_inserted() {
+    let access_token = || {
+        let mut access_token = item(
+            "AccessToken",
+            ApiItemKind::Struct,
+            "pub struct AccessToken {",
+        );
+        access_token.members.push(member(
+            "secret",
+            ApiMemberKind::Field,
+            "pub secret: Secret,",
+        ));
+        access_token
+    };
+    let base_module = ApiModule {
+        path: "demo".to_string(),
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        items: vec![
+            access_token(),
+            item("Secret", ApiItemKind::Struct, "pub struct Secret;"),
+        ],
+        modules: Vec::new(),
+    };
+    let expanded_module = ApiModule {
+        path: "demo".to_string(),
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        items: vec![
+            item("ANSWER", ApiItemKind::Const, "pub const ANSWER: u32 = 42;"),
+            access_token(),
+            item("Secret", ApiItemKind::Struct, "pub struct Secret;"),
+        ],
+        modules: Vec::new(),
+    };
+
+    let base_lines = render_module_contents(
+        &base_module,
+        &RenderOptions::default(),
+        &navigation_lookup(&base_module),
+    );
+    let expanded_lines = render_module_contents(
+        &expanded_module,
+        &RenderOptions::default(),
+        &navigation_lookup(&expanded_module),
+    );
+
+    let base_access_token = base_lines
+        .iter()
+        .find(|line| line.line_id.as_deref() == Some("module.demo.struct.AccessToken"))
+        .expect("expected base AccessToken line");
+    let expanded_access_token = expanded_lines
+        .iter()
+        .find(|line| line.line_id.as_deref() == Some("module.demo.struct.AccessToken"))
+        .expect("expected expanded AccessToken line");
+
+    assert_eq!(
+        find_child(
+            base_access_token,
+            "module.demo.struct.AccessToken.field.secret"
+        )
+        .line_id
+        .as_deref(),
+        find_child(
+            expanded_access_token,
+            "module.demo.struct.AccessToken.field.secret",
+        )
+        .line_id
+        .as_deref()
+    );
+}
+
+#[test]
+fn distinguishes_repeated_trait_impl_methods_by_impl_identity() {
+    let mut from_u8 = item("Error", ApiItemKind::TraitImpl, "impl From<u8> for Error {");
+    from_u8.owner_name = Some("Error".to_string());
+    from_u8.owner_kind = Some(ApiItemKind::Struct);
+    from_u8.members.push(member(
+        "from",
+        ApiMemberKind::Associated,
+        "fn from(value: u8) -> Self;",
+    ));
+
+    let mut from_u16 = item(
+        "Error",
+        ApiItemKind::TraitImpl,
+        "impl From<u16> for Error {",
+    );
+    from_u16.owner_name = Some("Error".to_string());
+    from_u16.owner_kind = Some(ApiItemKind::Struct);
+    from_u16.members.push(member(
+        "from",
+        ApiMemberKind::Associated,
+        "fn from(value: u16) -> Self;",
+    ));
+
+    let module = ApiModule {
+        path: "demo".to_string(),
+        doc_comments: Vec::new(),
+        attributes: Vec::new(),
+        items: vec![
+            item("Error", ApiItemKind::Struct, "pub struct Error;"),
+            from_u8,
+            from_u16,
+        ],
+        modules: Vec::new(),
+    };
+
+    let lines = render_module_contents(
+        &module,
+        &RenderOptions::default(),
+        &navigation_lookup(&module),
+    );
+    let from_line_ids = lines
+        .iter()
+        .flat_map(|line| line.children.iter())
+        .filter_map(|line| line.line_id.as_deref())
+        .filter(|line_id| line_id.ends_with(".associated.from"))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        from_line_ids,
+        vec![
+            "module.demo.trait_impl.impl_From_u8_for_Error.associated.from",
+            "module.demo.trait_impl.impl_From_u16_for_Error.associated.from",
+        ]
     );
 }


### PR DESCRIPTION
Use semantic APIView LineIds for items, impl blocks, and members so unrelated insertions no longer churn review anchors between revisions.

Teach generate_api to resolve library-like Cargo targets and run cargo rustdoc with --lib when needed, which restores APIView generation for crates such as azure_data_cosmos_driver_native.

Update APIView and driver regressions to lock the new IDs, repeated trait-impl member identities, and workspace rustdoc target selection.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 1ffbadde-a9f2-4018-a562-e3d0550b8386
