### PR TITLE
Relocate CARGO_HOME to the agent temp volume

### DIFF
--- a/eng/pipelines/templates/jobs/perf.yml
+++ b/eng/pipelines/templates/jobs/perf.yml
@@ -33,11 +33,6 @@ extends:
   parameters:
     Variables:
       - template: /eng/pipelines/templates/variables/globals.yml@self
-      # Keep the cargo cache off the OS volume like every other Rust pipeline.
-      # Set directly rather than pulling in `variables/rust.yml`, which would also
-      # apply `RUSTFLAGS: -Dwarnings` to perf builds.
-      - name: CARGO_HOME
-        value: $(Agent.TempDirectory)/cargo
     Language: Rust
     LanguageVersion: "N/A"
     InstallLanguageSteps:

--- a/eng/pipelines/templates/jobs/perf.yml
+++ b/eng/pipelines/templates/jobs/perf.yml
@@ -33,6 +33,11 @@ extends:
   parameters:
     Variables:
       - template: /eng/pipelines/templates/variables/globals.yml@self
+      # Keep the cargo cache off the OS volume like every other Rust pipeline.
+      # Set directly rather than pulling in `variables/rust.yml`, which would also
+      # apply `RUSTFLAGS: -Dwarnings` to perf builds.
+      - name: CARGO_HOME
+        value: $(Agent.TempDirectory)/cargo
     Language: Rust
     LanguageVersion: "N/A"
     InstallLanguageSteps:

--- a/eng/pipelines/templates/steps/use-rust.yml
+++ b/eng/pipelines/templates/steps/use-rust.yml
@@ -21,6 +21,18 @@ parameters:
     default: true
 
 steps:
+# `variables/rust.yml` relocates CARGO_HOME off the OS volume. Cargo finds its own
+# subcommands there, but tools invoked directly (taplo, cargo2junit) need it on PATH.
+- pwsh: |
+    $cargoBin = ([System.IO.Path]::Combine($env:CARGO_HOME, 'bin'))
+    New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
+
+    if (($env:PATH -split [System.IO.Path]::PathSeparator) -notcontains $cargoBin) {
+      Write-Host "##vso[task.prependpath]$cargoBin"
+    }
+  displayName: Add CARGO_HOME/bin to PATH
+  condition: and(succeeded(), ne(variables['CARGO_HOME'], ''))
+
 - ${{ if parameters.ConfigureRegistry }}:
   - pwsh: |
       $cargoHome = $env:CARGO_HOME

--- a/eng/pipelines/templates/variables/rust.yml
+++ b/eng/pipelines/templates/variables/rust.yml
@@ -1,4 +1,8 @@
 variables:
+  # The cargo registry cache and `cargo install` binaries can grow to several GB.
+  # Keep them on the agent's temp volume instead of the OS volume, which agents
+  # also clean up between jobs. `use-rust.yml` adds $(CARGO_HOME)/bin to PATH.
+  CARGO_HOME: $(Agent.TempDirectory)/cargo
   # 1.93 bumped the rustdocs version to v57, which cargo-semver-checks does not yet support.
   # Affects cargo-semver-checks, check_api_superset, generate_api_report
   PackToolchain: "1.92"


### PR DESCRIPTION
Cargo's registry cache and `cargo install` output live in `$CARGO_HOME` and can reach several GB on the OS volume. Point it at `$(Agent.TempDirectory)/cargo` from `variables/rust.yml` so every Rust pipeline, including release, picks it up.

- `use-rust.yml` prepends `$(CARGO_HOME)/bin` to `PATH` so `taplo` and `cargo2junit` still resolve
- Drops the `DOCKER_TMPDIR` and `TMPDIR` variables proposed in #4198: `DOCKER_TMPDIR` moves only Docker client scratch files, not the daemon image storage that fills the disk, and `TMPDIR` is ignored on Windows

Supersedes #4198.
