### PR TITLE
Add Analyze workflow to run source analysis in Actions

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,10 @@
 [advisories]
 ignore = [
   "RUSTSEC-2026-0097", # https://github.com/Azure/azure-sdk-for-rust/issues/4183
+  # TODO: UNDO BEFORE MERGE. Temporary, only to unblock cache benchmarking on this PR.
+  # rkyv 0.7.46 arrives via rust_decimal, whose default features are ["serde", "std"];
+  # rkyv is behind the opt-in rkyv/rkyv-safe features that nothing here enables, so the
+  # vulnerable code is never compiled. cargo audit reads the feature-agnostic Cargo.lock.
+  "RUSTSEC-2026-0235",
 ]
 severity_threshold = "critical"

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,10 +1,5 @@
 [advisories]
 ignore = [
   "RUSTSEC-2026-0097", # https://github.com/Azure/azure-sdk-for-rust/issues/4183
-  # TODO: UNDO BEFORE MERGE. Temporary, only to unblock cache benchmarking on this PR.
-  # rkyv 0.7.46 arrives via rust_decimal, whose default features are ["serde", "std"];
-  # rkyv is behind the opt-in rkyv/rkyv-safe features that nothing here enables, so the
-  # vulnerable code is never compiled. cargo audit reads the feature-agnostic Cargo.lock.
-  "RUSTSEC-2026-0235",
 ]
 severity_threshold = "critical"

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -37,10 +37,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev
+      # Both toolchains are required. Analyze-Code.ps1 runs `cargo +nightly docs-rs`
+      # per package, and eng/scripts/verify-*.rs are cargo scripts whose shebangs
+      # pin `cargo +nightly-2026-04-14 -Zscript`. Stable is installed last so it
+      # stays the active toolchain for everything else.
+      - name: Install Rust nightly
+        shell: pwsh
+        run: ./eng/scripts/Use-Rust.ps1 -Toolchain nightly
+
+      - name: Install Rust stable
+        shell: pwsh
+        run: ./eng/scripts/Use-Rust.ps1 -Toolchain stable
 
       # Install `cargo install` tools outside CARGO_HOME so they can be cached
       # independently of the rustup-managed toolchains in ~/.cargo/bin.
@@ -79,17 +86,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-analyze-target-${{ hashFiles('rust-toolchain.toml', 'eng/scripts/Language-Settings.ps1') }}-
 
-      # Analyze-Code.ps1 runs `cargo +nightly docs-rs`, so nightly is installed
-      # alongside stable. Stable is installed last so it remains the active toolchain.
-      - name: Install Rust nightly
-        shell: pwsh
-        run: ./eng/scripts/Use-Rust.ps1 -Toolchain nightly
-
-      - name: Install Rust stable
-        shell: pwsh
-        run: ./eng/scripts/Use-Rust.ps1 -Toolchain stable
-
       # Omitting -ServiceDirectory writes package properties for every service under sdk/.
+      # Analyze-Code.ps1 falls back to a workspace-wide shortcut that skips docs-rs
+      # entirely when this directory is missing, so it is required for full coverage.
       - name: Save package properties
         shell: pwsh
         run: ./eng/common/scripts/Save-Package-Properties.ps1 -OutDirectory '${{ runner.temp }}/PackageInfo'

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -7,9 +7,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    paths:
-      - .github/workflows/analyze.yml
   schedule:
     - cron: '0 12 * * *' # Daily at 12:00 PM UTC
   workflow_dispatch:

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -24,6 +24,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Incremental artifacts are large and never reused across runners.
+  CARGO_INCREMENTAL: 0
 
 jobs:
   analyze:
