### PR TITLE
Emit HTTP client span attributes

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/src/diagnostics/attributes.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/diagnostics/attributes.rs
@@ -73,3 +73,9 @@ pub(crate) const MACHINE_ID: &str = "azure.cosmosdb.machine_id";
 /// `azure.cosmosdb.sampling.reason` — why the operation was tail-sampled for
 /// emission (a failure, or which threshold it crossed).
 pub(crate) const SAMPLING_REASON: &str = "azure.cosmosdb.sampling.reason";
+
+pub(crate) const HTTP_REQUEST_METHOD: &str = "http.request.method";
+pub(crate) const URL_SCHEME: &str = "url.scheme";
+pub(crate) const URL_FULL: &str = "url.full";
+pub(crate) const HTTP_RESPONSE_STATUS_CODE: &str = "http.response.status_code";
+pub(crate) const NETWORK_PROTOCOL_VERSION: &str = "network.protocol.version";

--- a/sdk/cosmos/azure_data_cosmos/src/diagnostics/tracing/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/diagnostics/tracing/mod.rs
@@ -180,7 +180,7 @@ mod tests {
 
         let children: Vec<_> = spans
             .iter()
-            .filter(|s| s.name == "cosmosdb.request")
+            .filter(|s| s.name.starts_with("HTTP "))
             .collect();
         assert_eq!(children.len(), 2);
         for child in &children {
@@ -342,7 +342,7 @@ mod tests {
 
         let child_names: Vec<String> = spans
             .iter()
-            .filter(|s| s.name == "cosmosdb.request")
+            .filter(|s| s.name.starts_with("HTTP "))
             .filter_map(|s| {
                 s.attributes
                     .iter()
@@ -384,7 +384,7 @@ mod tests {
         let spans = exporter.get_finished_spans().unwrap();
         let children: Vec<_> = spans
             .iter()
-            .filter(|s| s.name == "cosmosdb.request")
+            .filter(|s| s.name.starts_with("HTTP "))
             .collect();
         assert_eq!(children.len(), 2);
         for child in children {
@@ -483,7 +483,7 @@ mod tests {
             .expect("root span present");
         let earliest_child = spans
             .iter()
-            .filter(|s| s.name == "cosmosdb.request")
+            .filter(|s| s.name.starts_with("HTTP "))
             .map(|s| s.start_time)
             .min()
             .expect("attempt children present");

--- a/sdk/cosmos/azure_data_cosmos/src/diagnostics/tracing/span_builder.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/diagnostics/tracing/span_builder.rs
@@ -30,9 +30,6 @@ use crate::diagnostics::CosmosOperationContext;
 /// Span name for the operation ("root") span when the operation name is unknown.
 const DEFAULT_OPERATION_SPAN_NAME: &str = "cosmosdb.operation";
 
-/// Span name for each per-attempt ("child") span.
-const REQUEST_SPAN_NAME: &str = "cosmosdb.request";
-
 /// Emits a backdated operation span with one child span per retained attempt.
 ///
 /// * `tracer` — the OpenTelemetry tracer to build spans on. Generic so tests can
@@ -235,14 +232,40 @@ pub(crate) fn emit_backdated_span_tree<T>(
         let req_status = req.status();
         let req_failed = !req_status.is_success();
 
+        let endpoint = url::Url::parse(req.endpoint()).ok();
         let mut child_attrs = vec![
             KeyValue::new(attributes::DB_SYSTEM_NAME, attributes::DB_SYSTEM_NAME_VALUE),
+            KeyValue::new(
+                attributes::HTTP_REQUEST_METHOD,
+                req.http_method().as_str().to_string(),
+            ),
+            KeyValue::new(
+                attributes::HTTP_RESPONSE_STATUS_CODE,
+                i64::from(u16::from(req_status.status_code())),
+            ),
             KeyValue::new(
                 attributes::DB_RESPONSE_STATUS_CODE,
                 u16::from(req_status.status_code()).to_string(),
             ),
             KeyValue::new(attributes::REQUEST_CHARGE, req.request_charge().value()),
         ];
+        if let Some(endpoint) = endpoint.as_ref() {
+            child_attrs.push(KeyValue::new(
+                attributes::URL_SCHEME,
+                endpoint.scheme().to_string(),
+            ));
+            child_attrs.push(KeyValue::new(
+                attributes::URL_FULL,
+                endpoint.as_str().to_string(),
+            ));
+            if let Some(port) = endpoint.port() {
+                child_attrs.push(KeyValue::new(attributes::SERVER_PORT, i64::from(port)));
+            }
+        }
+        child_attrs.push(KeyValue::new(
+            attributes::NETWORK_PROTOCOL_VERSION,
+            req.transport_http_version().to_string(),
+        ));
         if let Some(name) = req.operation_name().or(op_name_ref) {
             child_attrs.push(KeyValue::new(
                 attributes::DB_OPERATION_NAME,
@@ -280,7 +303,7 @@ pub(crate) fn emit_backdated_span_tree<T>(
         }
 
         let child_builder = tracer
-            .span_builder(REQUEST_SPAN_NAME)
+            .span_builder(format!("HTTP {}", req.http_method().as_str()))
             .with_kind(SpanKind::Client)
             .with_start_time(child_start)
             .with_attributes(child_attrs);

--- a/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/diagnostics_context.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/diagnostics/diagnostics_context.rs
@@ -13,7 +13,7 @@ use crate::{
     options::{DiagnosticsOptions, DiagnosticsThresholds, DiagnosticsVerbosity, Region},
     system::CpuMemoryMonitor,
 };
-use azure_core::http::StatusCode;
+use azure_core::http::{Method, StatusCode};
 use serde::Serialize;
 use std::{
     collections::HashMap,
@@ -411,6 +411,9 @@ pub struct RequestDiagnostics {
     )]
     operation_name: Option<Arc<str>>,
 
+    /// HTTP method used for this request.
+    http_method: Method,
+
     /// The pipeline type used for this request.
     pipeline_type: PipelineType,
 
@@ -499,6 +502,7 @@ impl RequestDiagnostics {
     /// Creates a new request diagnostics entry for a request being started.
     pub(crate) fn new(
         execution_context: ExecutionContext,
+        http_method: Method,
         pipeline_type: PipelineType,
         transport_security: TransportSecurity,
         transport_kind: TransportKind,
@@ -508,6 +512,7 @@ impl RequestDiagnostics {
         Self {
             execution_context,
             operation_name: None,
+            http_method,
             pipeline_type,
             transport_security,
             transport_kind,
@@ -558,6 +563,7 @@ impl RequestDiagnostics {
         Self {
             execution_context: ExecutionContext::Initial,
             operation_name: None,
+            http_method: Method::Get,
             pipeline_type: PipelineType::DataPlane,
             transport_security: TransportSecurity::Secure,
             transport_kind: TransportKind::Gateway,
@@ -734,6 +740,11 @@ impl RequestDiagnostics {
     /// context's [`operation_name`](DiagnosticsContext::operation_name).
     pub fn operation_name(&self) -> Option<&str> {
         self.operation_name.as_deref()
+    }
+
+    /// Returns the HTTP method used for this request.
+    pub fn http_method(&self) -> Method {
+        self.http_method
     }
 
     /// Returns the pipeline type used for this request.
@@ -1568,6 +1579,7 @@ impl DiagnosticsContextBuilder {
     pub(crate) fn start_request(
         &mut self,
         execution_context: ExecutionContext,
+        http_method: Method,
         pipeline_type: PipelineType,
         transport_security: TransportSecurity,
         transport_kind: TransportKind,
@@ -1576,6 +1588,7 @@ impl DiagnosticsContextBuilder {
     ) -> RequestHandle {
         let mut request = RequestDiagnostics::new(
             execution_context,
+            http_method,
             pipeline_type,
             transport_security,
             transport_kind,
@@ -2937,6 +2950,7 @@ mod tests {
             };
             self.start_request(
                 execution_context,
+                Method::Get,
                 PipelineType::DataPlane,
                 TransportSecurity::Secure,
                 TransportKind::Gateway,

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
@@ -753,6 +753,7 @@ impl CosmosDriver {
         let (response, cosmos_headers, status_code, sub_status, cosmos_status) = loop {
             let request_handle = diagnostics.start_request(
                 execution_context,
+                azure_core::http::Method::Get,
                 PipelineType::Metadata,
                 transport_security,
                 transport.diagnostics_kind(),

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/dataflow/mocks.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/dataflow/mocks.rs
@@ -340,6 +340,7 @@ pub(crate) fn response_with_request_diagnostics(requests: usize) -> CosmosRespon
     for _ in 0..requests {
         let _ = diagnostics.start_request(
             ExecutionContext::Initial,
+            azure_core::http::Method::Get,
             PipelineType::DataPlane,
             TransportSecurity::Secure,
             TransportKind::Gateway,

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/operation_pipeline.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/operation_pipeline.rs
@@ -9156,6 +9156,7 @@ mod tests {
         );
         let _ = child.start_request(
             super::ExecutionContext::Hedging,
+            azure_core::http::Method::Get,
             super::PipelineType::DataPlane,
             super::TransportSecurity::Secure,
             TransportKind::Gateway,
@@ -9272,6 +9273,7 @@ mod tests {
         );
         let _ = child.start_request(
             super::ExecutionContext::Hedging,
+            azure_core::http::Method::Get,
             super::PipelineType::DataPlane,
             super::TransportSecurity::Secure,
             TransportKind::Gateway,
@@ -9308,6 +9310,7 @@ mod tests {
         );
         let _ = child.start_request(
             super::ExecutionContext::Hedging,
+            azure_core::http::Method::Get,
             super::PipelineType::DataPlane,
             super::TransportSecurity::Secure,
             TransportKind::Gateway,

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/patch_handler.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/patch_handler.rs
@@ -1161,6 +1161,7 @@ mod tests {
                 );
                 let handle = builder.start_request(
                     crate::diagnostics::ExecutionContext::Initial,
+                    azure_core::http::Method::Get,
                     crate::diagnostics::PipelineType::DataPlane,
                     crate::diagnostics::TransportSecurity::Secure,
                     crate::diagnostics::TransportKind::Gateway,

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/transport/transport_pipeline.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/transport/transport_pipeline.rs
@@ -237,6 +237,7 @@ pub(crate) async fn execute_transport_pipeline(
 
         let request_handle = diagnostics.start_request(
             execution_context,
+            request.method,
             ctx.pipeline_type,
             ctx.transport_security,
             ctx.transport.diagnostics_kind(),
@@ -1908,6 +1909,7 @@ mod tests {
         );
         let request_handle = diagnostics.start_request(
             ExecutionContext::Initial,
+            azure_core::http::Method::Get,
             PipelineType::DataPlane,
             TransportSecurity::Secure,
             crate::diagnostics::TransportKind::GatewayV2,


### PR DESCRIPTION
Preserve HTTP request metadata in Cosmos diagnostics and emit semantic convention attributes on sampled client attempt spans.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>