### PR TITLE
[Storage] Add `SasUrlBuilder` to `azure_storage_sas`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -131,9 +131,9 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -176,13 +176,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -199,9 +199,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
@@ -453,7 +453,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "azure_core 1.2.0-beta.1",
- "base64",
+ "base64 0.22.1",
  "futures",
  "serde",
  "serde_json",
@@ -595,7 +595,7 @@ dependencies = [
  "azure_core_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure_data_cosmos_driver",
  "azure_identity 1.0.0",
- "base64",
+ "base64 0.22.1",
  "clap",
  "futures",
  "json-canon",
@@ -640,7 +640,7 @@ dependencies = [
  "azure_data_cosmos_macros 0.2.0",
  "azure_identity 1.0.0",
  "backtrace",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "crossbeam-epoch",
  "futures",
@@ -815,7 +815,7 @@ dependencies = [
  "azure_messaging_eventhubs",
  "azure_messaging_eventhubs_checkpointstore_blob",
  "azure_storage_blob 1.0.0",
- "base64",
+ "base64 0.22.1",
  "criterion",
  "fe2o3-amqp",
  "futures",
@@ -1032,12 +1032,13 @@ version = "0.2.0"
 dependencies = [
  "azure_core 1.2.0-beta.1",
  "azure_storage_common",
- "base64",
+ "base64 0.22.1",
  "hmac",
  "include-file",
  "percent-encoding",
  "sha2",
  "time",
+ "url",
 ]
 
 [[package]]
@@ -1060,6 +1061,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -1185,9 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1256,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1266,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1278,14 +1285,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1377,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1515,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1525,27 +1532,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1580,13 +1586,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1609,9 +1615,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "equivalent"
@@ -1741,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
@@ -1800,9 +1806,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1815,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1825,15 +1831,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1842,38 +1848,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2004,7 +2010,7 @@ version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "byteorder",
  "crossbeam-channel",
  "flate2",
@@ -2040,9 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2060,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2161,7 +2167,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2180,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2194,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2207,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2221,16 +2227,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -2241,15 +2248,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2322,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2417,9 +2424,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2467,9 +2474,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2479,9 +2486,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -2899,9 +2906,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plotters"
@@ -2933,15 +2940,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -3297,9 +3304,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3327,7 +3334,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3459,9 +3466,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3486,9 +3493,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3523,9 +3530,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3638,15 +3645,15 @@ dependencies = [
 
 [[package]]
 name = "serde_amqp_derive"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22da57ecf44834259b4416250608e11da620750be91305bf6ae5d398954ddc6d"
+checksum = "ec5a0471f6a9293ba027112967613234cf71a3f738cbfb1584ae45f9a1297cd9"
 dependencies = [
  "convert_case",
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3676,7 +3683,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3711,7 +3718,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3901,9 +3908,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3975,22 +3982,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4004,9 +4011,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4034,9 +4041,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4086,13 +4093,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4129,9 +4136,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4140,13 +4147,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -4198,9 +4206,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.4",
 ]
@@ -4220,7 +4228,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum 0.7.9",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -4248,7 +4256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http",
  "http-body",
@@ -4429,9 +4437,9 @@ dependencies = [
 
 [[package]]
 name = "trait-variant"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+checksum = "b19a4867a870f6edc4c283f2b455804b1879c0baf0e642f26b03ed8ee262d9d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4462,7 +4470,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "753a2fe021e407d4fc9ee6f4f0a33403cc306d5c54c4e4ebe1b8cbde0ca052b9"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "quick-xml",
@@ -4475,7 +4483,7 @@ dependencies = [
 name = "typespec"
 version = "1.2.0-beta.1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "quick-xml",
@@ -4492,7 +4500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0373af0f9d4f580b3a1a9d9639cedaabe015ed262b35bfbe13941bfb14fe1ea6"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "dyn-clone",
  "futures",
@@ -4515,7 +4523,7 @@ name = "typespec_client_core"
 version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "dyn-clone",
  "futures",
@@ -4582,11 +4590,11 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "der",
  "flate2",
  "log",
@@ -4600,11 +4608,11 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "http",
  "httparse",
  "log",
@@ -4642,9 +4650,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4655,9 +4663,9 @@ dependencies = [
 
 [[package]]
 name = "uuid-rng-internal"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dff7387287837acf196f2596a6216f94c555d947d5331e1cc48393131020119"
+checksum = "bbb6e4d912010d7646ef4e5a0ba89bafc6d9f8fd617c53433fe2aa86d26a3b77"
 dependencies = [
  "getrandom 0.4.3",
 ]
@@ -4716,9 +4724,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4730,9 +4738,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4740,9 +4748,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4750,9 +4758,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4763,9 +4771,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -4799,9 +4807,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5134,9 +5142,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wyz"
@@ -5172,18 +5180,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5219,9 +5227,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5230,9 +5238,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5241,13 +5249,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5266,9 +5274,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/sdk/storage/azure_storage_blob/README.md
+++ b/sdk/storage/azure_storage_blob/README.md
@@ -130,7 +130,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### Generating SAS URLs
 
-Use the [`azure_storage_sas`] crate to create a user delegation SAS. Obtain a `UserDelegationKey` from `BlobServiceClient::get_user_delegation_key`, build the token with `SasBuilder`, then set it as the query string on the resource URL.
+Use the [`azure_storage_sas`] crate to create a user delegation SAS. Obtain a `UserDelegationKey` from `BlobServiceClient::get_user_delegation_key`, build the token with `SasTokenBuilder`, then set it as the query string on the resource URL.
 
 ```rust no_run
 use azure_core::{
@@ -138,7 +138,7 @@ use azure_core::{
     time::OffsetDateTime,
 };
 use azure_storage_blob::{models::KeyInfo, BlobServiceClient};
-use azure_storage_sas::SasBuilder;
+use azure_storage_sas::SasTokenBuilder;
 use azure_identity::DeveloperToolsCredential;
 use time::Duration;
 
@@ -169,7 +169,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .into_model()?;
 
     // Build a read-only SAS token for a single blob, then set it on the blob URL.
-    let token = SasBuilder::new(storage_account_name, &udk, now + Duration::hours(1))?
+    let token = SasTokenBuilder::new(storage_account_name, &udk, now + Duration::hours(1))?
         .blob(container_name, blob_name)
         .read()
         .build();

--- a/sdk/storage/azure_storage_blob/tests/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client.rs
@@ -28,7 +28,7 @@ use azure_storage_blob::{
     },
     BlobClient, BlobClientOptions, BlobContainerClient, BlobContainerClientOptions, StorageError,
 };
-use azure_storage_sas::SasBuilder;
+use azure_storage_sas::SasTokenBuilder;
 use bytes::{BufMut, BytesMut};
 use common::{
     create_test_blob, get_blob_name, get_blob_service_client, get_container_client,
@@ -267,7 +267,7 @@ async fn test_start_copy_from_url_across_accounts(ctx: TestContext) -> Result<()
         .flatten()
         .rfind(|segment| !segment.is_empty())
         .expect("source container URL should contain a container name");
-    let sas = SasBuilder::new(
+    let sas = SasTokenBuilder::new(
         source_account_name.as_str(),
         &user_delegation_key,
         now + Duration::from_secs(60 * 60),
@@ -276,7 +276,7 @@ async fn test_start_copy_from_url_across_accounts(ctx: TestContext) -> Result<()
     .read()
     .build();
     let mut source_url = source_blob_client.url().clone();
-    source_url.set_query(Some(&sas));
+    source_url.set_query(Some(&*sas));
 
     // Act
     let response = destination_blob_client

--- a/sdk/storage/azure_storage_blob/tests/blob_sas.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_sas.rs
@@ -4,7 +4,7 @@
 //! End-to-end tests for blob user delegation SAS generation.
 //!
 //! These tests build a SAS token from a real user delegation key with
-//! [`SasBuilder`], assemble the authenticated URL by appending the token to the
+//! [`SasTokenBuilder`], assemble the authenticated URL by appending the token to the
 //! resource URL, and then use that URL (via an unauthenticated client) to access
 //! the resource. This proves the signature the SDK computes matches what the
 //! service expects.
@@ -18,7 +18,7 @@ use azure_core::{
 use azure_core_test::{recorded, TestContext};
 use azure_storage_blob::models::{BlobClientGetPropertiesResultHeaders, KeyInfo};
 use azure_storage_blob::{BlobClient, BlobServiceClient};
-use azure_storage_sas::{SasBuilder, UserDelegationKey};
+use azure_storage_sas::{SasTokenBuilder, UserDelegationKey};
 use common::{
     create_test_blob, get_blob_name, get_blob_service_client, get_container_client, StorageAccount,
 };
@@ -74,7 +74,7 @@ async fn test_blob_user_delegation_sas_read(ctx: TestContext) -> Result<(), Box<
     let service_client = get_blob_service_client(recording, StorageAccount::Standard, None)?;
     let udk = get_udk(&service_client).await?;
 
-    let token = SasBuilder::new(
+    let token = SasTokenBuilder::new(
         account_name.as_str(),
         &udk,
         OffsetDateTime::now_utc() + Duration::hours(1),
@@ -83,7 +83,7 @@ async fn test_blob_user_delegation_sas_read(ctx: TestContext) -> Result<(), Box<
     .read()
     .build();
     let mut sas_url = blob_client.url().clone();
-    sas_url.set_query(Some(&token));
+    sas_url.set_query(Some(&*token));
 
     // Download via an unauthenticated client using only the SAS URL.
     let sas_client = BlobClient::new(sas_url, None, None)?;
@@ -111,7 +111,7 @@ async fn test_blob_user_delegation_sas_write(ctx: TestContext) -> Result<(), Box
     let service_client = get_blob_service_client(recording, StorageAccount::Standard, None)?;
     let udk = get_udk(&service_client).await?;
 
-    let token = SasBuilder::new(
+    let token = SasTokenBuilder::new(
         account_name.as_str(),
         &udk,
         OffsetDateTime::now_utc() + Duration::hours(1),
@@ -122,7 +122,7 @@ async fn test_blob_user_delegation_sas_write(ctx: TestContext) -> Result<(), Box
     .create()
     .build();
     let mut sas_url = blob_client.url().clone();
-    sas_url.set_query(Some(&token));
+    sas_url.set_query(Some(&*token));
 
     let sas_client = BlobClient::new(sas_url, None, None)?;
     let new_data = b"written through sas";
@@ -179,7 +179,7 @@ async fn test_blob_version_user_delegation_sas(ctx: TestContext) -> Result<(), B
     // signed in the snapshot slot, but it is not emitted in the token, so the
     // base URL must carry `versionid=` (supplied here by `with_version`).
     let version_1_client = blob_client.with_version(&version_1)?;
-    let token = SasBuilder::new(
+    let token = SasTokenBuilder::new(
         account_name.as_str(),
         &udk,
         OffsetDateTime::now_utc() + Duration::hours(1),
@@ -194,7 +194,7 @@ async fn test_blob_version_user_delegation_sas(ctx: TestContext) -> Result<(), B
         Some(existing) if !existing.is_empty() => {
             sas_url.set_query(Some(&format!("{existing}&{token}")));
         }
-        _ => sas_url.set_query(Some(&token)),
+        _ => sas_url.set_query(Some(&*token)),
     }
     assert!(
         sas_url.query().is_some_and(|q| q.contains("sr=bv")),
@@ -251,7 +251,7 @@ async fn test_blob_snapshot_user_delegation_sas(ctx: TestContext) -> Result<(), 
     // The snapshot timestamp is signed in the snapshot slot and emitted as the
     // `snapshot=` query parameter of the token, so append the token to the plain
     // blob URL (the token already carries `snapshot=`).
-    let token = SasBuilder::new(
+    let token = SasTokenBuilder::new(
         account_name.as_str(),
         &udk,
         OffsetDateTime::now_utc() + Duration::hours(1),
@@ -261,7 +261,7 @@ async fn test_blob_snapshot_user_delegation_sas(ctx: TestContext) -> Result<(), 
     .read()
     .build();
     let mut sas_url = blob_client.url().clone();
-    sas_url.set_query(Some(&token));
+    sas_url.set_query(Some(&*token));
     assert!(
         sas_url.query().is_some_and(|q| q.contains("sr=bs")),
         "expected sr=bs in SAS URL, got: {sas_url}"
@@ -298,7 +298,7 @@ async fn test_container_user_delegation_sas(ctx: TestContext) -> Result<(), Box<
     let service_client = get_blob_service_client(recording, StorageAccount::Standard, None)?;
     let udk = get_udk(&service_client).await?;
 
-    let token = SasBuilder::new(
+    let token = SasTokenBuilder::new(
         account_name.as_str(),
         &udk,
         OffsetDateTime::now_utc() + Duration::hours(1),
@@ -319,7 +319,7 @@ async fn test_container_user_delegation_sas(ctx: TestContext) -> Result<(), Box<
             )
         })?
         .push(&blob_name);
-    blob_url.set_query(Some(&token));
+    blob_url.set_query(Some(&*token));
 
     let sas_client = BlobClient::new(blob_url, None, None)?;
     let body = sas_client.download(None).await?.body.collect().await?;

--- a/sdk/storage/azure_storage_queue/README.md
+++ b/sdk/storage/azure_storage_queue/README.md
@@ -118,7 +118,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### Generating SAS URLs
 
-Use the [`azure_storage_sas`] crate to create a user delegation SAS. Obtain a `UserDelegationKey` from `QueueServiceClient::get_user_delegation_key`, build the token with `SasBuilder`, then set it as the query string on the queue URL.
+Use the [`azure_storage_sas`] crate to create a user delegation SAS. Obtain a `UserDelegationKey` from `QueueServiceClient::get_user_delegation_key`, build the token with `SasTokenBuilder`, then set it as the query string on the queue URL.
 
 ```rust no_run
 use azure_core::{
@@ -126,7 +126,7 @@ use azure_core::{
     time::OffsetDateTime,
 };
 use azure_storage_queue::{models::KeyInfo, QueueServiceClient};
-use azure_storage_sas::SasBuilder;
+use azure_storage_sas::SasTokenBuilder;
 use azure_identity::DeveloperToolsCredential;
 use time::Duration;
 
@@ -156,7 +156,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .into_model()?;
 
     // Build a SAS token for a queue, then set it on the queue URL.
-    let token = SasBuilder::new(storage_account_name, &udk, now + Duration::hours(1))?
+    let token = SasTokenBuilder::new(storage_account_name, &udk, now + Duration::hours(1))?
         .queue(queue_name)
         .read()
         .add()

--- a/sdk/storage/azure_storage_queue/tests/queue_service_client.rs
+++ b/sdk/storage/azure_storage_queue/tests/queue_service_client.rs
@@ -728,7 +728,7 @@ pub async fn get_queue_service_client_secondary(
 async fn test_queue_user_delegation_sas(ctx: TestContext) -> Result<()> {
     use azure_storage_queue::models::QueueMessage;
     use azure_storage_queue::QueueClient;
-    use azure_storage_sas::SasBuilder;
+    use azure_storage_sas::SasTokenBuilder;
 
     let recording = ctx.recording();
     let account_name = recording.var("AZURE_STORAGE_ACCOUNT_NAME", None);
@@ -753,7 +753,7 @@ async fn test_queue_user_delegation_sas(ctx: TestContext) -> Result<()> {
         .into_model()?;
 
     // Generate a SAS token for the queue and set it on the queue URL.
-    let token = SasBuilder::new(account_name.as_str(), &udk, now + Duration::hours(1))?
+    let token = SasTokenBuilder::new(account_name.as_str(), &udk, now + Duration::hours(1))?
         .queue(&queue_name)
         .read()
         .add()
@@ -796,7 +796,7 @@ async fn test_queue_user_delegation_sas(ctx: TestContext) -> Result<()> {
 async fn test_queue_user_delegation_sas_message_lifecycle(ctx: TestContext) -> Result<()> {
     use azure_storage_queue::models::{QueueClientUpdateMessageOptions, QueueMessage};
     use azure_storage_queue::QueueClient;
-    use azure_storage_sas::SasBuilder;
+    use azure_storage_sas::SasTokenBuilder;
 
     let recording = ctx.recording();
     let account_name = recording.var("AZURE_STORAGE_ACCOUNT_NAME", None);
@@ -819,7 +819,7 @@ async fn test_queue_user_delegation_sas_message_lifecycle(ctx: TestContext) -> R
         .into_model()?;
 
     // Grant read, add, update, and process so the SAS can do the whole lifecycle.
-    let token = SasBuilder::new(account_name.as_str(), &udk, now + Duration::hours(1))?
+    let token = SasTokenBuilder::new(account_name.as_str(), &udk, now + Duration::hours(1))?
         .queue(&queue_name)
         .read()
         .add()

--- a/sdk/storage/azure_storage_sas/Cargo.toml
+++ b/sdk/storage/azure_storage_sas/Cargo.toml
@@ -21,6 +21,7 @@ hmac = { workspace = true }
 percent-encoding = { workspace = true }
 sha2 = { workspace = true }
 time = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 include-file.workspace = true

--- a/sdk/storage/azure_storage_sas/README.md
+++ b/sdk/storage/azure_storage_sas/README.md
@@ -21,26 +21,50 @@ cargo add azure_storage_sas
 
 ### Which API should I use?
 
-Use `SasBuilder` to construct a user delegation SAS token, then set it as the query string on the resource URL. Obtain the `UserDelegationKey` from `BlobServiceClient::get_user_delegation_key` (in `azure_storage_blob`) or `QueueServiceClient::get_user_delegation_key` (in `azure_storage_queue`), then pass it to `SasBuilder::new` along with the account name, permissions, and expiry.
+Two builders are provided:
+
+- **`SasTokenBuilder`** — produces a [`SasToken`], the signed query string (e.g. `sv=...&sr=b&...&sig=...`). Use this when you need to attach the query string to an existing URL yourself. `build()` is infallible.
+- **`SasUrlBuilder`** — produces a [`SasUrl`], a complete URL with the signed query string already embedded. Use this when you want the full URL ready to share. `build()` returns a `Result`. Use [`SasUrlBuilder::endpoint`] to override the default `https://{account}.{service}.core.windows.net` base (e.g. for Azurite or sovereign clouds).
+
+Both builders expose the same resource selectors and permission setters.
 
 ## Examples
 
-### Generate a read-only blob SAS
+### Generate a blob SAS URL
 
-Produce the signed SAS token and set it as the query on a blob URL. Use the resulting URL with an unauthenticated `BlobClient::new` to grant a caller time-bound read access:
+Use `SasUrlBuilder` to produce a complete signed URL in one step:
 
-```rust ignore read_blob_sas
-use azure_core::{
-    http::Url,
-    time::{Duration, OffsetDateTime},
-};
-use azure_storage_sas::SasBuilder;
+```rust ignore blob_sas_url
+use azure_storage_sas::{SasUrlBuilder, UserDelegationKey};
+use time::OffsetDateTime;
+
+let url = SasUrlBuilder::new(
+        "myaccount",
+        &udk,
+        OffsetDateTime::now_utc() + time::Duration::hours(1),
+    )?
+    .blob("images", "photo.jpg")
+    .read()
+    .content_type("image/jpeg")
+    .build()?;
+
+// `url` is a complete signed URL ready to share
+println!("{url}");
+```
+
+### Generate a blob SAS token (query string only)
+
+Use `SasTokenBuilder` when you need just the signed query string to attach to an existing URL:
+
+```rust ignore blob_sas_token
+use azure_core::{http::Url, time::{Duration, OffsetDateTime}};
+use azure_storage_sas::{SasTokenBuilder, UserDelegationKey};
 
 let storage_account_name = "myaccount";
 let container_name = "images";
 let blob_name = "photo.jpg";
 
-let token = SasBuilder::new(
+let token = SasTokenBuilder::new(
         storage_account_name,
         &udk,
         OffsetDateTime::now_utc() + Duration::hours(1),
@@ -55,7 +79,7 @@ let token = SasBuilder::new(
 let mut sas_url = Url::parse(&format!(
     "https://{storage_account_name}.blob.core.windows.net/{container_name}/{blob_name}"
 ))?;
-sas_url.set_query(Some(&token));
+sas_url.set_query(Some(&*token));
 ```
 
 ### Scope a container SAS to HTTPS and a single IP range
@@ -63,11 +87,11 @@ sas_url.set_query(Some(&token));
 Layer optional restrictions onto a container-level SAS: limit the caller to HTTPS only, pin them to a corporate egress range, and grant just enough permissions to list and read:
 
 ```rust ignore container_ip_range_sas
-use azure_storage_sas::{SasBuilder, SasIpRange, SasProtocol};
+use azure_storage_sas::{SasTokenBuilder, SasIpRange, SasProtocol};
 use std::net::Ipv4Addr;
 use time::OffsetDateTime;
 
-let sas = SasBuilder::new(
+let token = SasTokenBuilder::new(
         "myaccount",
         &udk,
         OffsetDateTime::now_utc() + time::Duration::hours(4),

--- a/sdk/storage/azure_storage_sas/src/blob/blob_resource.rs
+++ b/sdk/storage/azure_storage_sas/src/blob/blob_resource.rs
@@ -4,8 +4,8 @@
 /// A blob resource for user delegation SAS.
 ///
 /// By default targets a base blob (`sr=b`). A snapshot timestamp or version ID
-/// is set through the [`snapshot`](crate::SasBuilder::snapshot) or
-/// [`version`](crate::SasBuilder::version) builder setters.
+/// is set through the [`snapshot`](crate::SasTokenBuilder::snapshot) or
+/// [`version`](crate::SasTokenBuilder::version) builder setters.
 #[derive(Debug)]
 pub(crate) struct BlobResource {
     container: String,
@@ -49,12 +49,17 @@ impl BlobResource {
     pub(crate) fn snapshot_or_version_time(&self) -> Option<&str> {
         self.snapshot.as_deref().or(self.version_id.as_deref())
     }
+
+    pub(crate) fn url_path_segments(&self) -> [&str; 2] {
+        [&self.container, &self.blob]
+    }
 }
 
 /// Permissions for a blob SAS.
 ///
 /// Serialization order: `racwdxytmeopi`. Flags are set through the permission
-/// setters on [`SasBuilder<BlobState>`](crate::SasBuilder).
+/// setters on [`SasTokenBuilder<BlobState>`](crate::SasTokenBuilder) and
+/// [`SasUrlBuilder<BlobState>`](crate::SasUrlBuilder).
 #[derive(Clone, Copy, Default)]
 pub(crate) struct BlobPermissions {
     pub(crate) read: bool,

--- a/sdk/storage/azure_storage_sas/src/blob/container_resource.rs
+++ b/sdk/storage/azure_storage_sas/src/blob/container_resource.rs
@@ -18,13 +18,17 @@ impl ContainerResource {
     pub(crate) fn canonicalized_resource(&self, account: &str) -> String {
         format!("/blob/{}/{}", account, self.container)
     }
+
+    pub(crate) fn url_path_segments(&self) -> [&str; 1] {
+        [&self.container]
+    }
 }
 
 /// Permissions for a container or directory SAS.
 ///
 /// Serialization order: `racwdxyltmeopi`. Flags are set through the permission
-/// setters on [`SasBuilder<ContainerState>`](crate::SasBuilder) and
-/// [`SasBuilder<DirectoryState>`](crate::SasBuilder).
+/// setters on [`SasTokenBuilder<ContainerState>`](crate::SasTokenBuilder) and
+/// [`SasTokenBuilder<DirectoryState>`](crate::SasTokenBuilder).
 #[derive(Clone, Copy, Default)]
 pub(crate) struct ContainerPermissions {
     pub(crate) read: bool,

--- a/sdk/storage/azure_storage_sas/src/blob/directory_resource.rs
+++ b/sdk/storage/azure_storage_sas/src/blob/directory_resource.rs
@@ -16,20 +16,31 @@ impl DirectoryResource {
     pub(crate) fn new(container: impl Into<String>, directory: impl Into<String>) -> Self {
         Self {
             container: container.into(),
-            directory: directory.into(),
+            directory: directory.into().trim_matches('/').to_string(),
         }
     }
 
     pub(crate) fn depth(&self) -> u32 {
-        let trimmed = self.directory.trim_matches('/');
-        if trimmed.is_empty() {
+        if self.directory.is_empty() {
             0
         } else {
-            trimmed.split('/').count() as u32
+            self.directory.split('/').count() as u32
         }
     }
 
     pub(crate) fn canonicalized_resource(&self, account: &str) -> String {
         format!("/blob/{}/{}/{}", account, self.container, self.directory)
+    }
+
+    /// Returns path segments for URL construction.
+    ///
+    /// The directory string may contain `/`-separated sub-segments which are
+    /// returned individually so each segment is percent-encoded on its own.
+    pub(crate) fn url_path_segments(&self) -> Vec<&str> {
+        let mut segments = vec![self.container.as_str()];
+        if !self.directory.is_empty() {
+            segments.extend(self.directory.split('/'));
+        }
+        segments
     }
 }

--- a/sdk/storage/azure_storage_sas/src/blob/mod.rs
+++ b/sdk/storage/azure_storage_sas/src/blob/mod.rs
@@ -8,11 +8,11 @@
 //! ## Blob user delegation SAS
 //!
 //! ```rust no_run
-//! use azure_storage_sas::{SasBuilder, UserDelegationKey};
+//! use azure_storage_sas::{SasTokenBuilder, SasToken, UserDelegationKey};
 //! use time::OffsetDateTime;
 //!
 //! # fn example(udk: UserDelegationKey) -> azure_core::Result<()> {
-//! let token = SasBuilder::new("myaccount", &udk,
+//! let token: SasToken = SasTokenBuilder::new("myaccount", &udk,
 //!         OffsetDateTime::now_utc() + time::Duration::hours(1))?
 //!     .blob("images", "photo.jpg")
 //!     .read()
@@ -25,11 +25,11 @@
 //! ## Container SAS
 //!
 //! ```rust no_run
-//! use azure_storage_sas::{SasBuilder, UserDelegationKey};
+//! use azure_storage_sas::{SasTokenBuilder, SasToken, UserDelegationKey};
 //! use time::OffsetDateTime;
 //!
 //! # fn example(udk: UserDelegationKey) -> azure_core::Result<()> {
-//! let token = SasBuilder::new("myaccount", &udk,
+//! let token: SasToken = SasTokenBuilder::new("myaccount", &udk,
 //!         OffsetDateTime::now_utc() + time::Duration::hours(4))?
 //!     .container("logs")
 //!     .read()
@@ -55,7 +55,7 @@ pub(crate) use container_resource::ContainerPermissions;
 pub(crate) use container_resource::ContainerResource;
 pub(crate) use directory_resource::DirectoryResource;
 
-use crate::builder::SasBuilder;
+use crate::builder::{SasTokenBuilder, SasUrlBuilder};
 use crate::common::sealed::Sealed;
 use crate::common::{CommonFields, SasResource, ValidatedKey};
 use crate::SAS_VERSION;
@@ -197,7 +197,7 @@ mod options_access {
 // The `BlobOptions` bound grants mutable access to each blob state's
 // `BlobSasOptions` without exposing it on the public `BlobServiceState` trait.
 #[allow(private_bounds)]
-impl<S: BlobServiceState + BlobOptions> SasBuilder<'_, S> {
+impl<S: BlobServiceState + BlobOptions> SasTokenBuilder<'_, S> {
     /// Sets the encryption scope for the SAS.
     pub fn encryption_scope(mut self, scope: impl Into<String>) -> Self {
         self.state.options_mut().encryption_scope = Some(scope.into());
@@ -291,7 +291,7 @@ impl<S: BlobServiceState + BlobOptions> SasBuilder<'_, S> {
 }
 
 /// Permission and target setters for a blob SAS, gated on [`BlobState`].
-impl SasBuilder<'_, BlobState> {
+impl SasTokenBuilder<'_, BlobState> {
     /// Enables read permission.
     pub fn read(mut self) -> Self {
         self.state.permissions.read = true;
@@ -420,7 +420,7 @@ use permissions_access::ContainerPermsAccess;
 /// container permission set without exposing it publicly. `BlobState` does not
 /// implement the bound, so its own `read`/`write`/... setters do not conflict.
 #[allow(private_bounds)]
-impl<S: ContainerPermsAccess> SasBuilder<'_, S> {
+impl<S: ContainerPermsAccess> SasTokenBuilder<'_, S> {
     /// Enables read permission.
     pub fn read(mut self) -> Self {
         self.state.permissions_mut().read = true;
@@ -506,6 +506,181 @@ impl<S: ContainerPermsAccess> SasBuilder<'_, S> {
     }
 }
 
+#[allow(private_bounds)]
+impl<S: BlobServiceState + BlobOptions> SasUrlBuilder<'_, S> {
+    /// Sets the encryption scope for the SAS.
+    pub fn encryption_scope(self, scope: impl Into<String>) -> Self {
+        self.map(|b| b.encryption_scope(scope))
+    }
+    /// Sets the `Cache-Control` response header override.
+    pub fn cache_control(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.cache_control(value))
+    }
+    /// Sets the `Content-Disposition` response header override.
+    pub fn content_disposition(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.content_disposition(value))
+    }
+    /// Sets the `Content-Encoding` response header override.
+    pub fn content_encoding(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.content_encoding(value))
+    }
+    /// Sets the `Content-Language` response header override.
+    pub fn content_language(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.content_language(value))
+    }
+    /// Sets the `Content-Type` response header override.
+    pub fn content_type(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.content_type(value))
+    }
+    /// Sets the authorized AAD object ID (`saoid`).
+    pub fn authorized_object_id(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.authorized_object_id(value))
+    }
+    /// Sets the unauthorized AAD object ID (`suoid`).
+    pub fn unauthorized_object_id(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.unauthorized_object_id(value))
+    }
+    /// Sets the correlation ID (`scid`).
+    pub fn correlation_id(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.correlation_id(value))
+    }
+    /// Adds a signed request header constraint (`srh`).
+    pub fn signed_request_header(self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.map(|b| b.signed_request_header(key, value))
+    }
+    /// Adds a signed request query parameter constraint (`srq`).
+    pub fn signed_request_query_parameter(
+        self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        self.map(|b| b.signed_request_query_parameter(key, value))
+    }
+}
+
+impl SasUrlBuilder<'_, BlobState> {
+    /// Enables read permission.
+    pub fn read(self) -> Self {
+        self.map(|b| b.read())
+    }
+    /// Enables add permission.
+    pub fn add(self) -> Self {
+        self.map(|b| b.add())
+    }
+    /// Enables create permission.
+    pub fn create(self) -> Self {
+        self.map(|b| b.create())
+    }
+    /// Enables write permission.
+    pub fn write(self) -> Self {
+        self.map(|b| b.write())
+    }
+    /// Enables delete permission.
+    pub fn delete(self) -> Self {
+        self.map(|b| b.delete())
+    }
+    /// Enables delete version permission.
+    pub fn delete_version(self) -> Self {
+        self.map(|b| b.delete_version())
+    }
+    /// Enables permanent delete permission.
+    pub fn permanent_delete(self) -> Self {
+        self.map(|b| b.permanent_delete())
+    }
+    /// Enables tags permission.
+    pub fn tags(self) -> Self {
+        self.map(|b| b.tags())
+    }
+    /// Enables move blob permission.
+    pub fn move_blob(self) -> Self {
+        self.map(|b| b.move_blob())
+    }
+    /// Enables execute permission.
+    pub fn execute(self) -> Self {
+        self.map(|b| b.execute())
+    }
+    /// Enables ownership permission.
+    pub fn ownership(self) -> Self {
+        self.map(|b| b.ownership())
+    }
+    /// Enables permissions permission.
+    pub fn permissions(self) -> Self {
+        self.map(|b| b.permissions())
+    }
+    /// Enables set immutability policy permission.
+    pub fn set_immutability_policy(self) -> Self {
+        self.map(|b| b.set_immutability_policy())
+    }
+    /// Targets a specific snapshot of the blob (`sr=bs`).
+    pub fn snapshot(self, snapshot: impl Into<String>) -> Self {
+        self.map(|b| b.snapshot(snapshot))
+    }
+    /// Targets a specific version of the blob (`sr=bv`).
+    pub fn version(self, version_id: impl Into<String>) -> Self {
+        self.map(|b| b.version(version_id))
+    }
+}
+
+#[allow(private_bounds)]
+impl<S: ContainerPermsAccess> SasUrlBuilder<'_, S> {
+    /// Enables read permission.
+    pub fn read(self) -> Self {
+        self.map(|b| b.read())
+    }
+    /// Enables add permission.
+    pub fn add(self) -> Self {
+        self.map(|b| b.add())
+    }
+    /// Enables create permission.
+    pub fn create(self) -> Self {
+        self.map(|b| b.create())
+    }
+    /// Enables write permission.
+    pub fn write(self) -> Self {
+        self.map(|b| b.write())
+    }
+    /// Enables delete permission.
+    pub fn delete(self) -> Self {
+        self.map(|b| b.delete())
+    }
+    /// Enables delete version permission.
+    pub fn delete_version(self) -> Self {
+        self.map(|b| b.delete_version())
+    }
+    /// Enables permanent delete permission.
+    pub fn permanent_delete(self) -> Self {
+        self.map(|b| b.permanent_delete())
+    }
+    /// Enables list permission.
+    pub fn list(self) -> Self {
+        self.map(|b| b.list())
+    }
+    /// Enables tags permission.
+    pub fn tags(self) -> Self {
+        self.map(|b| b.tags())
+    }
+    /// Enables move blob permission.
+    pub fn move_blob(self) -> Self {
+        self.map(|b| b.move_blob())
+    }
+    /// Enables execute permission.
+    pub fn execute(self) -> Self {
+        self.map(|b| b.execute())
+    }
+    /// Enables ownership permission.
+    pub fn ownership(self) -> Self {
+        self.map(|b| b.ownership())
+    }
+    /// Enables permissions permission.
+    pub fn permissions(self) -> Self {
+        self.map(|b| b.permissions())
+    }
+    /// Enables set immutability policy permission.
+    pub fn set_immutability_policy(self) -> Self {
+        self.map(|b| b.set_immutability_policy())
+    }
+}
+
 impl SasResource for BlobState {
     fn string_to_sign(&self, common: &CommonFields, key: &ValidatedKey<'_>) -> String {
         let sp = self.permissions.to_sas_str();
@@ -542,6 +717,14 @@ impl SasResource for BlobState {
             signature,
         )
     }
+
+    fn url_path_segments(&self) -> Vec<&str> {
+        self.resource.url_path_segments().to_vec()
+    }
+
+    fn default_endpoint(account: &str) -> azure_core::Result<url::Url> {
+        crate::url::blob_endpoint(account)
+    }
 }
 
 impl SasResource for ContainerState {
@@ -559,6 +742,14 @@ impl SasResource for ContainerState {
     ) -> String {
         let sp = self.permissions.to_sas_str();
         blob_udk_query_parameters(&sp, common, &self.options, key, "c", None, None, signature)
+    }
+
+    fn url_path_segments(&self) -> Vec<&str> {
+        self.resource.url_path_segments().to_vec()
+    }
+
+    fn default_endpoint(account: &str) -> azure_core::Result<url::Url> {
+        crate::url::blob_endpoint(account)
     }
 }
 
@@ -587,6 +778,14 @@ impl SasResource for DirectoryState {
             Some(depth),
             signature,
         )
+    }
+
+    fn url_path_segments(&self) -> Vec<&str> {
+        self.resource.url_path_segments()
+    }
+
+    fn default_endpoint(account: &str) -> azure_core::Result<url::Url> {
+        crate::url::blob_endpoint(account)
     }
 }
 
@@ -859,5 +1058,17 @@ mod tests {
         let lines: Vec<&str> = sts.split('\n').collect();
         assert_eq!(lines[18], "bs"); // sr
         assert_eq!(lines[19], "2025-02-20T08:30:00.0000000Z"); // snapshot in slot
+    }
+
+    #[test]
+    fn container_string_to_sign_has_28_fields() {
+        let udk = test_udk();
+        let key = ValidatedKey::from_key(&udk).unwrap();
+        let common = test_common(datetime!(2025-06-01 12:00:00 UTC));
+        let options = BlobSasOptions::default();
+        let sts = blob_udk_string_to_sign("rl", &common, &options, &key, "c", "/blob/acct/c", "");
+        let lines: Vec<&str> = sts.split('\n').collect();
+        assert_eq!(lines.len(), 28);
+        assert_eq!(lines[18], "c");
     }
 }

--- a/sdk/storage/azure_storage_sas/src/builder.rs
+++ b/sdk/storage/azure_storage_sas/src/builder.rs
@@ -6,11 +6,69 @@ use crate::blob::{
     ContainerResource, ContainerState, DirectoryResource, DirectoryState,
 };
 use crate::common::{sign, CommonFields, SasResource, ValidatedKey};
+use crate::file::{
+    FilePermissions, FileResource, FileSasOptions, FileState, SharePermissions, ShareResource,
+    ShareState,
+};
 use crate::ip_range::SasIpRange;
 use crate::protocol::SasProtocol;
 use crate::queue::{QueuePermissions, QueueResource, QueueState};
+use crate::table::{TablePermissions, TableResource, TableState};
 use azure_storage_common::models::UserDelegationKey;
 use time::OffsetDateTime;
+
+/// The signed query string portion of a SAS token (the `?`-less query parameters).
+///
+/// `Deref`s to `str` for direct access to string methods. Implements
+/// [`Display`](std::fmt::Display) and converts to [`String`] via [`From`].
+#[derive(Debug, Clone)]
+pub struct SasToken(String);
+
+impl std::ops::Deref for SasToken {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for SasToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<SasToken> for String {
+    fn from(t: SasToken) -> String {
+        t.0
+    }
+}
+
+/// A complete signed SAS URL.
+///
+/// `Deref`s to [`url::Url`] for direct access to URL methods. Implements
+/// [`Display`](std::fmt::Display) and converts to [`url::Url`] via [`From`].
+#[derive(Debug, Clone)]
+pub struct SasUrl(url::Url);
+
+impl std::ops::Deref for SasUrl {
+    type Target = url::Url;
+    fn deref(&self) -> &url::Url {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for SasUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl From<SasUrl> for url::Url {
+    fn from(u: SasUrl) -> url::Url {
+        u.0
+    }
+}
+
 /// Initial state before a resource type has been selected.
 pub struct Untyped;
 
@@ -18,17 +76,19 @@ pub struct Untyped;
 ///
 /// The type parameter `S` tracks the builder state, gating which methods
 /// are available at compile time. Call a resource method (e.g.,
-/// [`.blob()`](SasBuilder::blob)) to transition from the initial untyped
-/// state to a typed state, then call `.build()` to produce the signed SAS
-/// token.
-pub struct SasBuilder<'a, S = Untyped> {
+/// [`.blob()`](SasTokenBuilder::blob)) to transition from the initial untyped
+/// state to a typed state, then call [`.build()`](SasTokenBuilder::build) to produce the signed SAS
+/// token as a [`SasToken`].
+///
+/// To build a complete signed URL instead, use [`SasUrlBuilder`].
+pub struct SasTokenBuilder<'a, S = Untyped> {
     pub(crate) key: ValidatedKey<'a>,
     pub(crate) common: CommonFields,
     pub(crate) state: S,
 }
 
-impl<'a> SasBuilder<'a, Untyped> {
-    /// Creates a new SAS builder.
+impl<'a> SasTokenBuilder<'a, Untyped> {
+    /// Creates a new SAS token builder.
     ///
     /// # Parameters
     /// - `account`: The storage account name.
@@ -62,13 +122,13 @@ impl<'a> SasBuilder<'a, Untyped> {
     ///
     /// Permissions, an optional snapshot/version target, and response header
     /// overrides are then set with the fluent setters available on the
-    /// resulting [`SasBuilder<BlobState>`].
+    /// resulting [`SasTokenBuilder<BlobState>`].
     pub fn blob(
         self,
         container: impl Into<String>,
         blob: impl Into<String>,
-    ) -> SasBuilder<'a, BlobState> {
-        SasBuilder {
+    ) -> SasTokenBuilder<'a, BlobState> {
+        SasTokenBuilder {
             key: self.key,
             common: self.common,
             state: BlobState {
@@ -80,8 +140,8 @@ impl<'a> SasBuilder<'a, Untyped> {
     }
 
     /// Selects a container resource and transitions the builder to container state.
-    pub fn container(self, container: impl Into<String>) -> SasBuilder<'a, ContainerState> {
-        SasBuilder {
+    pub fn container(self, container: impl Into<String>) -> SasTokenBuilder<'a, ContainerState> {
+        SasTokenBuilder {
             key: self.key,
             common: self.common,
             state: ContainerState {
@@ -97,8 +157,8 @@ impl<'a> SasBuilder<'a, Untyped> {
         self,
         container: impl Into<String>,
         directory: impl Into<String>,
-    ) -> SasBuilder<'a, DirectoryState> {
-        SasBuilder {
+    ) -> SasTokenBuilder<'a, DirectoryState> {
+        SasTokenBuilder {
             key: self.key,
             common: self.common,
             state: DirectoryState {
@@ -110,8 +170,8 @@ impl<'a> SasBuilder<'a, Untyped> {
     }
 
     /// Selects a queue resource and transitions the builder to queue state.
-    pub fn queue(self, queue: impl Into<String>) -> SasBuilder<'a, QueueState> {
-        SasBuilder {
+    pub fn queue(self, queue: impl Into<String>) -> SasTokenBuilder<'a, QueueState> {
+        SasTokenBuilder {
             key: self.key,
             common: self.common,
             state: QueueState {
@@ -120,10 +180,52 @@ impl<'a> SasBuilder<'a, Untyped> {
             },
         }
     }
+
+    /// Selects a table resource.
+    pub fn table(self, table: impl Into<String>) -> SasTokenBuilder<'a, TableState> {
+        SasTokenBuilder {
+            key: self.key,
+            common: self.common,
+            state: TableState {
+                resource: TableResource::new(table),
+                permissions: TablePermissions::default(),
+            },
+        }
+    }
+
+    /// Selects a file resource.
+    pub fn file(
+        self,
+        share: impl Into<String>,
+        path: impl Into<String>,
+    ) -> SasTokenBuilder<'a, FileState> {
+        SasTokenBuilder {
+            key: self.key,
+            common: self.common,
+            state: FileState {
+                resource: FileResource::new(share, path),
+                permissions: FilePermissions::default(),
+                options: FileSasOptions::default(),
+            },
+        }
+    }
+
+    /// Selects a share resource.
+    pub fn share(self, share: impl Into<String>) -> SasTokenBuilder<'a, ShareState> {
+        SasTokenBuilder {
+            key: self.key,
+            common: self.common,
+            state: ShareState {
+                resource: ShareResource::new(share),
+                permissions: SharePermissions::default(),
+                options: FileSasOptions::default(),
+            },
+        }
+    }
 }
 
 // Common setters available in any state.
-impl<S> SasBuilder<'_, S> {
+impl<S> SasTokenBuilder<'_, S> {
     /// Sets the optional start time for the SAS.
     pub fn start(mut self, start: OffsetDateTime) -> Self {
         self.common.start = Some(start);
@@ -152,13 +254,172 @@ impl<S> SasBuilder<'_, S> {
 // `SasResource` is a sealed crate-internal trait; the bound is intentionally
 // more private than the public `token` method it gates.
 #[allow(private_bounds)]
-impl<S: SasResource> SasBuilder<'_, S> {
+impl<S: SasResource> SasTokenBuilder<'_, S> {
     /// Signs the SAS and returns the token.
-    pub fn build(&self) -> String {
+    pub fn build(&self) -> SasToken {
         let sts = self.state.string_to_sign(&self.common, &self.key);
-        let signature = sign(self.key.value, &sts);
-        self.state
-            .query_parameters(&self.common, &self.key, &signature)
+        let sig = sign(self.key.value, &sts);
+        SasToken(self.state.query_parameters(&self.common, &self.key, &sig))
+    }
+}
+
+/// A builder for constructing complete signed Shared Access Signature URLs.
+///
+/// Functions identically to [`SasTokenBuilder`], but [`build`](SasUrlBuilder::build)
+/// returns a [`SasUrl`] — a complete URL with the signed query string embedded —
+/// rather than a bare query string.
+///
+/// Use [`endpoint`](SasUrlBuilder::endpoint) to override the default
+/// `https://{account}.{service}.core.windows.net` base (e.g. for Azurite or
+/// sovereign clouds).
+pub struct SasUrlBuilder<'a, S = Untyped> {
+    pub(crate) inner: SasTokenBuilder<'a, S>,
+    pub(crate) endpoint: Option<url::Url>,
+}
+
+impl<'a> SasUrlBuilder<'a, Untyped> {
+    /// Creates a new SAS URL builder.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `key` is missing any required field.
+    pub fn new(
+        account: impl Into<String>,
+        key: &'a UserDelegationKey,
+        expiry: OffsetDateTime,
+    ) -> azure_core::Result<Self> {
+        Ok(Self {
+            inner: SasTokenBuilder::new(account, key, expiry)?,
+            endpoint: None,
+        })
+    }
+
+    /// Selects a blob resource.
+    pub fn blob(
+        self,
+        container: impl Into<String>,
+        blob: impl Into<String>,
+    ) -> SasUrlBuilder<'a, BlobState> {
+        SasUrlBuilder {
+            inner: self.inner.blob(container, blob),
+            endpoint: self.endpoint,
+        }
+    }
+
+    /// Selects a container resource.
+    pub fn container(self, container: impl Into<String>) -> SasUrlBuilder<'a, ContainerState> {
+        SasUrlBuilder {
+            inner: self.inner.container(container),
+            endpoint: self.endpoint,
+        }
+    }
+
+    /// Selects a directory resource.
+    pub fn directory(
+        self,
+        container: impl Into<String>,
+        directory: impl Into<String>,
+    ) -> SasUrlBuilder<'a, DirectoryState> {
+        SasUrlBuilder {
+            inner: self.inner.directory(container, directory),
+            endpoint: self.endpoint,
+        }
+    }
+
+    /// Selects a queue resource.
+    pub fn queue(self, queue: impl Into<String>) -> SasUrlBuilder<'a, QueueState> {
+        SasUrlBuilder {
+            inner: self.inner.queue(queue),
+            endpoint: self.endpoint,
+        }
+    }
+
+    /// Selects a table resource.
+    pub fn table(self, table: impl Into<String>) -> SasUrlBuilder<'a, TableState> {
+        SasUrlBuilder {
+            inner: self.inner.table(table),
+            endpoint: self.endpoint,
+        }
+    }
+
+    /// Selects a file resource.
+    pub fn file(
+        self,
+        share: impl Into<String>,
+        path: impl Into<String>,
+    ) -> SasUrlBuilder<'a, FileState> {
+        SasUrlBuilder {
+            inner: self.inner.file(share, path),
+            endpoint: self.endpoint,
+        }
+    }
+
+    /// Selects a share resource.
+    pub fn share(self, share: impl Into<String>) -> SasUrlBuilder<'a, ShareState> {
+        SasUrlBuilder {
+            inner: self.inner.share(share),
+            endpoint: self.endpoint,
+        }
+    }
+}
+
+impl<'a, S> SasUrlBuilder<'a, S> {
+    /// Applies a transformation to the inner [`SasTokenBuilder`], preserving the endpoint.
+    pub(crate) fn map(
+        self,
+        f: impl FnOnce(SasTokenBuilder<'a, S>) -> SasTokenBuilder<'a, S>,
+    ) -> Self {
+        Self {
+            inner: f(self.inner),
+            endpoint: self.endpoint,
+        }
+    }
+
+    /// Sets the optional start time for the SAS.
+    pub fn start(self, start: OffsetDateTime) -> Self {
+        self.map(|b| b.start(start))
+    }
+
+    /// Sets the permitted protocol (HTTPS only, or HTTPS and HTTP).
+    pub fn protocol(self, protocol: SasProtocol) -> Self {
+        self.map(|b| b.protocol(protocol))
+    }
+
+    /// Restricts the SAS to requests from the given IP address or range.
+    pub fn ip_range(self, ip: SasIpRange) -> Self {
+        self.map(|b| b.ip_range(ip))
+    }
+
+    /// Sets the delegated user object ID (`sduoid`).
+    pub fn delegated_user_object_id(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.delegated_user_object_id(value))
+    }
+
+    /// Overrides the storage account endpoint base URL.
+    ///
+    /// Use for local emulators, sovereign clouds, or custom domains.
+    pub fn endpoint(mut self, endpoint: url::Url) -> Self {
+        self.endpoint = Some(endpoint);
+        self
+    }
+}
+
+#[allow(private_bounds)]
+impl<S: SasResource> SasUrlBuilder<'_, S> {
+    /// Signs the SAS and returns a complete URL with the signed query string embedded.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the endpoint URL cannot be used as a base (e.g. a
+    /// `data:` URL). Standard `https://` and `http://` URLs always succeed.
+    pub fn build(&self) -> azure_core::Result<SasUrl> {
+        let token = self.inner.build();
+        let endpoint = self
+            .endpoint
+            .clone()
+            .map_or_else(|| S::default_endpoint(&self.inner.common.account), Ok)?;
+        let url = crate::url::assemble(&endpoint, &self.inner.state.url_path_segments(), &token)?;
+        Ok(SasUrl(url))
     }
 }
 
@@ -166,46 +427,26 @@ impl<S: SasResource> SasBuilder<'_, S> {
 mod tests {
     use super::*;
     use crate::common::test_support::test_udk;
+    use crate::protocol::SasProtocol;
     use time::macros::datetime;
-
-    #[test]
-    fn blob_string_to_sign() {
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-
-        let qp = SasBuilder::new("myaccount", &udk, expiry)
-            .unwrap()
-            .start(datetime!(2025-01-15 00:00:00 UTC))
-            .protocol(SasProtocol::HttpsAndHttp)
-            .blob("mycontainer", "myblob.txt")
-            .read()
-            .write()
-            .build();
-
-        assert!(qp.contains("sp=rw"));
-        assert!(qp.contains("sr=b"));
-        assert!(qp.contains("skoid=oid-value"));
-        assert!(qp.contains("spr=https%2Chttp") || qp.contains("spr=https,http"));
-        assert!(qp.contains("sig="));
-    }
 
     #[test]
     fn blob_build_produces_signed_query() {
         let udk = test_udk();
         let expiry = datetime!(2025-06-01 12:00:00 UTC);
 
-        let qp = SasBuilder::new("myaccount", &udk, expiry)
+        let token = SasTokenBuilder::new("myaccount", &udk, expiry)
             .unwrap()
             .blob("mycontainer", "myblob.txt")
             .read()
             .cache_control("no-cache")
             .build();
 
-        assert!(qp.starts_with("sv=2026-04-06&sr=b&"));
-        assert!(qp.contains("sp=r"));
-        assert!(qp.contains("skoid=oid-value"));
-        assert!(qp.contains("rscc=no-cache"));
-        assert!(qp.contains("sig="));
+        assert!(token.starts_with("sv=2026-04-06&sr=b&"));
+        assert!(token.contains("sp=r"));
+        assert!(token.contains("skoid=oid-value"));
+        assert!(token.contains("rscc=no-cache"));
+        assert!(token.contains("sig="));
     }
 
     #[test]
@@ -213,16 +454,16 @@ mod tests {
         let udk = test_udk();
         let expiry = datetime!(2025-06-01 12:00:00 UTC);
 
-        let qp = SasBuilder::new("myaccount", &udk, expiry)
+        let token = SasTokenBuilder::new("myaccount", &udk, expiry)
             .unwrap()
             .container("mycontainer")
             .read()
             .list()
             .build();
 
-        assert!(qp.starts_with("sv=2026-04-06&sr=c&"));
-        assert!(qp.contains("sp=rl"));
-        assert!(qp.contains("sig="));
+        assert!(token.starts_with("sv=2026-04-06&sr=c&"));
+        assert!(token.contains("sp=rl"));
+        assert!(token.contains("sig="));
     }
 
     #[test]
@@ -230,67 +471,198 @@ mod tests {
         let udk = test_udk();
         let expiry = datetime!(2025-06-01 12:00:00 UTC);
 
-        let qp = SasBuilder::new("myaccount", &udk, expiry)
+        let token = SasTokenBuilder::new("myaccount", &udk, expiry)
             .unwrap()
             .queue("myqueue")
             .read()
             .add()
             .build();
 
-        assert!(qp.starts_with("sv=2026-04-06&"));
-        assert!(qp.contains("sp=ra"));
-        assert!(qp.contains("skoid=oid-value"));
-        assert!(qp.contains("sig="));
+        assert!(token.starts_with("sv=2026-04-06&"));
+        assert!(token.contains("sp=ra"));
+        assert!(token.contains("skoid=oid-value"));
+        assert!(token.contains("sig="));
         // Queue should not have blob-specific params
-        assert!(!qp.contains("sr="));
-        assert!(!qp.contains("rscc="));
+        assert!(!token.contains("sr="));
     }
 
     #[test]
-    fn queue_delegated_setters_are_percent_encoded() {
-        let mut udk = test_udk();
-        udk.signed_delegated_user_tid = Some("tenant id".into());
+    fn table_build() {
+        let udk = test_udk();
         let expiry = datetime!(2025-06-01 12:00:00 UTC);
 
-        let qp = SasBuilder::new("acct", &udk, expiry)
+        let token = SasTokenBuilder::new("myaccount", &udk, expiry)
             .unwrap()
-            .delegated_user_object_id("user/oid")
-            .queue("q")
+            .table("mytable")
             .read()
             .build();
 
-        assert!(qp.contains("skdutid=tenant%20id"), "got: {qp}");
-        assert!(qp.contains("sduoid=user%2Foid"), "got: {qp}");
+        assert!(token.contains("tn=mytable"));
+        assert!(token.contains("sp=r"));
+        assert!(!token.contains("sr="));
+        assert!(token.contains("sig="));
     }
 
     #[test]
-    fn delegated_setters_on_blob() {
-        let mut udk = test_udk();
-        udk.signed_delegated_user_tid = Some("dtid".into());
+    fn file_build() {
+        let udk = test_udk();
         let expiry = datetime!(2025-06-01 12:00:00 UTC);
 
-        let qp = SasBuilder::new("acct", &udk, expiry)
+        let token = SasTokenBuilder::new("myaccount", &udk, expiry)
             .unwrap()
-            .delegated_user_object_id("duoid")
-            .blob("c", "b")
+            .file("myshare", "path/file.txt")
             .read()
-            .cache_control("no-cache")
-            .content_disposition("inline")
-            .content_encoding("gzip")
-            .content_language("en-US")
-            .content_type("text/plain")
-            .authorized_object_id("saoid")
-            .unauthorized_object_id("suoid")
-            .correlation_id("scid")
             .build();
 
-        assert!(qp.contains("skdutid=dtid"));
-        assert!(qp.contains("sduoid=duoid"));
-        assert!(qp.contains("saoid=saoid"));
-        assert!(qp.contains("suoid=suoid"));
-        assert!(qp.contains("scid=scid"));
-        assert!(qp.contains("rscc=no-cache"));
-        assert!(qp.contains("rsct=text%2Fplain") || qp.contains("rsct=text/plain"));
+        assert!(token.contains("sr=f"));
+        assert!(token.contains("sp=r"));
+        assert!(token.contains("sig="));
+    }
+
+    #[test]
+    fn share_build() {
+        let udk = test_udk();
+        let expiry = datetime!(2025-06-01 12:00:00 UTC);
+
+        let token = SasTokenBuilder::new("myaccount", &udk, expiry)
+            .unwrap()
+            .share("myshare")
+            .read()
+            .list()
+            .build();
+
+        assert!(token.contains("sr=s"));
+        assert!(token.contains("sp=rl"));
+        assert!(token.contains("sig="));
+    }
+
+    #[test]
+    fn blob_build_url() {
+        let udk = test_udk();
+        let expiry = datetime!(2025-06-01 12:00:00 UTC);
+
+        let url = SasUrlBuilder::new("myaccount", &udk, expiry)
+            .unwrap()
+            .blob("mycontainer", "myblob.txt")
+            .read()
+            .build()
+            .unwrap();
+
+        assert_eq!(url.host_str(), Some("myaccount.blob.core.windows.net"));
+        assert!(url.path().ends_with("/mycontainer/myblob.txt"));
+        let qs = url.query().unwrap();
+        assert!(qs.contains("sr=b"));
+        assert!(qs.contains("sp=r"));
+        assert!(qs.contains("sig="));
+    }
+
+    #[test]
+    fn container_build_url() {
+        let udk = test_udk();
+        let expiry = datetime!(2025-06-01 12:00:00 UTC);
+
+        let url = SasUrlBuilder::new("myaccount", &udk, expiry)
+            .unwrap()
+            .container("mycontainer")
+            .read()
+            .list()
+            .build()
+            .unwrap();
+
+        assert_eq!(url.host_str(), Some("myaccount.blob.core.windows.net"));
+        assert!(url.path().ends_with("/mycontainer"));
+        assert!(url.query().unwrap().contains("sr=c"));
+    }
+
+    #[test]
+    fn queue_build_url() {
+        let udk = test_udk();
+        let expiry = datetime!(2025-06-01 12:00:00 UTC);
+
+        let url = SasUrlBuilder::new("myaccount", &udk, expiry)
+            .unwrap()
+            .queue("myqueue")
+            .read()
+            .build()
+            .unwrap();
+
+        assert_eq!(url.host_str(), Some("myaccount.queue.core.windows.net"));
+        assert!(url.path().ends_with("/myqueue"));
+    }
+
+    #[test]
+    fn table_build_url() {
+        let udk = test_udk();
+        let expiry = datetime!(2025-06-01 12:00:00 UTC);
+
+        let url = SasUrlBuilder::new("myaccount", &udk, expiry)
+            .unwrap()
+            .table("mytable")
+            .read()
+            .build()
+            .unwrap();
+
+        assert_eq!(url.host_str(), Some("myaccount.table.core.windows.net"));
+        assert!(url.path().ends_with("/mytable"));
+        assert!(url.query().unwrap().contains("tn=mytable"));
+    }
+
+    #[test]
+    fn file_build_url() {
+        let udk = test_udk();
+        let expiry = datetime!(2025-06-01 12:00:00 UTC);
+
+        let url = SasUrlBuilder::new("myaccount", &udk, expiry)
+            .unwrap()
+            .file("myshare", "dir/file.txt")
+            .read()
+            .build()
+            .unwrap();
+
+        assert_eq!(url.host_str(), Some("myaccount.file.core.windows.net"));
+        assert!(
+            url.path().ends_with("/myshare/dir/file.txt"),
+            "path: {}",
+            url.path()
+        );
+        assert!(url.query().unwrap().contains("sr=f"));
+    }
+
+    #[test]
+    fn share_build_url() {
+        let udk = test_udk();
+        let expiry = datetime!(2025-06-01 12:00:00 UTC);
+
+        let url = SasUrlBuilder::new("myaccount", &udk, expiry)
+            .unwrap()
+            .share("myshare")
+            .read()
+            .build()
+            .unwrap();
+
+        assert_eq!(url.host_str(), Some("myaccount.file.core.windows.net"));
+        assert!(url.path().ends_with("/myshare"));
+        assert!(url.query().unwrap().contains("sr=s"));
+    }
+
+    #[test]
+    fn custom_endpoint_used_in_build_url() {
+        let udk = test_udk();
+        let expiry = datetime!(2025-06-01 12:00:00 UTC);
+        let endpoint = url::Url::parse("http://127.0.0.1:10000/devstoreaccount1").unwrap();
+
+        let url = SasUrlBuilder::new("devstoreaccount1", &udk, expiry)
+            .unwrap()
+            .endpoint(endpoint)
+            .blob("container", "blob.txt")
+            .read()
+            .build()
+            .unwrap();
+
+        assert_eq!(url.host_str(), Some("127.0.0.1"));
+        assert!(url
+            .as_str()
+            .contains("/devstoreaccount1/container/blob.txt"));
     }
 
     #[test]
@@ -298,64 +670,17 @@ mod tests {
         let udk = test_udk();
         let expiry = datetime!(2025-06-01 12:00:00 UTC);
 
-        let qp = SasBuilder::new("acct", &udk, expiry)
+        let token = SasTokenBuilder::new("acct", &udk, expiry)
             .unwrap()
             .blob("c", "b")
             .snapshot("2025-01-15T12:00:00.0000000Z")
             .read()
             .build();
 
-        assert!(qp.contains("sr=bs"));
+        assert!(token.contains("sr=bs"));
         // The `:` characters in the snapshot timestamp are percent-encoded
         // when emitted in the SAS query string.
-        assert!(qp.contains("snapshot=2025-01-15T12%3A00%3A00.0000000Z"));
-    }
-
-    #[test]
-    fn response_header_overrides_are_percent_encoded() {
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .blob("c", "b")
-            .read()
-            .content_type("image/jpeg")
-            .content_disposition("attachment; filename=\"my file.txt\"")
-            .build();
-
-        // `/`, `;`, spaces, and quotes in user-supplied values must be
-        // percent-encoded so the resulting URL remains parseable.
-        assert!(qp.contains("rsct=image%2Fjpeg"), "got: {qp}");
-        assert!(
-            qp.contains("rscd=attachment%3B%20filename%3D%22my%20file.txt%22"),
-            "got: {qp}"
-        );
-    }
-
-    #[test]
-    fn blob_identity_and_scope_fields_are_percent_encoded() {
-        let mut udk = test_udk();
-        udk.signed_delegated_user_tid = Some("tenant id".into());
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .delegated_user_object_id("user/oid")
-            .blob("c", "b")
-            .read()
-            .encryption_scope("scope name")
-            .authorized_object_id("saoid/value")
-            .unauthorized_object_id("suoid value")
-            .correlation_id("scid id")
-            .build();
-
-        assert!(qp.contains("ses=scope%20name"), "got: {qp}");
-        assert!(qp.contains("skdutid=tenant%20id"), "got: {qp}");
-        assert!(qp.contains("sduoid=user%2Foid"), "got: {qp}");
-        assert!(qp.contains("saoid=saoid%2Fvalue"), "got: {qp}");
-        assert!(qp.contains("suoid=suoid%20value"), "got: {qp}");
-        assert!(qp.contains("scid=scid%20id"), "got: {qp}");
+        assert!(token.contains("snapshot=2025-01-15T12%3A00%3A00.0000000Z"));
     }
 
     #[test]
@@ -363,121 +688,30 @@ mod tests {
         let udk = test_udk();
         let expiry = datetime!(2025-06-01 12:00:00 UTC);
 
-        let qp = SasBuilder::new("acct", &udk, expiry)
+        let token = SasTokenBuilder::new("acct", &udk, expiry)
             .unwrap()
             .blob("c", "b")
             .version("2025-01-15T12:00:00.0000000Z")
             .read()
             .build();
 
-        assert!(qp.contains("sr=bv"));
+        assert!(token.contains("sr=bv"));
     }
 
     #[test]
-    fn blob_version_id_is_signed() {
+    fn protocol_https_only() {
         let udk = test_udk();
         let expiry = datetime!(2025-06-01 12:00:00 UTC);
 
-        let sig = |version: &str| {
-            let qp = SasBuilder::new("acct", &udk, expiry)
-                .unwrap()
-                .blob("c", "b")
-                .version(version)
-                .read()
-                .build();
-            qp.split("sig=").nth(1).unwrap().to_string()
-        };
-
-        // The version ID is placed in the snapshot slot of the string-to-sign,
-        // so two different versions must yield different signatures. Regression:
-        // previously the slot was always empty for `sr=bv`, so the signature did
-        // not cover the version ID and would not validate against the service.
-        assert_ne!(
-            sig("2025-01-15T12:00:00.0000000Z"),
-            sig("2025-02-20T08:30:00.0000000Z")
-        );
-    }
-
-    #[test]
-    fn skdutid_comes_from_key() {
-        let mut udk = test_udk();
-        udk.signed_delegated_user_tid = Some("delegated-tenant".into());
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .blob("c", "b")
-            .read()
-            .build();
-
-        assert!(qp.contains("skdutid=delegated-tenant"), "got: {qp}");
-    }
-
-    #[test]
-    fn no_skdutid_when_key_omits_it() {
-        // `test_udk()` has `signed_delegated_user_tid: None`.
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .blob("c", "b")
-            .read()
-            .build();
-
-        assert!(!qp.contains("skdutid="), "got: {qp}");
-    }
-
-    #[test]
-    fn format_time_produces_iso8601() {
-        let t = datetime!(2025-01-15 09:30:45 UTC);
-        assert_eq!(CommonFields::format_time(&t), "2025-01-15T09:30:45Z");
-    }
-
-    #[test]
-    fn format_time_normalizes_non_utc_to_utc() {
-        // 2025-01-15 14:30:45 +05:00 is the same instant as 09:30:45 UTC.
-        let t = datetime!(2025-01-15 14:30:45 +5);
-        assert_eq!(CommonFields::format_time(&t), "2025-01-15T09:30:45Z");
-    }
-
-    #[test]
-    fn encode_percent_encodes_special_chars() {
-        assert_eq!(CommonFields::encode("a+b/c=d"), "a%2Bb%2Fc%3Dd");
-        assert_eq!(CommonFields::encode("hello"), "hello");
-    }
-
-    #[test]
-    fn build_produces_deterministic_signature() {
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-
-        let builder = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .blob("c", "b")
-            .read();
-
-        let first = builder.build();
-        let second = builder.build();
-        assert_eq!(first, second);
-    }
-
-    #[test]
-    fn common_setters_before_and_after_transition() {
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-
-        // Common setters work before transition
-        let qp = SasBuilder::new("acct", &udk, expiry)
+        let token = SasTokenBuilder::new("acct", &udk, expiry)
             .unwrap()
             .protocol(SasProtocol::Https)
             .blob("c", "b")
             .read()
-            .start(datetime!(2025-01-15 00:00:00 UTC))
             .build();
 
-        assert!(qp.contains("spr=https"));
-        assert!(qp.contains("st=2025-01-15T00:00:00Z"));
+        assert!(token.contains("spr=https"));
+        assert!(!token.contains("spr=https,"));
     }
 
     #[test]
@@ -486,333 +720,43 @@ mod tests {
         udk.signed_oid = None;
         let expiry = datetime!(2025-06-01 12:00:00 UTC);
 
-        let err = match SasBuilder::new("acct", &udk, expiry) {
-            Ok(_) => panic!("missing signed_oid should error"),
-            Err(e) => e,
-        };
+        let err = SasTokenBuilder::new("acct", &udk, expiry)
+            .err()
+            .expect("expected error for missing field");
         assert!(format!("{err}").contains("signed_oid"));
     }
 
     #[test]
-    fn signed_request_header_in_blob_sas() {
+    fn directory_build_sets_sr_d_and_depth() {
         let udk = test_udk();
         let expiry = datetime!(2025-06-01 12:00:00 UTC);
 
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .blob("c", "b")
-            .read()
-            .signed_request_header("x-ms-blob-content-type", "application/json")
-            .build();
-
-        assert!(qp.contains("srh=x-ms-blob-content-type"), "got: {qp}");
-        assert!(qp.contains("sig="), "got: {qp}");
-    }
-
-    #[test]
-    fn signed_request_query_parameter_in_blob_sas() {
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .blob("c", "b")
-            .read()
-            .signed_request_query_parameter("comp", "list")
-            .build();
-
-        assert!(qp.contains("srq=comp"), "got: {qp}");
-        assert!(qp.contains("sig="), "got: {qp}");
-    }
-
-    #[test]
-    fn multiple_signed_request_headers_sorted() {
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .blob("c", "b")
-            .read()
-            .signed_request_header("x-ms-blob-type", "BlockBlob")
-            .signed_request_header("x-ms-blob-content-type", "text/plain")
-            .build();
-
-        // BTreeMap sorts keys: x-ms-blob-content-type < x-ms-blob-type.
-        // Commas between keys are structural separators and must NOT be
-        // percent-encoded (individual keys are encoded, commas are not).
-        assert!(
-            qp.contains("srh=x-ms-blob-content-type,x-ms-blob-type"),
-            "got: {qp}"
-        );
-    }
-
-    #[test]
-    fn signed_headers_change_signature() {
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-
-        let without = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .blob("c", "b")
-            .read()
-            .build();
-
-        let with_headers = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .blob("c", "b")
-            .read()
-            .signed_request_header("x-ms-blob-content-type", "application/json")
-            .build();
-
-        // Different string-to-sign must produce a different signature
-        let sig_without = without.split("sig=").nth(1).unwrap();
-        let sig_with = with_headers.split("sig=").nth(1).unwrap();
-        assert_ne!(sig_without, sig_with);
-    }
-
-    #[test]
-    fn signed_request_headers_on_container_sas() {
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .container("c")
-            .read()
-            .list()
-            .signed_request_header("x-ms-blob-content-type", "text/plain")
-            .build();
-
-        assert!(qp.contains("srh=x-ms-blob-content-type"), "got: {qp}");
-    }
-
-    #[test]
-    fn no_srh_srq_when_not_set() {
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .blob("c", "b")
-            .read()
-            .build();
-
-        assert!(!qp.contains("srh="), "got: {qp}");
-        assert!(!qp.contains("srq="), "got: {qp}");
-    }
-
-    #[test]
-    fn blob_version_query_omits_snapshot_param() {
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .blob("c", "b")
-            .version("2025-01-15T12:00:00.0000000Z")
-            .read()
-            .build();
-        assert!(qp.contains("sr=bv"));
-        assert!(
-            !qp.contains("snapshot="),
-            "version SAS must not emit a snapshot= query param; got: {qp}"
-        );
-    }
-
-    #[test]
-    fn blob_snapshot_query_includes_snapshot_param_not_version() {
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .blob("c", "b")
-            .snapshot("2025-01-15T12:00:00.0000000Z")
-            .read()
-            .build();
-        assert!(qp.contains("sr=bs"));
-        assert!(qp.contains("snapshot=2025-01-15T12%3A00%3A00.0000000Z"));
-        assert!(!qp.contains("versionid="), "got: {qp}");
-    }
-
-    #[test]
-    fn directory_build_sets_sr_d_and_sdd_depth() {
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-        let qp = SasBuilder::new("acct", &udk, expiry)
+        let token = SasTokenBuilder::new("acct", &udk, expiry)
             .unwrap()
             .directory("fs", "a/b/c")
             .read()
             .build();
-        assert!(qp.contains("sr=d"), "got: {qp}");
-        assert!(qp.contains("sdd=3"), "got: {qp}");
+
+        assert!(token.contains("sr=d"));
+        assert!(token.contains("sdd=3"));
     }
 
     #[test]
-    fn directory_root_has_zero_depth() {
+    fn table_with_key_range() {
         let udk = test_udk();
         let expiry = datetime!(2025-06-01 12:00:00 UTC);
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .directory("fs", "")
-            .read()
-            .build();
-        assert!(qp.contains("sdd=0"), "got: {qp}");
-    }
 
-    #[test]
-    fn ip_range_single_address_in_query() {
-        use std::net::Ipv4Addr;
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-        let qp = SasBuilder::new("acct", &udk, expiry)
+        let token = SasTokenBuilder::new("acct", &udk, expiry)
             .unwrap()
-            .ip_range(SasIpRange::Address(Ipv4Addr::new(1, 2, 3, 4)))
-            .blob("c", "b")
+            .table("t")
             .read()
-            .build();
-        assert!(qp.contains("sip=1.2.3.4"), "got: {qp}");
-    }
-
-    #[test]
-    fn ip_range_span_in_query() {
-        use std::net::Ipv4Addr;
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .ip_range(SasIpRange::InclusiveRange {
-                start: Ipv4Addr::new(10, 0, 0, 1),
-                end: Ipv4Addr::new(10, 0, 0, 255),
-            })
-            .blob("c", "b")
-            .read()
-            .build();
-        // The `-` between addresses must not be percent-encoded.
-        assert!(qp.contains("sip=10.0.0.1-10.0.0.255"), "got: {qp}");
-    }
-
-    #[test]
-    fn protocol_https_only_in_query() {
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .protocol(SasProtocol::Https)
-            .blob("c", "b")
-            .read()
-            .build();
-        assert!(qp.contains("spr=https"), "got: {qp}");
-        assert!(!qp.contains("spr=https,"), "got: {qp}");
-    }
-
-    #[test]
-    fn no_optional_params_when_unset() {
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .blob("c", "b")
-            .read()
-            .build();
-        for absent in [
-            "st=",
-            "sip=",
-            "spr=",
-            "saoid=",
-            "suoid=",
-            "scid=",
-            "skdutid=",
-            "sduoid=",
-            "ses=",
-            "snapshot=",
-            "rscc=",
-            "rscd=",
-            "rsce=",
-            "rscl=",
-            "rsct=",
-            "sdd=",
-        ] {
-            assert!(!qp.contains(absent), "unexpected `{absent}` in: {qp}");
-        }
-    }
-
-    #[test]
-    fn blob_permissions_serialize_in_canonical_order() {
-        // Pins the documented serialization order `racwdxytmeopi`. The setters
-        // are intentionally applied out of order to prove the order is fixed by
-        // the type, not by call order.
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .blob("c", "b")
-            .set_immutability_policy()
-            .permissions()
-            .ownership()
-            .execute()
-            .move_blob()
-            .tags()
-            .permanent_delete()
-            .delete_version()
-            .delete()
-            .write()
-            .create()
-            .add()
-            .read()
-            .build();
-        assert!(qp.contains("sp=racwdxytmeopi"), "got: {qp}");
-    }
-
-    #[test]
-    fn queue_query_has_no_blob_only_params() {
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .queue("q")
-            .read()
-            .build();
-        for absent in ["sr=", "snapshot=", "sdd=", "rscc=", "ses="] {
-            assert!(!qp.contains(absent), "unexpected `{absent}` in: {qp}");
-        }
-    }
-
-    #[test]
-    fn start_time_appears_in_query_and_sts() {
-        let udk = test_udk();
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-        let qp = SasBuilder::new("acct", &udk, expiry)
-            .unwrap()
-            .start(datetime!(2025-05-01 08:00:00 UTC))
-            .blob("c", "b")
-            .read()
-            .build();
-        assert!(qp.contains("st=2025-05-01T08:00:00Z"), "got: {qp}");
-    }
-
-    #[test]
-    fn delegated_key_changes_signature() {
-        // Two keys differing only in `signed_delegated_user_tid` must produce
-        // different signatures, proving `skdutid` is covered by the signature.
-        let expiry = datetime!(2025-06-01 12:00:00 UTC);
-
-        let udk_none = test_udk();
-        let sig_none = SasBuilder::new("acct", &udk_none, expiry)
-            .unwrap()
-            .blob("c", "b")
-            .read()
+            .start_key("partA", "row001")
+            .end_key("partZ", "row999")
             .build();
 
-        let mut udk_some = test_udk();
-        udk_some.signed_delegated_user_tid = Some("tenant".into());
-        let sig_some = SasBuilder::new("acct", &udk_some, expiry)
-            .unwrap()
-            .blob("c", "b")
-            .read()
-            .build();
-
-        let a = sig_none.split("sig=").nth(1).unwrap();
-        let b = sig_some.split("sig=").nth(1).unwrap();
-        assert_ne!(a, b);
+        assert!(token.contains("spk=partA"));
+        assert!(token.contains("srk=row001"));
+        assert!(token.contains("epk=partZ"));
+        assert!(token.contains("erk=row999"));
     }
 }

--- a/sdk/storage/azure_storage_sas/src/common.rs
+++ b/sdk/storage/azure_storage_sas/src/common.rs
@@ -162,6 +162,10 @@ pub(crate) trait SasResource: sealed::Sealed {
         key: &ValidatedKey<'_>,
         signature: &str,
     ) -> String;
+    /// Returns the URL path segments for this resource (each segment is individually encoded).
+    fn url_path_segments(&self) -> Vec<&str>;
+    /// Returns the default service endpoint for this resource type.
+    fn default_endpoint(account: &str) -> azure_core::Result<url::Url>;
 }
 
 /// Computes an HMAC-SHA256 signature and returns it as a base64 string.

--- a/sdk/storage/azure_storage_sas/src/file.rs
+++ b/sdk/storage/azure_storage_sas/src/file.rs
@@ -1,0 +1,527 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Azure Files resource types for user delegation SAS.
+//!
+//! | Type | `sr` | Scope |
+//! |------|------|-------|
+//! | [`FileState`] | `f` | A single file |
+//! | [`ShareState`] | `s` | All files in a share |
+//!
+//! <https://learn.microsoft.com/rest/api/storageservices/create-user-delegation-sas>
+
+use crate::builder::{SasTokenBuilder, SasUrlBuilder};
+use crate::common::sealed::Sealed;
+use crate::common::{CommonFields, SasResource, ValidatedKey};
+use crate::SAS_VERSION;
+
+/// Minimum API version for Azure Files user delegation SAS.
+pub const FILE_MIN_VERSION: &str = "2025-07-05";
+
+pub(crate) struct FileResource {
+    share: String,
+    path: String,
+}
+
+impl FileResource {
+    pub(crate) fn new(share: impl Into<String>, path: impl Into<String>) -> Self {
+        Self {
+            share: share.into(),
+            path: path.into().trim_matches('/').to_string(),
+        }
+    }
+
+    pub(crate) fn canonicalized_resource(&self, account: &str) -> String {
+        format!("/file/{}/{}/{}", account, self.share, self.path)
+    }
+
+    /// Returns individually encodable path segments.
+    ///
+    /// The path within the share may contain `/`-separated components; each is
+    /// returned as a separate segment so the URL crate encodes them individually.
+    pub(crate) fn url_path_segments(&self) -> Vec<&str> {
+        let mut segments = vec![self.share.as_str()];
+        if !self.path.is_empty() {
+            segments.extend(self.path.split('/'));
+        }
+        segments
+    }
+}
+
+pub(crate) struct ShareResource {
+    share: String,
+}
+
+impl ShareResource {
+    pub(crate) fn new(share: impl Into<String>) -> Self {
+        Self {
+            share: share.into(),
+        }
+    }
+
+    pub(crate) fn canonicalized_resource(&self, account: &str) -> String {
+        format!("/file/{}/{}", account, self.share)
+    }
+
+    pub(crate) fn url_path_segments(&self) -> [&str; 1] {
+        [&self.share]
+    }
+}
+
+/// Shared response-header override options for Azure Files SAS resources.
+#[derive(Default)]
+pub(crate) struct FileSasOptions {
+    pub cache_control: Option<String>,
+    pub content_disposition: Option<String>,
+    pub content_encoding: Option<String>,
+    pub content_language: Option<String>,
+    pub content_type: Option<String>,
+}
+
+/// Permissions for a file SAS.
+///
+/// Serialization order: `rwd`.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct FilePermissions {
+    pub(crate) read: bool,
+    pub(crate) write: bool,
+    pub(crate) delete: bool,
+}
+
+impl FilePermissions {
+    pub(crate) fn to_sas_str(self) -> String {
+        let mut s = String::with_capacity(3);
+        if self.read {
+            s.push('r');
+        }
+        if self.write {
+            s.push('w');
+        }
+        if self.delete {
+            s.push('d');
+        }
+        s
+    }
+}
+
+/// Permissions for a share SAS.
+///
+/// Serialization order: `rwdlc`.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct SharePermissions {
+    pub(crate) read: bool,
+    pub(crate) write: bool,
+    pub(crate) delete: bool,
+    pub(crate) list: bool,
+    pub(crate) create: bool,
+}
+
+impl SharePermissions {
+    pub(crate) fn to_sas_str(self) -> String {
+        let mut s = String::with_capacity(5);
+        if self.read {
+            s.push('r');
+        }
+        if self.write {
+            s.push('w');
+        }
+        if self.delete {
+            s.push('d');
+        }
+        if self.list {
+            s.push('l');
+        }
+        if self.create {
+            s.push('c');
+        }
+        s
+    }
+}
+
+/// State after selecting a file resource.
+pub struct FileState {
+    pub(crate) resource: FileResource,
+    pub(crate) permissions: FilePermissions,
+    pub(crate) options: FileSasOptions,
+}
+
+/// State after selecting a share resource.
+pub struct ShareState {
+    pub(crate) resource: ShareResource,
+    pub(crate) permissions: SharePermissions,
+    pub(crate) options: FileSasOptions,
+}
+
+impl Sealed for FileState {}
+impl Sealed for ShareState {}
+
+impl SasTokenBuilder<'_, FileState> {
+    /// Enables read permission.
+    pub fn read(mut self) -> Self {
+        self.state.permissions.read = true;
+        self
+    }
+    /// Enables write permission.
+    pub fn write(mut self) -> Self {
+        self.state.permissions.write = true;
+        self
+    }
+    /// Enables delete permission.
+    pub fn delete(mut self) -> Self {
+        self.state.permissions.delete = true;
+        self
+    }
+    /// Sets the `Cache-Control` response header override (`rscc`).
+    pub fn cache_control(mut self, value: impl Into<String>) -> Self {
+        self.state.options.cache_control = Some(value.into());
+        self
+    }
+    /// Sets the `Content-Disposition` response header override (`rscd`).
+    pub fn content_disposition(mut self, value: impl Into<String>) -> Self {
+        self.state.options.content_disposition = Some(value.into());
+        self
+    }
+    /// Sets the `Content-Encoding` response header override (`rsce`).
+    pub fn content_encoding(mut self, value: impl Into<String>) -> Self {
+        self.state.options.content_encoding = Some(value.into());
+        self
+    }
+    /// Sets the `Content-Language` response header override (`rscl`).
+    pub fn content_language(mut self, value: impl Into<String>) -> Self {
+        self.state.options.content_language = Some(value.into());
+        self
+    }
+    /// Sets the `Content-Type` response header override (`rsct`).
+    pub fn content_type(mut self, value: impl Into<String>) -> Self {
+        self.state.options.content_type = Some(value.into());
+        self
+    }
+}
+
+impl SasUrlBuilder<'_, FileState> {
+    /// Enables read permission.
+    pub fn read(self) -> Self {
+        self.map(|b| b.read())
+    }
+    /// Enables write permission.
+    pub fn write(self) -> Self {
+        self.map(|b| b.write())
+    }
+    /// Enables delete permission.
+    pub fn delete(self) -> Self {
+        self.map(|b| b.delete())
+    }
+    /// Sets the `Cache-Control` response header override (`rscc`).
+    pub fn cache_control(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.cache_control(value))
+    }
+    /// Sets the `Content-Disposition` response header override (`rscd`).
+    pub fn content_disposition(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.content_disposition(value))
+    }
+    /// Sets the `Content-Encoding` response header override (`rsce`).
+    pub fn content_encoding(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.content_encoding(value))
+    }
+    /// Sets the `Content-Language` response header override (`rscl`).
+    pub fn content_language(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.content_language(value))
+    }
+    /// Sets the `Content-Type` response header override (`rsct`).
+    pub fn content_type(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.content_type(value))
+    }
+}
+
+impl SasTokenBuilder<'_, ShareState> {
+    /// Enables read permission.
+    pub fn read(mut self) -> Self {
+        self.state.permissions.read = true;
+        self
+    }
+    /// Enables write permission.
+    pub fn write(mut self) -> Self {
+        self.state.permissions.write = true;
+        self
+    }
+    /// Enables delete permission.
+    pub fn delete(mut self) -> Self {
+        self.state.permissions.delete = true;
+        self
+    }
+    /// Enables list permission.
+    pub fn list(mut self) -> Self {
+        self.state.permissions.list = true;
+        self
+    }
+    /// Enables create permission.
+    pub fn create(mut self) -> Self {
+        self.state.permissions.create = true;
+        self
+    }
+    /// Sets the `Cache-Control` response header override (`rscc`).
+    pub fn cache_control(mut self, value: impl Into<String>) -> Self {
+        self.state.options.cache_control = Some(value.into());
+        self
+    }
+    /// Sets the `Content-Disposition` response header override (`rscd`).
+    pub fn content_disposition(mut self, value: impl Into<String>) -> Self {
+        self.state.options.content_disposition = Some(value.into());
+        self
+    }
+    /// Sets the `Content-Encoding` response header override (`rsce`).
+    pub fn content_encoding(mut self, value: impl Into<String>) -> Self {
+        self.state.options.content_encoding = Some(value.into());
+        self
+    }
+    /// Sets the `Content-Language` response header override (`rscl`).
+    pub fn content_language(mut self, value: impl Into<String>) -> Self {
+        self.state.options.content_language = Some(value.into());
+        self
+    }
+    /// Sets the `Content-Type` response header override (`rsct`).
+    pub fn content_type(mut self, value: impl Into<String>) -> Self {
+        self.state.options.content_type = Some(value.into());
+        self
+    }
+}
+
+impl SasUrlBuilder<'_, ShareState> {
+    /// Enables read permission.
+    pub fn read(self) -> Self {
+        self.map(|b| b.read())
+    }
+    /// Enables write permission.
+    pub fn write(self) -> Self {
+        self.map(|b| b.write())
+    }
+    /// Enables delete permission.
+    pub fn delete(self) -> Self {
+        self.map(|b| b.delete())
+    }
+    /// Enables list permission.
+    pub fn list(self) -> Self {
+        self.map(|b| b.list())
+    }
+    /// Enables create permission.
+    pub fn create(self) -> Self {
+        self.map(|b| b.create())
+    }
+    /// Sets the `Cache-Control` response header override (`rscc`).
+    pub fn cache_control(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.cache_control(value))
+    }
+    /// Sets the `Content-Disposition` response header override (`rscd`).
+    pub fn content_disposition(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.content_disposition(value))
+    }
+    /// Sets the `Content-Encoding` response header override (`rsce`).
+    pub fn content_encoding(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.content_encoding(value))
+    }
+    /// Sets the `Content-Language` response header override (`rscl`).
+    pub fn content_language(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.content_language(value))
+    }
+    /// Sets the `Content-Type` response header override (`rsct`).
+    pub fn content_type(self, value: impl Into<String>) -> Self {
+        self.map(|b| b.content_type(value))
+    }
+}
+
+impl SasResource for FileState {
+    fn string_to_sign(&self, common: &CommonFields, key: &ValidatedKey<'_>) -> String {
+        let sp = self.permissions.to_sas_str();
+        let canonical = self.resource.canonicalized_resource(&common.account);
+        file_udk_string_to_sign(&sp, common, key, &canonical, "f", &self.options)
+    }
+
+    fn query_parameters(
+        &self,
+        common: &CommonFields,
+        key: &ValidatedKey<'_>,
+        signature: &str,
+    ) -> String {
+        let sp = self.permissions.to_sas_str();
+        file_udk_query_parameters(&sp, common, key, signature, "f", &self.options)
+    }
+
+    fn url_path_segments(&self) -> Vec<&str> {
+        self.resource.url_path_segments()
+    }
+
+    fn default_endpoint(account: &str) -> azure_core::Result<url::Url> {
+        crate::url::file_endpoint(account)
+    }
+}
+
+impl SasResource for ShareState {
+    fn string_to_sign(&self, common: &CommonFields, key: &ValidatedKey<'_>) -> String {
+        let sp = self.permissions.to_sas_str();
+        let canonical = self.resource.canonicalized_resource(&common.account);
+        file_udk_string_to_sign(&sp, common, key, &canonical, "s", &self.options)
+    }
+
+    fn query_parameters(
+        &self,
+        common: &CommonFields,
+        key: &ValidatedKey<'_>,
+        signature: &str,
+    ) -> String {
+        let sp = self.permissions.to_sas_str();
+        file_udk_query_parameters(&sp, common, key, signature, "s", &self.options)
+    }
+
+    fn url_path_segments(&self) -> Vec<&str> {
+        self.resource.url_path_segments().to_vec()
+    }
+
+    fn default_endpoint(account: &str) -> azure_core::Result<url::Url> {
+        crate::url::file_endpoint(account)
+    }
+}
+
+fn file_udk_string_to_sign(
+    permissions: &str,
+    common: &CommonFields,
+    key: &ValidatedKey<'_>,
+    canonicalized_resource: &str,
+    sr: &str,
+    options: &FileSasOptions,
+) -> String {
+    let skdutid = key.signed_delegated_user_tid.unwrap_or("");
+    let sduoid = common.delegated_user_object_id.as_deref().unwrap_or("");
+    let sip = common.ip_str();
+    let spr = common.protocol_str();
+    let st = common.start_str();
+    let se = common.expiry_str();
+    let skt = CommonFields::format_time(key.signed_start);
+    let ske = CommonFields::format_time(key.signed_expiry);
+    let rscc = options.cache_control.as_deref().unwrap_or("");
+    let rscd = options.content_disposition.as_deref().unwrap_or("");
+    let rsce = options.content_encoding.as_deref().unwrap_or("");
+    let rscl = options.content_language.as_deref().unwrap_or("");
+    let rsct = options.content_type.as_deref().unwrap_or("");
+    let _ = sr; // sr is in query params but not string-to-sign for files
+
+    #[rustfmt::skip]
+    let parts: Vec<&str> = vec![
+        permissions,            // [0]  signedPermissions
+        &st,                    // [1]  signedStart
+        &se,                    // [2]  signedExpiry
+        canonicalized_resource, // [3]  canonicalizedResource
+        key.signed_oid,         // [4]  signedKeyObjectId
+        key.signed_tid,         // [5]  signedKeyTenantId
+        &skt,                   // [6]  signedKeyStart
+        &ske,                   // [7]  signedKeyExpiry
+        key.signed_service,     // [8]  signedKeyService
+        key.signed_version,     // [9]  signedKeyVersion
+        skdutid,                // [10] signedDelegatedUserTenantId (from key)
+        sduoid,                 // [11] signedDelegatedUserObjectId
+        &sip,                   // [12] signedIP
+        &spr,                   // [13] signedProtocol
+        SAS_VERSION,            // [14] signedVersion
+        rscc,                   // [15] rscc
+        rscd,                   // [16] rscd
+        rsce,                   // [17] rsce
+        rscl,                   // [18] rscl
+        rsct,                   // [19] rsct
+    ];
+    parts.join("\n")
+}
+
+fn file_udk_query_parameters(
+    permissions: &str,
+    common: &CommonFields,
+    key: &ValidatedKey<'_>,
+    signature: &str,
+    sr: &str,
+    options: &FileSasOptions,
+) -> String {
+    let mut parts = Vec::with_capacity(20);
+    parts.push(format!("sv={SAS_VERSION}"));
+    parts.push(format!("sr={sr}"));
+    if let Some(ref start) = common.start {
+        parts.push(format!("st={}", CommonFields::format_time(start)));
+    }
+    parts.push(format!("se={}", common.expiry_str()));
+    parts.push(format!("sp={permissions}"));
+    if let Some(ref ip) = common.ip_range {
+        parts.push(format!("sip={}", ip.sip_value()));
+    }
+    if let Some(ref proto) = common.protocol {
+        parts.push(format!("spr={proto}"));
+    }
+    parts.push(format!("skoid={}", key.signed_oid));
+    parts.push(format!("sktid={}", key.signed_tid));
+    parts.push(format!(
+        "skt={}",
+        CommonFields::format_time(key.signed_start)
+    ));
+    parts.push(format!(
+        "ske={}",
+        CommonFields::format_time(key.signed_expiry)
+    ));
+    parts.push(format!("sks={}", key.signed_service));
+    parts.push(format!("skv={}", key.signed_version));
+    if let Some(v) = key.signed_delegated_user_tid {
+        parts.push(format!("skdutid={}", CommonFields::encode(v)));
+    }
+    if let Some(ref v) = common.delegated_user_object_id {
+        parts.push(format!("sduoid={}", CommonFields::encode(v)));
+    }
+    if let Some(ref v) = options.cache_control {
+        parts.push(format!("rscc={}", CommonFields::encode(v)));
+    }
+    if let Some(ref v) = options.content_disposition {
+        parts.push(format!("rscd={}", CommonFields::encode(v)));
+    }
+    if let Some(ref v) = options.content_encoding {
+        parts.push(format!("rsce={}", CommonFields::encode(v)));
+    }
+    if let Some(ref v) = options.content_language {
+        parts.push(format!("rscl={}", CommonFields::encode(v)));
+    }
+    if let Some(ref v) = options.content_type {
+        parts.push(format!("rsct={}", CommonFields::encode(v)));
+    }
+    parts.push(format!("sig={}", CommonFields::encode(signature)));
+    parts.join("&")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::test_support::{test_common, test_udk};
+    use time::macros::datetime;
+
+    #[test]
+    fn file_string_to_sign_has_20_fields() {
+        let udk = test_udk();
+        let key = ValidatedKey::from_key(&udk).unwrap();
+        let common = test_common(datetime!(2025-06-01 12:00:00 UTC));
+        let options = FileSasOptions::default();
+        let sts =
+            file_udk_string_to_sign("rw", &common, &key, "/file/acct/share/path", "f", &options);
+        let lines: Vec<&str> = sts.split('\n').collect();
+        assert_eq!(lines.len(), 20, "file STS must have exactly 20 fields");
+        assert_eq!(lines[0], "rw");
+        assert_eq!(lines[3], "/file/acct/share/path");
+        assert_eq!(lines[14], "2026-04-06");
+        assert_eq!(lines[15], "");
+        assert_eq!(lines[19], "");
+    }
+
+    #[test]
+    fn share_string_to_sign_has_20_fields() {
+        let udk = test_udk();
+        let key = ValidatedKey::from_key(&udk).unwrap();
+        let common = test_common(datetime!(2025-06-01 12:00:00 UTC));
+        let options = FileSasOptions::default();
+        let sts =
+            file_udk_string_to_sign("rwdlc", &common, &key, "/file/acct/share", "s", &options);
+        let lines: Vec<&str> = sts.split('\n').collect();
+        assert_eq!(lines.len(), 20);
+        assert_eq!(lines[3], "/file/acct/share");
+    }
+}

