### PR TITLE
Remove cargo scripts from linkedProjects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,12 +20,6 @@
   "rust-analyzer.check.command": "clippy",
   "rust-analyzer.linkedProjects": [
     "Cargo.toml",
-    "eng/tools/Cargo.toml",
-    "eng/scripts/update-cratenames.rs",
-    "eng/scripts/update-pathversions.rs",
-    "eng/scripts/update-samples.rs",
-    "eng/scripts/verify-dependencies.rs",
-    "eng/scripts/verify-keywords.rs",
   ],
   "yaml.format.printWidth": 240,
   "[powershell]": {


### PR DESCRIPTION
`rust-analyzer` 1.95 - despite being in use for a while - was emitting errors on cargo scripts that required nightly when we were pinning to 1.95 stable.
While I can't be certain this was causing some OOM issues, commenting these lines out (and just removing them here) did reduce the memory working set by ~1.5GB
and I didn't experience further OOM issues.
