### PR TITLE
test(eventhubs): cover consumer receive options

### DIFF
--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_receive_options.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_receive_options.rs
@@ -1,0 +1,545 @@
+// Copyright (c) Microsoft Corporation. All Rights reserved
+// Licensed under the MIT license.
+
+//! Live tests for the consumer receive options and the client identifiers.
+//!
+//! Each test reads the tail of its partition first, then sends events that
+//! carry its own run marker. The assertions look only at events with that
+//! marker. Traffic that another run writes to the same partition arrives after
+//! the boundary and the marker filter drops it, so it never enters a result.
+
+use azure_core_amqp::AmqpErrorKind;
+use azure_core_test::{recorded, TestContext};
+use azure_messaging_eventhubs::{
+    error::ErrorKind,
+    models::{AmqpSimpleValue, EventData, ReceivedEventData},
+    ConsumerClient, EventDataBatchOptions, EventHubsError, OpenReceiverOptions, ProducerClient,
+    StartLocation, StartPosition,
+};
+use futures::{Stream, StreamExt};
+use std::{env, error::Error, time::Duration};
+
+/// Application property that names the run which sent an event.
+const RUN_MARKER_KEY: &str = "receive-options-run";
+/// Application property that names the position of an event inside its run.
+const EVENT_LABEL_KEY: &str = "receive-options-label";
+
+const EVENT_COUNT: usize = 10;
+const READ_DEADLINE: Duration = Duration::from_secs(90);
+const ATTACH_POKE: Duration = Duration::from_secs(2);
+
+const IDLE_TIMEOUT: azure_core::time::Duration = azure_core::time::Duration::seconds(5);
+const MIN_IDLE_ELAPSED: Duration = Duration::from_secs(4);
+const MAX_IDLE_ELAPSED: Duration = Duration::from_secs(15);
+const IDLE_DEADLINE: Duration = Duration::from_secs(120);
+const END_POLL: Duration = Duration::from_secs(10);
+
+const SLOW_TIMEOUT: azure_core::time::Duration = azure_core::time::Duration::seconds(10);
+const SLOW_COUNT: usize = 6;
+const SEND_INTERVAL: Duration = Duration::from_secs(3);
+const SLOW_DEADLINE: Duration = Duration::from_secs(120);
+
+/// The two clients a test needs, plus the marker that identifies its events.
+struct Clients {
+    producer: ProducerClient,
+    consumer: ConsumerClient,
+    run_marker: String,
+}
+
+/// Opens a producer and a consumer against the live Event Hub.
+///
+/// `test_name` becomes the application identifier on both clients. When
+/// `instance_id` is set, the consumer also carries that instance identifier.
+async fn open_clients(
+    ctx: &TestContext,
+    test_name: &str,
+    instance_id: Option<&str>,
+) -> Result<Clients, Box<dyn Error>> {
+    let host = env::var("EVENTHUBS_HOST")?;
+    let eventhub = env::var("EVENTHUB_NAME")?;
+    let credential = ctx.recording().credential();
+
+    let producer = ProducerClient::builder()
+        .with_application_id(test_name.to_string())
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
+        .await?;
+
+    let mut builder = ConsumerClient::builder().with_application_id(test_name.to_string());
+    if let Some(instance_id) = instance_id {
+        builder = builder.with_instance_id(instance_id.to_string());
+    }
+    let consumer = builder.open(host.as_str(), eventhub, credential).await?;
+
+    Ok(Clients {
+        producer,
+        consumer,
+        run_marker: format!("{test_name}-{}", azure_core::Uuid::new_v4()),
+    })
+}
+
+/// Returns the sequence number of the last event in the partition.
+///
+/// The read goes through the consumer on purpose. It opens the consumer
+/// connection, so the later link attach is short.
+async fn boundary_sequence(
+    consumer: &ConsumerClient,
+    partition: &str,
+) -> Result<i64, Box<dyn Error>> {
+    Ok(consumer
+        .get_partition_properties(partition)
+        .await?
+        .last_enqueued_sequence_number)
+}
+
+/// Sends one batch of labeled events to a partition.
+async fn send_labeled_batch(
+    producer: &ProducerClient,
+    partition: &str,
+    run_marker: &str,
+    labels: &[String],
+) -> azure_messaging_eventhubs::Result<()> {
+    let batch = producer
+        .create_batch(Some(EventDataBatchOptions {
+            partition_id: Some(partition.to_string()),
+            ..Default::default()
+        }))
+        .await?;
+
+    for label in labels {
+        assert!(
+            batch.try_add_event_data(
+                EventData::builder()
+                    .with_body(label.clone())
+                    .add_property(RUN_MARKER_KEY.to_string(), run_marker.to_string())
+                    .add_property(EVENT_LABEL_KEY.to_string(), label.clone())
+                    .build(),
+                None,
+            )?,
+            "the batch refused label {label} of run marker {run_marker} for partition {partition}"
+        );
+    }
+
+    producer.send_batch(batch, None).await
+}
+
+/// Returns the label of an event, but only when the event belongs to this run.
+fn tagged_label(event: &ReceivedEventData, run_marker: &str) -> Option<String> {
+    let properties = event.event_data().properties()?;
+    let AmqpSimpleValue::String(marker) = properties.get(RUN_MARKER_KEY)? else {
+        return None;
+    };
+    if marker != run_marker {
+        return None;
+    }
+    let AmqpSimpleValue::String(label) = properties.get(EVENT_LABEL_KEY)? else {
+        return None;
+    };
+    Some(label.clone())
+}
+
+/// Collects the labels of this run from the stream, in arrival order.
+///
+/// The read stops at `want` labels or at `deadline`. A short read returns what
+/// it has, and the caller asserts on the count.
+async fn read_tagged<S>(
+    stream: &mut S,
+    run_marker: &str,
+    want: usize,
+    deadline: Duration,
+) -> Vec<String>
+where
+    S: Stream<Item = azure_messaging_eventhubs::Result<ReceivedEventData>> + Unpin,
+{
+    let mut seen: Vec<String> = Vec::with_capacity(want);
+    let _ = tokio::time::timeout(deadline, async {
+        while seen.len() < want {
+            match stream.next().await {
+                Some(Ok(event)) => {
+                    if let Some(label) = tagged_label(&event, run_marker) {
+                        seen.push(label);
+                    }
+                }
+                Some(Err(err)) => panic!(
+                    "the stream failed for run marker {run_marker} after it read {seen:?}: {err:?}"
+                ),
+                None => break,
+            }
+        }
+    })
+    .await;
+    seen
+}
+
+#[recorded::test(live)]
+async fn prefetch_custom_delivers_every_event(ctx: TestContext) -> Result<(), Box<dyn Error>> {
+    const PARTITION: &str = "1";
+    const PREFETCH: u32 = 3;
+
+    let clients = open_clients(&ctx, "prefetch_custom_delivers_every_event", None).await?;
+    let boundary = boundary_sequence(&clients.consumer, PARTITION).await?;
+
+    let labels: Vec<String> = (0..EVENT_COUNT)
+        .map(|index| format!("event-{index}"))
+        .collect();
+    // Send before the attach, so the receiver drains a real backlog and a
+    // prefetch smaller than the backlog must replenish its link credit.
+    send_labeled_batch(&clients.producer, PARTITION, &clients.run_marker, &labels).await?;
+
+    let receiver = clients
+        .consumer
+        .open_receiver_on_partition(
+            PARTITION.to_string(),
+            Some(OpenReceiverOptions {
+                prefetch: Some(PREFETCH),
+                start_position: Some(StartPosition {
+                    location: StartLocation::SequenceNumber(boundary),
+                    inclusive: false,
+                }),
+                // A receive timeout ends the stream when it fires, which would
+                // truncate this read, so leave it unset.
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+    let seen = {
+        let mut stream = receiver.stream_events();
+        read_tagged(&mut stream, &clients.run_marker, EVENT_COUNT, READ_DEADLINE).await
+    };
+
+    assert_eq!(
+        seen.len(),
+        EVENT_COUNT,
+        "run marker {} on partition {PARTITION} with prefetch {PREFETCH} read {seen:?} in {READ_DEADLINE:?}",
+        clients.run_marker
+    );
+    assert_eq!(
+        seen, labels,
+        "partition {PARTITION} delivered run marker {} out of order",
+        clients.run_marker
+    );
+
+    receiver.close().await?;
+    clients.consumer.close().await?;
+    clients.producer.close().await?;
+
+    Ok(())
+}
+
+#[recorded::test(live)]
+async fn prefetch_one_delivers_every_event(ctx: TestContext) -> Result<(), Box<dyn Error>> {
+    const PARTITION: &str = "1";
+    // One is the smallest usable prefetch. Zero gives the link no credit and the
+    // reader then waits forever.
+    const PREFETCH: u32 = 1;
+
+    let clients = open_clients(&ctx, "prefetch_one_delivers_every_event", None).await?;
+    let boundary = boundary_sequence(&clients.consumer, PARTITION).await?;
+
+    let labels: Vec<String> = (0..EVENT_COUNT)
+        .map(|index| format!("event-{index}"))
+        .collect();
+    send_labeled_batch(&clients.producer, PARTITION, &clients.run_marker, &labels).await?;
+
+    let receiver = clients
+        .consumer
+        .open_receiver_on_partition(
+            PARTITION.to_string(),
+            Some(OpenReceiverOptions {
+                prefetch: Some(PREFETCH),
+                start_position: Some(StartPosition {
+                    location: StartLocation::SequenceNumber(boundary),
+                    inclusive: false,
+                }),
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+    let seen = {
+        let mut stream = receiver.stream_events();
+        read_tagged(&mut stream, &clients.run_marker, EVENT_COUNT, READ_DEADLINE).await
+    };
+
+    assert_eq!(
+        seen.len(),
+        EVENT_COUNT,
+        "run marker {} on partition {PARTITION} with prefetch {PREFETCH} read {seen:?} in {READ_DEADLINE:?}",
+        clients.run_marker
+    );
+    assert_eq!(
+        seen, labels,
+        "partition {PARTITION} delivered run marker {} out of order",
+        clients.run_marker
+    );
+
+    receiver.close().await?;
+    clients.consumer.close().await?;
+    clients.producer.close().await?;
+
+    Ok(())
+}
+
+#[recorded::test(live)]
+async fn receive_timeout_ends_stream_when_idle(ctx: TestContext) -> Result<(), Box<dyn Error>> {
+    const PARTITION: &str = "3";
+
+    let clients = open_clients(&ctx, "receive_timeout_ends_stream_when_idle", None).await?;
+    let boundary = boundary_sequence(&clients.consumer, PARTITION).await?;
+
+    // This test sends nothing, so the receiver starts at the tail and stays idle.
+    let receiver = clients
+        .consumer
+        .open_receiver_on_partition(
+            PARTITION.to_string(),
+            Some(OpenReceiverOptions {
+                start_position: Some(StartPosition {
+                    location: StartLocation::SequenceNumber(boundary),
+                    inclusive: false,
+                }),
+                receive_timeout: Some(IDLE_TIMEOUT),
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+    let (elapsed, err, ended) = {
+        let mut stream = receiver.stream_events();
+
+        // The receive timer starts only after the link attach, so start the
+        // clock here and poke the stream to make the attach happen. A cancelled
+        // poke does not cancel the receive, so the timer keeps running and the
+        // measured window covers the attach as well.
+        let mut mark = std::time::Instant::now();
+        let _ = tokio::time::timeout(ATTACH_POKE, stream.next()).await;
+
+        let measured = tokio::time::timeout(IDLE_DEADLINE, async {
+            loop {
+                match stream.next().await {
+                    // A delivery restarts the receive timer, so restart the clock.
+                    Some(Ok(_)) => mark = std::time::Instant::now(),
+                    Some(Err(err)) => break (mark.elapsed(), err),
+                    None => {
+                        panic!("the stream ended with no error before the receive timeout fired")
+                    }
+                }
+            }
+        })
+        .await;
+
+        let (elapsed, err) = match measured {
+            Ok(outcome) => outcome,
+            Err(_) => panic!(
+                "run marker {} saw no receive timeout on partition {PARTITION} in {IDLE_DEADLINE:?} with a receive timeout of {IDLE_TIMEOUT:?}, so the partition carried continuous foreign traffic",
+                clients.run_marker
+            ),
+        };
+
+        let ended = matches!(
+            tokio::time::timeout(END_POLL, stream.next()).await,
+            Ok(None)
+        );
+        (elapsed, err, ended)
+    };
+
+    let ErrorKind::AmqpError(amqp) = &err.kind else {
+        panic!("the receive timeout gave {err:?}, which is not an AMQP error");
+    };
+    let AmqpErrorKind::AzureCore(core) = amqp.kind() else {
+        panic!("the receive timeout gave {amqp:?}, which is not an Azure core error");
+    };
+    assert!(
+        matches!(core.kind(), azure_core::error::ErrorKind::Io),
+        "the receive timeout gave {core:?}, which is not an I/O error"
+    );
+    let io = core
+        .source()
+        .and_then(|source| source.downcast_ref::<std::io::Error>())
+        .unwrap_or_else(|| panic!("the receive timeout error {core:?} has no I/O source"));
+    assert_eq!(
+        io.kind(),
+        std::io::ErrorKind::TimedOut,
+        "the receive timeout gave the I/O error kind {:?}",
+        io.kind()
+    );
+    assert!(
+        elapsed >= MIN_IDLE_ELAPSED,
+        "the receive timeout of {IDLE_TIMEOUT:?} fired after only {elapsed:?} on partition {PARTITION}"
+    );
+    assert!(
+        elapsed <= MAX_IDLE_ELAPSED,
+        "the receive timeout of {IDLE_TIMEOUT:?} fired late, after {elapsed:?}, on partition {PARTITION}"
+    );
+    assert!(
+        ended,
+        "the stream did not end in {END_POLL:?} after it reported the receive timeout on partition {PARTITION}"
+    );
+
+    receiver.close().await?;
+    clients.consumer.close().await?;
+    clients.producer.close().await?;
+
+    Ok(())
+}
+
+#[recorded::test(live)]
+async fn receive_timeout_does_not_truncate_a_slow_stream(
+    ctx: TestContext,
+) -> Result<(), Box<dyn Error>> {
+    const PARTITION: &str = "0";
+
+    let clients = open_clients(
+        &ctx,
+        "receive_timeout_does_not_truncate_a_slow_stream",
+        None,
+    )
+    .await?;
+    let boundary = boundary_sequence(&clients.consumer, PARTITION).await?;
+
+    let receiver = clients
+        .consumer
+        .open_receiver_on_partition(
+            PARTITION.to_string(),
+            Some(OpenReceiverOptions {
+                start_position: Some(StartPosition {
+                    location: StartLocation::SequenceNumber(boundary),
+                    inclusive: false,
+                }),
+                receive_timeout: Some(SLOW_TIMEOUT),
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+    let labels: Vec<String> = (0..SLOW_COUNT)
+        .map(|index| format!("slow-{index}"))
+        .collect();
+
+    // The whole send takes longer than the receive timeout, but no single gap
+    // comes near it. The stream must therefore carry every event.
+    let (send_result, seen) = {
+        let mut stream = receiver.stream_events();
+        let _ = tokio::time::timeout(ATTACH_POKE, stream.next()).await;
+
+        let sender = async {
+            for label in &labels {
+                send_labeled_batch(
+                    &clients.producer,
+                    PARTITION,
+                    &clients.run_marker,
+                    std::slice::from_ref(label),
+                )
+                .await?;
+                tokio::time::sleep(SEND_INTERVAL).await;
+            }
+            Ok::<(), EventHubsError>(())
+        };
+        let reader = read_tagged(&mut stream, &clients.run_marker, SLOW_COUNT, SLOW_DEADLINE);
+
+        tokio::join!(sender, reader)
+    };
+
+    send_result?;
+    assert_eq!(
+        seen.len(),
+        SLOW_COUNT,
+        "run marker {} sent one event every {SEND_INTERVAL:?} on partition {PARTITION} and read {seen:?}; the receive timeout of {SLOW_TIMEOUT:?} must apply to each delivery, not to the whole read",
+        clients.run_marker
+    );
+    assert_eq!(
+        seen, labels,
+        "partition {PARTITION} delivered run marker {} out of order",
+        clients.run_marker
+    );
+
+    receiver.close().await?;
+    clients.consumer.close().await?;
+    clients.producer.close().await?;
+
+    Ok(())
+}
+
+#[recorded::test(live)]
+async fn consumer_instance_id_receives_events(ctx: TestContext) -> Result<(), Box<dyn Error>> {
+    const PARTITION: &str = "2";
+
+    // The instance identifier becomes the AMQP link name, so the unique suffix
+    // keeps parallel runs from claiming the same link.
+    let instance_id = format!("receive-options-instance-{}", azure_core::Uuid::new_v4());
+    let clients = open_clients(
+        &ctx,
+        "consumer_instance_id_receives_events",
+        Some(&instance_id),
+    )
+    .await?;
+    let boundary = boundary_sequence(&clients.consumer, PARTITION).await?;
+
+    let labels: Vec<String> = (0..EVENT_COUNT)
+        .map(|index| format!("event-{index}"))
+        .collect();
+    send_labeled_batch(&clients.producer, PARTITION, &clients.run_marker, &labels).await?;
+
+    let receiver = clients
+        .consumer
+        .open_receiver_on_partition(
+            PARTITION.to_string(),
+            Some(OpenReceiverOptions {
+                start_position: Some(StartPosition {
+                    location: StartLocation::SequenceNumber(boundary),
+                    inclusive: false,
+                }),
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+    let seen = {
+        let mut stream = receiver.stream_events();
+        read_tagged(&mut stream, &clients.run_marker, EVENT_COUNT, READ_DEADLINE).await
+    };
+
+    assert_eq!(
+        seen.len(),
+        EVENT_COUNT,
+        "the consumer with instance id {instance_id} read {seen:?} on partition {PARTITION} in {READ_DEADLINE:?}"
+    );
+    assert_eq!(
+        seen, labels,
+        "the consumer with instance id {instance_id} read partition {PARTITION} out of order"
+    );
+
+    receiver.close().await?;
+    clients.consumer.close().await?;
+    clients.producer.close().await?;
+
+    Ok(())
+}
+
+#[recorded::test(live)]
+async fn producer_application_id_sends_events(ctx: TestContext) -> Result<(), Box<dyn Error>> {
+    const PARTITION: &str = "2";
+    const SEND_COUNT: usize = 3;
+
+    // This test overlaps the existing producer coverage on purpose, so the
+    // application identifier requirement maps to a named test. The identifier
+    // goes into the AMQP connection properties and the client cannot read it
+    // back, so a successful send is the only outcome a test can observe.
+    let application_id = format!("receive-options-producer-{}", azure_core::Uuid::new_v4());
+    let clients = open_clients(&ctx, &application_id, None).await?;
+
+    let labels: Vec<String> = (0..SEND_COUNT)
+        .map(|index| format!("produced-{index}"))
+        .collect();
+    let result =
+        send_labeled_batch(&clients.producer, PARTITION, &clients.run_marker, &labels).await;
+
+    assert!(
+        result.is_ok(),
+        "the producer with application id {application_id} failed to send {SEND_COUNT} events to partition {PARTITION}: {result:?}"
+    );
+
+    clients.consumer.close().await?;
+    clients.producer.close().await?;
+
+    Ok(())
+}

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_receive_options.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_receive_options.rs
@@ -352,9 +352,13 @@ async fn receive_timeout_ends_stream_when_idle(ctx: TestContext) -> Result<(), B
         matches!(core.kind(), azure_core::error::ErrorKind::Io),
         "the receive timeout gave {core:?}, which is not an I/O error"
     );
+    // The receiver wraps the cause in a redundant `Box::new` before it reaches
+    // `azure_core::Error::new`, which boxes again, so the stored concrete type
+    // is `Box<std::io::Error>` and not `std::io::Error`. Accept either, so this
+    // test keeps passing once that extra box goes away.
     let io = core
-        .source()
-        .and_then(|source| source.downcast_ref::<std::io::Error>())
+        .downcast_ref::<std::io::Error>()
+        .or_else(|| core.downcast_ref::<Box<std::io::Error>>().map(|b| &**b))
         .unwrap_or_else(|| panic!("the receive timeout error {core:?} has no I/O source"));
     assert_eq!(
         io.kind(),


### PR DESCRIPTION
## Summary

This change adds `tests/eventhubs_receive_options.rs` with six live tests for the consumer receive options. The tests cover a custom `prefetch` value, the smallest usable `prefetch` value, the `receive_timeout` semantics on an idle partition and on a slow partition, the consumer `with_instance_id` option, and the producer `with_application_id` option.

## Motivation

Prefetch sets the credit that the receiver grants to the AMQP link, so a wrong value can stall a stream or waste memory, and no test sets `OpenReceiverOptions::prefetch` today. The receive timeout controls what happens when a partition is idle; five tests set `receive_timeout` and none assert it. `ConsumerClientBuilder::with_instance_id` has no caller in the repository. Part of #4886.

## Changes

- Add `tests/eventhubs_receive_options.rs` with six `#[recorded::test(live)]` tests.
- Cover a custom prefetch of 3 and the smallest usable prefetch of 1, and assert that every event of the run arrives in order.
- Assert that an idle partition yields a receive-timeout error whose chain reaches `std::io::ErrorKind::TimedOut`, that it arrives inside a timing window, and that the stream then ends.
- Assert that a stream fed slower than the receive timeout is not truncated, which pins the documented per-delivery meaning of the option.
- Cover `ConsumerClientBuilder::with_instance_id` and `ProducerClientBuilder::with_application_id`.
- Tag every event with a per-run marker, so each test asserts on its own events and tolerates the foreign traffic that shares a partition.

## Test plan

- `CARGO_BUILD_JOBS=1 RUSTFLAGS=-Dwarnings cargo test --no-run --package azure_messaging_eventhubs` exits 0. CI sets `RUSTFLAGS: "-Dwarnings"`, so this gate catches an unused import, an unused constant, or an uncalled helper.
- `cargo test --package azure_messaging_eventhubs --test eventhubs_receive_options -- --test-threads=1` reports `0 passed; 0 failed; 6 ignored`, because the tests are live-gated.
- `cargo test --package azure_messaging_eventhubs -- --test-threads=1` reports 196 passed and 0 failed across all targets.
- `cargo fmt --package azure_messaging_eventhubs -- --check`, `cargo clippy --package azure_messaging_eventhubs --all-features --all-targets` with `-Dwarnings`, and `cargo doc --package azure_messaging_eventhubs --all-features --no-deps` with `-Dwarnings` all exit 0.
- `npx cspell lint --config ./.vscode/cspell.json --no-must-find-files --no-gitignore --root . <the new file>` reports `Files checked: 1, Issues found: 0`.
- No red proof accompanies these tests, and none is possible. They pin behavior that the shipped source already has, this change touches no source file, and a live-gated test cannot run without a namespace. A throwaway unit test invented to produce a failing run would prove nothing.

### Assumptions and divergences from the .NET tests

- The small prefetch value is 1, not 0. `prefetch` maps to `ReceiverCreditMode::Auto(n)`, and a value of 0 gives the link no credit and stalls the reader, so no test pins that path. .NET maps `PrefetchCount = 0` to `AutoSendFlow = false` and issues credit per read instead, which this crate cannot express through `OpenReceiverOptions`. A follow-up issue should decide whether `prefetch: Some(0)` ought to select `ReceiverCreditMode::Manual`.
- The idle test asserts the current Rust behavior, which is that the stream yields an error and then ends. .NET `ReadEventOptions.MaximumWaitTime` yields a repeatable empty event and never ends the enumeration, so a direct port of `ConsumerRespectsTheWaitTimeWhenReading` could not pass. A follow-up issue should decide whether the Rust stream ought to surface an idle interval in band instead.
- The producer test uses `with_application_id`, because `ProducerClientBuilder` has no `with_instance_id`. Adding one is a public API change and is out of scope for a test change. A follow-up issue should decide whether the producer needs identifier parity with the consumer.
- The producer test overlaps existing coverage in `tests/eventhubs_producer.rs` on purpose, so the third item in #4891 maps to a named test.
- The two prefetch tests cannot detect a regression that silently drops `prefetch` and substitutes the default of 300, because the negotiated link credit is not observable through the public API. They do catch a broken credit replenishment and a rejected small credit.

Closes #4891.

### Live validation

Every test here ran against a live Event Hubs namespace on 2026-08-20: 6 passed, 0 failed.

Command: `AZURE_TEST_MODE=live cargo test --package azure_messaging_eventhubs --test eventhubs_receive_options -- --test-threads=1`.

One assertion was widened after that run. The receive timeout cause could not be downcast to `std::io::Error`, because the receiver wraps it in `Box::new` at `common/recoverable/receiver.rs:129` and `azure_core::Error::new` boxes again, so the stored type is `Box<std::io::Error>`. The test accepts either shape, so it keeps passing once the extra box goes away. The extra box is tracked in #5098.