--- a/sdk/storage/azure_storage_sas/src/lib.rs
+++ b/sdk/storage/azure_storage_sas/src/lib.rs
@@ -1,30 +1,49 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#![doc = include_str!("../README.md")]
+//! User delegation Shared Access Signature (SAS) builder for Azure Storage.
 //!
 //! # Supported resource types
 //!
-//! Select a resource by calling the matching method on [`SasBuilder`], then
-//! chain the permission setters available in that state:
+//! Select a resource by calling the matching method on [`SasTokenBuilder`] or
+//! [`SasUrlBuilder`], then chain the permission setters available in that state:
 //!
-//! - [`SasBuilder::blob`] — blob-level user delegation SAS (also covers snapshots and versions)
-//! - [`SasBuilder::container`] — container-level user delegation SAS
-//! - [`SasBuilder::directory`] — directory-level (ADLS Gen2) user delegation SAS
-//! - [`SasBuilder::queue`] — queue-level user delegation SAS
+//! - [`SasTokenBuilder::blob`] — blob-level user delegation SAS (also covers snapshots and versions)
+//! - [`SasTokenBuilder::container`] — container-level user delegation SAS
+//! - [`SasTokenBuilder::directory`] — directory-level (ADLS Gen2) user delegation SAS
+//! - [`SasTokenBuilder::queue`] — queue-level user delegation SAS
+//! - [`SasTokenBuilder::table`] — table-level user delegation SAS
+//! - [`SasTokenBuilder::file`] — file-level user delegation SAS
+//! - [`SasTokenBuilder::share`] — share-level user delegation SAS
+//!
+//! # Output format
+//!
+//! Use [`SasTokenBuilder`] to produce a [`SasToken`] — the signed query string
+//! (e.g. `sv=...&sr=b&...&sig=...`). Use [`SasUrlBuilder`] to produce a [`SasUrl`]
+//! — a complete URL with the signed query string embedded.
+//!
+//! ```rust,ignore
+//! let token: SasToken = SasTokenBuilder::new("myaccount", &udk, expiry)?.blob("c", "b").read().build();
+//! let url: SasUrl = SasUrlBuilder::new("myaccount", &udk, expiry)?.blob("c", "b").read().build()?;
+//! ```
+//!
+//! Use [`SasUrlBuilder::endpoint`] to override the default
+//! `https://{account}.{service}.core.windows.net` base (e.g. for Azurite or sovereign clouds).
 
 mod builder;
 mod common;
 mod ip_range;
 mod protocol;