@@ -73,6 +75,16 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-analyze-registry-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-analyze-registry-
+
+      # Compiled artifacts are only reusable under the same toolchains, so both the stable
+      # pin (rust-toolchain.toml) and the nightly pin (Language-Settings.ps1) gate the key.
+      - name: Cache cargo build artifacts
+        uses: actions/cache@v4
+        with:
+          path: target/
+          key: ${{ runner.os }}-${{ runner.arch }}-analyze-target-${{ hashFiles('rust-toolchain.toml', 'eng/scripts/Language-Settings.ps1') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-analyze-target-${{ hashFiles('rust-toolchain.toml', 'eng/scripts/Language-Settings.ps1') }}-
 
       # Omitting -ServiceDirectory writes package properties for every service under sdk/.
       # Analyze-Code.ps1 falls back to a workspace-wide shortcut that skips docs-rs

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,0 +1,104 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+name: Analyze
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - .github/workflows/analyze.yml
+  schedule:
+    - cron: '0 12 * * *' # Daily at 12:00 PM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  # Incremental artifacts are large and never reused across runners.
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev
+
+      # Install `cargo install` tools outside CARGO_HOME so they can be cached
+      # independently of the rustup-managed toolchains in ~/.cargo/bin.
+      - name: Configure cargo tool install root
+        run: |
+          echo "CARGO_INSTALL_ROOT=$RUNNER_TEMP/cargo-tools" >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/cargo-tools/bin" >> "$GITHUB_PATH"
+
+      # Tool versions are pinned in eng/cgmanifest.json and read by Analyze-Code.ps1,
+      # so a cache hit lets every `cargo install` short-circuit without rebuilding.
+      - name: Cache analysis tools
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/cargo-tools
+          key: ${{ runner.os }}-${{ runner.arch }}-analyze-tools-${{ hashFiles('eng/cgmanifest.json', 'rust-toolchain.toml') }}
+
+      # Downloaded sources are toolchain independent, so an older entry is always safe to reuse.
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-${{ runner.arch }}-analyze-registry-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-analyze-registry-
+
+      # Compiled artifacts are only reusable under the same toolchains, so both the stable
+      # pin (rust-toolchain.toml) and the nightly pin (Language-Settings.ps1) gate the key.
+      - name: Cache cargo build artifacts
+        uses: actions/cache@v4
+        with:
+          path: target/
+          key: ${{ runner.os }}-${{ runner.arch }}-analyze-target-${{ hashFiles('rust-toolchain.toml', 'eng/scripts/Language-Settings.ps1') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-analyze-target-${{ hashFiles('rust-toolchain.toml', 'eng/scripts/Language-Settings.ps1') }}-
+
+      # Analyze-Code.ps1 runs `cargo +nightly docs-rs`, so nightly is installed
+      # alongside stable. Stable is installed last so it remains the active toolchain.
+      - name: Install Rust nightly
+        shell: pwsh
+        run: ./eng/scripts/Use-Rust.ps1 -Toolchain nightly
+
+      - name: Install Rust stable
+        shell: pwsh
+        run: ./eng/scripts/Use-Rust.ps1 -Toolchain stable
+
+      # Omitting -ServiceDirectory writes package properties for every service under sdk/.
+      - name: Save package properties
+        shell: pwsh
+        run: ./eng/common/scripts/Save-Package-Properties.ps1 -OutDirectory '${{ runner.temp }}/PackageInfo'
+
+      - name: Run source analysis
+        shell: pwsh
+        run: |
+          ./eng/scripts/Analyze-Code.ps1 `
+            -PackageInfoDirectory '${{ runner.temp }}/PackageInfo' `
+            -Toolchain 'nightly' `
+            -Audit `
+            -Deny

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -24,8 +24,6 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  # Incremental artifacts are large and never reused across runners.
-  CARGO_INCREMENTAL: 0
 
 jobs:
   analyze:
@@ -75,16 +73,6 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-analyze-registry-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-analyze-registry-
-
-      # Compiled artifacts are only reusable under the same toolchains, so both the stable
-      # pin (rust-toolchain.toml) and the nightly pin (Language-Settings.ps1) gate the key.
-      - name: Cache cargo build artifacts
-        uses: actions/cache@v4
-        with:
-          path: target/
-          key: ${{ runner.os }}-${{ runner.arch }}-analyze-target-${{ hashFiles('rust-toolchain.toml', 'eng/scripts/Language-Settings.ps1') }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-analyze-target-${{ hashFiles('rust-toolchain.toml', 'eng/scripts/Language-Settings.ps1') }}-
 
       # Omitting -ServiceDirectory writes package properties for every service under sdk/.
       # Analyze-Code.ps1 falls back to a workspace-wide shortcut that skips docs-rs

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -24,8 +24,6 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  # Incremental artifacts are large and never reused across runners.
-  CARGO_INCREMENTAL: 0
 
 jobs:
   analyze:


### PR DESCRIPTION
Runs Analyze-Code.ps1 with `-Audit` on a schedule and against pushes to the `main` branch. This PR is primarily intended to run audit validation which cannot run in the Azure DevOps pipelines. 