### PR TITLE
[AMQP] Add transaction coordinator and transactional state support

### DIFF
--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -51,6 +51,10 @@ fe2o3_amqp = [
   "serde_bytes",
   "azure_core/tokio",
 ]
+transaction = [
+  "fe2o3-amqp?/transaction",
+  "fe2o3-amqp-types?/transaction",
+]
 
 [lints]
 workspace = true

--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -34,6 +34,7 @@ typespec = { path = "../typespec", version = "1.2.0-beta.1" }
 typespec_macros = { path = "../typespec_macros", version = "1.1.0-beta.1" }
 
 [dev-dependencies]
+fe2o3-amqp = { workspace = true, features = ["acceptor"] }
 serde_json.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 

--- a/sdk/core/azure_core_amqp/src/error/mod.rs
+++ b/sdk/core/azure_core_amqp/src/error/mod.rs
@@ -66,6 +66,10 @@ pub enum AmqpErrorKind {
     /// Transport Implementation Error
     TransportImplementationError(Box<dyn std::error::Error + Send + Sync>),
 
+    #[cfg(feature = "transaction")]
+    /// Transactions are not supported by the remote peer.
+    TransactionsNotSupported(Box<dyn std::error::Error + Send + Sync>),
+
     /// A send was rejected.
     SendRejected,
 }
@@ -193,6 +197,9 @@ impl std::error::Error for AmqpError {
             | AmqpErrorKind::FramingError(e)
             | AmqpErrorKind::IdleTimeoutElapsed(e) => Some(e.as_ref()),
 
+            #[cfg(feature = "transaction")]
+            AmqpErrorKind::TransactionsNotSupported(e) => Some(e.as_ref()),
+
             AmqpErrorKind::ManagementStatusCode(_, _)
             | AmqpErrorKind::NonTerminalDeliveryState
             | AmqpErrorKind::SimpleMessage(_)
@@ -247,6 +254,10 @@ impl std::fmt::Display for AmqpError {
             }
             AmqpErrorKind::TransportImplementationError(s) => {
                 write!(f, "Transport Implementation Error: {}", s)
+            }
+            #[cfg(feature = "transaction")]
+            AmqpErrorKind::TransactionsNotSupported(s) => {
+                write!(f, "Transactions not supported by the remote peer: {}", s)
             }
             AmqpErrorKind::ConnectionDropped(s) => {
                 write!(f, "Connection dropped: {}", s)

--- a/sdk/core/azure_core_amqp/src/fe2o3/error.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/error.rs
@@ -65,6 +65,12 @@ impl From<&fe2o3_amqp_types::definitions::ErrorCondition> for AmqpErrorCondition
             fe2o3_amqp_types::definitions::ErrorCondition::Custom(symbol) => {
                 AmqpErrorCondition::from(AmqpSymbol::from(symbol))
             }
+            #[cfg(feature = "transaction")]
+            fe2o3_amqp_types::definitions::ErrorCondition::TransactionError(
+                ref transaction_error,
+            ) => AmqpErrorCondition::from(AmqpSymbol::from(
+                fe2o3_amqp_types::primitives::Symbol::from(transaction_error),
+            )),
         }
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_target.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_target.rs
@@ -1,2 +1,95 @@
 // Copyright (c) Microsoft Corporation. All Rights reserved
 // Licensed under the MIT license.
+
+use crate::{messaging::AmqpTarget, value::AmqpValue};
+
+pub(crate) fn to_fe2o3_target(target: AmqpTarget) -> fe2o3_amqp_types::messaging::Target {
+    let mut builder = fe2o3_amqp_types::messaging::Target::builder();
+
+    if let Some(address) = target.address {
+        builder = builder.address(address);
+    }
+    if let Some(durable) = target.durable {
+        builder = builder.durable(durable.into());
+    }
+    if let Some(expiry_policy) = target.expiry_policy {
+        builder = builder.expiry_policy(expiry_policy.into());
+    }
+    if let Some(timeout) = target.timeout {
+        builder = builder.timeout(timeout);
+    }
+    if let Some(dynamic) = target.dynamic {
+        builder = builder.dynamic(dynamic);
+    }
+    if let Some(dynamic_node_properties) = target.dynamic_node_properties {
+        builder = builder.dynamic_node_properties(
+            dynamic_node_properties
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        fe2o3_amqp_types::primitives::Symbol::from(k.as_str()),
+                        v.into(),
+                    )
+                })
+                .collect::<fe2o3_amqp_types::definitions::Fields>(),
+        );
+    }
+    if let Some(capabilities) = target.capabilities {
+        builder = builder.capabilities(
+            capabilities
+                .into_iter()
+                .map(|v| match v {
+                    AmqpValue::Symbol(s) => fe2o3_amqp_types::primitives::Symbol::from(s.0),
+                    AmqpValue::String(s) => fe2o3_amqp_types::primitives::Symbol::from(s),
+                    _ => fe2o3_amqp_types::primitives::Symbol::from(format!("{:?}", v)),
+                })
+                .collect::<fe2o3_amqp_types::primitives::Array<
+                    fe2o3_amqp_types::primitives::Symbol,
+                >>(),
+        );
+    }
+    builder.build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        messaging::{TerminusDurability, TerminusExpiryPolicy},
+        value::{AmqpOrderedMap, AmqpSymbol},
+    };
+
+    #[test]
+    fn message_target_conversion_to_fe2o3() {
+        let mut dynamic_node_properties = AmqpOrderedMap::new();
+        dynamic_node_properties.insert("prop".to_string(), AmqpValue::from("val"));
+
+        let amqp_target = AmqpTarget::builder()
+            .with_address("test".to_string())
+            .with_durable(TerminusDurability::UnsettledState)
+            .with_expiry_policy(TerminusExpiryPolicy::SessionEnd)
+            .with_timeout(95)
+            .with_dynamic(false)
+            .with_dynamic_node_properties(dynamic_node_properties)
+            .with_capabilities(vec![AmqpValue::Symbol(AmqpSymbol::from("capability"))])
+            .build();
+
+        let fe2o3_target = to_fe2o3_target(amqp_target);
+
+        assert_eq!(fe2o3_target.address.unwrap().as_str(), "test");
+        assert_eq!(
+            fe2o3_target.durable,
+            fe2o3_amqp_types::messaging::TerminusDurability::UnsettledState
+        );
+        assert_eq!(
+            fe2o3_target.expiry_policy,
+            fe2o3_amqp_types::messaging::TerminusExpiryPolicy::SessionEnd
+        );
+        assert_eq!(fe2o3_target.timeout, 95);
+        assert_eq!(fe2o3_target.dynamic, false);
+        assert_eq!(
+            fe2o3_target.capabilities.unwrap().as_slice(),
+            &[fe2o3_amqp_types::primitives::Symbol::from("capability")]
+        );
+    }
+}

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
@@ -75,10 +75,10 @@ impl From<fe2o3_amqp_types::messaging::Outcome> for AmqpOutcome {
             fe2o3_amqp_types::messaging::Outcome::Released(_) => AmqpOutcome::Released,
             fe2o3_amqp_types::messaging::Outcome::Rejected(_) => AmqpOutcome::Rejected,
             fe2o3_amqp_types::messaging::Outcome::Modified(_) => AmqpOutcome::Modified,
-            // Unreachable: fe2o3's Declared outcome is only produced by transaction coordinator links,
-            // which are introduced in a later commit. Dedicated outcome variants land in a later commit.
             #[cfg(feature = "transaction")]
-            fe2o3_amqp_types::messaging::Outcome::Declared(_) => AmqpOutcome::Accepted,
+            fe2o3_amqp_types::messaging::Outcome::Declared(declared) => {
+                AmqpOutcome::Declared(declared.txn_id.into_vec())
+            }
         }
     }
 }