+mod url;
 
 pub mod blob;
+pub mod file;
 pub mod queue;
+pub mod table;
 
 pub use azure_storage_common::models::UserDelegationKey;
-pub use builder::SasBuilder;
+pub use builder::{SasToken, SasTokenBuilder, SasUrl, SasUrlBuilder};
 pub use ip_range::SasIpRange;
 pub use protocol::SasProtocol;
 
-/// The SAS service version targeted by this crate.
 pub(crate) const SAS_VERSION: &str = "2026-04-06";

--- a/sdk/storage/azure_storage_sas/src/queue.rs
+++ b/sdk/storage/azure_storage_sas/src/queue.rs
@@ -6,11 +6,11 @@
 //! # Example
 //!
 //! ```rust no_run
-//! use azure_storage_sas::{SasBuilder, SasProtocol, UserDelegationKey};
+//! use azure_storage_sas::{SasTokenBuilder, SasProtocol, UserDelegationKey};
 //! use time::OffsetDateTime;
 //!
 //! # fn example(udk: UserDelegationKey) -> azure_core::Result<()> {
-//! let token = SasBuilder::new("myaccount", &udk,
+//! let token = SasTokenBuilder::new("myaccount", &udk,
 //!         OffsetDateTime::now_utc() + time::Duration::hours(8))?
 //!     .queue("work-items")
 //!     .read()
