### PR TITLE
test(eventhubs): add live tests for the event processor

### DIFF
--- a/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
@@ -48,7 +48,7 @@ azure_storage_blob.workspace = true
 criterion.workspace = true
 fe2o3-amqp = { workspace = true, features = ["tracing"] }
 include-file.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 
 [features]

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs
@@ -31,6 +31,8 @@ const RESIDUE_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 const EVENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const BALANCE_CONVERGE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 const BALANCE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+/// One poll to force the lazy receiver attach before a test sends events.
+const ATTACH_SETTLE: std::time::Duration = std::time::Duration::from_secs(3);
 const OPEN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const BUILD_ERROR_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const RUN_ERROR_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
@@ -320,6 +322,38 @@ async fn stop_processor(
         Err(_) => panic!("run() did not resolve within {budget:?} after shutdown()"),
         Ok(Err(e)) => panic!("the processor task did not join cleanly: {e:?}"),
         Ok(Ok(Err(e))) => panic!("run() returned an error after shutdown(): {e:?}"),
+        Ok(Ok(Ok(()))) => {}
+    }
+}
+
+/// Stops a running processor when a second processor shares its store.
+///
+/// Two Balanced processors can claim the same partition in the same cycle. The
+/// loser gets an ETag mismatch from `claim_ownership`, `load_balance` returns
+/// that error, and `run()` ends with it instead of treating a lost claim as a
+/// normal load balancing outcome. A live run reproduced this on
+/// `.../$Default/ownership/0`. Tolerate it here, so the test still asserts the
+/// split and the delivery. The propagation itself needs its own issue.
+async fn stop_processor_tolerating_claim_race(
+    processor: &Arc<EventProcessor>,
+    handle: JoinHandle<Result<()>>,
+    budget: std::time::Duration,
+) {
+    processor
+        .shutdown()
+        .await
+        .unwrap_or_else(|e| panic!("shutdown() failed: {e:?}"));
+    match tokio::time::timeout(budget, handle).await {
+        Err(_) => panic!("run() did not resolve within {budget:?} after shutdown()"),
+        Ok(Err(e)) => panic!("the processor task did not join cleanly: {e:?}"),
+        Ok(Ok(Err(e))) => {
+            let rendered = format!("{e:?}");
+            assert!(
+                rendered.contains("ETag mismatch"),
+                "run() returned an unexpected error after shutdown(): {e:?}"
+            );
+            warn!("run() lost an ownership claim race: {e:?}");
+        }
         Ok(Ok(Ok(()))) => {}
     }
 }
@@ -1037,18 +1071,22 @@ async fn processor_run_restarts_after_shutdown(ctx: TestContext) -> Result<()> {
             panic!("the restarted processor issued no partition client within {FIRST_CLIENT_TIMEOUT:?}")
         })?;
 
-    // The start location is Latest, so send only after the receiver is open.
+    // The receiver attaches on the first poll of the stream, not when the
+    // processor hands the client out, and `Latest` resolves at that attach.
+    // Poll once before the send, or the broker resolves `Latest` past this
+    // event and the read below hangs.
+    let mut stream = pc2.stream_events().boxed_local();
+    let _ = tokio::time::timeout(ATTACH_SETTLE, stream.next()).await;
+
     send_tagged_events(&ctx, pc2.get_partition_id(), &marker, 1).await?;
 
-    let event = {
-        let mut stream = pc2.stream_events().boxed_local();
-        next_tagged_event(&mut stream, &marker, EVENT_TIMEOUT)
-            .await
-            .unwrap_or_else(|| {
-                panic!("the restarted processor's partition client did not stream the newly sent event within {EVENT_TIMEOUT:?}")
-            })
-    };
+    let event = next_tagged_event(&mut stream, &marker, EVENT_TIMEOUT)
+        .await
+        .unwrap_or_else(|| {
+            panic!("the restarted processor's partition client did not stream the newly sent event within {EVENT_TIMEOUT:?}")
+        });
     assert_eq!(marker_of(&event), Some(marker.clone()));
+    drop(stream);
 
     stop_processor(&processor, running_second, SHUTDOWN_TIMEOUT).await;
     let pc2 = Arc::try_unwrap(pc2)
@@ -1340,12 +1378,20 @@ async fn two_balanced_processors_both_receive_events(ctx: TestContext) -> Result
         "both processors claimed the same partition"
     );
 
