### PR TITLE
Cosmos: add endpoint-unavailability lifecycle tests

### DIFF
--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/operation_pipeline.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/operation_pipeline.rs
@@ -6550,6 +6550,158 @@ mod tests {
         assert_eq!(routing.endpoint, available_endpoint);
     }
 
+    /// The endpoint-unavailability lifecycle has two halves. The *membership*
+    /// half (mark -> cooldown -> probe -> restore) is a deterministic in-memory
+    /// unit test in `driver::routing::location_state_store`. This test pins the
+    /// *routing* half — how a mark is consumed by `resolve_endpoint` — in one
+    /// `[r1, r2]` multi-write topology, deterministically and in-memory (no
+    /// network, no sleeps). It asserts, as one ordered sequence, both the
+    /// demote-to-tail-not-removal behavior and the read/write/both distinction
+    /// that the single-purpose tests above each cover only one facet of:
+    ///   * a both-affecting reason (`ServiceUnavailable`) demotes r1 for BOTH
+    ///     reads and writes (r2 chosen);
+    ///   * a write-only reason (`WriteForbidden`) demotes r1 for writes only —
+    ///     reads still route to r1;
+    ///   * when every candidate is marked, the marked head is still returned
+    ///     (`first_unavailable`), never dropped — demotion is to the tail, not
+    ///     removal;
+    ///   * once a mark ages past the TTL the endpoint is available again.
+    #[test]
+    fn resolve_endpoint_unavailability_demotes_to_tail_by_reason_for_reads_and_writes() {
+        let r1 = CosmosEndpoint::regional(
+            "eastus".into(),
+            Url::parse("https://test-eastus.documents.azure.com:443/").unwrap(),
+        );
+        let r2 = CosmosEndpoint::regional(
+            "westus2".into(),
+            Url::parse("https://test-westus2.documents.azure.com:443/").unwrap(),
+        );
+
+        let ttl = Duration::from_secs(60);
+
+        let make_location = |unavailable: std::collections::HashMap<
+            Url,
+            (
+                std::time::Instant,
+                crate::driver::routing::UnavailableReason,
+            ),
+        >| {
+            LocationSnapshot::for_tests(Arc::new(AccountEndpointState {
+                generation: 0,
+                preferred_read_endpoints: vec![r1.clone(), r2.clone()].into(),
+                preferred_write_endpoints: vec![r1.clone(), r2.clone()].into(),
+                account_write_endpoints: vec![r1.clone(), r2.clone()].into(),
+                unavailable_endpoints: unavailable,
+                multiple_write_locations_enabled: true,
+                default_endpoint: r1.clone(),
+            }))
+        };
+
+        let read_op = CosmosOperation::read_all_databases(test_account());
+        let write_item =
+            ItemReference::from_name(&test_container(), PartitionKey::from("pk1"), "doc1");
+        let write_op = CosmosOperation::create_item(write_item).with_body(b"{}".to_vec());
+
+        // Multi-write retry state so reads use the read list and writes use the
+        // write list, both `[r1, r2]`.
+        let state = crate::driver::pipeline::components::OperationRetryState::initial(
+            0,
+            true,
+            Vec::new(),
+            3,
+            2,
+        );
+
+        let resolve = |op: &CosmosOperation, loc: &LocationSnapshot| {
+            super::resolve_endpoint(op, &state, loc, false, true, ttl).endpoint
+        };
+
+        // Case A — both-affecting reason (ServiceUnavailable) demotes r1 for
+        // reads AND writes.
+        let mut both = std::collections::HashMap::new();
+        both.insert(
+            r1.url().clone(),
+            (
+                std::time::Instant::now(),
+                crate::driver::routing::UnavailableReason::ServiceUnavailable,
+            ),
+        );
+        let loc = make_location(both);
+        assert_eq!(
+            resolve(&read_op, &loc),
+            r2,
+            "a both-affecting mark on r1 must demote it for reads",
+        );
+        assert_eq!(
+            resolve(&write_op, &loc),
+            r2,
+            "a both-affecting mark on r1 must demote it for writes",
+        );
+
+        // Case B — write-only reason (WriteForbidden): reads keep r1, writes
+        // demote to r2.
+        let mut write_forbidden = std::collections::HashMap::new();
+        write_forbidden.insert(
+            r1.url().clone(),
+            (
+                std::time::Instant::now(),
+                crate::driver::routing::UnavailableReason::WriteForbidden,
+            ),
+        );
+        let loc = make_location(write_forbidden);
+        assert_eq!(
+            resolve(&read_op, &loc),
+            r1,
+            "WriteForbidden must not demote r1 for reads",
+        );
+        assert_eq!(
+            resolve(&write_op, &loc),
+            r2,
+            "WriteForbidden must demote r1 for writes",
+        );
+
+        // Case C — every candidate marked: the head is still returned (present,
+        // tail-of-rotation), never removed.
+        let mut all_marked = std::collections::HashMap::new();
+        all_marked.insert(
+            r1.url().clone(),
+            (
+                std::time::Instant::now(),
+                crate::driver::routing::UnavailableReason::ServiceUnavailable,
+            ),
+        );
+        all_marked.insert(
+            r2.url().clone(),
+            (
+                std::time::Instant::now(),
+                crate::driver::routing::UnavailableReason::ServiceUnavailable,
+            ),
+        );
+        let loc = make_location(all_marked);
+        assert_eq!(
+            resolve(&read_op, &loc),
+            r1,
+            "when all candidates are marked, the marked head must still be \
+             returned rather than dropped from rotation",
+        );
+
+        // Case D — an aged mark (older than the TTL) makes r1 available again.
+        let mut expired = std::collections::HashMap::new();
+        expired.insert(
+            r1.url().clone(),
+            (
+                std::time::Instant::now() - (ttl + Duration::from_secs(1)),
+                crate::driver::routing::UnavailableReason::ServiceUnavailable,
+            ),
+        );
+        let loc = make_location(expired);
+        assert_eq!(
+            resolve(&read_op, &loc),
+            r1,
+            "a mark older than the TTL must no longer demote r1",
+        );
+    }
+
     // ── PPAF write-retry cross-region fallback ─────────────────────────
 
     fn make_pending_partition_mark_for_region(

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/routing/location_state_store.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/routing/location_state_store.rs
@@ -1497,6 +1497,127 @@ mod tests {
         );
     }
 
