### PR TITLE
Generate Cargo SBOMs for governance

### DIFF
--- a/eng/pipelines/templates/jobs/pack.yml
+++ b/eng/pipelines/templates/jobs/pack.yml
@@ -135,6 +135,13 @@ jobs:
           -OutBuildOrderFile '$(Build.ArtifactStagingDirectory)/release-order.json'
           $(AdditionalPackageParams)
 
+  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    - task: PowerShell@2
+      displayName: Generate Cargo SBOMs
+      inputs:
+        pwsh: true
+        filePath: $(Build.SourcesDirectory)/eng/scripts/Generate-CargoSbom.ps1
+        arguments: -PackageNames ${{ join(',', parameters.Artifacts.*.name) }}
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:

--- a/eng/pipelines/templates/jobs/pack.yml
+++ b/eng/pipelines/templates/jobs/pack.yml
@@ -44,6 +44,7 @@ jobs:
 
   - template: /eng/pipelines/templates/steps/use-rust.yml@self
     parameters:
+      Toolchain: nightly
       WorkingDirectory: $(System.DefaultWorkingDirectory)/eng/tools
       SetDefault: false
 
@@ -108,7 +109,6 @@ jobs:
           Write-Host "##vso[task.setvariable variable=AdditionalPackageParams]"
         }
       displayName: Configure crate packing
-      condition: and(succeeded(), ne(variables['NoPackagesChanged'],'true'))
 
     - task: PowerShell@2
       displayName: Check SemVer compatibility
@@ -141,7 +141,10 @@ jobs:
       inputs:
         pwsh: true
         filePath: $(Build.SourcesDirectory)/eng/scripts/Generate-CargoSbom.ps1
-        arguments: -PackageNames ${{ join(',', parameters.Artifacts.*.name) }}
+        ${{ if or(eq('auto', parameters.ServiceDirectory), endsWith(variables['Build.DefinitionName'], 'weekly')) }}:
+          arguments: -Workspace
+        ${{ else }}:
+          arguments: -PackageNames '$(PackageNames)'
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:

--- a/eng/scripts/Generate-CargoSbom.ps1
+++ b/eng/scripts/Generate-CargoSbom.ps1
@@ -4,9 +4,14 @@
 # Licensed under the MIT License.
 
 #Requires -Version 7.0
+[CmdletBinding(DefaultParameterSetName = 'Workspace')]
 param(
-  [Alias('PackageNames')]
-  [string[]] $PackageName
+  [Parameter(Mandatory, ParameterSetName = 'PackageNames')]
+  [ValidateNotNullOrEmpty()]
+  [string] $PackageNames,
+
+  [Parameter(Mandatory, ParameterSetName = 'Workspace')]
+  [switch] $Workspace
 )
 
 $ErrorActionPreference = 'Stop'
@@ -26,11 +31,11 @@ $stableRustc = (
     Select-Object -First 1
 ).Trim()
 
-$packageArgs = if ($PackageName) {
-  '--package ' + ($PackageName -join ' --package ')
+$packageArgs = if ($Workspace) {
+  '--workspace'
 }
 else {
-  '--workspace'
+  '--package ' + (($PackageNames -split ',') -join ' --package ')
 }
 
 # Cargo owns SBOM generation, so nightly Cargo can drive the stable compiler without

--- a/eng/scripts/Generate-CargoSbom.ps1
+++ b/eng/scripts/Generate-CargoSbom.ps1
@@ -1,0 +1,60 @@
+#!/usr/bin/env pwsh
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+#Requires -Version 7.0
+param(
+  [Alias('PackageNames')]
+  [string[]] $PackageName
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+. ([System.IO.Path]::Combine($PSScriptRoot, '..', 'common', 'scripts', 'common.ps1'))
+. ([System.IO.Path]::Combine($PSScriptRoot, 'shared', 'Cargo.ps1'))
+
+$nightlyToolchain = Get-ResolvedRustToolchain -Toolchain 'nightly'
+$stableToolchain = Get-ResolvedRustToolchain -Toolchain 'stable'
+$nightlyCargo = (
+  Invoke-LoggedCommand "rustup which --toolchain $nightlyToolchain cargo" |
+    Select-Object -First 1
+).Trim()
+$stableRustc = (
+  Invoke-LoggedCommand "rustup which --toolchain $stableToolchain rustc" |
+    Select-Object -First 1
+).Trim()
+
+$packageArgs = if ($PackageName) {
+  '--package ' + ($PackageName -join ' --package ')
+}
+else {
+  '--workspace'
+}
+
+# Cargo owns SBOM generation, so nightly Cargo can drive the stable compiler without
+# weakening the stable-toolchain validation performed by the rest of the pipeline.
+$env:CARGO_BUILD_SBOM = 'true'
+$env:RUSTC = $stableRustc
+$env:RUSTUP_TOOLCHAIN = $stableToolchain
+
+Invoke-LoggedCommand `
+  "& `"$nightlyCargo`" -Z sbom build --locked --all-features --keep-going $packageArgs" `
+  -GroupOutput
+
+$metadata = Invoke-LoggedCommand `
+  "& `"$nightlyCargo`" metadata --no-deps --format-version 1 --locked" |
+    ConvertFrom-Json
+$sbomFiles = Get-ChildItem `
+  -Path $metadata.target_directory `
+  -Filter '*.cargo-sbom.json' `
+  -File `
+  -Recurse
+
+if (!$sbomFiles) {
+  LogError "Cargo completed without generating any SBOM precursor files."
+  exit 1
+}
+
+Write-Host "Generated $($sbomFiles.Count) Cargo SBOM precursor files."


### PR DESCRIPTION
Component Governance currently falls back to Cargo metadata or `Cargo.lock`, which can report crates that are not present in built SDK artifacts and creates false-positive governance alerts.

Use the repository-pinned nightly Cargo only for unstable SBOM precursor generation while forcing the repository-pinned stable `rustc`. Internal Pack jobs generate precursors for their service artifacts with all features before the injected Component Governance scan, and fail if Cargo emits none.

The split is intentional: no unstable Cargo configuration is checked in, so existing stable build and test workflows remain unchanged.