### PR TITLE
Migrate CFS feed to public feed

### DIFF
--- a/eng/templates/config.toml.template
+++ b/eng/templates/config.toml.template
@@ -7,24 +7,9 @@
 # CARGO_REGISTRIES_AZURE_SDK_FOR_RUST_PUBLIC_TOKEN / _CREDENTIAL_PROVIDER variables that
 # cargo needs to authenticate against the feed.
 #
-# The `~force-auth` suffix on the feed name is required. The feed lives in the public
-# `azure-sdk` project, so Azure Artifacts answers the anonymous probe cargo makes for
-# `Cargo/index/config.json` with "auth-required": false. Cargo caches that answer and
-# only re-requests with credentials for config.json itself, so every crate lookup goes
-# out anonymously and the token is never used. Anonymous callers may read crates already
-# saved in the feed, but saving a new crate from the crates.io upstream requires an
-# identity with at least the Feed and Upstream Reader role, so the first crate not yet
-# cached fails with HTTP 401 and "No local versions of package '<crate>'". `~force-auth`
-# makes the feed 401 the anonymous config.json probe instead, which is the one case
-# cargo retries with credentials, so the whole session is authenticated and upstream
-# saves succeed. See https://learn.microsoft.com/azure/devops/artifacts/cargo/cargo-upstream-source.
-#
-# The `~force-auth` suffix belongs only in the index URL. The registry is still named
-# `azure-sdk-for-rust-public` everywhere else, including the environment variables above.
-#
-# The [source] replacement redirects index.crates.io and static.crates.io to the
-# feed.
-#
+# The `~force-auth` suffix on the feed name is required. See
+# https://learn.microsoft.com/azure/devops/artifacts/cargo/cargo-upstream-source.
+
 [registries]
 azure-sdk-for-rust-public = { index = "sparse+https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-rust-public~force-auth/Cargo/index/" }
 

--- a/eng/templates/config.toml.template
+++ b/eng/templates/config.toml.template
@@ -4,15 +4,29 @@
 # This file should be copied to $CARGO_HOME/config.toml
 #
 # CargoAuthenticate@0 parses the [registries] table below and exports the
-# CARGO_REGISTRIES_AZURE_SDK_FOR_RUST_TOKEN / _CREDENTIAL_PROVIDER variables that cargo
-# needs to authenticate against the feed. The feed sets "auth-required": true, so the
-# token is required even for reads.
+# CARGO_REGISTRIES_AZURE_SDK_FOR_RUST_PUBLIC_TOKEN / _CREDENTIAL_PROVIDER variables that
+# cargo needs to authenticate against the feed.
+#
+# The `~force-auth` suffix on the feed name is required. The feed lives in the public
+# `azure-sdk` project, so Azure Artifacts answers the anonymous probe cargo makes for
+# `Cargo/index/config.json` with "auth-required": false. Cargo caches that answer and
+# only re-requests with credentials for config.json itself, so every crate lookup goes
+# out anonymously and the token is never used. Anonymous callers may read crates already
+# saved in the feed, but saving a new crate from the crates.io upstream requires an
+# identity with at least the Feed and Upstream Reader role, so the first crate not yet
+# cached fails with HTTP 401 and "No local versions of package '<crate>'". `~force-auth`
+# makes the feed 401 the anonymous config.json probe instead, which is the one case
+# cargo retries with credentials, so the whole session is authenticated and upstream
+# saves succeed. See https://learn.microsoft.com/azure/devops/artifacts/cargo/cargo-upstream-source.
+#
+# The `~force-auth` suffix belongs only in the index URL. The registry is still named
+# `azure-sdk-for-rust-public` everywhere else, including the environment variables above.
 #
 # The [source] replacement redirects index.crates.io and static.crates.io to the
 # feed.
 #
 [registries]
-azure-sdk-for-rust-public = { index = "sparse+https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-rust-public/Cargo/index/" }
+azure-sdk-for-rust-public = { index = "sparse+https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-rust-public~force-auth/Cargo/index/" }
 
 [source.crates-io]
 replace-with = "azure-sdk-for-rust-public"

--- a/eng/templates/config.toml.template
+++ b/eng/templates/config.toml.template
@@ -12,10 +12,10 @@
 # feed.
 #
 [registries]
-azure-sdk-for-rust = { index = "sparse+https://pkgs.dev.azure.com/azure-sdk/_packaging/azure-sdk-for-rust/Cargo/index/" }
+azure-sdk-for-rust-public = { index = "sparse+https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-rust-public/Cargo/index/" }
 
 [source.crates-io]
-replace-with = "azure-sdk-for-rust"
+replace-with = "azure-sdk-for-rust-public"
 
 # Both `cargo package` and `cargo publish` refuse to run while crates-io is replaced
 # unless the target registry is named, failing with:
@@ -34,4 +34,4 @@ replace-with = "azure-sdk-for-rust"
 # the only `cargo publish` in the repo is Pack-Crates.ps1's `--dry-run` validation, and
 # releases ship through ESRP.
 [registry]
-default = "azure-sdk-for-rust"
+default = "azure-sdk-for-rust-public"

--- a/eng/templates/config.toml.template
+++ b/eng/templates/config.toml.template
@@ -20,8 +20,8 @@ replace-with = "azure-sdk-for-rust-public"
 # Both `cargo package` and `cargo publish` refuse to run while crates-io is replaced
 # unless the target registry is named, failing with:
 #
-#   error: crates-io is replaced with remote registry azure-sdk-for-rust;
-#   include `--registry azure-sdk-for-rust` or `--registry crates-io`
+#   error: crates-io is replaced with remote registry azure-sdk-for-rust-public;
+#   include `--registry azure-sdk-for-rust-public` or `--registry crates-io`
 #
 # The target registry must be the replacement, not crates-io. When packaging several
 # workspace members at once, cargo satisfies their unpublished inter-member versions

--- a/sdk/canary/azure_canary/README.md
+++ b/sdk/canary/azure_canary/README.md
@@ -1,5 +1,3 @@
 # Azure Canary client library for Rust
 
-Trivial change to test pullrequest pipeline behavior
-
 > Canary crate for Azure SDK pipeline testing and to showcase various rust themes/concepts to use as a testing ground for the rust-api-parser.

--- a/sdk/canary/azure_canary/README.md
+++ b/sdk/canary/azure_canary/README.md
@@ -1,3 +1,5 @@
 # Azure Canary client library for Rust
 
+Trivial change to test pullrequest pipeline behavior
+
 > Canary crate for Azure SDK pipeline testing and to showcase various rust themes/concepts to use as a testing ground for the rust-api-parser.


### PR DESCRIPTION
Uses a feed hosted in "public" project instead of the org-scoped feed we had preivously. Feed names must be unique across the org so this is "azure-sdk-for-rust-public" for now... we might remove the org scoped feed eventually and create a new public feed to keep naming consistent.