### PR TITLE
chore: add core AMQP owners to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,6 +45,9 @@
 # PRLabel: %Azure.Core
 /sdk/core/               @heaths @xirzec @RickWinter @LarryOsterman
 
+# PRLabel: %Azure.Core
+/sdk/core/azure_core_amqp/    @heaths @xirzec @RickWinter @LarryOsterman @j7nw4r @sagar0207 @SwayGom @sjkwak @hmlam
+
 # AzureSDKOwners: @heaths
 # ServiceLabel: %Azure.Identity
 # PRLabel: %Azure.Identity


### PR DESCRIPTION
## Summary

The core AMQP library has no CODEOWNERS entry of its own, so pull requests to it do not reach the people who maintain it.

## Motivation

`/sdk/core/azure_core_amqp/` matches only the `/sdk/core/` catch-all entry. GitHub asks the general core owners for review, and the people who work on the AMQP stack find out about a change only when someone tells them. A dedicated entry puts the AMQP maintainers on the review path.

## Changes

Add a path entry for the core AMQP library. The entry keeps the current `/sdk/core/` owners and adds @j7nw4r, @sagar0207, @SwayGom, @sjkwak, and @hmlam. CODEOWNERS matches from the bottom up, so the new entry sits below the `/sdk/core/` entry and applies to that path. No current owner loses review rights.

## Validation

The change is one path entry and its `# PRLabel` comment. The entry uses the existing `%Azure.Core` label, so it adds no new label. The codeowners linter runs on this pull request.