@@ -21,7 +21,7 @@
 //! # }
 //! ```
 
-use crate::builder::SasBuilder;
+use crate::builder::{SasTokenBuilder, SasUrlBuilder};
 use crate::common::sealed::Sealed;
 use crate::common::{CommonFields, SasResource, ValidatedKey};
 use crate::SAS_VERSION;
@@ -43,12 +43,16 @@ impl QueueResource {
     pub(crate) fn canonicalized_resource(&self, account: &str) -> String {
         format!("/queue/{}/{}", account, self.queue)
     }
+
+    pub(crate) fn url_path_segments(&self) -> [&str; 1] {
+        [&self.queue]
+    }
 }
 
 /// Permissions for a queue SAS.
 ///
 /// Serialization order: `raup`. Flags are set through the permission setters on
-/// [`SasBuilder<QueueState>`](crate::SasBuilder).
+/// [`SasTokenBuilder<QueueState>`](crate::SasTokenBuilder).
 #[derive(Clone, Copy, Default)]
 pub(crate) struct QueuePermissions {
     pub(crate) read: bool,
@@ -86,7 +90,7 @@ pub struct QueueState {
 impl Sealed for QueueState {}
 
 /// Permission setters for a queue SAS, gated on [`QueueState`].
-impl SasBuilder<'_, QueueState> {
+impl SasTokenBuilder<'_, QueueState> {
     /// Enables read permission.
     pub fn read(mut self) -> Self {
         self.state.permissions.read = true;
@@ -112,6 +116,25 @@ impl SasBuilder<'_, QueueState> {
     }
 }
 
+impl SasUrlBuilder<'_, QueueState> {
+    /// Enables read permission.
+    pub fn read(self) -> Self {
+        self.map(|b| b.read())
+    }
+    /// Enables add permission.
+    pub fn add(self) -> Self {
+        self.map(|b| b.add())
+    }
+    /// Enables update permission.
+    pub fn update(self) -> Self {
+        self.map(|b| b.update())
+    }
+    /// Enables process permission.
+    pub fn process(self) -> Self {
+        self.map(|b| b.process())
+    }
+}
+
 impl SasResource for QueueState {
     fn string_to_sign(&self, common: &CommonFields, key: &ValidatedKey<'_>) -> String {
         let sp = self.permissions.to_sas_str();
@@ -127,6 +150,14 @@ impl SasResource for QueueState {
     ) -> String {
         let sp = self.permissions.to_sas_str();
         queue_udk_query_parameters(&sp, common, key, signature)
+    }
+
+    fn url_path_segments(&self) -> Vec<&str> {
+        self.resource.url_path_segments().to_vec()
+    }
+
+    fn default_endpoint(account: &str) -> azure_core::Result<url::Url> {
+        crate::url::queue_endpoint(account)
     }
 }
 
@@ -160,7 +191,7 @@ fn queue_udk_string_to_sign(
         &ske,                   // [7]  signedKeyExpiry
         key.signed_service,     // [8]  signedKeyService
         key.signed_version,     // [9]  signedKeyVersion
-        skdutid,                // [10] signedDelegatedUserTenantId
+        skdutid,                // [10] signedDelegatedUserTenantId (from key)
         sduoid,                 // [11] signedDelegatedUserObjectId
         &sip,                   // [12] signedIP
         &spr,                   // [13] signedProtocol
@@ -244,6 +275,6 @@ mod tests {
         let common = test_common(datetime!(2025-06-01 12:00:00 UTC));
         let sts = queue_udk_string_to_sign("r", &common, &key, "/queue/acct/q");
         let lines: Vec<&str> = sts.split('\n').collect();
-        assert_eq!(lines[10], ""); // skdutid empty
+        assert_eq!(lines[10], "");
     }
 }

--- a/sdk/storage/azure_storage_sas/src/table.rs
+++ b/sdk/storage/azure_storage_sas/src/table.rs
@@ -1,0 +1,318 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Table Storage resource for user delegation SAS.
+//!
+//! Table SAS uses `tn` instead of `sr` and optionally restricts access to
+//! a partition/row key range.
+//!
+//! <https://learn.microsoft.com/rest/api/storageservices/create-user-delegation-sas>
+
+use crate::builder::{SasTokenBuilder, SasUrlBuilder};
+use crate::common::sealed::Sealed;
+use crate::common::{CommonFields, SasResource, ValidatedKey};
+use crate::SAS_VERSION;
+
+/// Minimum API version for Table Storage user delegation SAS.
+pub const TABLE_MIN_VERSION: &str = "2025-07-05";
+
+pub(crate) struct TableResource {
+    table: String,
+    start_partition_key: Option<String>,
+    start_row_key: Option<String>,
+    end_partition_key: Option<String>,
+    end_row_key: Option<String>,
+}
+
+impl TableResource {
+    pub(crate) fn new(table: impl Into<String>) -> Self {
+        Self {
+            table: table.into().to_lowercase(),
+            start_partition_key: None,
+            start_row_key: None,
+            end_partition_key: None,
+            end_row_key: None,
+        }
+    }
+
+    pub(crate) fn canonicalized_resource(&self, account: &str) -> String {
+        format!("/table/{}/{}", account, self.table)
+    }
+
+    pub(crate) fn url_path_segments(&self) -> [&str; 1] {
+        [&self.table]
+    }
+}
+
+/// Permissions for a Table Storage SAS.
+///
+/// Serialization order: `raud`.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct TablePermissions {
+    pub(crate) read: bool,
+    pub(crate) add: bool,
+    pub(crate) update: bool,
+    pub(crate) delete: bool,
+}
+
+impl TablePermissions {
+    pub(crate) fn to_sas_str(self) -> String {
+        let mut s = String::with_capacity(4);
+        if self.read {
+            s.push('r');
+        }
+        if self.add {
+            s.push('a');
+        }
+        if self.update {
+            s.push('u');
+        }
+        if self.delete {
+            s.push('d');
+        }
+        s
+    }
+}
+
+/// State after selecting a table resource.
+pub struct TableState {
+    pub(crate) resource: TableResource,
+    pub(crate) permissions: TablePermissions,
+}
+
+impl Sealed for TableState {}
+
+impl SasTokenBuilder<'_, TableState> {
+    /// Enables read permission.
+    pub fn read(mut self) -> Self {
+        self.state.permissions.read = true;
+        self
+    }
+    /// Enables add permission.
+    pub fn add(mut self) -> Self {
+        self.state.permissions.add = true;
+        self
+    }
+    /// Enables update permission.
+    pub fn update(mut self) -> Self {
+        self.state.permissions.update = true;
+        self
+    }
+    /// Enables delete permission.
+    pub fn delete(mut self) -> Self {
+        self.state.permissions.delete = true;
+        self
+    }
+    /// Restricts access to rows with partition/row keys >= the given values (`spk`/`srk`).
+    pub fn start_key(
+        mut self,
+        partition_key: impl Into<String>,
+        row_key: impl Into<String>,
+    ) -> Self {
+        self.state.resource.start_partition_key = Some(partition_key.into());
+        self.state.resource.start_row_key = Some(row_key.into());
+        self
+    }
+    /// Restricts access to rows with partition/row keys <= the given values (`epk`/`erk`).
+    pub fn end_key(mut self, partition_key: impl Into<String>, row_key: impl Into<String>) -> Self {
+        self.state.resource.end_partition_key = Some(partition_key.into());
+        self.state.resource.end_row_key = Some(row_key.into());
+        self
+    }
+}
+
+impl SasUrlBuilder<'_, TableState> {
+    /// Enables read permission.
+    pub fn read(self) -> Self {
+        self.map(|b| b.read())
+    }
+    /// Enables add permission.
+    pub fn add(self) -> Self {
+        self.map(|b| b.add())
+    }
+    /// Enables update permission.
+    pub fn update(self) -> Self {
+        self.map(|b| b.update())
+    }
+    /// Enables delete permission.
+    pub fn delete(self) -> Self {
+        self.map(|b| b.delete())
+    }
+    /// Restricts access to rows with partition/row keys >= the given values (`spk`/`srk`).
+    pub fn start_key(self, partition_key: impl Into<String>, row_key: impl Into<String>) -> Self {
+        self.map(|b| b.start_key(partition_key, row_key))
+    }
+    /// Restricts access to rows with partition/row keys <= the given values (`epk`/`erk`).
+    pub fn end_key(self, partition_key: impl Into<String>, row_key: impl Into<String>) -> Self {
+        self.map(|b| b.end_key(partition_key, row_key))
+    }
+}
+
+impl SasResource for TableState {
+    fn string_to_sign(&self, common: &CommonFields, key: &ValidatedKey<'_>) -> String {
+        let sp = self.permissions.to_sas_str();
+        let canonical = self.resource.canonicalized_resource(&common.account);
+        table_udk_string_to_sign(&sp, common, key, &canonical, &self.resource)
+    }
+
+    fn query_parameters(
+        &self,
+        common: &CommonFields,
+        key: &ValidatedKey<'_>,
+        signature: &str,
+    ) -> String {
+        let sp = self.permissions.to_sas_str();
+        table_udk_query_parameters(&sp, common, key, signature, &self.resource)
+    }
+
+    fn url_path_segments(&self) -> Vec<&str> {
+        self.resource.url_path_segments().to_vec()
+    }
+
+    fn default_endpoint(account: &str) -> azure_core::Result<url::Url> {
+        crate::url::table_endpoint(account)
+    }
+}
+
+fn table_udk_string_to_sign(
+    permissions: &str,
+    common: &CommonFields,
+    key: &ValidatedKey<'_>,
+    canonicalized_resource: &str,
+    resource: &TableResource,
+) -> String {
+    let skdutid = key.signed_delegated_user_tid.unwrap_or("");
+    let sduoid = common.delegated_user_object_id.as_deref().unwrap_or("");
+    let sip = common.ip_str();
+    let spr = common.protocol_str();
+    let st = common.start_str();
+    let se = common.expiry_str();
+    let skt = CommonFields::format_time(key.signed_start);
+    let ske = CommonFields::format_time(key.signed_expiry);
+    let spk = resource.start_partition_key.as_deref().unwrap_or("");
+    let srk = resource.start_row_key.as_deref().unwrap_or("");
+    let epk = resource.end_partition_key.as_deref().unwrap_or("");
+    let erk = resource.end_row_key.as_deref().unwrap_or("");
+
+    #[rustfmt::skip]
+    let parts: Vec<&str> = vec![
+        permissions,            // [0]  signedPermissions
+        &st,                    // [1]  signedStart
+        &se,                    // [2]  signedExpiry
+        canonicalized_resource, // [3]  canonicalizedResource
+        key.signed_oid,         // [4]  signedKeyObjectId
+        key.signed_tid,         // [5]  signedKeyTenantId
+        &skt,                   // [6]  signedKeyStart
+        &ske,                   // [7]  signedKeyExpiry
+        key.signed_service,     // [8]  signedKeyService
+        key.signed_version,     // [9]  signedKeyVersion
+        skdutid,                // [10] signedDelegatedUserTenantId (from key)
+        sduoid,                 // [11] signedDelegatedUserObjectId
+        &sip,                   // [12] signedIP
+        &spr,                   // [13] signedProtocol
+        SAS_VERSION,            // [14] signedVersion
+        spk,                    // [15] startingPartitionKey
+        srk,                    // [16] startingRowKey
+        epk,                    // [17] endingPartitionKey
+        erk,                    // [18] endingRowKey
+    ];
+    parts.join("\n")
+}
+
+fn table_udk_query_parameters(
+    permissions: &str,
+    common: &CommonFields,
+    key: &ValidatedKey<'_>,
+    signature: &str,
+    resource: &TableResource,
+) -> String {
+    let mut parts = Vec::with_capacity(20);
+    parts.push(format!("sv={SAS_VERSION}"));
+    if let Some(ref start) = common.start {
+        parts.push(format!("st={}", CommonFields::format_time(start)));
+    }
+    parts.push(format!("se={}", common.expiry_str()));
+    parts.push(format!("sp={permissions}"));
+    if let Some(ref ip) = common.ip_range {
+        parts.push(format!("sip={}", ip.sip_value()));
+    }
+    if let Some(ref proto) = common.protocol {
+        parts.push(format!("spr={proto}"));
+    }
+    parts.push(format!("skoid={}", key.signed_oid));
+    parts.push(format!("sktid={}", key.signed_tid));
+    parts.push(format!(
+        "skt={}",
+        CommonFields::format_time(key.signed_start)
+    ));
+    parts.push(format!(
+        "ske={}",
+        CommonFields::format_time(key.signed_expiry)
+    ));
+    parts.push(format!("sks={}", key.signed_service));
+    parts.push(format!("skv={}", key.signed_version));
+    if let Some(v) = key.signed_delegated_user_tid {
+        parts.push(format!("skdutid={}", CommonFields::encode(v)));
+    }
+    if let Some(ref v) = common.delegated_user_object_id {
+        parts.push(format!("sduoid={}", CommonFields::encode(v)));
+    }
+    parts.push(format!("tn={}", CommonFields::encode(&resource.table)));
+    if let Some(ref v) = resource.start_partition_key {
+        parts.push(format!("spk={}", CommonFields::encode(v)));
+    }
+    if let Some(ref v) = resource.start_row_key {
+        parts.push(format!("srk={}", CommonFields::encode(v)));
+    }
+    if let Some(ref v) = resource.end_partition_key {
+        parts.push(format!("epk={}", CommonFields::encode(v)));
+    }
+    if let Some(ref v) = resource.end_row_key {
+        parts.push(format!("erk={}", CommonFields::encode(v)));
+    }
+    parts.push(format!("sig={}", CommonFields::encode(signature)));
+    parts.join("&")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::test_support::{test_common, test_udk};
+    use time::macros::datetime;
+
+    #[test]
+    fn table_string_to_sign_has_19_fields() {
+        let udk = test_udk();
+        let key = ValidatedKey::from_key(&udk).unwrap();
+        let common = test_common(datetime!(2025-06-01 12:00:00 UTC));
+        let resource = TableResource::new("mytable");
+        let sts = table_udk_string_to_sign("raud", &common, &key, "/table/acct/mytable", &resource);
+        let lines: Vec<&str> = sts.split('\n').collect();
+        assert_eq!(lines.len(), 19, "table STS must have exactly 19 fields");
+        assert_eq!(lines[0], "raud");
+        assert_eq!(lines[3], "/table/acct/mytable");
+        assert_eq!(lines[14], "2026-04-06");
+        assert_eq!(lines[15], "");
+        assert_eq!(lines[16], "");
+        assert_eq!(lines[17], "");
+        assert_eq!(lines[18], "");
+    }
+
+    #[test]
+    fn table_string_to_sign_includes_key_range() {
+        let udk = test_udk();
+        let key = ValidatedKey::from_key(&udk).unwrap();
+        let common = test_common(datetime!(2025-06-01 12:00:00 UTC));
+        let mut resource = TableResource::new("mytable");
+        resource.start_partition_key = Some("partA".into());
+        resource.start_row_key = Some("row001".into());
+        resource.end_partition_key = Some("partZ".into());
+        resource.end_row_key = Some("row999".into());
+        let sts = table_udk_string_to_sign("r", &common, &key, "/table/acct/mytable", &resource);
+        let lines: Vec<&str> = sts.split('\n').collect();
+        assert_eq!(lines[15], "partA");
+        assert_eq!(lines[16], "row001");
+        assert_eq!(lines[17], "partZ");
+        assert_eq!(lines[18], "row999");
+    }
+}

