### PR TITLE
test(eventhubs): drive both processors in the displacement test

### DIFF
--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs
@@ -557,7 +557,8 @@ async fn second_processor_displaces_first_with_consumer_disconnected(
                 Some((_partition_id, Ok(_event))) => continue,
                 Some((partition_id, Err(err))) => return (partition_id, Some(err)),
                 // All streams ended without an error: the bug we guard against.
-                None => return (String::new(), None),
+                // No single partition owns this outcome, so name them all.
+                None => return ("(all)".to_string(), None),
             }
         }
     };

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_processor.rs
@@ -442,10 +442,18 @@ async fn receive_events_from_processor(ctx: TestContext) -> Result<()> {
 /// The test watches every partition client A claims (not just the first),
 /// because B will only steal a fair share of partitions and that share is
 /// not deterministic.
+///
+/// A receiver reaches the broker on the first poll of `stream_events()`, and
+/// not when `next_partition_client()` hands the client out. The test polls B's
+/// streams, or B holds no link and steals nothing. Attach order also decides
+/// the direction: with an equal owner level the broker disconnects whichever
+/// receiver attached first, so every one of A's must attach before B starts.
 #[recorded::test(live)]
 async fn second_processor_displaces_first_with_consumer_disconnected(
     ctx: TestContext,
 ) -> Result<()> {
+    use futures::stream::select_all;
+
     // Use a short update interval so load balancing converges quickly; the
     // validation rule on the builder requires expiration > interval.
     const UPDATE_INTERVAL: Duration = Duration::seconds(5);
@@ -453,10 +461,13 @@ async fn second_processor_displaces_first_with_consumer_disconnected(
     // Give the broker + load balancer up to this long to displace at least
     // one of the first processor's receivers and propagate the AMQP detach.
     const STEAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
-    // How long to collect A's initial claims before starting B. With a 5s
-    // interval, two cycles is enough for A to grab whatever it is going to
-    // grab under a Greedy strategy.
+    // How long to collect a processor's claims before moving on. With a 5s
+    // interval, two cycles is enough for a Greedy processor to grab whatever
+    // it is going to grab.
     const COLLECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+    // How long to poll A's streams so every one of A's receivers reaches the
+    // broker before B contends for the same partitions.
+    const ATTACH_WINDOW: std::time::Duration = std::time::Duration::from_secs(15);
 
     let consumer_a = create_consumer_client(&ctx).await?;
     let processor_a = processor_builder(ProcessorStrategy::Greedy, UPDATE_INTERVAL, EXPIRATION)
@@ -475,6 +486,36 @@ async fn second_processor_displaces_first_with_consumer_disconnected(
         partition_clients_a.len()
     );
 
+    // Merge every partition's stream into one and watch for the first
+    // error. `select_all` does not require `Send`, which matters because
+    // `PartitionClient::stream_events` returns a non-`Send` boxed stream.
+    let tagged_streams = partition_clients_a.iter().map(|client| {
+        let partition_id = client.get_partition_id().to_string();
+        client
+            .stream_events()
+            .map(move |result| (partition_id.clone(), result))
+            .boxed_local()
+    });
+    let mut merged_a = select_all(tagged_streams);
+
+    // Polling is the only way to attach, so this window is what makes A the
+    // older receiver. An error here is a failed attach, not a displacement.
+    info!("Attaching processor A's receivers before the second processor starts.");
+    let attach_deadline = tokio::time::Instant::now() + ATTACH_WINDOW;
+    loop {
+        match tokio::time::timeout_at(attach_deadline, merged_a.next()).await {
+            Err(_) => break,
+            Ok(Some((_partition_id, Ok(_event)))) => continue,
+            Ok(Some((partition_id, Err(err)))) => panic!(
+                "partition {} failed on processor A before the second processor started: {:?}",
+                partition_id, err
+            ),
+            Ok(None) => {
+                panic!("every processor A stream ended before the second processor started")
+            }
+        }
+    }
+
     // Start the second processor against the same hub + consumer group;
     // it will open epoch-0 receivers and the broker will disconnect at
     // least one of A's receivers within the load-balancing window.
@@ -485,22 +526,34 @@ async fn second_processor_displaces_first_with_consumer_disconnected(
     let running_b = start_processor_running(&processor_b).await;
     info!("Second processor started; watching every partition A holds for a steal.");
 
-    // Merge every partition's stream into one and watch for the first
-    // error. `select_all` does not require `Send`, which matters because
-    // `PartitionClient::stream_events` returns a non-`Send` boxed stream.
-    use futures::stream::select_all;
-    let tagged_streams = partition_clients_a.iter().map(|client| {
-        let partition_id = client.get_partition_id().to_string();
-        client
-            .stream_events()
-            .map(move |result| (partition_id.clone(), result))
-            .boxed_local()
-    });
-    let mut merged = select_all(tagged_streams);
+    // `run()` claims partitions but attaches no receiver, so B steals nothing
+    // until something polls B's streams. They are not `Send`, so they run here.
+    let drive_b = async {
+        let partition_clients_b = drain_partition_clients(&processor_b, COLLECT_TIMEOUT).await;
+        assert!(
+            !partition_clients_b.is_empty(),
+            "processor B did not claim any partitions within the collect window"
+        );
+        info!(
+            "Processor B holds {} partition clients; attaching them now.",
+            partition_clients_b.len()
+        );
+        let streams_b = partition_clients_b
+            .iter()
+            .map(|client| client.stream_events().boxed_local());
+        let mut merged_b = select_all(streams_b);
+        while let Some(result) = merged_b.next().await {
+            if let Err(err) = result {
+                warn!(err = ?err, "Processor B stream reported an error.");
+            }
+        }
+        // Park, so the `select!` below never polls a finished future.
+        futures::future::pending::<()>().await
+    };
 
     let race = async {
         loop {
-            match merged.next().await {
+            match merged_a.next().await {
                 Some((_partition_id, Ok(_event))) => continue,
                 Some((partition_id, Err(err))) => return (partition_id, Some(err)),
                 // All streams ended without an error: the bug we guard against.
@@ -508,7 +561,14 @@ async fn second_processor_displaces_first_with_consumer_disconnected(
             }
         }
     };
-    let observed = tokio::time::timeout(STEAL_TIMEOUT, race).await;
+
+    let observed = tokio::time::timeout(STEAL_TIMEOUT, async {
+        tokio::select! {
+            result = race => result,
+            _ = drive_b => unreachable!("the processor B driver parks and never finishes"),
+        }
+    })
+    .await;
 
     // Stop both before asserting so a panic does not leak background tasks.
     running_a.abort();


### PR DESCRIPTION
## Summary

The live test `second_processor_displaces_first_with_consumer_disconnected` never made the second processor attach an AMQP receiver, so nothing displaced the first processor and the expected `ConsumerDisconnected` never arrived. The test now attaches processor A before processor B starts, and it drives processor B's partition clients so B holds real links. The assertion on `ErrorKind::ConsumerDisconnected` does not change.

## Motivation

A receiver reaches the broker on the first poll of `stream_events()`, and not when `next_partition_client()` hands the partition client out (see #5094). `EventProcessor::run()` claims partitions and builds `EventReceiver` values, but it polls nothing, and the old test polled processor A's streams only. Processor B therefore held no link on any partition, and one receiver on a partition creates no epoch contention, so the 90 second budget expired with no error. The attach order was wrong as well: both processors attach at `PROCESSOR_OWNER_LEVEL = 0`, and the broker disconnects the receiver that attached first when a receiver with an equal or higher epoch arrives, so an A that attached after B would displace B instead. The displacement path itself is intact, and unit tests cover both the map from `amqp:link:stolen` to `ErrorKind::ConsumerDisconnected` and the retry decider that refuses to reattach a stolen link. The partition count lead in the issue is ruled out: the `at least one of 5 partitions` text prints `partition_clients_a.len()`, and no assertion depends on that number.

## Changes

- Poll processor A's merged stream for a bounded attach window before processor B is built, so every one of A's receivers reaches the broker first.
- Fail with a clear message when a partition errors inside that window, because nothing else holds a link yet, so the error is a failed attach and not a displacement.
- Drain processor B's partition clients and poll their merged stream, so B attaches the epoch 0 links that displace A.
- Run the B driver on the same task as the A race, because `PartitionClient::stream_events()` is not `Send` and cannot move to a spawned task.
- Park the B driver on `futures::future::pending` after its streams end, so `tokio::select!` never polls a finished future.
- State both rules in the test's doc comment: the attach happens on the first poll, and the attach order decides the direction of the steal.

## Test plan

- `CARGO_BUILD_JOBS=1 RUSTFLAGS=-Dwarnings cargo test --no-run --package azure_messaging_eventhubs` exits 0.
- `CARGO_BUILD_JOBS=1 RUSTFLAGS=-Dwarnings cargo clippy -p azure_messaging_eventhubs --all-features --all-targets` exits 0.
- `CARGO_BUILD_JOBS=1 cargo test -p azure_messaging_eventhubs --lib -- --test-threads=1` exits 0, with 144 passed and 0 failed. That set holds the stolen-link tests that prove the library half of the path.
- `cargo fmt --package azure_messaging_eventhubs -- --check` exits 0, and cspell reports 0 issues over 1 file.
### Live validation

The test ran against a real namespace on 2026-08-20. This change is necessary and it is not sufficient. Measured, four runs:

| | test as on main | test with this change |
|---|---|---|
| `azure_core_amqp` 1.1.0 from crates.io | FAIL | FAIL |
| in-tree `azure_core_amqp` 1.2.0-beta.1 | FAIL | PASS |

The second blocker is a dependency, not a test defect. `azure_messaging_eventhubs` links the crates.io `azure_core_amqp` 1.1.0, whose receiver builder calls `.properties()` before `.name()`. In `fe2o3-amqp` 0.14.0 the `name()` builder method rebuilds the struct with `properties: Default::default()`, so it discards them, and the `com.microsoft:epoch` link property that carries the owner level never reaches the broker. With no epoch, the broker never arbitrates and nothing is displaced. The in-tree copy fixed that order in #4805.

So this pull request must not merge alone and be expected to turn the live test green. It needs the dependency flip that PR #5078 already carries, or a released `azure_core_amqp` 1.2.0. See #5100 for the full matrix.
- Confidence in the diagnosis is high, because the lazy attach is plain in `open_receiver_on_partition` and issue #5094 reports the same behavior from a separate investigation. Confidence that the fix makes the live test pass is medium, because attach timing against a real namespace is not proven here.
- The live command to confirm it: `AZURE_TEST_MODE=live EVENTHUBS_HOST=<namespace>.servicebus.windows.net EVENTHUB_NAME=<hub> cargo test --package azure_messaging_eventhubs --test eventhubs_processor second_processor_displaces_first_with_consumer_disconnected -- --exact --test-threads=1`.

Closes #5100