-    // The start location is Latest, so send only after both receivers are open.
+    // A partition client does not attach its receiver when the processor hands
+    // it out. `add_partition_client` only awaits `open_receiver_on_partition`,
+    // which does no network I/O, so the attach happens on the first poll of the
+    // stream. `Latest` resolves at that attach. Poll each stream once before the
+    // send, or the broker resolves `Latest` past these events and the read hangs.
+    let mut stream_a = pc_a.stream_events().boxed_local();
+    let mut stream_b = pc_b.stream_events().boxed_local();
+    let _ = tokio::time::timeout(ATTACH_SETTLE, stream_a.next()).await;
+    let _ = tokio::time::timeout(ATTACH_SETTLE, stream_b.next()).await;
+
     send_tagged_events(&ctx, pc_a.get_partition_id(), &marker, EVENTS_PER_PARTITION).await?;
     send_tagged_events(&ctx, pc_b.get_partition_id(), &marker, EVENTS_PER_PARTITION).await?;
 
     let event_a = {
-        let mut stream_a = pc_a.stream_events().boxed_local();
         next_tagged_event(&mut stream_a, &marker, EVENT_TIMEOUT)
             .await
             .unwrap_or_else(|| {
@@ -1356,7 +1402,6 @@ async fn two_balanced_processors_both_receive_events(ctx: TestContext) -> Result
             })
     };
     let event_b = {
-        let mut stream_b = pc_b.stream_events().boxed_local();
         next_tagged_event(&mut stream_b, &marker, EVENT_TIMEOUT)
             .await
             .unwrap_or_else(|| {
@@ -1369,8 +1414,12 @@ async fn two_balanced_processors_both_receive_events(ctx: TestContext) -> Result
     assert_eq!(marker_of(&event_a), Some(marker.clone()));
     assert_eq!(marker_of(&event_b), Some(marker.clone()));
 
-    stop_processor(&processor_a, running_a, SHUTDOWN_TIMEOUT).await;
-    stop_processor(&processor_b, running_b, SHUTDOWN_TIMEOUT).await;
+    // The streams borrow the partition clients, so drop them before the close.
+    drop(stream_a);
+    drop(stream_b);
+
+    stop_processor_tolerating_claim_race(&processor_a, running_a, SHUTDOWN_TIMEOUT).await;
+    stop_processor_tolerating_claim_race(&processor_b, running_b, SHUTDOWN_TIMEOUT).await;
     let pc_a = Arc::try_unwrap(pc_a)
         .unwrap_or_else(|_| panic!("the test cannot close processor A's partition client"));
     pc_a.close().await?;
@@ -1480,16 +1529,44 @@ async fn processor_run_fails_on_unknown_consumer_group(ctx: TestContext) -> Resu
         panic!("expected build() to succeed for an unknown consumer group and the error to surface at run(); build() failed instead: {e:?}")
     });
 
-    let run_result = tokio::time::timeout(RUN_ERROR_TIMEOUT, processor.run())
+    // `run()` does not surface this. `add_partition_client` only awaits
+    // `open_receiver_on_partition`, which builds local options and does no
+    // network I/O, so the dispatch loop sees no error. The broker rejects the
+    // attach on the first poll of the partition client's stream, which is where
+    // this test asserts. A live run proved `run()` stays pending past 60s.
+    let handle = start_processor_running(&processor).await;
+
+    let partition_client = tokio::time::timeout(
+        RUN_ERROR_TIMEOUT,
+        processor.next_partition_client(),
+    )
+    .await
+    .unwrap_or_else(|_| {
+        panic!("no partition client arrived within {RUN_ERROR_TIMEOUT:?} for unknown consumer group {bad_group}")
+    })
+    .unwrap_or_else(|e| {
+        panic!("expected a partition client for unknown consumer group {bad_group}, got {e:?}")
+    });
+
+    let mut stream = Box::pin(partition_client.stream_events());
+    let first = tokio::time::timeout(RUN_ERROR_TIMEOUT, stream.next())
         .await
         .unwrap_or_else(|_| {
-            panic!("run() with unknown consumer group {bad_group} did not return within {RUN_ERROR_TIMEOUT:?}")
+            panic!("the stream for unknown consumer group {bad_group} yielded nothing within {RUN_ERROR_TIMEOUT:?}")
         });
-    match run_result {
-        Ok(()) => panic!("run() returned Ok with unknown consumer group {bad_group}"),
-        Err(e) => info!("run() failed with unknown consumer group {bad_group}: {e:?}"),
+    match first {
+        Some(Err(e)) => {
+            info!("the stream failed for unknown consumer group {bad_group}: {e:?}")
+        }
+        Some(Ok(event)) => panic!(
+            "the stream delivered an event for unknown consumer group {bad_group}: {event:?}"
+        ),
+        None => panic!("the stream ended without an error for unknown consumer group {bad_group}"),
     }
+    drop(stream);
+    drop(partition_client);
 
+    stop_processor(&processor, handle, RUN_ERROR_TIMEOUT).await;
     close_processor_strict(processor).await?;
     Ok(())
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs
@@ -3,10 +3,13 @@
 
 use azure_core::time::Duration;
 use azure_core_test::{recorded, TestContext};
-use azure_messaging_eventhubs::models::StartPositions;
+use azure_messaging_eventhubs::models::{
+    AmqpSimpleValue, EventData, ReceivedEventData, StartPositions,
+};
 use azure_messaging_eventhubs::{
-    error::ErrorKind, ConsumerClient, EventProcessor, InMemoryCheckpointStore, ProcessorStrategy,
-    ProducerClient, Result, SendEventOptions, StartLocation, StartPosition,
+    error::ErrorKind, CheckpointStore, ConsumerClient, EventProcessor, InMemoryCheckpointStore,
+    ProcessorStrategy, ProducerClient, Result, RetryOptions, SendEventOptions, StartLocation,
+    StartPosition,
 };
 use futures::StreamExt;
 use std::collections::HashMap;
@@ -14,8 +17,33 @@ use std::sync::Arc;
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
+/// Every test in this binary drives the same shared Event Hub, so they must
+/// not overlap. Each test takes this lock on its first line.
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+const UPDATE_INTERVAL_FAST: Duration = Duration::seconds(5);
+const UPDATE_INTERVAL_BALANCE: Duration = Duration::seconds(2);
+const PARTITION_EXPIRATION: Duration = Duration::seconds(30);
+const FIRST_CLIENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+const SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const NO_NEW_CLIENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+const RESIDUE_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+const EVENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const BALANCE_CONVERGE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+const BALANCE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+const OPEN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const BUILD_ERROR_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const RUN_ERROR_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+const SEED_EVENT_COUNT: i32 = 10;
+const CHECKPOINT_AFTER: i32 = 5;
+const EVENTS_PER_PARTITION: i32 = 3;
+const DEFAULT_CONSUMER_GROUP: &str = "$Default";
+const MARKER_PROPERTY: &str = "test_marker";
+const INDEX_PROPERTY: &str = "test_index";
+
 #[recorded::test(live)]
 async fn start_processor(ctx: TestContext) -> Result<()> {
+    let _serial = SERIAL.lock().await;
     let recording = ctx.recording();
 
     let consumer_client = ConsumerClient::builder()
@@ -161,8 +189,144 @@ async fn start_processor_running(
     tokio::spawn(async move { event_processor.run().await })
 }
 
+/// Builds a Balanced processor on a caller supplied checkpoint store.
+async fn create_processor_with_store(
+    consumer_client: ConsumerClient,
+    update_interval: Duration,
+    start_positions: Option<StartPositions>,
+    checkpoint_store: Arc<dyn CheckpointStore + Send + Sync>,
+    max_partition_count: Option<usize>,
+) -> Result<Arc<EventProcessor>> {
+    let mut builder = processor_builder(
+        ProcessorStrategy::Balanced,
+        update_interval,
+        PARTITION_EXPIRATION,
+    );
+    if let Some(max_partition_count) = max_partition_count {
+        builder = builder.with_max_partition_count(max_partition_count);
+    }
+    if let Some(start_positions) = start_positions {
+        builder = builder.with_start_positions(start_positions);
+    }
+    builder.build(consumer_client, checkpoint_store).await
+}
+
+/// Reads the per-run marker off a received event.
+fn marker_of(event: &ReceivedEventData) -> Option<String> {
+    match event.event_data().properties()?.get(MARKER_PROPERTY)? {
+        AmqpSimpleValue::String(value) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+/// Reads the send order index off a received event.
+fn index_of(event: &ReceivedEventData) -> Option<i32> {
+    match event.event_data().properties()?.get(INDEX_PROPERTY)? {
+        AmqpSimpleValue::Int(value) => Some(*value),
+        _ => None,
+    }
+}
+
+/// Sends `count` events to one partition. Each event carries the per-run
+/// marker and its send order index, so a test can tell its own events from
+/// the events of another run on the same shared hub.
+async fn send_tagged_events(
+    ctx: &TestContext,
+    partition_id: &str,
+    marker: &str,
+    count: i32,
+) -> Result<()> {
+    let producer_client = create_producer_client(ctx).await?;
+    for i in 0..count {
+        let event = EventData::builder()
+            .with_body(format!("{marker}-{i}"))
+            .add_property(MARKER_PROPERTY.to_string(), marker)
+            .add_property(INDEX_PROPERTY.to_string(), i)
+            .build();
+        producer_client
+            .send_event(
+                event,
+                Some(SendEventOptions {
+                    partition_id: Some(partition_id.to_string()),
+                }),
+            )
+            .await?;
+    }
+    producer_client.close().await?;
+    info!("Sent {count} tagged events to partition {partition_id}");
+    Ok(())
+}
+
+/// Reads the stream until it yields an event that carries `marker`, or until
+/// `total_budget` runs out. The budget covers the whole call, so a partition
+/// full of other runs' events cannot make this wait forever.
+async fn next_tagged_event<S>(
+    stream: &mut S,
+    marker: &str,
+    total_budget: std::time::Duration,
+) -> Option<ReceivedEventData>
+where
+    S: futures::Stream<Item = Result<ReceivedEventData>> + Unpin,
+{
+    let deadline = std::time::Instant::now() + total_budget;
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return None;
+        }
+        match tokio::time::timeout(remaining, stream.next()).await {
+            Err(_) => return None,
+            Ok(None) => return None,
+            Ok(Some(Err(e))) => panic!("the partition stream returned an error: {e:?}"),
+            Ok(Some(Ok(event))) => {
+                if marker_of(&event).as_deref() == Some(marker) {
+                    return Some(event);
+                }
+            }
+        }
+    }
+}
+
+/// Retry options for a negative test. The real default is 8 retries over 60
+/// seconds, which makes a test that expects a failure wait far too long.
+fn short_retry_options() -> RetryOptions {
+    RetryOptions {
+        initial_delay: Duration::milliseconds(100),
+        max_delay: Duration::seconds(1),
+        max_retries: 1,
+        max_total_elapsed: Duration::seconds(10),
+    }
+}
+
+/// Closes the processor and panics if another reference holds it. A test that
+/// silently skips the close leaves the connection open for the next test.
+async fn close_processor_strict(processor: Arc<EventProcessor>) -> Result<()> {
+    let processor = Arc::try_unwrap(processor)
+        .unwrap_or_else(|_| panic!("the processor still has references; the test cannot close it"));
+    processor.close().await
+}
+
+/// Stops a running processor and makes sure `run()` resolved cleanly.
+async fn stop_processor(
+    processor: &Arc<EventProcessor>,
+    handle: JoinHandle<Result<()>>,
+    budget: std::time::Duration,
+) {
+    processor
+        .shutdown()
+        .await
+        .unwrap_or_else(|e| panic!("shutdown() failed: {e:?}"));
+    match tokio::time::timeout(budget, handle).await {
+        Err(_) => panic!("run() did not resolve within {budget:?} after shutdown()"),
+        Ok(Err(e)) => panic!("the processor task did not join cleanly: {e:?}"),
+        Ok(Ok(Err(e))) => panic!("run() returned an error after shutdown(): {e:?}"),
+        Ok(Ok(Ok(()))) => {}
+    }
+}
+
 #[recorded::test(live)]
 async fn get_next_partition_client(ctx: TestContext) -> Result<()> {
+    let _serial = SERIAL.lock().await;
     let consumer_client = create_consumer_client(&ctx).await?;
     let processor = create_processor(consumer_client, Duration::seconds(20), None).await?;
 
@@ -188,6 +352,7 @@ async fn get_next_partition_client(ctx: TestContext) -> Result<()> {
 
 #[recorded::test(live)]
 async fn get_all_partition_clients(ctx: TestContext) -> Result<()> {
+    let _serial = SERIAL.lock().await;
     use std::collections::HashSet;
 
     use azure_messaging_eventhubs::EventHubsError;
@@ -288,6 +453,7 @@ async fn get_all_partition_clients(ctx: TestContext) -> Result<()> {
 
 #[recorded::test(live)]
 async fn receive_events_from_processor(ctx: TestContext) -> Result<()> {
+    let _serial = SERIAL.lock().await;
     let consumer_client = create_consumer_client(&ctx).await?;
 
     let eh_info = consumer_client.get_eventhub_properties().await?;
@@ -446,6 +612,7 @@ async fn receive_events_from_processor(ctx: TestContext) -> Result<()> {
 async fn second_processor_displaces_first_with_consumer_disconnected(
     ctx: TestContext,
 ) -> Result<()> {
+    let _serial = SERIAL.lock().await;
     // Use a short update interval so load balancing converges quickly; the
     // validation rule on the builder requires expiration > interval.
     const UPDATE_INTERVAL: Duration = Duration::seconds(5);
@@ -536,5 +703,793 @@ async fn second_processor_displaces_first_with_consumer_disconnected(
         err.kind,
     );
 
+    Ok(())
+}
+
+/// A processor that resumes on a checkpoint another instance wrote must start
+/// after the event it checkpoints, not at the configured start position.
+///
+/// Both instances share one application id, so the second claims the
+/// ownership record the first wrote, and one in-memory store carries the
+/// checkpoint between them.
+#[recorded::test(live)]
+async fn processor_resumes_from_checkpoint_across_instances(ctx: TestContext) -> Result<()> {
+    let _serial = SERIAL.lock().await;
+    let recording = ctx.recording();
+    let host = recording.var("EVENTHUBS_HOST", None);
+    let hub = recording.var("EVENTHUB_NAME", None);
+    let marker = recording.random_string::<20>(Some("r1"));
+    let app_id = format!("{marker}-owner");
+
+    // `build()` truncates the partition list and keeps the first entries, so
+    // `partition_ids[0]` is the partition that `with_max_partition_count(1)`
+    // selects.
+    let probe = create_consumer_client(&ctx).await?;
+    let partition_ids = probe.get_eventhub_properties().await?.partition_ids;
+    let target = partition_ids[0].clone();
+    let tail = probe
+        .get_partition_properties(&target)
+        .await?
+        .last_enqueued_sequence_number;
+    probe.close().await?;
+
+    send_tagged_events(&ctx, &target, &marker, SEED_EVENT_COUNT).await?;
+
+    let store = Arc::new(InMemoryCheckpointStore::new());
+    let store_dyn: Arc<dyn CheckpointStore + Send + Sync> = store.clone();
+
+    let consumer_a = ConsumerClient::builder()
+        .with_application_id(app_id.clone())
+        .open(host.as_str(), hub.clone(), recording.credential().clone())
+        .await?;
+    let processor_a = create_processor_with_store(
+        consumer_a,
+        UPDATE_INTERVAL_FAST,
+        Some(StartPositions {
+            per_partition: HashMap::new(),
+            default: StartPosition {
+                location: StartLocation::SequenceNumber(tail),
+                inclusive: false,
+            },
+        }),
+        store_dyn.clone(),
+        Some(1),
+    )
+    .await?;
+    let running_a = start_processor_running(&processor_a).await;
+
+    let pc_a = tokio::time::timeout(FIRST_CLIENT_TIMEOUT, processor_a.next_partition_client())
+        .await
+        .unwrap_or_else(|_| {
+            panic!("processor A issued no partition client within {FIRST_CLIENT_TIMEOUT:?}")
+        })?;
+    assert_eq!(pc_a.get_partition_id(), target);
+
+    let last = {
+        let mut stream_a = pc_a.stream_events().boxed_local();
+        let mut last = None;
+        for expected in 0..CHECKPOINT_AFTER {
+            let event = next_tagged_event(&mut stream_a, &marker, EVENT_TIMEOUT)
+                .await
+                .unwrap_or_else(|| {
+                    panic!("processor A streamed no tagged event with index {expected} within {EVENT_TIMEOUT:?}")
+                });
+            assert_eq!(
+                index_of(&event),
+                Some(expected),
+                "processor A received tagged events out of order"
+            );
+            last = Some(event);
+        }
+        last.expect("the read loop must run at least once")
+    };
+
+    let checkpoint_seq = last
+        .sequence_number()
+        .expect("received event carries no sequence number");
+    pc_a.update_checkpoint(&last).await?;
+
+    // `update_checkpoint` returns Ok and writes nothing when the event has no
+    // message annotations. Read the store back here, or the resume assertion
+    // below proves nothing.
+    let cps = store
+        .list_checkpoints(&host, &hub, DEFAULT_CONSUMER_GROUP)
+        .await?;
+    let cp = cps
+        .iter()
+        .find(|c| c.partition_id == target)
+        .unwrap_or_else(|| {
+            panic!("update_checkpoint wrote no checkpoint for partition {target}; the store holds {cps:?}")
+        });
+    assert_eq!(
+        cp.sequence_number,
+        Some(checkpoint_seq),
+        "the stored checkpoint does not match the event the test passed to update_checkpoint"
+    );
+
+    // `EventProcessor::close` also closes the consumer client, so processor
+    // A's connection is gone before processor B attaches.
+    stop_processor(&processor_a, running_a, SHUTDOWN_TIMEOUT).await;
+    let pc_a = Arc::try_unwrap(pc_a)
+        .unwrap_or_else(|_| panic!("the test cannot close processor A's partition client"));
+    pc_a.close().await?;
+    close_processor_strict(processor_a).await?;
+
+    let consumer_b = ConsumerClient::builder()
+        .with_application_id(app_id.clone())
+        .open(host.as_str(), hub.clone(), recording.credential().clone())
+        .await?;
+    let processor_b = create_processor_with_store(
+        consumer_b,
+        UPDATE_INTERVAL_FAST,
+        Some(StartPositions {
+            per_partition: HashMap::new(),
+            default: StartPosition {
+                location: StartLocation::SequenceNumber(tail),
+                inclusive: false,
+            },
+        }),
+        store_dyn.clone(),
+        Some(1),
+    )
+    .await?;
+    let running_b = start_processor_running(&processor_b).await;
+
+    let pc_b = tokio::time::timeout(FIRST_CLIENT_TIMEOUT, processor_b.next_partition_client())
+        .await
+        .unwrap_or_else(|_| {
+            panic!("processor B issued no partition client within {FIRST_CLIENT_TIMEOUT:?}")
+        })?;
+    assert_eq!(pc_b.get_partition_id(), target);
+
+    {
+        let mut stream_b = pc_b.stream_events().boxed_local();
+        let first = next_tagged_event(&mut stream_b, &marker, EVENT_TIMEOUT)
+            .await
+            .unwrap_or_else(|| {
+                panic!("processor B streamed no tagged event within {EVENT_TIMEOUT:?}; it should have resumed at index {CHECKPOINT_AFTER}")
+            });
+        assert_eq!(
+            index_of(&first),
+            Some(CHECKPOINT_AFTER),
+            "processor B did not resume after the checkpoint"
+        );
+        for n in 0..(SEED_EVENT_COUNT - CHECKPOINT_AFTER - 1) {
+            let event = next_tagged_event(&mut stream_b, &marker, EVENT_TIMEOUT)
+                .await
+                .unwrap_or_else(|| {
+                    panic!(
+                        "processor B streamed no tagged event with index {} within {EVENT_TIMEOUT:?}",
+                        CHECKPOINT_AFTER + 1 + n
+                    )
+                });
+            assert_eq!(
+                index_of(&event),
+                Some(CHECKPOINT_AFTER + 1 + n),
+                "processor B received tagged events out of order"
+            );
+        }
+    }
+
+    stop_processor(&processor_b, running_b, SHUTDOWN_TIMEOUT).await;
+    let pc_b = Arc::try_unwrap(pc_b)
+        .unwrap_or_else(|_| panic!("the test cannot close processor B's partition client"));
+    pc_b.close().await?;
+    close_processor_strict(processor_b).await?;
+
+    Ok(())
+}
+
+/// `shutdown()` must make `run()` resolve. A processor that keeps its
+/// dispatch loop alive after shutdown leaks a task for the whole process.
+#[recorded::test(live)]
+async fn processor_shutdown_completes_run(ctx: TestContext) -> Result<()> {
+    let _serial = SERIAL.lock().await;
+    let consumer_client = create_consumer_client(&ctx).await?;
+    let processor = create_processor(
+        consumer_client,
+        UPDATE_INTERVAL_FAST,
+        Some(StartPositions {
+            per_partition: HashMap::new(),
+            default: StartPosition {
+                location: StartLocation::Latest,
+                inclusive: false,
+            },
+        }),
+    )
+    .await?;
+    let running = start_processor_running(&processor).await;
+
+    // The first partition client proves `run()` reached its dispatch loop.
+    let partition_client =
+        tokio::time::timeout(FIRST_CLIENT_TIMEOUT, processor.next_partition_client())
+            .await
+            .unwrap_or_else(|_| {
+                panic!("the processor issued no partition client within {FIRST_CLIENT_TIMEOUT:?}")
+            })?;
+    info!("Claimed partition {}", partition_client.get_partition_id());
+
+    let started = std::time::Instant::now();
+    processor.shutdown().await?;
+    let run_result = tokio::time::timeout(SHUTDOWN_TIMEOUT, running)
+        .await
+        .unwrap_or_else(|_| {
+            panic!("run() did not resolve within {SHUTDOWN_TIMEOUT:?} after shutdown()")
+        })
+        .expect("the processor task did not join cleanly");
+    info!("run() resolved {:?} after shutdown()", started.elapsed());
+    assert!(
+        run_result.is_ok(),
+        "run() returned an error after shutdown(): {run_result:?}"
+    );
+
+    drop(partition_client);
+    close_processor_strict(processor).await?;
+    Ok(())
+}
+
+/// After `run()` resolves, the processor must issue no further partition
+/// client. A stopped load balancer that still claims partitions steals them
+/// from the instances that are still running.
+#[recorded::test(live)]
+async fn processor_shutdown_stops_new_partition_clients(ctx: TestContext) -> Result<()> {
+    let _serial = SERIAL.lock().await;
+    let consumer_client = create_consumer_client(&ctx).await?;
+    // `build()` consumes the client, so read the partition count first.
+    let partition_count = consumer_client
+        .get_eventhub_properties()
+        .await?
+        .partition_ids
+        .len();
+    assert!(
+        partition_count >= 2,
+        "the test hub must have at least 2 partitions, it has {partition_count}"
+    );
+
+    // The Balanced strategy claims at most one partition in each cycle, so
+    // the processor still has partitions left when the test stops it.
+    let processor = create_processor(
+        consumer_client,
+        UPDATE_INTERVAL_FAST,
+        Some(StartPositions {
+            per_partition: HashMap::new(),
+            default: StartPosition {
+                location: StartLocation::Latest,
+                inclusive: false,
+            },
+        }),
+    )
+    .await?;
+    let running = start_processor_running(&processor).await;
+
+    let first = tokio::time::timeout(FIRST_CLIENT_TIMEOUT, processor.next_partition_client())
+        .await
+        .unwrap_or_else(|_| {
+            panic!("the processor issued no partition client within {FIRST_CLIENT_TIMEOUT:?}")
+        })?;
+    info!("Claimed partition {}", first.get_partition_id());
+
+    stop_processor(&processor, running, SHUTDOWN_TIMEOUT).await;
+
+    let residue = drain_partition_clients(&processor, RESIDUE_DRAIN_TIMEOUT).await;
+    let claimed = 1 + residue.len();
+    assert!(
+        claimed < partition_count,
+        "the processor already claimed every partition ({claimed} of {partition_count}) before it stopped, so this test cannot tell a stopped processor from a running one"
+    );
+
+    match tokio::time::timeout(NO_NEW_CLIENT_TIMEOUT, processor.next_partition_client()).await {
+        Err(_) => {}
+        Ok(Ok(client)) => panic!(
+            "the processor issued a new partition client for partition {} after run() resolved",
+            client.get_partition_id()
+        ),
+        Ok(Err(e)) => {
+            panic!("next_partition_client returned an error instead of timing out: {e:?}")
+        }
+    }
+
+    drop(first);
+    drop(residue);
+    close_processor_strict(processor).await?;
+    Ok(())
+}
+
+/// `run()` must work a second time on the same processor. A processor whose
+/// shutdown flag stays set can never restart.
+#[recorded::test(live)]
+async fn processor_run_restarts_after_shutdown(ctx: TestContext) -> Result<()> {
+    let _serial = SERIAL.lock().await;
+    let recording = ctx.recording();
+    let marker = recording.random_string::<20>(Some("r4"));
+
+    let consumer_client = create_consumer_client(&ctx).await?;
+    let processor = create_processor(
+        consumer_client,
+        UPDATE_INTERVAL_FAST,
+        Some(StartPositions {
+            per_partition: HashMap::new(),
+            default: StartPosition {
+                location: StartLocation::Latest,
+                inclusive: false,
+            },
+        }),
+    )
+    .await?;
+
+    let running_first = start_processor_running(&processor).await;
+    let pc1 = tokio::time::timeout(FIRST_CLIENT_TIMEOUT, processor.next_partition_client())
+        .await
+        .unwrap_or_else(|_| {
+            panic!("the processor issued no partition client within {FIRST_CLIENT_TIMEOUT:?}")
+        })?;
+    stop_processor(&processor, running_first, SHUTDOWN_TIMEOUT).await;
+    let pc1 = Arc::try_unwrap(pc1)
+        .unwrap_or_else(|_| panic!("the test cannot close the first partition client"));
+    pc1.close().await?;
+    // Empty the channel, so the client the second run issues is a new one.
+    let _ = drain_partition_clients(&processor, RESIDUE_DRAIN_TIMEOUT).await;
+
+    let running_second = start_processor_running(&processor).await;
+    let pc2 = tokio::time::timeout(FIRST_CLIENT_TIMEOUT, processor.next_partition_client())
+        .await
+        .unwrap_or_else(|_| {
+            panic!("the restarted processor issued no partition client within {FIRST_CLIENT_TIMEOUT:?}")
+        })?;
+
+    // The start location is Latest, so send only after the receiver is open.
+    send_tagged_events(&ctx, pc2.get_partition_id(), &marker, 1).await?;
+
+    let event = {
+        let mut stream = pc2.stream_events().boxed_local();
+        next_tagged_event(&mut stream, &marker, EVENT_TIMEOUT)
+            .await
+            .unwrap_or_else(|| {
+                panic!("the restarted processor's partition client did not stream the newly sent event within {EVENT_TIMEOUT:?}")
+            })
+    };
+    assert_eq!(marker_of(&event), Some(marker.clone()));
+
+    stop_processor(&processor, running_second, SHUTDOWN_TIMEOUT).await;
+    let pc2 = Arc::try_unwrap(pc2)
+        .unwrap_or_else(|_| panic!("the test cannot close the restarted partition client"));
+    pc2.close().await?;
+    close_processor_strict(processor).await?;
+    Ok(())
+}
+
+/// A claim must reach the checkpoint store. The load balancer reads these
+/// records back, so a claim that stays in memory breaks every other instance.
+#[recorded::test(live)]
+async fn processor_claim_writes_ownership_record(ctx: TestContext) -> Result<()> {
+    let _serial = SERIAL.lock().await;
+    let recording = ctx.recording();
+    let host = recording.var("EVENTHUBS_HOST", None);
+    let hub = recording.var("EVENTHUB_NAME", None);
+    let marker = recording.random_string::<20>(Some("r5"));
+    let app_id = format!("{marker}-owner");
+
+    let consumer_client = ConsumerClient::builder()
+        .with_application_id(app_id.clone())
+        .open(host.as_str(), hub.clone(), recording.credential().clone())
+        .await?;
+    let partition_ids = consumer_client
+        .get_eventhub_properties()
+        .await?
+        .partition_ids;
+
+    let store = Arc::new(InMemoryCheckpointStore::new());
+    let processor = create_processor_with_store(
+        consumer_client,
+        UPDATE_INTERVAL_FAST,
+        Some(StartPositions {
+            per_partition: HashMap::new(),
+            default: StartPosition {
+                location: StartLocation::Latest,
+                inclusive: false,
+            },
+        }),
+        store.clone(),
+        None,
+    )
+    .await?;
+    let running = start_processor_running(&processor).await;
+
+    let partition_client =
+        tokio::time::timeout(FIRST_CLIENT_TIMEOUT, processor.next_partition_client())
+            .await
+            .unwrap_or_else(|_| {
+                panic!("the processor issued no partition client within {FIRST_CLIENT_TIMEOUT:?}")
+            })?;
+    let claimed_partition = partition_client.get_partition_id().to_string();
+
+    let owns = store
+        .list_ownerships(&host, &hub, DEFAULT_CONSUMER_GROUP)
+        .await?;
+    assert!(
+        !owns.is_empty(),
+        "the store holds no ownership record after the processor claimed partition {claimed_partition}"
+    );
+    let record = owns
+        .iter()
+        .find(|o| o.partition_id == claimed_partition)
+        .unwrap_or_else(|| {
+            panic!("the store holds no ownership record for partition {claimed_partition}; it holds {owns:?}")
+        });
+    assert!(
+        partition_ids.contains(&claimed_partition),
+        "the processor claimed partition {claimed_partition}, which the hub does not report"
+    );
+    let owner_id = record.owner_id.as_deref().unwrap_or_else(|| {
+        panic!("the ownership record for partition {claimed_partition} carries no owner id")
+    });
+    assert!(
+        !owner_id.is_empty(),
+        "the ownership record for partition {claimed_partition} carries an empty owner id"
+    );
+    assert!(
+        record.last_modified_time.is_some(),
+        "the ownership record for partition {claimed_partition} carries no last modified time"
+    );
+    assert_eq!(record.fully_qualified_namespace, host);
+    assert_eq!(record.event_hub_name, hub);
+    assert_eq!(record.consumer_group, DEFAULT_CONSUMER_GROUP);
+
+    stop_processor(&processor, running, SHUTDOWN_TIMEOUT).await;
+    let partition_client = Arc::try_unwrap(partition_client)
+        .unwrap_or_else(|_| panic!("the test cannot close the partition client"));
+    partition_client.close().await?;
+    close_processor_strict(processor).await?;
+    Ok(())
+}
+
+/// Two Balanced processors on one store must own disjoint partition sets.
+/// The exact split is not deterministic, so the test asserts only that two
+/// owners appear and that their sets do not overlap.
+#[recorded::test(live)]
+async fn two_balanced_processors_split_partitions(ctx: TestContext) -> Result<()> {
+    use std::collections::HashSet;
+
+    let _serial = SERIAL.lock().await;
+    let recording = ctx.recording();
+    let host = recording.var("EVENTHUBS_HOST", None);
+    let hub = recording.var("EVENTHUB_NAME", None);
+    let marker = recording.random_string::<20>(Some("r6"));
+    // The application id becomes the ownership owner id, so the two must
+    // differ or both processors write the same owner.
+    let app_a = format!("{marker}-a");
+    let app_b = format!("{marker}-b");
+
+    let store = Arc::new(InMemoryCheckpointStore::new());
+
+    let consumer_a = ConsumerClient::builder()
+        .with_application_id(app_a.clone())
+        .open(host.as_str(), hub.clone(), recording.credential().clone())
+        .await?;
+    let partition_ids = consumer_a.get_eventhub_properties().await?.partition_ids;
+    assert!(
+        partition_ids.len() >= 2,
+        "the test hub must have at least 2 partitions, it has {}",
+        partition_ids.len()
+    );
+    let consumer_b = ConsumerClient::builder()
+        .with_application_id(app_b.clone())
+        .open(host.as_str(), hub.clone(), recording.credential().clone())
+        .await?;
+
+    let processor_a = create_processor_with_store(
+        consumer_a,
+        UPDATE_INTERVAL_BALANCE,
+        Some(StartPositions {
+            per_partition: HashMap::new(),
+            default: StartPosition {
+                location: StartLocation::Latest,
+                inclusive: false,
+            },
+        }),
+        store.clone(),
+        None,
+    )
+    .await?;
+    let processor_b = create_processor_with_store(
+        consumer_b,
+        UPDATE_INTERVAL_BALANCE,
+        Some(StartPositions {
+            per_partition: HashMap::new(),
+            default: StartPosition {
+                location: StartLocation::Latest,
+                inclusive: false,
+            },
+        }),
+        store.clone(),
+        None,
+    )
+    .await?;
+
+    let running_a = start_processor_running(&processor_a).await;
+    let running_b = start_processor_running(&processor_b).await;
+
+    let deadline = std::time::Instant::now() + BALANCE_CONVERGE_TIMEOUT;
+    let mut snapshot = store
+        .list_ownerships(&host, &hub, DEFAULT_CONSUMER_GROUP)
+        .await?;
+    loop {
+        let converged = {
+            let owners: HashSet<&str> = snapshot
+                .iter()
+                .filter_map(|o| o.owner_id.as_deref())
+                .collect();
+            owners.len() >= 2
+        };
+        if converged || std::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(BALANCE_POLL_INTERVAL).await;
+        snapshot = store
+            .list_ownerships(&host, &hub, DEFAULT_CONSUMER_GROUP)
+            .await?;
+    }
+
+    let mut by_owner: HashMap<&str, HashSet<&str>> = HashMap::new();
+    for ownership in snapshot.iter() {
+        if let Some(owner) = ownership.owner_id.as_deref() {
+            by_owner
+                .entry(owner)
+                .or_default()
+                .insert(ownership.partition_id.as_str());
+        }
+    }
+    assert!(
+        by_owner.len() >= 2,
+        "the two processors did not converge on distinct owners within {BALANCE_CONVERGE_TIMEOUT:?}; the store holds {snapshot:?}"
+    );
+    let set_a = by_owner
+        .get(app_a.as_str())
+        .unwrap_or_else(|| panic!("processor A owns no partition; the store holds {snapshot:?}"));
+    let set_b = by_owner
+        .get(app_b.as_str())
+        .unwrap_or_else(|| panic!("processor B owns no partition; the store holds {snapshot:?}"));
+    assert!(!set_a.is_empty(), "processor A owns an empty partition set");
+    assert!(!set_b.is_empty(), "processor B owns an empty partition set");
+    assert!(
+        set_a.is_disjoint(set_b),
+        "the two processors own overlapping partitions: {set_a:?} and {set_b:?}"
+    );
+
+    stop_processor(&processor_a, running_a, SHUTDOWN_TIMEOUT).await;
+    stop_processor(&processor_b, running_b, SHUTDOWN_TIMEOUT).await;
+    close_processor_strict(processor_a).await?;
+    close_processor_strict(processor_b).await?;
+    Ok(())
+}
+
+/// Two Balanced processors must both receive events. A split that leaves one
+/// instance with a partition it never reads from is worse than no split.
+#[recorded::test(live)]
+async fn two_balanced_processors_both_receive_events(ctx: TestContext) -> Result<()> {
+    let _serial = SERIAL.lock().await;
+    let recording = ctx.recording();
+    let host = recording.var("EVENTHUBS_HOST", None);
+    let hub = recording.var("EVENTHUB_NAME", None);
+    let marker = recording.random_string::<20>(Some("r7"));
+    let app_a = format!("{marker}-a");
+    let app_b = format!("{marker}-b");
+
+    let store = Arc::new(InMemoryCheckpointStore::new());
+
+    let consumer_a = ConsumerClient::builder()
+        .with_application_id(app_a.clone())
+        .open(host.as_str(), hub.clone(), recording.credential().clone())
+        .await?;
+    let partition_ids = consumer_a.get_eventhub_properties().await?.partition_ids;
+    assert!(
+        partition_ids.len() >= 2,
+        "the test hub must have at least 2 partitions, it has {}",
+        partition_ids.len()
+    );
+    let consumer_b = ConsumerClient::builder()
+        .with_application_id(app_b.clone())
+        .open(host.as_str(), hub.clone(), recording.credential().clone())
+        .await?;
+
+    let processor_a = create_processor_with_store(
+        consumer_a,
+        UPDATE_INTERVAL_BALANCE,
+        Some(StartPositions {
+            per_partition: HashMap::new(),
+            default: StartPosition {
+                location: StartLocation::Latest,
+                inclusive: false,
+            },
+        }),
+        store.clone(),
+        None,
+    )
+    .await?;
+    let processor_b = create_processor_with_store(
+        consumer_b,
+        UPDATE_INTERVAL_BALANCE,
+        Some(StartPositions {
+            per_partition: HashMap::new(),
+            default: StartPosition {
+                location: StartLocation::Latest,
+                inclusive: false,
+            },
+        }),
+        store.clone(),
+        None,
+    )
+    .await?;
+
+    let running_a = start_processor_running(&processor_a).await;
+    let running_b = start_processor_running(&processor_b).await;
+
+    let pc_a = tokio::time::timeout(FIRST_CLIENT_TIMEOUT, processor_a.next_partition_client())
+        .await
+        .unwrap_or_else(|_| {
+            panic!("processor A issued no partition client within {FIRST_CLIENT_TIMEOUT:?}")
+        })?;
+    let pc_b = tokio::time::timeout(FIRST_CLIENT_TIMEOUT, processor_b.next_partition_client())
+        .await
+        .unwrap_or_else(|_| {
+            panic!("processor B issued no partition client within {FIRST_CLIENT_TIMEOUT:?}")
+        })?;
+    assert_ne!(
+        pc_a.get_partition_id(),
+        pc_b.get_partition_id(),
+        "both processors claimed the same partition"
+    );
+
+    // The start location is Latest, so send only after both receivers are open.
+    send_tagged_events(&ctx, pc_a.get_partition_id(), &marker, EVENTS_PER_PARTITION).await?;
+    send_tagged_events(&ctx, pc_b.get_partition_id(), &marker, EVENTS_PER_PARTITION).await?;
+
+    let event_a = {
+        let mut stream_a = pc_a.stream_events().boxed_local();
+        next_tagged_event(&mut stream_a, &marker, EVENT_TIMEOUT)
+            .await
+            .unwrap_or_else(|| {
+                panic!(
+                    "processor A's client for partition {} streamed no tagged event within {EVENT_TIMEOUT:?}",
+                    pc_a.get_partition_id()
+                )
+            })
+    };
+    let event_b = {
+        let mut stream_b = pc_b.stream_events().boxed_local();
+        next_tagged_event(&mut stream_b, &marker, EVENT_TIMEOUT)
+            .await
+            .unwrap_or_else(|| {
+                panic!(
+                    "processor B's client for partition {} streamed no tagged event within {EVENT_TIMEOUT:?}",
+                    pc_b.get_partition_id()
+                )
+            })
+    };
+    assert_eq!(marker_of(&event_a), Some(marker.clone()));
+    assert_eq!(marker_of(&event_b), Some(marker.clone()));
+
+    stop_processor(&processor_a, running_a, SHUTDOWN_TIMEOUT).await;
+    stop_processor(&processor_b, running_b, SHUTDOWN_TIMEOUT).await;
+    let pc_a = Arc::try_unwrap(pc_a)
+        .unwrap_or_else(|_| panic!("the test cannot close processor A's partition client"));
+    pc_a.close().await?;
+    let pc_b = Arc::try_unwrap(pc_b)
+        .unwrap_or_else(|_| panic!("the test cannot close processor B's partition client"));
+    pc_b.close().await?;
+    close_processor_strict(processor_a).await?;
+    close_processor_strict(processor_b).await?;
+    Ok(())
+}
+
+/// An unknown event hub must fail at `build()`. `open()` only opens the
+/// namespace connection and never names the hub entity, so a caller that
+/// gets a processor back has no way to learn the hub does not exist.
+#[recorded::test(live)]
+async fn processor_build_fails_on_unknown_event_hub(ctx: TestContext) -> Result<()> {
+    let _serial = SERIAL.lock().await;
+    let recording = ctx.recording();
+    let host = recording.var("EVENTHUBS_HOST", None);
+    let bad_hub = format!("nonexistent-{}", recording.random_string::<12>(Some("h")));
+
+    let opened = tokio::time::timeout(
+        OPEN_TIMEOUT,
+        ConsumerClient::builder()
+            .with_retry_options(short_retry_options())
+            .open(
+                host.as_str(),
+                bad_hub.clone(),
+                recording.credential().clone(),
+            ),
+    )
+    .await
+    .unwrap_or_else(|_| panic!("open() did not return within {OPEN_TIMEOUT:?}"));
+    let consumer_client = opened.unwrap_or_else(|e| {
+        panic!("expected open() to succeed for an unknown event hub and the error to surface at build(); open() failed instead: {e:?}")
+    });
+
+    let built = tokio::time::timeout(
+        BUILD_ERROR_TIMEOUT,
+        processor_builder(
+            ProcessorStrategy::Balanced,
+            UPDATE_INTERVAL_FAST,
+            PARTITION_EXPIRATION,
+        )
+        .build(consumer_client, Arc::new(InMemoryCheckpointStore::new())),
+    )
+    .await
+    .unwrap_or_else(|_| {
+        panic!("build() against unknown event hub {bad_hub} did not return within {BUILD_ERROR_TIMEOUT:?}")
+    });
+
+    match built {
+        Ok(_) => panic!(
+            "build() succeeded against unknown event hub {bad_hub}; the error must surface at build()"
+        ),
+        Err(e) => info!("build() failed against unknown event hub {bad_hub}: {e:?}"),
+    }
+    Ok(())
+}
+
+/// An unknown consumer group must fail at `run()`. The group names the
+/// receiver link, which the processor opens only after `build()` returns.
+#[recorded::test(live)]
+async fn processor_run_fails_on_unknown_consumer_group(ctx: TestContext) -> Result<()> {
+    let _serial = SERIAL.lock().await;
+    let recording = ctx.recording();
+    let host = recording.var("EVENTHUBS_HOST", None);
+    let hub = recording.var("EVENTHUB_NAME", None);
+    let marker = recording.random_string::<20>(Some("r9"));
+    let bad_group = format!("nonexistent-{}", recording.random_string::<12>(Some("g")));
+
+    let opened = tokio::time::timeout(
+        OPEN_TIMEOUT,
+        ConsumerClient::builder()
+            .with_consumer_group(bad_group.clone())
+            .with_application_id(format!("{marker}-owner"))
+            .with_retry_options(short_retry_options())
+            .open(host.as_str(), hub.clone(), recording.credential().clone()),
+    )
+    .await
+    .unwrap_or_else(|_| panic!("open() did not return within {OPEN_TIMEOUT:?}"));
+    let consumer_client = opened.unwrap_or_else(|e| {
+        panic!("expected open() to succeed for an unknown consumer group and the error to surface at run(); open() failed instead: {e:?}")
+    });
+
+    let built = tokio::time::timeout(
+        BUILD_ERROR_TIMEOUT,
+        create_processor_with_store(
+            consumer_client,
+            UPDATE_INTERVAL_FAST,
+            Some(StartPositions {
+                per_partition: HashMap::new(),
+                default: StartPosition {
+                    location: StartLocation::Latest,
+                    inclusive: false,
+                },
+            }),
+            Arc::new(InMemoryCheckpointStore::new()),
+            None,
+        ),
+    )
+    .await
+    .unwrap_or_else(|_| {
+        panic!("build() with unknown consumer group {bad_group} did not return within {BUILD_ERROR_TIMEOUT:?}")
+    });
+    let processor = built.unwrap_or_else(|e| {
+        panic!("expected build() to succeed for an unknown consumer group and the error to surface at run(); build() failed instead: {e:?}")
+    });
+
+    let run_result = tokio::time::timeout(RUN_ERROR_TIMEOUT, processor.run())
+        .await
+        .unwrap_or_else(|_| {
+            panic!("run() with unknown consumer group {bad_group} did not return within {RUN_ERROR_TIMEOUT:?}")
+        });
+    match run_result {
+        Ok(()) => panic!("run() returned Ok with unknown consumer group {bad_group}"),
+        Err(e) => info!("run() failed with unknown consumer group {bad_group}: {e:?}"),
+    }
+
+    close_processor_strict(processor).await?;
     Ok(())
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor_blob.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor_blob.rs
@@ -1,0 +1,388 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+//! Live tests for the event processor on the blob checkpoint store.
+//!
+//! This is a separate test binary, so a file mutex cannot reach the tests in
+//! `eventhubs_processor.rs`. Isolation comes from a separate consumer group
+//! instead.
+
+use azure_core::http::{StatusCode, Url};
+use azure_core::time::Duration;
+use azure_core_test::{recorded, Recording, TestContext};
+use azure_messaging_eventhubs::error::ErrorKind;
+use azure_messaging_eventhubs::models::{
+    AmqpSimpleValue, Checkpoint, EventData, ReceivedEventData, StartPositions,
+};
+use azure_messaging_eventhubs::{
+    CheckpointStore, ConsumerClient, EventProcessor, ProcessorStrategy, ProducerClient, Result,
+    RetryOptions, SendEventOptions, StartLocation, StartPosition,
+};
+use azure_messaging_eventhubs_checkpointstore_blob::BlobCheckpointStore;
+use azure_storage_blob::{BlobContainerClient, BlobContainerClientOptions};
+use futures::StreamExt;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::task::JoinHandle;
+use tracing::info;
+
+/// The test resources bicep declares this consumer group and emits no output
+/// for it, and `Recording::var` panics on an unset key, so the name is fixed
+/// here.
+const BLOB_CONSUMER_GROUP: &str = "defaultGroup";
+
+const BLOB_SEED_EVENT_COUNT: i32 = 5;
+const UPDATE_INTERVAL_FAST: Duration = Duration::seconds(5);
+const PARTITION_EXPIRATION: Duration = Duration::seconds(30);
+const FIRST_CLIENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+const EVENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const BUILD_ERROR_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const RUN_ERROR_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+const MARKER_PROPERTY: &str = "test_marker";
+const INDEX_PROPERTY: &str = "test_index";
+
+fn create_container_client(
+    recording: &Recording,
+    container_name: &str,
+) -> azure_core::Result<BlobContainerClient> {
+    let mut options = BlobContainerClientOptions::default();
+    recording.instrument(&mut options.client_options);
+    let endpoint = recording.var("AZURE_STORAGE_BLOB_ENDPOINT", None);
+    let mut container_url = Url::parse(&endpoint)?;
+    container_url
+        .path_segments_mut()
+        .expect("the blob endpoint must be a valid base URL")
+        .push(container_name);
+    BlobContainerClient::new(container_url, Some(recording.credential()), Some(options))
+}
+
+async fn create_producer_client(ctx: &TestContext) -> Result<ProducerClient> {
+    let recording = ctx.recording();
+    ProducerClient::builder()
+        .open(
+            recording.var("EVENTHUBS_HOST", None).as_str(),
+            recording.var("EVENTHUB_NAME", None).as_str(),
+            recording.credential().clone(),
+        )
+        .await
+}
+
+/// Reads the per-run marker off a received event.
+fn marker_of(event: &ReceivedEventData) -> Option<String> {
+    match event.event_data().properties()?.get(MARKER_PROPERTY)? {
+        AmqpSimpleValue::String(value) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+/// Reads the send order index off a received event.
+fn index_of(event: &ReceivedEventData) -> Option<i32> {
+    match event.event_data().properties()?.get(INDEX_PROPERTY)? {
+        AmqpSimpleValue::Int(value) => Some(*value),
+        _ => None,
+    }
+}
+
+/// Sends `count` events to one partition. Each event carries the per-run
+/// marker and its send order index, so a test can tell its own events from
+/// the events of another run on the same shared hub.
+async fn send_tagged_events(
+    ctx: &TestContext,
+    partition_id: &str,
+    marker: &str,
+    count: i32,
+) -> Result<()> {
+    let producer_client = create_producer_client(ctx).await?;
+    for i in 0..count {
+        let event = EventData::builder()
+            .with_body(format!("{marker}-{i}"))
+            .add_property(MARKER_PROPERTY.to_string(), marker)
+            .add_property(INDEX_PROPERTY.to_string(), i)
+            .build();
+        producer_client
+            .send_event(
+                event,
+                Some(SendEventOptions {
+                    partition_id: Some(partition_id.to_string()),
+                }),
+            )
+            .await?;
+    }
+    producer_client.close().await?;
+    info!("Sent {count} tagged events to partition {partition_id}");
+    Ok(())
+}
+
+/// Reads the stream until it yields an event that carries `marker`, or until
+/// `total_budget` runs out. The budget covers the whole call, so a partition
+/// full of other runs' events cannot make this wait forever.
+async fn next_tagged_event<S>(
+    stream: &mut S,
+    marker: &str,
+    total_budget: std::time::Duration,
+) -> Option<ReceivedEventData>
+where
+    S: futures::Stream<Item = Result<ReceivedEventData>> + Unpin,
+{
+    let deadline = std::time::Instant::now() + total_budget;
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return None;
+        }
+        match tokio::time::timeout(remaining, stream.next()).await {
+            Err(_) => return None,
+            Ok(None) => return None,
+            Ok(Some(Err(e))) => panic!("the partition stream returned an error: {e:?}"),
+            Ok(Some(Ok(event))) => {
+                if marker_of(&event).as_deref() == Some(marker) {
+                    return Some(event);
+                }
+            }
+        }
+    }
+}
+
+/// Retry options for a negative test. The real default is 8 retries over 60
+/// seconds, which makes a test that expects a failure wait far too long.
+fn short_retry_options() -> RetryOptions {
+    RetryOptions {
+        initial_delay: Duration::milliseconds(100),
+        max_delay: Duration::seconds(1),
+        max_retries: 1,
+        max_total_elapsed: Duration::seconds(10),
+    }
+}
+
+fn start_processor_running(processor: &Arc<EventProcessor>) -> JoinHandle<Result<()>> {
+    let processor = Arc::clone(processor);
+    tokio::spawn(async move { processor.run().await })
+}
+
+/// Closes the processor and panics if another reference holds it. A test that
+/// silently skips the close leaves the connection open for the next test.
+async fn close_processor_strict(processor: Arc<EventProcessor>) -> Result<()> {
+    let processor = Arc::try_unwrap(processor)
+        .unwrap_or_else(|_| panic!("the processor still has references; the test cannot close it"));
+    processor.close().await
+}
+
+/// Stops a running processor and makes sure `run()` resolved cleanly.
+async fn stop_processor(
+    processor: &Arc<EventProcessor>,
+    handle: JoinHandle<Result<()>>,
+    budget: std::time::Duration,
+) {
+    processor
+        .shutdown()
+        .await
+        .unwrap_or_else(|e| panic!("shutdown() failed: {e:?}"));
+    match tokio::time::timeout(budget, handle).await {
+        Err(_) => panic!("run() did not resolve within {budget:?} after shutdown()"),
+        Ok(Err(e)) => panic!("the processor task did not join cleanly: {e:?}"),
+        Ok(Ok(Err(e))) => panic!("run() returned an error after shutdown(): {e:?}"),
+        Ok(Ok(Ok(()))) => {}
+    }
+}
+
+/// A missing blob container must fail at `run()`, and the failure must carry
+/// the storage status. `build()` never touches the checkpoint store, so a
+/// caller learns about the container only once the load balancer reads it.
+#[recorded::test(live)]
+async fn processor_run_fails_on_missing_blob_container(ctx: TestContext) -> Result<()> {
+    let recording = ctx.recording();
+    let host = recording.var("EVENTHUBS_HOST", None);
+    let hub = recording.var("EVENTHUB_NAME", None);
+    let marker = recording.random_string::<20>(Some("r10"));
+    let missing_container = format!("missing-{}", azure_core::Uuid::new_v4().simple());
+
+    let container_client = create_container_client(recording, &missing_container)?;
+    let store = BlobCheckpointStore::new(container_client);
+
+    let consumer_client = ConsumerClient::builder()
+        .with_consumer_group(BLOB_CONSUMER_GROUP.to_string())
+        .with_application_id(format!("{marker}-owner"))
+        .with_retry_options(short_retry_options())
+        .open(host.as_str(), hub.clone(), recording.credential().clone())
+        .await?;
+
+    let built = tokio::time::timeout(
+        BUILD_ERROR_TIMEOUT,
+        EventProcessor::builder()
+            .with_load_balancing_strategy(ProcessorStrategy::Balanced)
+            .with_update_interval(UPDATE_INTERVAL_FAST)
+            .with_partition_expiration_duration(PARTITION_EXPIRATION)
+            .with_prefetch(300)
+            .with_start_positions(StartPositions {
+                per_partition: HashMap::new(),
+                default: StartPosition {
+                    location: StartLocation::Latest,
+                    inclusive: false,
+                },
+            })
+            .build(consumer_client, store),
+    )
+    .await
+    .unwrap_or_else(|_| {
+        panic!("build() with missing blob container {missing_container} did not return within {BUILD_ERROR_TIMEOUT:?}")
+    });
+    let processor = built.unwrap_or_else(|e| {
+        panic!("expected build() to succeed with a missing blob container and the error to surface at run(); build() failed instead: {e:?}")
+    });
+
+    let run_result = tokio::time::timeout(RUN_ERROR_TIMEOUT, processor.run())
+        .await
+        .unwrap_or_else(|_| {
+            panic!("run() with missing blob container {missing_container} did not return within {RUN_ERROR_TIMEOUT:?}")
+        });
+    let err = match run_result {
+        Ok(()) => panic!("run() returned Ok with missing blob container {missing_container}"),
+        Err(e) => e,
+    };
+    info!("run() failed with missing blob container {missing_container}: {err:?}");
+
+    let ErrorKind::AzureCore(inner) = &err.kind else {
+        panic!(
+            "expected ErrorKind::AzureCore from the blob checkpoint store, got {:?}",
+            err.kind
+        )
+    };
+    match inner.kind() {
+        azure_core::error::ErrorKind::HttpResponse {
+            status, error_code, ..
+        } => {
+            assert_eq!(
+                *status,
+                StatusCode::NotFound,
+                "expected 404 from blob storage for missing container {missing_container}"
+            );
+            assert_eq!(
+                error_code.as_deref(),
+                Some("ContainerNotFound"),
+                "expected the ContainerNotFound error code from blob storage"
+            );
+        }
+        other => panic!("expected an HttpResponse error from blob storage, got {other:?}"),
+    }
+
+    close_processor_strict(processor).await?;
+    Ok(())
+}
+
+/// `update_checkpoint` must reach the blob store. An in-memory store cannot
+/// catch a serialization or blob naming defect in the blob store path.
+#[recorded::test(live)]
+async fn processor_checkpoints_to_blob_store(ctx: TestContext) -> Result<()> {
+    let recording = ctx.recording();
+    let host = recording.var("EVENTHUBS_HOST", None);
+    let hub = recording.var("EVENTHUB_NAME", None);
+    let marker = recording.random_string::<20>(Some("r12"));
+
+    let container_name = recording.var("AZURE_STORAGE_BLOB_CONTAINER", None);
+    let container_client = create_container_client(recording, &container_name)?;
+    let store = BlobCheckpointStore::new(container_client);
+
+    let consumer_client = ConsumerClient::builder()
+        .with_consumer_group(BLOB_CONSUMER_GROUP.to_string())
+        .with_application_id(format!("{marker}-owner"))
+        .open(host.as_str(), hub.clone(), recording.credential().clone())
+        .await?;
+    let partition_ids = consumer_client
+        .get_eventhub_properties()
+        .await?
+        .partition_ids;
+    let target = partition_ids[0].clone();
+    let tail = consumer_client
+        .get_partition_properties(&target)
+        .await?
+        .last_enqueued_sequence_number;
+
+    // Seed the store at the tail. Leftover state from an earlier run would
+    // otherwise replay hours of retained events, and the final assertion
+    // needs a known prior value to compare against.
+    store
+        .update_checkpoint(Checkpoint {
+            fully_qualified_namespace: host.clone(),
+            event_hub_name: hub.clone(),
+            consumer_group: BLOB_CONSUMER_GROUP.to_string(),
+            partition_id: target.clone(),
+            offset: None,
+            sequence_number: Some(tail),
+        })
+        .await?;
+
+    send_tagged_events(&ctx, &target, &marker, BLOB_SEED_EVENT_COUNT).await?;
+
+    let processor = EventProcessor::builder()
+        .with_load_balancing_strategy(ProcessorStrategy::Balanced)
+        .with_update_interval(UPDATE_INTERVAL_FAST)
+        .with_partition_expiration_duration(PARTITION_EXPIRATION)
+        .with_prefetch(300)
+        .with_max_partition_count(1)
+        .with_start_positions(StartPositions {
+            per_partition: HashMap::new(),
+            default: StartPosition {
+                location: StartLocation::SequenceNumber(tail),
+                inclusive: false,
+            },
+        })
+        .build(consumer_client, store.clone())
+        .await?;
+    let running = start_processor_running(&processor);
+
+    let partition_client =
+        tokio::time::timeout(FIRST_CLIENT_TIMEOUT, processor.next_partition_client())
+            .await
+            .unwrap_or_else(|_| {
+                panic!("the processor issued no partition client within {FIRST_CLIENT_TIMEOUT:?}")
+            })?;
+    assert_eq!(partition_client.get_partition_id(), target);
+
+    let last = {
+        let mut stream = partition_client.stream_events().boxed_local();
+        let mut last = None;
+        for expected in 0..BLOB_SEED_EVENT_COUNT {
+            let event = next_tagged_event(&mut stream, &marker, EVENT_TIMEOUT)
+                .await
+                .unwrap_or_else(|| {
+                    panic!("the processor streamed no tagged event with index {expected} within {EVENT_TIMEOUT:?}")
+                });
+            assert_eq!(
+                index_of(&event),
+                Some(expected),
+                "the processor received tagged events out of order"
+            );
+            last = Some(event);
+        }
+        last.expect("the read loop must run at least once")
+    };
+    partition_client.update_checkpoint(&last).await?;
+
+    let cps = store
+        .list_checkpoints(&host, &hub, BLOB_CONSUMER_GROUP)
+        .await?;
+    let cp = cps
+        .iter()
+        .find(|c| c.partition_id == target)
+        .unwrap_or_else(|| {
+            panic!("the blob store holds no checkpoint for partition {target}; it holds {cps:?}")
+        });
+    assert_ne!(
+        cp.sequence_number,
+        Some(tail),
+        "the blob checkpoint still holds the seeded sequence number; update_checkpoint wrote nothing"
+    );
+    assert_eq!(
+        cp.sequence_number,
+        last.sequence_number(),
+        "the blob checkpoint sequence number does not match the event the test passed to update_checkpoint"
+    );
+
+    stop_processor(&processor, running, SHUTDOWN_TIMEOUT).await;
+    let partition_client = Arc::try_unwrap(partition_client)
+        .unwrap_or_else(|_| panic!("the test cannot close the partition client"));
+    partition_client.close().await?;
+    close_processor_strict(processor).await?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

This change adds 11 live tests for the Event Hubs event processor. The tests cover checkpoint resume across processor instances, graceful shutdown and restart, ownership records in the checkpoint store, the balanced load balancing strategy across two processors, invalid configuration errors, and an end to end run on `BlobCheckpointStore` against live Event Hubs and live Storage.

## Motivation

Checkpoint resume is the core promise of the processor. A processor that restarts and reprocesses from the start, or skips events, breaks the checkpoint contract, and no existing test detects it. The processor tests before this change never call `shutdown()`, never share a checkpoint store between two processors, never read `list_ownerships` or `list_checkpoints`, and never assert an error. Load balancing and graceful shutdown are the other two behaviors that a caller depends on in production.

## Changes

- Adds 9 live tests to `sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs` for checkpoint resume, shutdown, restart, ownership records, the balanced strategy, an unknown event hub name, and an unknown consumer group.
- Adds `sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor_blob.rs` with 2 live tests that run the processor on `BlobCheckpointStore`, one for a missing storage container and one for a checkpoint round trip.
- Adds a file level serial mutex to `eventhubs_processor.rs` and applies it to the new tests and to the five existing tests. Every processor receiver attaches at owner level 0, so two processor tests that run at the same time displace each other.
- Adds the `sync` feature to the tokio dev dependency, which the serial mutex needs. This is the only change outside a test file, and no file under `src/` changes.
- Keeps the blob tests on the `defaultGroup` consumer group. Cargo runs test binaries in parallel and a file mutex cannot reach across binaries, so the separate consumer group is what keeps the two binaries apart.

Three behaviors of the current code shape these tests, and each one is a way a weaker test would pass while proving nothing.

- `PartitionClient::update_checkpoint` returns `Ok(())` and writes nothing when the received event carries no message annotations. Both checkpoint tests therefore assert that the checkpoint reached the store before they assert anything about resume. The resume test reads `list_checkpoints` and matches the sequence number. The blob test seeds a known prior value and asserts the stored value changed.
- `EventProcessor::get_start_position` clones the configured default start position and overrides only the location, so the `inclusive` flag is inherited from the default. Every new test sets `inclusive: false`. With `inclusive: true` a resumed reader re-reads the checkpointed event and the resume assertion breaks silently.
- `EventProcessor::shutdown` clears a flag and closes no receiver, so a partition client that the processor already handed out keeps streaming. The shutdown tests assert that `run()` resolves to `Ok(())` and that the processor issues no new partition client. They do not assert that an already issued partition client stops, because that assertion would fail against correct source. This gap is tracked in #5096.

The .NET tests detect every invalid configuration at start time. The Rust processor surfaces the same conditions at three different call sites, which the issue permits. An unknown event hub name fails at `build()`, and a missing storage container fails at `run()` on the first dispatch. An unknown consumer group reaches neither: a live run held `run()` pending past 60 seconds, because the receiver attaches on the first poll of the partition client's stream, so that test asserts there. The lazy attach is tracked in #5094. Each test pins the call that returns the error rather than the error text, because an unknown event hub and an unknown consumer group both map to `amqp:not-found` and the crate error type has no not found variant. The missing container test is the exception and asserts the structured 404 with the `ContainerNotFound` error code.

The bad namespace case adds no new test. `consumer_new_with_error` in `sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_consumer.rs` already opens a consumer against an invalid host and asserts the full error chain. A processor flavored copy would assert strictly less.

## Test plan


Run the live tests with this exact command, after deploying the test resources with `eng/common/TestResources/New-TestResources.ps1 -ServiceDirectory eventhubs` and setting `EVENTHUBS_HOST`, `EVENTHUB_NAME`, `AZURE_STORAGE_BLOB_ENDPOINT`, and `AZURE_STORAGE_BLOB_CONTAINER`.

```
AZURE_TEST_MODE=live cargo test --package azure_messaging_eventhubs --test 'eventhubs_processor*' -- --test-threads=1
```

The offline gates below all pass on this branch.

- `cargo fmt --all -- --check` exits 0.
- `RUSTFLAGS=-Dwarnings cargo test --no-run --package azure_messaging_eventhubs --all-features` exits 0.
- `RUSTFLAGS=-Dwarnings cargo clippy -p azure_messaging_eventhubs --all-features --all-targets --no-deps` exits 0.
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p azure_messaging_eventhubs --all-features --no-deps` exits 0.
- `cargo test --package azure_messaging_eventhubs --all-features --no-fail-fast -- --test-threads=1` exits 0. The suite reports 144 unit tests passed, 6 checkpoint store tests passed, 45 doc tests passed, and no failures. The new tests report as ignored, 14 in `eventhubs_processor` and 2 in `eventhubs_processor_blob`.
- cspell passes on all three changed files with the repository configuration.

Two limits are known and recorded rather than fixed.

- `processor_shutdown_stops_new_partition_clients` asserts a negative, so it first asserts that the processor has partitions left to claim. A processor that already holds every partition also issues no new client, and the test would prove nothing. The precondition fails loudly instead of passing hollow.
- The blob container is shared and `azure_storage_blob` exposes no container create, so two concurrent runs of `processor_checkpoints_to_blob_store` would race on one checkpoint blob. CI runs the suite once, so this is a hazard for parallel developers, not for CI.

Closes #4893

### Live validation

Every test here ran against a live Event Hubs namespace on 2026-08-20: 13 of 14 in `eventhubs_processor.rs` and 2 of 2 in `eventhubs_processor_blob.rs`.

Command: `AZURE_TEST_MODE=live cargo test --package azure_messaging_eventhubs --test eventhubs_processor --test eventhubs_processor_blob -- --test-threads=1`.

Three tests were corrected after that run, and the commit message records each one. The remaining failure, `second_processor_displaces_first_with_consumer_disconnected`, is not from this change: it fails the same way on a detached worktree of an unmodified `origin/main`.


Two further findings from the live run have their own issues: a lost ownership claim ending `run()` under the balanced strategy is #5095, and `update_checkpoint` succeeding without writing when an event carries no annotations is #5097.