--- a/sdk/storage/azure_storage_sas/src/url.rs
+++ b/sdk/storage/azure_storage_sas/src/url.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! URL assembly helpers for [`SasUrl`](crate::SasUrl) output.
+//!
+//! Handles Azurite-style endpoints that have an existing path
+//! (e.g. `http://127.0.0.1:10000/devstoreaccount1`) by appending to it
+//! rather than replacing it. Each path segment is individually percent-encoded
+//! by the `url` crate's `PathSegmentsMut`. The signed query string is set via
+//! `set_query`, which preserves existing percent-encoding.
+
+pub(crate) fn assemble(
+    endpoint: &url::Url,
+    path_segments: &[&str],
+    query_string: &str,
+) -> azure_core::Result<url::Url> {
+    let mut url = endpoint.clone();
+    url.path_segments_mut()
+        .map_err(|_| {
+            azure_core::Error::with_message(
+                azure_core::error::ErrorKind::Other,
+                "SAS endpoint URL cannot be used as a base URL",
+            )
+        })?
+        .pop_if_empty()
+        .extend(path_segments);
+    url.set_query(Some(query_string));
+    Ok(url)
+}
+
+fn parse_endpoint(url: &str) -> azure_core::Result<url::Url> {
+    url::Url::parse(url).map_err(|e| {
+        azure_core::Error::with_message(azure_core::error::ErrorKind::Other, format!("{e}"))
+    })
+}
+
+pub(crate) fn blob_endpoint(account: &str) -> azure_core::Result<url::Url> {
+    parse_endpoint(&format!("https://{account}.blob.core.windows.net"))
+}
+
+pub(crate) fn queue_endpoint(account: &str) -> azure_core::Result<url::Url> {
+    parse_endpoint(&format!("https://{account}.queue.core.windows.net"))
+}
+
+pub(crate) fn table_endpoint(account: &str) -> azure_core::Result<url::Url> {
+    parse_endpoint(&format!("https://{account}.table.core.windows.net"))
+}
+
+pub(crate) fn file_endpoint(account: &str) -> azure_core::Result<url::Url> {
+    parse_endpoint(&format!("https://{account}.file.core.windows.net"))
+}

--- a/sdk/storage/azure_storage_sas/tests/readme.rs
+++ b/sdk/storage/azure_storage_sas/tests/readme.rs
@@ -12,7 +12,8 @@ fn readme() -> azure_core::Result<()> {
     let udk = UserDelegationKey::default();
 
     // Each macro invocation is in its own block to prevent errors with duplicate imports.
-    include_markdown!("README.md", "read_blob_sas", scope);
+    include_markdown!("README.md", "blob_sas_url", scope);
+    include_markdown!("README.md", "blob_sas_token", scope);
     include_markdown!("README.md", "container_ip_range_sas", scope);
 
     Ok(())


### PR DESCRIPTION
Closes #4444 

Adds `SasUrlBuilder` alongside the existing token builder (renamed to `SasTokenBuilder`), giving callers a dedicated builder that produces a complete signed `SasUrl` rather than a bare query string.