### PR TITLE
Complete Cosmos diagnostic span attributes

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/src/diagnostics/attributes.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/diagnostics/attributes.rs
@@ -79,3 +79,4 @@ pub(crate) const URL_SCHEME: &str = "url.scheme";
 pub(crate) const URL_FULL: &str = "url.full";
 pub(crate) const HTTP_RESPONSE_STATUS_CODE: &str = "http.response.status_code";
 pub(crate) const NETWORK_PROTOCOL_VERSION: &str = "network.protocol.version";
+pub(crate) const RETURNED_ROWS: &str = "db.client.response.returned_rows";

--- a/sdk/cosmos/azure_data_cosmos/src/diagnostics/operation_context.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/diagnostics/operation_context.rs
@@ -18,6 +18,9 @@ use std::borrow::Cow;
 
 use azure_core::fmt::SafeDebug;
 
+#[cfg(feature = "distributed_tracing")]
+use opentelemetry::Context as OtelContext;
+
 /// SDK-supplied, operation-scope identity for a single Cosmos operation.
 ///
 /// The driver's [`DiagnosticsContext`](crate::diagnostics::DiagnosticsContext)
@@ -46,7 +49,7 @@ use azure_core::fmt::SafeDebug;
 /// that are set. All setters accept anything convertible into a
 /// `Cow<'static, str>`, so canonical static operation names (e.g. `"read_item"`)
 /// are stored without allocating.
-#[derive(Clone, Default, SafeDebug, PartialEq, Eq)]
+#[derive(Clone, Default, SafeDebug)]
 pub struct CosmosOperationContext {
     operation_name: Option<Cow<'static, str>>,
     database_name: Option<Cow<'static, str>>,
@@ -55,12 +58,18 @@ pub struct CosmosOperationContext {
     consistency_level: Option<Cow<'static, str>>,
     connection_mode: Option<Cow<'static, str>>,
     returned_item_count: Option<u64>,
+    #[cfg(feature = "distributed_tracing")]
+    parent_context: OtelContext,
 }
 
 impl CosmosOperationContext {
     /// Creates an empty operation context.
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            #[cfg(feature = "distributed_tracing")]
+            parent_context: OtelContext::current(),
+            ..Self::default()
+        }
     }
 
     /// Sets the canonical operation name (`db.operation.name`), e.g. `read_item`.
@@ -146,5 +155,11 @@ impl CosmosOperationContext {
     /// The number of items returned, if set.
     pub fn returned_item_count(&self) -> Option<u64> {
         self.returned_item_count
+    }
+
+    /// Returns the caller context captured when this operation was created.
+    #[cfg(feature = "distributed_tracing")]
+    pub(crate) fn parent_context(&self) -> &OtelContext {
+        &self.parent_context
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/src/diagnostics/tracing/span_builder.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/diagnostics/tracing/span_builder.rs
@@ -136,6 +136,21 @@ pub(crate) fn emit_backdated_span_tree<T>(
             collection.to_string(),
         ));
     }
+    if let Some(consistency) = op.and_then(CosmosOperationContext::consistency_level) {
+        root_attrs.push(KeyValue::new(
+            attributes::CONSISTENCY_LEVEL,
+            consistency.to_string(),
+        ));
+    }
+    if let Some(mode) = op.and_then(CosmosOperationContext::connection_mode) {
+        root_attrs.push(KeyValue::new(attributes::CONNECTION_MODE, mode.to_string()));
+    }
+    if let Some(rows) = op.and_then(CosmosOperationContext::returned_item_count) {
+        root_attrs.push(KeyValue::new(
+            attributes::RETURNED_ROWS,
+            i64::try_from(rows).unwrap_or(i64::MAX),
+        ));
+    }
     if let Some(status) = diagnostics.effective_status() {
         root_attrs.push(KeyValue::new(
             attributes::DB_RESPONSE_STATUS_CODE,
@@ -173,6 +188,11 @@ pub(crate) fn emit_backdated_span_tree<T>(
         .map(str::to_string)
         .or_else(|| requests.first().and_then(server_address));
     if let Some(addr) = server_addr {
+        if let Ok(url) = url::Url::parse(&addr) {
+            if let Some(port) = url.port() {
+                root_attrs.push(KeyValue::new(attributes::SERVER_PORT, i64::from(port)));
+            }
+        }
         root_attrs.push(KeyValue::new(attributes::SERVER_ADDRESS, addr));
     }
     if let Some(machine_id) = diagnostics.machine_id() {
@@ -210,7 +230,11 @@ pub(crate) fn emit_backdated_span_tree<T>(
         .with_kind(SpanKind::Client)
         .with_start_time(op_start)
         .with_attributes(root_attrs);
-    let mut root = tracer.build_with_context(root_builder, &Context::current());
+    let parent_context = op
+        .map(CosmosOperationContext::parent_context)
+        .cloned()
+        .unwrap_or_default();
+    let mut root = tracer.build_with_context(root_builder, &parent_context);
     if op_failed {
         root.set_status(Status::error("operation failed"));
     }


### PR DESCRIPTION
Add the remaining Cosmos operation attributes and preserve caller trace context.\n\nFixes #3036