@@ -102,18 +102,27 @@ impl From<AmqpOutcome> for fe2o3_amqp_types::messaging::Outcome {
                     message_annotations: None,
                 },
             ),
+            #[cfg(feature = "transaction")]
+            AmqpOutcome::Declared(txn_id) => fe2o3_amqp_types::messaging::Outcome::Declared(
+                fe2o3_amqp_types::transaction::Declared {
+                    txn_id: serde_bytes::ByteBuf::from(txn_id),
+                },
+            ),
         }
     }
 }
 
 #[test]
 fn test_outcome_round_trip() {
-    let outcomes = vec![
+    #[cfg_attr(not(feature = "transaction"), allow(unused_mut))]
+    let mut outcomes = vec![
         AmqpOutcome::Accepted,
         AmqpOutcome::Released,
         AmqpOutcome::Rejected,
         AmqpOutcome::Modified,
     ];
+    #[cfg(feature = "transaction")]
+    outcomes.push(AmqpOutcome::Declared(vec![1, 2, 3, 4]));
 
     for outcome in outcomes {
         let fe2o3_outcome: fe2o3_amqp_types::messaging::Outcome = outcome.clone().into();

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
@@ -75,6 +75,10 @@ impl From<fe2o3_amqp_types::messaging::Outcome> for AmqpOutcome {
             fe2o3_amqp_types::messaging::Outcome::Released(_) => AmqpOutcome::Released,
             fe2o3_amqp_types::messaging::Outcome::Rejected(_) => AmqpOutcome::Rejected,
             fe2o3_amqp_types::messaging::Outcome::Modified(_) => AmqpOutcome::Modified,
+            // Unreachable: fe2o3's Declared outcome is only produced by transaction coordinator links,
+            // which are introduced in a later commit. Dedicated outcome variants land in a later commit.
+            #[cfg(feature = "transaction")]
+            fe2o3_amqp_types::messaging::Outcome::Declared(_) => AmqpOutcome::Accepted,
         }
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/mod.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/mod.rs
@@ -8,4 +8,6 @@ pub(crate) mod messaging;
 pub(crate) mod receiver;
 pub(crate) mod sender;
 pub(crate) mod session;
+#[cfg(feature = "transaction")]
+pub(crate) mod transaction;
 pub(crate) mod value;

--- a/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
@@ -13,11 +13,20 @@ use std::sync::OnceLock;
 use tokio::sync::Mutex;
 use tracing::{info, trace, warn};
 
+#[cfg(feature = "transaction")]
+use crate::TransactionId;
+#[cfg(feature = "transaction")]
+use fe2o3_amqp::transaction::OwnedTransaction;
+#[cfg(feature = "transaction")]
+use std::{collections::HashMap, sync::Arc};
+
 use super::error::Fe2o3ReceiverAttachError;
 
 #[derive(Default)]
 pub(crate) struct Fe2o3AmqpReceiver {
     receiver: OnceLock<Mutex<fe2o3_amqp::Receiver>>,
+    #[cfg(feature = "transaction")]
+    transactions: OnceLock<Arc<Mutex<HashMap<TransactionId, OwnedTransaction>>>>,
 }
 
 /// The fe2o3 link builder for a receiver, after the name, source and target are set.
@@ -95,6 +104,8 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
         self.receiver
             .set(Mutex::new(receiver))
             .map_err(|_| Self::could_not_set_message_receiver())?;
+        #[cfg(feature = "transaction")]
+        let _ = self.transactions.set(session.implementation.transactions());
         Ok(())
     }
 
@@ -130,7 +141,8 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
 
     async fn credit_mode(&self) -> Result<ReceiverCreditMode> {
         let receiver = self.receiver.get().ok_or_else(Self::receiver_not_set)?;
-        Ok(receiver.lock().await.credit_mode().into())
+        let guard = receiver.lock().await;
+        Ok(guard.credit_mode().into())
     }
 
     async fn receive_delivery(&self) -> Result<AmqpDelivery> {
@@ -141,10 +153,7 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
             .lock()
             .await;
 
-        let delivery: fe2o3_amqp::link::delivery::Delivery<
-            fe2o3_amqp_types::messaging::Body<fe2o3_amqp_types::primitives::Value>,
-        > = receiver.recv().await.map_err(AmqpError::from)?;
-        trace!("Received delivery: {:?}", delivery);
+        let delivery = receiver.recv().await.map_err(AmqpError::from)?;
         Ok(delivery.into())
     }
 
@@ -201,12 +210,47 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
 
         Ok(())
     }
+
+    #[cfg(feature = "transaction")]
+    async fn settle_with_transaction(
+        &self,
+        delivery: &AmqpDelivery,
+        outcome: crate::messaging::AmqpOutcome,
+        txn_id: crate::TransactionId,
+    ) -> Result<()> {
+        use fe2o3_amqp::transaction::TransactionalRetirement;
+
+        let mut receiver = self
+            .receiver
+            .get()
+            .ok_or_else(Self::receiver_not_set)?
+            .lock()
+            .await;
+
+        let transactions = self.transactions.get().ok_or_else(Self::receiver_not_set)?;
+
+        trace!("Settling delivery with transaction.");
+        let fe2o3_outcome: fe2o3_amqp_types::messaging::Outcome = outcome.into();
+        let active_txns = transactions.lock().await;
+        let txn = active_txns.get(&txn_id).ok_or_else(|| {
+            AmqpError::with_message("Transaction not found or already discharged")
+        })?;
+
+        txn.retire(&mut receiver, &delivery.0.delivery, fe2o3_outcome)
+            .await
+            .map_err(AmqpError::from)?;
+        trace!("Settled delivery with transaction.");
+
+        Ok(())
+    }
 }
 
 impl Fe2o3AmqpReceiver {
     pub fn new() -> Self {
         Self {
             receiver: OnceLock::new(),
+            #[cfg(feature = "transaction")]
+            transactions: OnceLock::new(),
         }
     }
 
@@ -276,6 +320,10 @@ mod tests {
     use super::*;
     use crate::messaging::AmqpSource;
     use crate::value::{AmqpOrderedMap, AmqpSymbol, AmqpValue};
+    #[cfg(feature = "transaction")]
+    use fe2o3_amqp::{acceptor::ConnectionAcceptor, connection::Connection};
+    #[cfg(feature = "transaction")]
+    use tokio::{io::duplex, sync::oneshot};
 
     // Makes sure the link properties survive the fe2o3 builder chain. The
     // `name` method clears the properties, so it must run before
@@ -412,5 +460,67 @@ mod tests {
                 .is_some(),
             "the reported error must carry the LinkStateError, not the enclosing RecvError"
         );
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "transaction")]
+    async fn settle_with_transaction_unattached_receiver_fails() {
+        let (client_io, server_io) = duplex(65536);
+        let (done_tx, done_rx) = oneshot::channel::<()>();
+
+        let server_task = tokio::spawn(async move {
+            let acceptor = ConnectionAcceptor::new("test-container");
+            let mut connection = acceptor.accept(server_io).await.unwrap();
+            let session_acceptor = fe2o3_amqp::acceptor::SessionAcceptor::new();
+            let mut session = session_acceptor.accept(&mut connection).await.unwrap();
+            let link_acceptor = fe2o3_amqp::acceptor::LinkAcceptor::new();
+            let fe2o3_amqp::acceptor::LinkEndpoint::Sender(mut sender_link) =
+                link_acceptor.accept(&mut session).await.unwrap()
+            else {
+                panic!("expected Sender link");
+            };
+            let message = fe2o3_amqp_types::messaging::Message::builder()
+                .value(42i32)
+                .build();
+            tokio::spawn(async move {
+                let _ = sender_link.send(message).await;
+            });
+            let _ = done_rx.await;
+        });
+
+        let mut connection = Connection::builder()
+            .container_id("client-container")
+            .open_with_stream(client_io)
+            .await
+            .unwrap();
+        let mut session = fe2o3_amqp::session::Session::begin(&mut connection)
+            .await
+            .unwrap();
+        let mut receiver_link = fe2o3_amqp::Receiver::builder()
+            .name("test-receiver")
+            .source("test-source")
+            .credit_mode(fe2o3_amqp::link::receiver::CreditMode::Auto(10))
+            .attach(&mut session)
+            .await
+            .unwrap();
+
+        let fe2o3_delivery = receiver_link
+            .recv::<fe2o3_amqp_types::messaging::Body<fe2o3_amqp_types::primitives::Value>>()
+            .await
+            .unwrap();
+        let delivery: AmqpDelivery = fe2o3_delivery.into();
+
+        let receiver = Fe2o3AmqpReceiver::new();
+        let result = receiver
+            .settle_with_transaction(
+                &delivery,
+                crate::messaging::AmqpOutcome::Accepted,
+                vec![1, 2, 3],
+            )
+            .await;
+        assert!(result.is_err());
+
+        let _ = done_tx.send(());
+        let _ = server_task.await;
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
@@ -255,8 +255,15 @@ impl From<fe2o3_amqp::link::SenderAttachError> for AmqpError {
             | fe2o3_amqp::link::SenderAttachError::IllegalState => {
                 AmqpErrorKind::ConnectionDropped(Box::new(e)).into()
             }
-            fe2o3_amqp::link::SenderAttachError::CoordinatorIsNotImplemented
-            | fe2o3_amqp::link::SenderAttachError::DuplicatedLinkName
+            #[cfg(feature = "transaction")]
+            fe2o3_amqp::link::SenderAttachError::CoordinatorIsNotImplemented => {
+                AmqpErrorKind::TransactionsNotSupported(Box::new(e)).into()
+            }
+            #[cfg(not(feature = "transaction"))]
+            fe2o3_amqp::link::SenderAttachError::CoordinatorIsNotImplemented => {
+                AmqpErrorKind::TransportImplementationError(Box::new(e)).into()
+            }
+            fe2o3_amqp::link::SenderAttachError::DuplicatedLinkName
             | fe2o3_amqp::link::SenderAttachError::NonAttachFrameReceived
             | fe2o3_amqp::link::SenderAttachError::ExpectImmediateDetach
             | fe2o3_amqp::link::SenderAttachError::IncomingTargetIsNone
@@ -330,5 +337,27 @@ mod tests {
             capabilities.as_slice(),
             &[fe2o3_amqp_types::primitives::Symbol::from("capability")]
         );
+    }
+
+    #[test]
+    #[cfg(feature = "transaction")]
+    fn test_coordinator_is_not_implemented_maps_to_transactions_not_supported() {
+        let fe2o3_err = fe2o3_amqp::link::SenderAttachError::CoordinatorIsNotImplemented;
+        let err: AmqpError = fe2o3_err.into();
+        assert!(matches!(
+            err.kind(),
+            AmqpErrorKind::TransactionsNotSupported(_)
+        ));
+    }
+
+    #[test]
+    #[cfg(not(feature = "transaction"))]
+    fn test_coordinator_is_not_implemented_maps_to_transport_implementation_error() {
+        let fe2o3_err = fe2o3_amqp::link::SenderAttachError::CoordinatorIsNotImplemented;
+        let err: AmqpError = fe2o3_err.into();
+        assert!(matches!(
+            err.kind(),
+            AmqpErrorKind::TransportImplementationError(_)
+        ));
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
@@ -195,10 +195,10 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
             fe2o3_amqp_types::messaging::Outcome::Modified(ref m) => {
                 AmqpSendOutcome::Modified(m.into())
             }
-            // Unreachable: fe2o3's Declared outcome is only produced by transaction coordinator links,
-            // which are introduced in a later commit. Dedicated outcome variants land in a later commit.
             #[cfg(feature = "transaction")]
-            fe2o3_amqp_types::messaging::Outcome::Declared(_) => AmqpSendOutcome::Accepted,
+            fe2o3_amqp_types::messaging::Outcome::Declared(declared) => {
+                AmqpSendOutcome::Declared(declared.txn_id.into_vec())
+            }
         })
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
@@ -192,6 +192,10 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
             fe2o3_amqp_types::messaging::Outcome::Modified(ref m) => {
                 AmqpSendOutcome::Modified(m.into())
             }
