### PR TITLE
[Storage] Bump dates for `azure_storage_blob` `v1.1.0-beta.2` release

### DIFF
--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.0-beta.2 (Unreleased)
+## 1.1.0-beta.2 (2026-08-11)
 
 ### Features Added
 


### PR DESCRIPTION
As title states.