+    /// Exercises the account endpoint-unavailability LIFECYCLE as one ordered
+    /// state machine: mark-unavailable -> (still present, not removed) ->
+    /// cooldown gate -> expiry via backdated `marked_at` -> successful probe ->
+    /// restore.
+    ///
+    /// Deterministic in-memory unit test: no network, no sleeps. It drives
+    /// `probe_and_failback_unavailable_endpoints` directly and backdates
+    /// `marked_at` to simulate an elapsed cooldown, because the background probe
+    /// loop's cadence (`ENDPOINT_PROBE_INTERVAL`) is a fixed 60s const and is not
+    /// test-injectable.
+    ///
+    /// Coverage split: this module owns the *membership* half of the lifecycle
+    /// (a mark living in / leaving `unavailable_endpoints`, and never mutating
+    /// the preferred order). The *routing* consequences of a mark —
+    /// demote-to-tail (the marked endpoint is skipped during selection but kept
+    /// as a last resort, never removed) and the read/write/both distinction
+    /// (`WriteForbidden` demotes writes only) — are enforced by the resolver and
+    /// are covered by the `resolve_endpoint` tests in
+    /// `driver::pipeline::operation_pipeline`.
+    #[cfg(feature = "tokio")]
+    #[tokio::test]
+    async fn endpoint_unavailability_lifecycle_mark_cooldown_probe_restore() {
+        let default_endpoint = CosmosEndpoint::global(test_endpoint().url().clone());
+        let refresh = Arc::new(|_previous: Option<Arc<AccountProperties>>| {
+            let payload = test_refresh_payload();
+            let fut: BoxFuture<'static, crate::error::Result<AccountProperties>> =
+                Box::pin(async move { Ok(payload) });
+            fut
+        });
+
+        // Non-zero cooldown so the "not yet due" gate is observable.
+        let cooldown = Duration::from_secs(60);
+        let store = LocationStateStore::new(
+            Arc::new(AccountMetadataCache::new()),
+            test_endpoint(),
+            default_endpoint.clone(),
+            refresh,
+            false,
+            cooldown,
+            PartitionFailoverOptions::default(),
+            Vec::new(),
+            None,
+        );
+
+        let endpoint_url = default_endpoint.url().clone();
+        // The preferred read order that the mark/restore must never mutate.
+        let preferred_before = store.snapshot().account.preferred_read_endpoints.clone();
+        assert!(
+            preferred_before.iter().any(|e| e.url() == &endpoint_url),
+            "precondition: the endpoint under test is in the preferred read order",
+        );
+
+        // 1. MARK UNAVAILABLE (a both-affecting reason, not WriteForbidden).
+        store
+            .apply(&[LocationEffect::MarkEndpointUnavailable {
+                endpoint: default_endpoint.clone(),
+                reason: UnavailableReason::TransportError,
+            }])
+            .await;
+        let marked = store.snapshot();
+        assert!(
+            marked
+                .account
+                .unavailable_endpoints
+                .contains_key(&endpoint_url),
+            "mark must record the endpoint as unavailable",
+        );
+        // NOT REMOVAL: marking leaves the preferred read order untouched, so the
+        // endpoint is only ever demoted (by the resolver), never dropped.
+        assert_eq!(
+            marked.account.preferred_read_endpoints.as_ref(),
+            preferred_before.as_ref(),
+            "marking unavailable must not remove or reorder the preferred read endpoints",
+        );
+
+        // 2. COOLDOWN GATE: before the TTL elapses, even a reachable probe is a
+        //    no-op — nothing is due, so the mark survives.
+        let reachable: EndpointProbeFn =
+            Arc::new(|_url: Url| Box::pin(async move { true }) as BoxFuture<'static, bool>);
+        store
+            .probe_and_failback_unavailable_endpoints(&reachable)
+            .await;
+        assert!(
+            store
+                .snapshot()
+                .account
+                .unavailable_endpoints
+                .contains_key(&endpoint_url),
+            "an endpoint still within its cooldown must not be probed or failed back",
+        );
+
+        // 3. EXPIRY: backdate `marked_at` past the TTL so the endpoint is due.
+        store.apply_account(|current| {
+            let mut next = current.clone();
+            if let Some((marked_at, _)) = next.unavailable_endpoints.get_mut(&endpoint_url) {
+                *marked_at = Instant::now() - (cooldown + Duration::from_secs(1));
+            }
+            next
+        });
+
+        // 4. PROBE + RESTORE: a reachable probe on the due endpoint clears the
+        //    mark, returning the endpoint to rotation.
+        store
+            .probe_and_failback_unavailable_endpoints(&reachable)
+            .await;
+        let restored = store.snapshot();
+        assert!(
+            !restored
+                .account
+                .unavailable_endpoints
+                .contains_key(&endpoint_url),
+            "a due endpoint must fail back after a successful probe",
+        );
+        // The preferred order was never mutated across the whole lifecycle.
+        assert_eq!(
+            restored.account.preferred_read_endpoints.as_ref(),
+            preferred_before.as_ref(),
+            "restore must leave the preferred read endpoints unchanged",
+        );
+    }
+
     #[test]
     fn account_sync_preserves_unavailable_marks_for_probe_loop() {
         let default_endpoint = CosmosEndpoint::global(test_endpoint().url().clone());


### PR DESCRIPTION
Adds deterministic, in-memory unit tests for the account **endpoint-unavailability lifecycle** — mark-unavailable → demote-to-tail (not removal) → cooldown/expiry → probe → restore — for [#3527](https://github.com/Azure/azure-sdk-for-rust/issues/3527) (Cosmos: Availability and Resiliency for Multi-Write accounts). These transitions were previously covered only by scattered, isolated tests.

The lifecycle spans two layers, so coverage is split to test each behavior where it actually lives:

- **Membership** (a mark living in / leaving `unavailable_endpoints`, never mutating the preferred order) lives in `location_state_store.rs`.
- **Routing consequences** (demote-to-tail and the read/write/both distinction) are enforced by the resolver in `operation_pipeline.rs`.

## Changes

- **`location_state_store.rs`** — new `endpoint_unavailability_lifecycle_mark_cooldown_probe_restore` drives the membership state machine as one ordered sequence: mark unavailable → assert still present (not removed/reordered) → cooldown gate (a pre-TTL probe is a no-op) → expiry via a backdated `Instant` → successful probe restores. Reuses existing scaffolding and the directly-callable `probe_and_failback_unavailable_endpoints`, so it needs no sleeps. The failed-probe-resets-cooldown case is already covered by an existing test and is not duplicated.
- **`operation_pipeline.rs`** — new `resolve_endpoint_unavailability_demotes_to_tail_by_reason_for_reads_and_writes` pins the routing half in one `[r1, r2]` multi-write topology via the existing `resolve_endpoint` harness: a both-affecting reason (`ServiceUnavailable`) demotes `r1` for reads **and** writes; `WriteForbidden` demotes writes only (reads keep `r1` — filling the previously untested write side); an all-marked head is still returned (`first_unavailable`, demote-to-tail not removal); and an aged mark past the TTL is available again.

No production code changed; this is test-only coverage.