+            // Unreachable: fe2o3's Declared outcome is only produced by transaction coordinator links,
+            // which are introduced in a later commit. Dedicated outcome variants land in a later commit.
+            #[cfg(feature = "transaction")]
+            fe2o3_amqp_types::messaging::Outcome::Declared(_) => AmqpSendOutcome::Accepted,
         })
     }
 }
@@ -258,6 +262,10 @@ impl From<fe2o3_amqp::link::SenderAttachError> for AmqpError {
             | fe2o3_amqp::link::SenderAttachError::TargetAddressIsNoneWhenDynamicIsTrue
             | fe2o3_amqp::link::SenderAttachError::SourceAddressIsSomeWhenDynamicIsTrue
             | fe2o3_amqp::link::SenderAttachError::DynamicNodePropertiesIsSomeWhenDynamicIsFalse => {
+                AmqpErrorKind::TransportImplementationError(Box::new(e)).into()
+            }
+            #[cfg(feature = "transaction")]
+            fe2o3_amqp::link::SenderAttachError::DesireTxnCapabilitiesNotSupported => {
                 AmqpErrorKind::TransportImplementationError(Box::new(e)).into()
             }
         }

--- a/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
@@ -51,7 +51,10 @@ fn build_sender_link(
     target: AmqpTarget,
     options: Option<AmqpSenderOptions>,
 ) -> Fe2o3SenderBuilder {
-    let mut builder = fe2o3_amqp::Sender::builder().name(name).target(target);
+    let fe2o3_target = super::messaging::message_target::to_fe2o3_target(target);
+    let mut builder = fe2o3_amqp::Sender::builder()
+        .name(name)
+        .target(fe2o3_target);
 
     if let Some(options) = options {
         if let Some(sender_settle_mode) = options.sender_settle_mode {
@@ -303,6 +306,29 @@ mod tests {
                 "com.microsoft:epoch"
             )),
             Some(&fe2o3_amqp_types::primitives::Value::Long(3))
+        );
+    }
+
+    #[test]
+    fn sender_link_keeps_target_capabilities() {
+        let target = AmqpTarget::builder()
+            .with_address("amqps://example.servicebus.windows.net/eh".to_string())
+            .with_capabilities(vec![AmqpValue::Symbol(AmqpSymbol::from("capability"))])
+            .build();
+
+        let builder = build_sender_link("test-sender".into(), target, None);
+
+        let target = builder
+            .target
+            .as_ref()
+            .expect("target must be set on builder");
+        let capabilities = target
+            .capabilities
+            .as_ref()
+            .expect("target capabilities must survive the builder chain");
+        assert_eq!(
+            capabilities.as_slice(),
+            &[fe2o3_amqp_types::primitives::Symbol::from("capability")]
         );
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/session.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/session.rs
@@ -174,16 +174,21 @@ impl From<fe2o3_amqp::session::Error> for AmqpError {
             | fe2o3_amqp::session::Error::TransferFrameToSender => {
                 AmqpErrorKind::TransportImplementationError(Box::new(e)).into()
             }
-            #[cfg(feature = "transaction")]
-            fe2o3_amqp::session::Error::UnknownTxnId => {
-                AmqpErrorKind::TransportImplementationError(Box::new(e)).into()
-            }
+
             fe2o3_amqp::session::Error::RemoteEnded => {
                 AmqpErrorKind::SessionClosedByRemote(Box::new(e)).into()
             }
             fe2o3_amqp::session::Error::RemoteEndedWithError(error) => {
                 AmqpErrorKind::AmqpDescribedError(error.into()).into()
             }
+            // fe2o3-amqp's session::Error may gain variants (e.g. UnknownTxnId) when
+            // dependent crates unify features we don't control from our own Cargo.toml
+            // (e.g. dev-dependency `acceptor` enabling extra fe2o3 variants during
+            // `cargo test`). We can't `cfg`-detect a dependency's own feature state,
+            // so a narrow wildcard is required here — every variant we CAN see by
+            // name above stays explicitly matched.
+            #[allow(unreachable_patterns)]
+            _ => AmqpErrorKind::TransportImplementationError(Box::new(e)).into(),
         }
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/session.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/session.rs
@@ -14,9 +14,18 @@ use std::{
 use tokio::sync::Mutex;
 use tracing::{debug, trace};
 
+#[cfg(feature = "transaction")]
+use crate::TransactionId;
+#[cfg(feature = "transaction")]
+use fe2o3_amqp::transaction::OwnedTransaction;
+#[cfg(feature = "transaction")]
+use std::collections::HashMap;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct Fe2o3AmqpSession {
     session: OnceLock<Arc<Mutex<fe2o3_amqp::session::SessionHandle<()>>>>,
+    #[cfg(feature = "transaction")]
+    transactions: Arc<Mutex<HashMap<TransactionId, OwnedTransaction>>>,
 }
 
 impl Drop for Fe2o3AmqpSession {
@@ -29,6 +38,8 @@ impl Fe2o3AmqpSession {
     pub fn new() -> Self {
         Self {
             session: OnceLock::new(),
+            #[cfg(feature = "transaction")]
+            transactions: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -39,6 +50,11 @@ impl Fe2o3AmqpSession {
             .get()
             .ok_or_else(Self::session_not_set)?
             .clone())
+    }
+
+    #[cfg(feature = "transaction")]
+    pub fn transactions(&self) -> Arc<Mutex<HashMap<TransactionId, OwnedTransaction>>> {
+        self.transactions.clone()
     }
 
     fn session_already_attached() -> AmqpError {
@@ -156,6 +172,10 @@ impl From<fe2o3_amqp::session::Error> for AmqpError {
             | fe2o3_amqp::session::Error::IllegalState
             | fe2o3_amqp::session::Error::IllegalConnectionState
             | fe2o3_amqp::session::Error::TransferFrameToSender => {
+                AmqpErrorKind::TransportImplementationError(Box::new(e)).into()
+            }
+            #[cfg(feature = "transaction")]
+            fe2o3_amqp::session::Error::UnknownTxnId => {
                 AmqpErrorKind::TransportImplementationError(Box::new(e)).into()
             }
             fe2o3_amqp::session::Error::RemoteEnded => {

--- a/sdk/core/azure_core_amqp/src/fe2o3/transaction.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/transaction.rs
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All Rights reserved
+// Licensed under the MIT license.
+
+use crate::{
+    error::Result, session::AmqpSession, transaction::AmqpTransactionCoordinatorApis, AmqpError,
+    TransactionId,
+};
+use fe2o3_amqp::transaction::{OwnedTransaction, TransactionDischarge, TransactionExt};
+use std::{
+    borrow::BorrowMut,
+    collections::HashMap,
+    sync::atomic::{AtomicBool, Ordering},
+};
+use tokio::sync::Mutex;
+use tracing::debug;
+
+pub(crate) struct Fe2o3TransactionCoordinator {
+    attached: AtomicBool,
+    active_transactions: Mutex<HashMap<TransactionId, OwnedTransaction>>,
+    session: AmqpSession,
+}
+
+impl Fe2o3TransactionCoordinator {
+    pub fn new(session: AmqpSession) -> Result<Self> {
+        Ok(Self {
+            attached: AtomicBool::new(false),
+            active_transactions: Mutex::new(HashMap::new()),
+            session,
+        })
+    }
+
+    fn coordinator_not_attached() -> AmqpError {
+        AmqpError::with_message("Transaction coordinator is not attached")
+    }
+}
+
+impl Drop for Fe2o3TransactionCoordinator {
+    fn drop(&mut self) {
+        debug!("Dropping Fe2o3TransactionCoordinator.");
+    }
+}
+
+#[async_trait::async_trait]
+impl AmqpTransactionCoordinatorApis for Fe2o3TransactionCoordinator {
+    async fn attach(&self) -> Result<()> {
+        let session = self.session.implementation.get()?;
+        let _guard = session.lock().await;
+        self.attached.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn detach(mut self) -> Result<()> {
+        self.attached.store(false, Ordering::SeqCst);
+        let mut transactions = self.active_transactions.lock().await;
+        for (txn_id, mut txn) in transactions.drain() {
+            if let Err(e) = txn.discharge(true).await {
+                tracing::warn!(?txn_id, error = ?e, "failed to roll back transaction during detach");
+            }
+        }
+        Ok(())
+    }
+
+    async fn declare(&self) -> Result<TransactionId> {
+        if !self.attached.load(Ordering::SeqCst) {
+            return Err(Self::coordinator_not_attached());
+        }
+
+        let session = self.session.implementation.get()?;
+        let mut session_guard = session.lock().await;
+
+        let txn = OwnedTransaction::declare(session_guard.borrow_mut(), "coordinator-link", None)
+            .await
+            .map_err(AmqpError::from)?;
+
+        let txn_id = txn.txn_id().as_slice().to_vec();
+        self.active_transactions
+            .lock()
+            .await
+            .insert(txn_id.clone(), txn);
+
+        Ok(txn_id)
+    }
+
+    async fn discharge(&self, txn_id: TransactionId, fail: bool) -> Result<()> {
+        if !self.attached.load(Ordering::SeqCst) {
+            return Err(Self::coordinator_not_attached());
+        }
+
+        let mut txn = self
+            .active_transactions
+            .lock()
+            .await
+            .remove(&txn_id)
+            .ok_or_else(|| {
+                AmqpError::with_message("Transaction not found or already discharged")
+            })?;
+
+        txn.discharge(fail).await.map_err(AmqpError::from)?;
+        Ok(())
+    }
+}
+
+impl From<fe2o3_amqp::transaction::OwnedDeclareError> for AmqpError {
+    fn from(e: fe2o3_amqp::transaction::OwnedDeclareError) -> Self {
+        crate::error::AmqpErrorKind::TransportImplementationError(Box::new(e)).into()
+    }
+}
+
+impl From<fe2o3_amqp::transaction::OwnedDischargeError> for AmqpError {
+    fn from(e: fe2o3_amqp::transaction::OwnedDischargeError) -> Self {
+        crate::error::AmqpErrorKind::TransportImplementationError(Box::new(e)).into()
+    }
+}

--- a/sdk/core/azure_core_amqp/src/fe2o3/transaction.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/transaction.rs
@@ -9,22 +9,26 @@ use fe2o3_amqp::transaction::{OwnedTransaction, TransactionDischarge, Transactio
 use std::{
     borrow::BorrowMut,
     collections::HashMap,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 use tokio::sync::Mutex;
 use tracing::debug;
 
 pub(crate) struct Fe2o3TransactionCoordinator {
     attached: AtomicBool,
-    active_transactions: Mutex<HashMap<TransactionId, OwnedTransaction>>,
+    transactions: Arc<Mutex<HashMap<TransactionId, OwnedTransaction>>>,
     session: AmqpSession,
 }
 
 impl Fe2o3TransactionCoordinator {
     pub fn new(session: AmqpSession) -> Result<Self> {
+        let transactions = session.implementation.transactions();
         Ok(Self {
             attached: AtomicBool::new(false),
-            active_transactions: Mutex::new(HashMap::new()),
+            transactions,
             session,
         })
     }
@@ -49,9 +53,10 @@ impl AmqpTransactionCoordinatorApis for Fe2o3TransactionCoordinator {
         Ok(())
     }
 
+    // Detaching the coordinator clears and rolls back all active transactions associated with the session.
     async fn detach(mut self) -> Result<()> {
         self.attached.store(false, Ordering::SeqCst);
-        let mut transactions = self.active_transactions.lock().await;
+        let mut transactions = self.transactions.lock().await;
         for (txn_id, mut txn) in transactions.drain() {
             if let Err(e) = txn.discharge(true).await {
                 tracing::warn!(?txn_id, error = ?e, "failed to roll back transaction during detach");
@@ -73,10 +78,7 @@ impl AmqpTransactionCoordinatorApis for Fe2o3TransactionCoordinator {
             .map_err(AmqpError::from)?;
 
         let txn_id = txn.txn_id().as_slice().to_vec();
-        self.active_transactions
-            .lock()
-            .await
-            .insert(txn_id.clone(), txn);
+        self.transactions.lock().await.insert(txn_id.clone(), txn);
 
         Ok(txn_id)
     }
@@ -87,7 +89,7 @@ impl AmqpTransactionCoordinatorApis for Fe2o3TransactionCoordinator {
         }
 
         let mut txn = self
-            .active_transactions
+            .transactions
             .lock()
             .await
             .remove(&txn_id)

--- a/sdk/core/azure_core_amqp/src/lib.rs
+++ b/sdk/core/azure_core_amqp/src/lib.rs
@@ -27,6 +27,8 @@ pub use cbs::{AmqpClaimsBasedSecurity, AmqpClaimsBasedSecurityApis};
 pub use connection::{AmqpConnection, AmqpConnectionApis, AmqpConnectionOptions};
 pub use error::*;
 pub use management::{AmqpManagement, AmqpManagementApis};
+#[cfg(feature = "transaction")]
+pub use messaging::TransactionId;
 pub use messaging::{AmqpDelivery, AmqpDeliveryApis, AmqpMessage, AmqpSource, AmqpTarget};
 pub use receiver::{AmqpReceiver, AmqpReceiverApis, AmqpReceiverOptions, ReceiverCreditMode};
 pub use sender::{AmqpSendOptions, AmqpSendOutcome, AmqpSender, AmqpSenderApis, AmqpSenderOptions};

--- a/sdk/core/azure_core_amqp/src/lib.rs
+++ b/sdk/core/azure_core_amqp/src/lib.rs
@@ -11,6 +11,9 @@ mod fe2o3;
 #[cfg(not(feature = "fe2o3_amqp"))]
 mod noop;
 
+#[cfg(feature = "transaction")]
+mod transaction;
+
 mod cbs;
 mod connection;
 /// AMQP error types.
@@ -35,6 +38,8 @@ pub use sender::{AmqpSendOptions, AmqpSendOutcome, AmqpSender, AmqpSenderApis, A
 pub use session::{AmqpSession, AmqpSessionApis, AmqpSessionOptions};
 pub use simple_value::AmqpSimpleValue;
 use std::fmt::Debug;
+#[cfg(feature = "transaction")]
+pub use transaction::{AmqpTransactionCoordinator, AmqpTransactionCoordinatorApis};
 pub use value::{AmqpDescribed, AmqpList, AmqpOrderedMap, AmqpSymbol, AmqpTimestamp, AmqpValue};
 
 /// Builders for AMQP types.

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -180,6 +180,9 @@ pub enum AmqpOutcome {
     Released,
     /// The message was modified before forwarding.
     Modified,
+    /// The transaction was declared.
+    #[cfg(feature = "transaction")]
+    Declared(TransactionId),
 }
 
 impl From<AmqpOutcome> for AmqpSymbol {
@@ -189,6 +192,8 @@ impl From<AmqpOutcome> for AmqpSymbol {
             AmqpOutcome::Rejected => AmqpSymbol::from("amqp:rejected:list"),
             AmqpOutcome::Released => AmqpSymbol::from("amqp:released:list"),
             AmqpOutcome::Modified => AmqpSymbol::from("amqp:modified:list"),
+            #[cfg(feature = "transaction")]
+            AmqpOutcome::Declared(_) => AmqpSymbol::from("amqp:declared:list"),
         }
     }
 }

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -122,6 +122,10 @@ impl AmqpDelivery {
 pub type DeliveryNumber = u32;
 pub type DeliveryTag = Vec<u8>;
 
+/// An AMQP transaction ID.
+#[cfg(feature = "transaction")]
+pub type TransactionId = Vec<u8>;
+
 /// Trait defining the APIs for interacting with an AMQP delivery.
 pub trait AmqpDeliveryApis {
     /// Get the message
@@ -2193,5 +2197,12 @@ mod tests {
             let deserialized = AmqpMessage::decode(&serialized).unwrap();
             assert_eq!(deserialized, message);
         }
+    }
+
+    #[test]
+    #[cfg(feature = "transaction")]
+    fn test_transaction_id() {
+        let txn_id: super::TransactionId = vec![1, 2, 3, 4];
+        assert_eq!(txn_id.len(), 4);
     }
 }

--- a/sdk/core/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure_core_amqp/src/noop.rs
@@ -251,3 +251,34 @@ impl AmqpDeliveryApis for NoopAmqpDelivery {
         unimplemented!();
     }
 }
+
+#[cfg(feature = "transaction")]
+#[derive(Default)]
+pub(crate) struct NoopAmqpTransactionCoordinator {}
+
+#[cfg(feature = "transaction")]
+impl NoopAmqpTransactionCoordinator {
+    pub fn new(_session: AmqpSession) -> Result<Self> {
+        Ok(Self {})
+    }
+}
+
+#[cfg(feature = "transaction")]
+#[async_trait::async_trait]
+impl crate::transaction::AmqpTransactionCoordinatorApis for NoopAmqpTransactionCoordinator {
+    async fn attach(&self) -> Result<()> {
+        unimplemented!();
+    }
+
+    async fn detach(self) -> Result<()> {
+        unimplemented!();
+    }
+
+    async fn declare(&self) -> Result<crate::TransactionId> {
+        unimplemented!();
+    }
+
+    async fn discharge(&self, _txn_id: crate::TransactionId, _fail: bool) -> Result<()> {
+        unimplemented!();
+    }
+}

--- a/sdk/core/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure_core_amqp/src/noop.rs
@@ -231,6 +231,16 @@ impl AmqpReceiverApis for NoopAmqpReceiver {
     async fn release_delivery(&self, delivery: &AmqpDelivery) -> Result<()> {
         unimplemented!();
     }
+
+    #[cfg(feature = "transaction")]
+    async fn settle_with_transaction(
+        &self,
+        _delivery: &AmqpDelivery,
+        _outcome: crate::messaging::AmqpOutcome,
+        _txn_id: crate::TransactionId,
+    ) -> Result<()> {
+        unimplemented!();
+    }
 }
 
 impl AmqpDeliveryApis for NoopAmqpDelivery {

--- a/sdk/core/azure_core_amqp/src/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/receiver.rs
@@ -9,6 +9,9 @@ use crate::{
     ReceiverSettleMode,
 };
 
+#[cfg(feature = "transaction")]
+use crate::TransactionId;
+
 #[cfg(feature = "fe2o3_amqp")]
 type ReceiverImplementation = super::fe2o3::receiver::Fe2o3AmqpReceiver;
 
@@ -108,6 +111,15 @@ pub trait AmqpReceiverApis {
 
     /// Releases a delivery from the AMQP receiver.
     async fn release_delivery(&self, delivery: &AmqpDelivery) -> Result<()>;
+
+    /// Settles a delivery as part of a transaction.
+    #[cfg(feature = "transaction")]
+    async fn settle_with_transaction(
+        &self,
+        delivery: &AmqpDelivery,
+        outcome: crate::messaging::AmqpOutcome,
+        txn_id: TransactionId,
+    ) -> Result<()>;
 }
 
 /// Struct representing the AMQP receiver functionality.
@@ -159,6 +171,18 @@ impl AmqpReceiverApis for AmqpReceiver {
 
     async fn release_delivery(&self, delivery: &AmqpDelivery) -> Result<()> {
         self.implementation.release_delivery(delivery).await
+    }
+
+    #[cfg(feature = "transaction")]
+    async fn settle_with_transaction(
+        &self,
+        delivery: &AmqpDelivery,
+        outcome: crate::messaging::AmqpOutcome,
+        txn_id: TransactionId,
+    ) -> Result<()> {
+        self.implementation
+            .settle_with_transaction(delivery, outcome, txn_id)
+            .await
     }
 }
 

--- a/sdk/core/azure_core_amqp/src/sender.rs
+++ b/sdk/core/azure_core_amqp/src/sender.rs
@@ -159,6 +159,9 @@ pub enum AmqpSendOutcome {
     /// not and will not be acted upon, and that the message SHOULD be modified in the
     /// specified ways at the node.
     Modified(SendModification),
+    /// The transaction was declared.
+    #[cfg(feature = "transaction")]
+    Declared(crate::TransactionId),
 }
 
 /// If the message was modified in transit, this struct contains the details of the modification.

--- a/sdk/core/azure_core_amqp/src/transaction.rs
+++ b/sdk/core/azure_core_amqp/src/transaction.rs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All Rights reserved
+// Licensed under the MIT license.
+
+use super::session::AmqpSession;
+use crate::{error::Result, TransactionId};
+
+#[cfg(feature = "fe2o3_amqp")]
+type TransactionCoordinatorImplementation = crate::fe2o3::transaction::Fe2o3TransactionCoordinator;
+
+#[cfg(not(feature = "fe2o3_amqp"))]
+type TransactionCoordinatorImplementation = crate::noop::NoopAmqpTransactionCoordinator;
+
+/// Trait defining the asynchronous APIs for AMQP Transaction Coordinator operations.
+#[async_trait::async_trait]
+pub trait AmqpTransactionCoordinatorApis {
+    /// Asynchronously initializes the transaction coordinator on the AMQP session and verifies readiness.
+    async fn attach(&self) -> Result<()>;
+
+    /// Asynchronously detaches the transaction coordinator from the AMQP session, explicitly rolling back any remaining active transactions.
+    async fn detach(self) -> Result<()>;
+
+    /// Asynchronously declares a new transaction.
+    async fn declare(&self) -> Result<TransactionId>;
+
+    /// Asynchronously discharges (commits or rolls back) a transaction.
+    ///
+    /// # Parameters
+    /// - `txn_id`: The ID of the transaction to discharge.
+    /// - `fail`: `true` to roll back/abort, `false` to commit.
+    async fn discharge(&self, txn_id: TransactionId, fail: bool) -> Result<()>;
+}
+
+/// Struct representing an AMQP Transaction Coordinator link.
+pub struct AmqpTransactionCoordinator {
+    implementation: TransactionCoordinatorImplementation,
+}
+
+impl AmqpTransactionCoordinator {
+    /// Creates a new instance of `AmqpTransactionCoordinator` using the provided AMQP session.
+    pub fn new(session: AmqpSession) -> Result<Self> {
+        Ok(Self {
+            implementation: TransactionCoordinatorImplementation::new(session)?,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl AmqpTransactionCoordinatorApis for AmqpTransactionCoordinator {
+    async fn attach(&self) -> Result<()> {
+        self.implementation.attach().await
+    }
+
+    async fn detach(self) -> Result<()> {
+        self.implementation.detach().await
+    }
+
+    async fn declare(&self) -> Result<TransactionId> {
+        self.implementation.declare().await
+    }
+
+    async fn discharge(&self, txn_id: TransactionId, fail: bool) -> Result<()> {
+        self.implementation.discharge(txn_id, fail).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn unattached_coordinator_declare_and_discharge_fail() {
+        let session = AmqpSession::new();
+        let coordinator = AmqpTransactionCoordinator::new(session).unwrap();
+
+        assert!(coordinator.declare().await.is_err());
+        assert!(coordinator.discharge(vec![1, 2, 3], false).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn unattached_session_attach_fails() {
+        let session = AmqpSession::new();
+        let coordinator = AmqpTransactionCoordinator::new(session).unwrap();
+
+        assert!(coordinator.attach().await.is_err());
+    }
+}


### PR DESCRIPTION
Fixes #4937

Adds transaction support to azure_core_amqp, behind a `transaction` feature flag. Tier 0 for #4934.

A few decisions worth flagging for review:

- Used `OwnedTransaction` (attaches its own control link per transaction) instead of holding a persistent `Controller` — the latter would need a borrowed `Transaction<'t>` stored in a map, which isn't safe without an unsafe cast. Side benefit: a transaction spanning a reconnect fails cleanly on its own, which the issue asked for.

- `detach()` explicitly discharges any remaining transactions instead of just dropping them — `OwnedTransaction` doesn't send a real AMQP frame on drop, so relying on that would mean rollback only happens after a broker timeout.

- Transaction state is shared per-session (`Arc<Mutex<...>>` on the session), not global, so separate sessions don't see each other's transactions.

- `CoordinatorIsNotImplemented` now maps to its own error kind instead of the generic transport error bucket, so callers can distinguish "broker doesn't support transactions" from other attach failures.

Open question: should this target main, or is there a feature branch for the Service Bus GA epic? Let me know and I'll retarget.