### PR TITLE
test(eventhubs): cover blob checkpoint store isolation

### DIFF
--- a/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/tests/checkpoint_store_isolation_tests.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/tests/checkpoint_store_isolation_tests.rs
@@ -1,0 +1,665 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Isolation and error tests for the blob checkpoint store.
+
+use azure_core::{
+    error::ErrorKind,
+    http::{StatusCode, Url},
+    Result,
+};
+use azure_core_test::{recorded, Recording, TestContext};
+use azure_messaging_eventhubs::{
+    models::{Checkpoint, Ownership},
+    CheckpointStore,
+};
+use azure_messaging_eventhubs_checkpointstore_blob::BlobCheckpointStore;
+use azure_storage_blob::{
+    models::StorageErrorCode, BlobContainerClient, BlobContainerClientOptions, StorageError,
+};
+use std::sync::Arc;
+
+// The checkpoint store never resolves the namespace or the event hub against a
+// service, so a random name for each key part keeps the blob prefix unique to
+// one test run in a shared container.
+fn unique(recording: &Recording, prefix: &str) -> String {
+    recording.random_string::<24>(Some(prefix))
+}
+
+fn missing_container_name(recording: &Recording) -> String {
+    recording
+        .random_string::<32>(Some("nonexistent-"))
+        .to_ascii_lowercase()
+}
+
+fn create_checkpoint_store(
+    recording: &Recording,
+    container_name: &str,
+) -> Result<Arc<BlobCheckpointStore>> {
+    let credential = recording.credential();
+    let mut options = BlobContainerClientOptions::default();
+    recording.instrument(&mut options.client_options);
+    let endpoint = recording.var("AZURE_STORAGE_BLOB_ENDPOINT", None);
+    let mut container_url = Url::parse(&endpoint)?;
+    container_url
+        .path_segments_mut()
+        .expect("endpoint must be a valid base URL")
+        .push(container_name);
+    let blob_container_client =
+        BlobContainerClient::new(container_url, Some(credential), Some(options))?;
+
+    Ok(BlobCheckpointStore::new(blob_container_client))
+}
+
+#[recorded::test(live)]
+async fn checkpoint_isolation_by_event_hub(ctx: TestContext) -> Result<()> {
+    let recording = ctx.recording();
+    let container = recording.var("AZURE_STORAGE_BLOB_CONTAINER", None);
+    let checkpoint_store = create_checkpoint_store(recording, &container)?;
+
+    let namespace = unique(recording, "ns-");
+    let consumer_group = unique(recording, "cg-");
+    let event_hub_a = unique(recording, "eh-");
+    let event_hub_b = unique(recording, "eh-");
+
+    checkpoint_store
+        .update_checkpoint(Checkpoint {
+            fully_qualified_namespace: namespace.clone(),
+            event_hub_name: event_hub_a.clone(),
+            consumer_group: consumer_group.clone(),
+            partition_id: "isolation-a".to_string(),
+            offset: Some("1000".to_string()),
+            sequence_number: Some(1),
+        })
+        .await?;
+
+    checkpoint_store
+        .update_checkpoint(Checkpoint {
+            fully_qualified_namespace: namespace.clone(),
+            event_hub_name: event_hub_b.clone(),
+            consumer_group: consumer_group.clone(),
+            partition_id: "isolation-b".to_string(),
+            offset: Some("2000".to_string()),
+            sequence_number: Some(2),
+        })
+        .await?;
+
+    let listed = checkpoint_store
+        .list_checkpoints(&namespace, &event_hub_a, &consumer_group)
+        .await?;
+
+    assert!(
+        !listed.iter().any(|c| c.partition_id == "isolation-b"),
+        "a checkpoint from the other event hub leaked into the listing: {listed:?}"
+    );
+    assert_eq!(
+        listed.len(),
+        1,
+        "expected only the checkpoint written under the first event hub: {listed:?}"
+    );
+    assert_eq!(listed[0].partition_id, "isolation-a");
+    assert_eq!(
+        listed[0].offset,
+        Some("1000".to_string()),
+        "listed metadata must come from the first event hub's blob"
+    );
+
+    Ok(())
+}
+
+#[recorded::test(live)]
+async fn checkpoint_isolation_by_consumer_group(ctx: TestContext) -> Result<()> {
+    let recording = ctx.recording();
+    let container = recording.var("AZURE_STORAGE_BLOB_CONTAINER", None);
+    let checkpoint_store = create_checkpoint_store(recording, &container)?;
+
+    let namespace = unique(recording, "ns-");
+    let event_hub = unique(recording, "eh-");
+    let consumer_group_a = unique(recording, "cg-");
+    let consumer_group_b = unique(recording, "cg-");
+
+    checkpoint_store
+        .update_checkpoint(Checkpoint {
+            fully_qualified_namespace: namespace.clone(),
+            event_hub_name: event_hub.clone(),
+            consumer_group: consumer_group_a.clone(),
+            partition_id: "isolation-a".to_string(),
+            offset: Some("1000".to_string()),
+            sequence_number: Some(1),
+        })
+        .await?;
+
+    checkpoint_store
+        .update_checkpoint(Checkpoint {
+            fully_qualified_namespace: namespace.clone(),
+            event_hub_name: event_hub.clone(),
+            consumer_group: consumer_group_b.clone(),
+            partition_id: "isolation-b".to_string(),
+            offset: Some("2000".to_string()),
+            sequence_number: Some(2),
+        })
+        .await?;
+
+    let listed = checkpoint_store
+        .list_checkpoints(&namespace, &event_hub, &consumer_group_a)
+        .await?;
+
+    assert!(
+        !listed.iter().any(|c| c.partition_id == "isolation-b"),
+        "a checkpoint from the other consumer group leaked into the listing: {listed:?}"
+    );
+    assert_eq!(
+        listed.len(),
+        1,
+        "expected only the checkpoint written under the first consumer group: {listed:?}"
+    );
+    assert_eq!(listed[0].partition_id, "isolation-a");
+    assert_eq!(
+        listed[0].offset,
+        Some("1000".to_string()),
+        "listed metadata must come from the first consumer group's blob"
+    );
+
+    Ok(())
+}
+
+#[recorded::test(live)]
+async fn checkpoint_isolation_by_namespace(ctx: TestContext) -> Result<()> {
+    let recording = ctx.recording();
+    let container = recording.var("AZURE_STORAGE_BLOB_CONTAINER", None);
+    let checkpoint_store = create_checkpoint_store(recording, &container)?;
+
+    let event_hub = unique(recording, "eh-");
+    let consumer_group = unique(recording, "cg-");
+    let namespace_a = unique(recording, "ns-");
+    let namespace_b = unique(recording, "ns-");
+
+    checkpoint_store
+        .update_checkpoint(Checkpoint {
+            fully_qualified_namespace: namespace_a.clone(),
+            event_hub_name: event_hub.clone(),
+            consumer_group: consumer_group.clone(),
+            partition_id: "isolation-a".to_string(),
+            offset: Some("1000".to_string()),
+            sequence_number: Some(1),
+        })
+        .await?;
+
+    checkpoint_store
+        .update_checkpoint(Checkpoint {
+            fully_qualified_namespace: namespace_b.clone(),
+            event_hub_name: event_hub.clone(),
+            consumer_group: consumer_group.clone(),
+            partition_id: "isolation-b".to_string(),
+            offset: Some("2000".to_string()),
+            sequence_number: Some(2),
+        })
+        .await?;
+
+    let listed = checkpoint_store
+        .list_checkpoints(&namespace_a, &event_hub, &consumer_group)
+        .await?;
+
+    assert!(
+        !listed.iter().any(|c| c.partition_id == "isolation-b"),
+        "a checkpoint from the other namespace leaked into the listing: {listed:?}"
+    );
+    assert_eq!(
+        listed.len(),
+        1,
+        "expected only the checkpoint written under the first namespace: {listed:?}"
+    );
+    assert_eq!(listed[0].partition_id, "isolation-a");
+    assert_eq!(
+        listed[0].offset,
+        Some("1000".to_string()),
+        "listed metadata must come from the first namespace's blob"
+    );
+
+    Ok(())
+}
+
+#[recorded::test(live)]
+async fn ownership_isolation_by_event_hub(ctx: TestContext) -> Result<()> {
+    let recording = ctx.recording();
+    let container = recording.var("AZURE_STORAGE_BLOB_CONTAINER", None);
+    let checkpoint_store = create_checkpoint_store(recording, &container)?;
+
+    let namespace = unique(recording, "ns-");
+    let consumer_group = unique(recording, "cg-");
+    let event_hub_a = unique(recording, "eh-");
+    let event_hub_b = unique(recording, "eh-");
+
+    let ownership_a = Ownership {
+        fully_qualified_namespace: namespace.clone(),
+        event_hub_name: event_hub_a.clone(),
+        consumer_group: consumer_group.clone(),
+        partition_id: "isolation-a".to_string(),
+        owner_id: Some("owner-a".to_string()),
+        etag: None,
+        last_modified_time: None,
+    };
+    checkpoint_store.claim_ownership(&[ownership_a]).await?;
+
+    let ownership_b = Ownership {
+        fully_qualified_namespace: namespace.clone(),
+        event_hub_name: event_hub_b.clone(),
+        consumer_group: consumer_group.clone(),
+        partition_id: "isolation-b".to_string(),
+        owner_id: Some("owner-b".to_string()),
+        etag: None,
+        last_modified_time: None,
+    };
+    checkpoint_store.claim_ownership(&[ownership_b]).await?;
+
+    let listed = checkpoint_store
+        .list_ownerships(&namespace, &event_hub_a, &consumer_group)
+        .await?;
+
+    assert!(
+        !listed.iter().any(|o| o.partition_id == "isolation-b"),
+        "an ownership from the other event hub leaked into the listing: {listed:?}"
+    );
+    assert_eq!(
+        listed.len(),
+        1,
+        "expected only the ownership written under the first event hub: {listed:?}"
+    );
+    assert_eq!(listed[0].partition_id, "isolation-a");
+    assert_eq!(
+        listed[0].owner_id,
+        Some("owner-a".to_string()),
+        "listed owner must come from the first event hub's blob"
+    );
+
+    Ok(())
+}
+
+#[recorded::test(live)]
+async fn ownership_isolation_by_consumer_group(ctx: TestContext) -> Result<()> {
+    let recording = ctx.recording();
+    let container = recording.var("AZURE_STORAGE_BLOB_CONTAINER", None);
+    let checkpoint_store = create_checkpoint_store(recording, &container)?;
+
+    let namespace = unique(recording, "ns-");
+    let event_hub = unique(recording, "eh-");
+    let consumer_group_a = unique(recording, "cg-");
+    let consumer_group_b = unique(recording, "cg-");
+
+    let ownership_a = Ownership {
+        fully_qualified_namespace: namespace.clone(),
+        event_hub_name: event_hub.clone(),
+        consumer_group: consumer_group_a.clone(),
+        partition_id: "isolation-a".to_string(),
+        owner_id: Some("owner-a".to_string()),
+        etag: None,
+        last_modified_time: None,
+    };
+    checkpoint_store.claim_ownership(&[ownership_a]).await?;
+
+    let ownership_b = Ownership {
+        fully_qualified_namespace: namespace.clone(),
+        event_hub_name: event_hub.clone(),
+        consumer_group: consumer_group_b.clone(),
+        partition_id: "isolation-b".to_string(),
+        owner_id: Some("owner-b".to_string()),
+        etag: None,
+        last_modified_time: None,
+    };
+    checkpoint_store.claim_ownership(&[ownership_b]).await?;
+
+    let listed = checkpoint_store
+        .list_ownerships(&namespace, &event_hub, &consumer_group_a)
+        .await?;
+
+    assert!(
+        !listed.iter().any(|o| o.partition_id == "isolation-b"),
+        "an ownership from the other consumer group leaked into the listing: {listed:?}"
+    );
+    assert_eq!(
+        listed.len(),
+        1,
+        "expected only the ownership written under the first consumer group: {listed:?}"
+    );
+    assert_eq!(listed[0].partition_id, "isolation-a");
+    assert_eq!(
+        listed[0].owner_id,
+        Some("owner-a".to_string()),
+        "listed owner must come from the first consumer group's blob"
+    );
+
+    Ok(())
+}
+
+#[recorded::test(live)]
+async fn ownership_isolation_by_namespace(ctx: TestContext) -> Result<()> {
+    let recording = ctx.recording();
+    let container = recording.var("AZURE_STORAGE_BLOB_CONTAINER", None);
+    let checkpoint_store = create_checkpoint_store(recording, &container)?;
+
+    let event_hub = unique(recording, "eh-");
+    let consumer_group = unique(recording, "cg-");
+    let namespace_a = unique(recording, "ns-");
+    let namespace_b = unique(recording, "ns-");
+
+    let ownership_a = Ownership {
+        fully_qualified_namespace: namespace_a.clone(),
+        event_hub_name: event_hub.clone(),
+        consumer_group: consumer_group.clone(),
+        partition_id: "isolation-a".to_string(),
+        owner_id: Some("owner-a".to_string()),
+        etag: None,
+        last_modified_time: None,
+    };
+    checkpoint_store.claim_ownership(&[ownership_a]).await?;
+
+    let ownership_b = Ownership {
+        fully_qualified_namespace: namespace_b.clone(),
+        event_hub_name: event_hub.clone(),
+        consumer_group: consumer_group.clone(),
+        partition_id: "isolation-b".to_string(),
+        owner_id: Some("owner-b".to_string()),
+        etag: None,
+        last_modified_time: None,
+    };
+    checkpoint_store.claim_ownership(&[ownership_b]).await?;
+
+    let listed = checkpoint_store
+        .list_ownerships(&namespace_a, &event_hub, &consumer_group)
+        .await?;
+
+    assert!(
+        !listed.iter().any(|o| o.partition_id == "isolation-b"),
+        "an ownership from the other namespace leaked into the listing: {listed:?}"
+    );
+    assert_eq!(
+        listed.len(),
+        1,
+        "expected only the ownership written under the first namespace: {listed:?}"
+    );
+    assert_eq!(listed[0].partition_id, "isolation-a");
+    assert_eq!(
+        listed[0].owner_id,
+        Some("owner-a".to_string()),
+        "listed owner must come from the first namespace's blob"
+    );
+
+    Ok(())
+}
+
+#[recorded::test(live)]
+async fn list_checkpoints_missing_container_reports_container_not_found(
+    ctx: TestContext,
+) -> Result<()> {
+    let recording = ctx.recording();
+    let container = missing_container_name(recording);
+    let checkpoint_store = create_checkpoint_store(recording, &container)?;
+
+    let namespace = unique(recording, "ns-");
+    let event_hub = unique(recording, "eh-");
+    let consumer_group = unique(recording, "cg-");
+
+    let err = checkpoint_store
+        .list_checkpoints(&namespace, &event_hub, &consumer_group)
+        .await
+        .expect_err("list_checkpoints on a missing container must fail");
+
+    let storage_error = StorageError::try_from(err).expect("expected an HTTP response error");
+    assert_eq!(
+        storage_error.status_code,
+        StatusCode::NotFound,
+        "expected HTTP 404 from list_checkpoints on a missing container"
+    );
+    assert_eq!(
+        storage_error.error_code.as_ref(),
+        Some(&StorageErrorCode::ContainerNotFound),
+        "expected the ContainerNotFound error code from list_checkpoints"
+    );
+
+    Ok(())
+}
+
+#[recorded::test(live)]
+async fn list_ownerships_missing_container_reports_container_not_found(
+    ctx: TestContext,
+) -> Result<()> {
+    let recording = ctx.recording();
+    let container = missing_container_name(recording);
+    let checkpoint_store = create_checkpoint_store(recording, &container)?;
+
+    let namespace = unique(recording, "ns-");
+    let event_hub = unique(recording, "eh-");
+    let consumer_group = unique(recording, "cg-");
+
+    let err = checkpoint_store
+        .list_ownerships(&namespace, &event_hub, &consumer_group)
+        .await
+        .expect_err("list_ownerships on a missing container must fail");
+
+    let storage_error = StorageError::try_from(err).expect("expected an HTTP response error");
+    assert_eq!(
+        storage_error.status_code,
+        StatusCode::NotFound,
+        "expected HTTP 404 from list_ownerships on a missing container"
+    );
+    assert_eq!(
+        storage_error.error_code.as_ref(),
+        Some(&StorageErrorCode::ContainerNotFound),
+        "expected the ContainerNotFound error code from list_ownerships"
+    );
+
+    Ok(())
+}
+
+#[recorded::test(live)]
+async fn update_checkpoint_missing_container_reports_container_not_found(
+    ctx: TestContext,
+) -> Result<()> {
+    let recording = ctx.recording();
+    let container = missing_container_name(recording);
+    let checkpoint_store = create_checkpoint_store(recording, &container)?;
+
+    let namespace = unique(recording, "ns-");
+    let event_hub = unique(recording, "eh-");
+    let consumer_group = unique(recording, "cg-");
+
+    let err = checkpoint_store
+        .update_checkpoint(Checkpoint {
+            fully_qualified_namespace: namespace,
+            event_hub_name: event_hub,
+            consumer_group,
+            partition_id: "isolation-a".to_string(),
+            offset: Some("1000".to_string()),
+            sequence_number: Some(1),
+        })
+        .await
+        .expect_err("update_checkpoint on a missing container must fail");
+
+    let storage_error = StorageError::try_from(err).expect("expected an HTTP response error");
+    assert_eq!(
+        storage_error.status_code,
+        StatusCode::NotFound,
+        "expected HTTP 404 from update_checkpoint on a missing container"
+    );
+    assert_eq!(
+        storage_error.error_code.as_ref(),
+        Some(&StorageErrorCode::ContainerNotFound),
+        "expected the ContainerNotFound error code from update_checkpoint"
+    );
+
+    Ok(())
+}
+
+#[recorded::test(live)]
+async fn claim_ownership_missing_container_reports_container_not_found(
+    ctx: TestContext,
+) -> Result<()> {
+    let recording = ctx.recording();
+    let container = missing_container_name(recording);
+    let checkpoint_store = create_checkpoint_store(recording, &container)?;
+
+    let namespace = unique(recording, "ns-");
+    let event_hub = unique(recording, "eh-");
+    let consumer_group = unique(recording, "cg-");
+
+    let ownership = Ownership {
+        fully_qualified_namespace: namespace,
+        event_hub_name: event_hub,
+        consumer_group,
+        partition_id: "isolation-a".to_string(),
+        owner_id: Some("owner-a".to_string()),
+        etag: None,
+        last_modified_time: None,
+    };
+
+    let err = checkpoint_store
+        .claim_ownership(&[ownership])
+        .await
+        .expect_err("claim_ownership on a missing container must fail");
+
+    let storage_error = StorageError::try_from(err).expect("expected an HTTP response error");
+    assert_eq!(
+        storage_error.status_code,
+        StatusCode::NotFound,
+        "expected HTTP 404 from claim_ownership on a missing container"
+    );
+    assert_eq!(
+        storage_error.error_code.as_ref(),
+        Some(&StorageErrorCode::ContainerNotFound),
+        "expected the ContainerNotFound error code from claim_ownership"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn checkpoint_blob_prefix_name_layout() -> Result<()> {
+    assert_eq!(
+        Checkpoint::get_checkpoint_blob_prefix_name("ns1", "eh1", "cg1")?,
+        "ns1/eh1/cg1/checkpoint/"
+    );
+    Ok(())
+}
+
+#[test]
+fn checkpoint_blob_name_appends_partition_id() -> Result<()> {
+    assert_eq!(
+        Checkpoint::get_checkpoint_blob_name("ns1", "eh1", "cg1", "7")?,
+        "ns1/eh1/cg1/checkpoint/7"
+    );
+    Ok(())
+}
+
+#[test]
+fn ownership_prefix_name_layout() -> Result<()> {
+    assert_eq!(
+        Ownership::get_ownership_prefix_name("ns1", "eh1", "cg1")?,
+        "ns1/eh1/cg1/ownership/"
+    );
+    Ok(())
+}
+
+#[test]
+fn ownership_name_appends_partition_id() -> Result<()> {
+    assert_eq!(
+        Ownership::get_ownership_name("ns1", "eh1", "cg1", "7")?,
+        "ns1/eh1/cg1/ownership/7"
+    );
+    Ok(())
+}
+
+#[test]
+fn checkpoint_blob_name_differs_for_each_key_part() -> Result<()> {
+    let base = Checkpoint::get_checkpoint_blob_name("ns1", "eh1", "cg1", "7")?;
+    assert_ne!(
+        base,
+        Checkpoint::get_checkpoint_blob_name("ns2", "eh1", "cg1", "7")?,
+        "the namespace must change the checkpoint blob name"
+    );
+    assert_ne!(
+        base,
+        Checkpoint::get_checkpoint_blob_name("ns1", "eh2", "cg1", "7")?,
+        "the event hub must change the checkpoint blob name"
+    );
+    assert_ne!(
+        base,
+        Checkpoint::get_checkpoint_blob_name("ns1", "eh1", "cg2", "7")?,
+        "the consumer group must change the checkpoint blob name"
+    );
+    Ok(())
+}
+
+#[test]
+fn ownership_name_differs_for_each_key_part() -> Result<()> {
+    let base = Ownership::get_ownership_name("ns1", "eh1", "cg1", "7")?;
+    assert_ne!(
+        base,
+        Ownership::get_ownership_name("ns2", "eh1", "cg1", "7")?,
+        "the namespace must change the ownership blob name"
+    );
+    assert_ne!(
+        base,
+        Ownership::get_ownership_name("ns1", "eh2", "cg1", "7")?,
+        "the event hub must change the ownership blob name"
+    );
+    assert_ne!(
+        base,
+        Ownership::get_ownership_name("ns1", "eh1", "cg2", "7")?,
+        "the consumer group must change the ownership blob name"
+    );
+    Ok(())
+}
+
+#[test]
+fn key_builders_reject_empty_key_parts() {
+    let cases: Vec<(Result<String>, &str)> = vec![
+        (
+            Checkpoint::get_checkpoint_blob_prefix_name("", "eh1", "cg1"),
+            "fully_qualified_namespace",
+        ),
+        (
+            Checkpoint::get_checkpoint_blob_prefix_name("ns1", "", "cg1"),
+            "event_hub_name",
+        ),
+        (
+            Checkpoint::get_checkpoint_blob_prefix_name("ns1", "eh1", ""),
+            "consumer_group",
+        ),
+        (
+            Ownership::get_ownership_prefix_name("", "eh1", "cg1"),
+            "fully_qualified_namespace",
+        ),
+        (
+            Ownership::get_ownership_prefix_name("ns1", "", "cg1"),
+            "event_hub_name",
+        ),
+        (
+            Ownership::get_ownership_prefix_name("ns1", "eh1", ""),
+            "consumer_group",
+        ),
+        (
+            Checkpoint::get_checkpoint_blob_name("ns1", "eh1", "cg1", ""),
+            "partition_id",
+        ),
+        (
+            Ownership::get_ownership_name("ns1", "eh1", "cg1", ""),
+            "partition_id",
+        ),
+    ];
+
+    for (result, field) in cases {
+        let Err(err) = result else {
+            panic!("an empty {field} must be rejected");
+        };
+        assert!(
+            matches!(err.kind(), ErrorKind::Other),
+            "expected ErrorKind::Other for the empty {field} case, got {:?}",
+            err.kind()
+        );
+        assert_eq!(
+            err.to_string(),
+            format!("Required field {field} is empty"),
+            "unexpected message for the empty {field} case"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`azure_messaging_eventhubs_checkpointstore_blob` had 14 tests, which covered claims, etag versions, and a stale etag failure. This change adds 17 tests. They cover record isolation across the event hub, the consumer group, and the namespace, and the error that store operations return against a container that does not exist.

## Motivation

The blob checkpoint store keys every record by namespace, event hub, consumer group, and partition. A wrong key lets two unrelated processors overwrite each other's checkpoints, and events are then lost or processed twice. No test pinned that key. The four key builders in `event_processor/models.rs` had no unit test at all, and no test covered a container that does not exist.

Two of the existing tests look like isolation proofs but cannot fail. `list_checkpoints` and `list_ownerships` copy the namespace, the event hub, and the consumer group from the caller's own arguments onto every returned record, so an assertion on those three fields proves nothing. The new tests do not use that shape.

## Changes

- Add `tests/checkpoint_store_isolation_tests.rs` with 17 tests and no change to any other file.
- Add 6 live isolation tests, one for each of the event hub, the consumer group, and the namespace, for checkpoints and again for ownership.
- Add 4 live tests that prove `list_checkpoints`, `list_ownerships`, `update_checkpoint`, and `claim_ownership` give HTTP 404 with the `ContainerNotFound` error code against a container that does not exist.
- Add 7 plain `#[test]` unit tests over the four public key builders, which pin the blob name layout with no service.
- Prove isolation by presence, by absence, by `partition_id`, and by blob metadata, never by the three fields that the list methods copy from their arguments.
- Randomize all three key parts in each isolation test, so the expected count of 1 is exact in the shared container.
- Keep the file free of `mod checkpoint_unit_tests;`, which would compile and run the 7 existing checkpoint tests a third time.

## Test plan

- The 10 service tests use `#[recorded::test(live)]`, not `#[recorded::test]`. A new recorded test name has no recording in the tag that `assets.json` pins, so CI fails it with `header not found x-recording-id`. A live test is compiled with `#[ignore]` unless `AZURE_TEST_MODE=live`, so it needs no recording asset. `assets.json` is unchanged, and no recording must be pushed for this change.
- `CARGO_BUILD_JOBS=1 cargo test -p azure_messaging_eventhubs_checkpointstore_blob --test checkpoint_store_isolation_tests -- --test-threads=1` gives 7 passed, 0 failed, 10 ignored.
- The 7 unit tests carry a mutation proof. Seven single-line edits to `sdk/eventhubs/azure_messaging_eventhubs/src/event_processor/models.rs` each broke the predicted tests and were then reverted. A change of `/checkpoint/` to `/checkpoints/` at line 58 breaks the two checkpoint layout tests. A dropped `+ partition_id` at line 73 breaks `checkpoint_blob_name_appends_partition_id` alone. A dropped consumer group at lines 56 and 57 breaks `checkpoint_blob_name_differs_for_each_key_part`. A dropped `check_non_empty_parameter!(consumer_group);` at line 52 breaks `key_builders_reject_empty_key_parts` alone. The ownership builders give the same result at lines 116, 134, 112, and 113.
- `cargo fmt --check`, `cargo clippy --all-features --all-targets` with `-Dwarnings`, `cargo doc --all-features --no-deps` with `-Dwarnings`, and cspell with the repository configuration all pass.

Three findings from this work are out of scope here and need their own issues.

- .NET lowercases the namespace, the event hub, and the consumer group before it builds the blob key, and the Rust builders do not. A Rust processor and a .NET processor that share one container write to different blobs.
- `set_checkpoint_metadata_on_blob` treats every 404 from `set_metadata` as a missing blob and retries with an upload. For a missing container it logs "Blob ... not found, creating." and then fails on the upload. The returned error is correct, and the log names the wrong cause.
- The assertions at `checkpoint_unit_tests.rs:65-66` and `ownership_unit_tests.rs:52-53` and their peers stay vacuous, because this change adds a file and edits none.

Closes #4894.

### Live validation

Every test here ran against a live Event Hubs namespace on 2026-08-20: 17 passed, 0 failed.

Command: `AZURE_TEST_MODE=live cargo test --package azure_messaging_eventhubs_checkpointstore_blob -- --test-threads=1`.

No change was needed. The tests passed as written on the first live run.
