### PR TITLE
Harden federated-auth tenant selection for live tests

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -126,7 +126,22 @@ jobs:
         inline: |
           $account = (Get-AzContext).Account;
           $env:AZURESUBSCRIPTION_CLIENT_ID = $account.Id;
-          $env:AZURESUBSCRIPTION_TENANT_ID = $account.Tenants;
+          # $account.Tenants is an array; assigning it directly space-joins multiple
+          # entries into a value that downstream tenant-ID validation rejects. Take the
+          # first (home) tenant so the minted token has a well-formed issuer tenant.
+          $env:AZURESUBSCRIPTION_TENANT_ID = $account.Tenants | Select-Object -First 1;
+
+          # Diagnostics (tenant/app IDs are not secrets): the token issuer tenant must
+          # match the resource's home tenant. A mismatch causes data-plane AAD failures
+          # such as Cosmos 401/5007 AadTokenInvalidIssuer. Print both to compare.
+          $ctx = Get-AzContext;
+          Write-Host "Federated auth context:";
+          Write-Host "  Client (app) ID: $($account.Id)";
+          Write-Host "  Account.Tenants count: $(@($account.Tenants).Count)";
+          Write-Host "  Account.Tenants: $($account.Tenants -join ', ')";
+          Write-Host "  Issuer tenant (AZURESUBSCRIPTION_TENANT_ID): $($env:AZURESUBSCRIPTION_TENANT_ID)";
+          Write-Host "  Context tenant (Tenant.Id): $($ctx.Tenant.Id)";
+          Write-Host "  Subscription tenant: $($ctx.Subscription.TenantId)";
 
           Write-Host "./eng/scripts/Test-Packages.ps1 -PackageInfoDirectory '$(Build.ArtifactStagingDirectory)/PackageInfo'"
           ./eng/scripts/Test-Packages.ps1 -PackageInfoDirectory '$(Build.ArtifactStagingDirectory)/PackageInfo'


### PR DESCRIPTION
## Summary

Investigation into the new weekly Cosmos AAD data-plane live leg
`Test ubuntu_stable_aad_auth_SessionMultiWrite`, which fails on the **first**
request with `401/5007 AadTokenInvalidIssuer`. The leg was added in `5346110eb5`
(PR #4730) and has never passed — this is not a regression.

This PR lands the safe in-repo hardening surfaced by that investigation and adds
diagnostics so the next weekly run pins down the exact tenant mismatch. **It does
not, on its own, make the AAD leg pass** — the remaining fix is a
service-connection/tenant configuration change outside this repo (described below).

## Root cause

- The federated-auth live-test task mints an AAD token via `AzurePipelinesCredential`
  with issuer `https://sts.windows.net/<AZURESUBSCRIPTION_TENANT_ID>/`, where
  `AZURESUBSCRIPTION_TENANT_ID = (Get-AzContext).Account.Tenants` evaluated under the
  `azure-sdk-tests-cosmos` service connection.
- Cosmos DB SQL validates data-plane AAD tokens **only** against the account's home
  Entra tenant (the tenant of the subscription the account is deployed into). When the
  issuer tenant differs, Cosmos returns 5007 (trusted list redacted as `[]`).
- The token was minted for a single valid tenant GUID (otherwise the failure would be
  a credential-construction error, not a Cosmos 401 — `validate_tenant_id` in
  `azure_identity` rejects any space-containing tenant string). So the issuer tenant is
  genuinely a different tenant than the one the Cosmos account trusts.
- Cosmos is the only Rust service overriding the connection to `azure-sdk-tests-cosmos`;
  every other service uses `azure-sdk-tests-public` and its AAD data-plane live tests
  pass. Control-plane deploy succeeds (works cross-tenant), but data-plane AAD does not
  — a classic cross-tenant split rooted in the dedicated connection's tenant topology.

## Changes

`eng/pipelines/templates/jobs/live.tests.yml` (shared federated-auth task):

- Select `$account.Tenants | Select-Object -First 1` so `AZURESUBSCRIPTION_TENANT_ID`
  is always a single well-formed GUID. Previously, a multi-tenant `$account.Tenants`
  space-joined into a value that downstream tenant-ID validation rejects. This is
  defensive hardening for all services; it is behavior-preserving in the common
  single-tenant case.
- Add non-secret diagnostics (tenant/app IDs are not secrets) printing the account
  tenants, the chosen issuer tenant, and the selected subscription/context tenant, so
  a mismatch between issuer tenant and the resource's home tenant is visible in the
  live logs.

## Not fixable in-repo

- **Bicep tenant-trust is not applicable.** Cosmos SQL accounts expose no ARM/bicep
  property to trust additional issuer tenants; `test-resources.bicep` cannot grant
  cross-tenant trust.

## Infra change required (outside this repo)

Owned by the Cosmos test-infra / engineering-system team. One of:

- **Preferred:** Ensure the `azure-sdk-tests-cosmos` service connection's federated app
  registration issues tokens from the **same Entra tenant** as the Cosmos test
  subscription where `test-resources.bicep` deploys — either home the app + federated
  identity credential in that tenant, or provision a federated service principal for the
  app in that tenant and drive `AZURESUBSCRIPTION_TENANT_ID` to it — so the JWT issuer
  matches the account's home tenant and satisfies the `testApplicationOid` RBAC grant.
- **Alternative:** Move the Cosmos test subscription under the tenant the
  `azure-sdk-tests-cosmos` SP already issues tokens from.
- **Simplest, if capacity allows:** Retire the dedicated connection and run Cosmos on
  the standard `azure-sdk-tests-public` connection used by all other (passing) Rust
  services (requires the public test subscription to host these Cosmos accounts:
  multi-region, continuous backup, vector/full-text capabilities, cost/quota).

The new diagnostics will print the exact issuer-vs-home tenant GUIDs to hand to whoever
owns the connection.