### PR TITLE
Fix a compile error with default feature set

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/Test-Setup.ps1
+++ b/sdk/cosmos/azure_data_cosmos/Test-Setup.ps1
@@ -2,3 +2,4 @@
 # Licensed under the MIT License.
 
 . "$PSScriptRoot\..\eng\scripts\Invoke-CosmosTestSetup.ps1"
+. "$PSScriptRoot\..\eng\scripts\Invoke-CosmosDefaultFeatureCheck.ps1"

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos_runtime.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos_runtime.rs
@@ -26,17 +26,22 @@
 //! cargo run --example cosmos_runtime --features key_auth
 //! ```
 
+// Only the `key_auth` code paths below build a client; the fallbacks just report
+// that the feature is missing, so everything else is gated to keep the
+// default-feature build warning-free.
+#[cfg(feature = "key_auth")]
 use azure_core::credentials::Secret;
-use azure_data_cosmos::options::Region;
+#[cfg(feature = "key_auth")]
 use azure_data_cosmos::options::{
-    ConnectionPoolOptions, ServerCertificateValidation, UserAgentSuffix,
+    ConnectionPoolOptions, Region, ServerCertificateValidation, UserAgentSuffix,
 };
-use azure_data_cosmos::{
-    AccountEndpoint, AccountReference, CosmosClient, CosmosRuntime, RoutingStrategy,
-};
+use azure_data_cosmos::CosmosClient;
+#[cfg(feature = "key_auth")]
+use azure_data_cosmos::{AccountEndpoint, AccountReference, CosmosRuntime, RoutingStrategy};
 use std::error::Error;
 
 /// The well-known emulator account key.
+#[cfg(feature = "key_auth")]
 const EMULATOR_KEY: &str =
     "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
 

--- a/sdk/cosmos/azure_data_cosmos/src/feed/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/feed/mod.rs
@@ -24,7 +24,8 @@ pub use query_page::QueryFeedPage;
 // Crate-internal re-exports
 // =========================================================================
 
-#[cfg(feature = "control_plane")]
+// Not gated: `models::response_body` deserializes feed envelopes on the
+// default-feature data plane, not just under `control_plane`.
 pub(crate) use page::FeedBody;
 
 // =========================================================================

--- a/sdk/cosmos/azure_data_cosmos_driver/Test-Setup.ps1
+++ b/sdk/cosmos/azure_data_cosmos_driver/Test-Setup.ps1
@@ -2,3 +2,4 @@
 # Licensed under the MIT License.
 
 . "$PSScriptRoot\..\eng\scripts\Invoke-CosmosTestSetup.ps1"
+. "$PSScriptRoot\..\eng\scripts\Invoke-CosmosDefaultFeatureCheck.ps1"

--- a/sdk/cosmos/eng/scripts/Invoke-CosmosDefaultFeatureCheck.ps1
+++ b/sdk/cosmos/eng/scripts/Invoke-CosmosDefaultFeatureCheck.ps1
@@ -1,0 +1,30 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Every other build, lint, and test step in CI compiles the Cosmos crates with
+# `--all-features`, so an item that a default-feature code path uses but a cargo
+# feature gates only fails once it reaches a consumer on the default feature set.
+
+. ([System.IO.Path]::Combine($PSScriptRoot, '..', '..', '..', '..', 'eng', 'common', 'scripts', 'common.ps1'))
+
+# Work around a temporary issue where Invoke-LoggedCommand, which calls us, needs LASTEXITCODE to be set
+$global:LASTEXITCODE = 0
+
+# Test-Setup.ps1 runs once per package, but this check already covers every
+# Cosmos crate, so only the first invocation in a job does the work.
+if ($env:AZURE_COSMOS_DEFAULT_FEATURE_CHECK_COMPLETE -eq 'true') {
+  Write-Host 'Default-feature check already ran for this job; skipping.'
+  return
+}
+
+$packages = @(
+  'azure_data_cosmos'
+  'azure_data_cosmos_driver'
+)
+$packageArgs = '--package ' + ($packages -join ' --package ')
+
+LogGroupStart 'Checking Cosmos crates with default features'
+Invoke-LoggedCommand "cargo check $packageArgs --all-targets --keep-going"
+LogGroupEnd
+
+$env:AZURE_COSMOS_DEFAULT_FEATURE_CHECK_COMPLETE = 'true'


### PR DESCRIPTION
I am intentionally doing this Cosmos-local for now - and using the existing hook at beginning of tests. But the check is cheap and this should not be an issue for now.

If Core decides to run the check for default features across all crates, we can always remove it.