### PR TITLE
Hotfix: cache Key Vault challenge scope only after validation (1.0.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "azure_security_keyvault_certificates"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "azure_security_keyvault_keys"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "azure_security_keyvault_secrets"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/sdk/keyvault/azure_security_keyvault_certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure_security_keyvault_certificates/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.1 (2026-08-25)
+
+### Bugs Fixed
+
+- Fixed the challenge authentication policy to cache the challenge scope only after the challenge resource is verified, so that a rejected challenge is not cached and reused by subsequent requests.
+
 ## 1.0.0 (2026-05-12)
 
 ### Features Added

--- a/sdk/keyvault/azure_security_keyvault_certificates/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_certificates/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_security_keyvault_certificates"
-version = "1.0.0"
+version = "1.0.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Azure Key Vault Certificates"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/keyvault/azure_security_keyvault_keys/CHANGELOG.md
+++ b/sdk/keyvault/azure_security_keyvault_keys/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.1 (2026-08-25)
+
+### Bugs Fixed
+
+- Fixed the challenge authentication policy to cache the challenge scope only after the challenge resource is verified, so that a rejected challenge is not cached and reused by subsequent requests.
+
 ## 1.0.0 (2026-05-12)
 
 ### Features Added

--- a/sdk/keyvault/azure_security_keyvault_keys/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_security_keyvault_keys"
-version = "1.0.0"
+version = "1.0.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Azure Key Vault Keys"
 readme = "README.md"
 authors.workspace = true

--- a/sdk/keyvault/azure_security_keyvault_keys/src/authorizer.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/authorizer.rs
@@ -120,10 +120,6 @@ impl OnChallenge for KeyVaultAuthorizer {
     ) -> Result<()> {
         let challenge = headers.get_str(&WWW_AUTHENTICATE)?;
         let scope = KeyVaultAuthorizer::parse_scope_from_challenge(challenge)?;
-        {
-            let mut cached_scope = self.scope.write().await;
-            *cached_scope = scope.clone();
-        }
         if self.verify_challenge_resource {
             // the challenge resource's host must match the requested domain's host
             let challenge_url = Url::parse(&scope).map_err(|_| {
@@ -152,6 +148,10 @@ impl OnChallenge for KeyVaultAuthorizer {
                             "challenge resource '{scope}' doesn't match the requested domain '{request_host}'. Set verify_challenge_resource in client options to disable this validation if necessary. See https://aka.ms/azsdk/blog/vault-uri for more information`"
                 )));
             }
+        }
+        {
+            let mut cached_scope = self.scope.write().await;
+            *cached_scope = scope.clone();
         }
         if let Some(saved_body) = context.value::<Body>() {
             request.set_body(saved_body);
@@ -409,6 +409,82 @@ mod tests {
             }
             _ => panic!("unexpected error kind: {err:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn rejected_challenge_is_not_cached() {
+        let mock_credential = Arc::new(MockCredential::new(
+            vec![AccessToken {
+                token: Secret::new("token".to_string()),
+                expires_on: OffsetDateTime::now_utc() + Duration::seconds(3600),
+            }],
+            "https://a.b/.default".to_string(),
+        ));
+        let requests = Arc::new(AtomicUsize::new(0));
+        let transport = Transport::new(Arc::new(MockHttpClient::new({
+            let requests = Arc::clone(&requests);
+            move |req| {
+                let requests = Arc::clone(&requests);
+                async move {
+                    requests.fetch_add(1, Ordering::SeqCst);
+                    assert!(
+                        req.headers()
+                            .get_str(&HeaderName::from_static("authorization"))
+                            .is_err(),
+                        "rejected challenge must not authorize later requests"
+                    );
+                    assert_eq!(req.body().is_empty(), Some(true), "request body should be stripped");
+
+                    let mut headers = Headers::new();
+                    headers.insert(WWW_AUTHENTICATE, r#"Bearer authorization="https://login.microsoftonline.com/tenant", resource="https://a.b""#);
+                    Ok(AsyncRawResponse::from_bytes(
+                        StatusCode::Unauthorized,
+                        headers,
+                        Bytes::new(),
+                    ))
+                }
+                .boxed()
+            }
+        })));
+        let client_options = azure_core::http::ClientOptions {
+            transport: Some(transport),
+            ..Default::default()
+        };
+
+        let authorizer = KeyVaultAuthorizer::new(true);
+        let auth_policy: Arc<dyn Policy> = Arc::new(
+            BearerTokenAuthorizationPolicy::new(mock_credential.clone(), Vec::<String>::new())
+                .with_on_request(authorizer.clone())
+                .with_on_challenge(authorizer),
+        );
+        let pipeline = Pipeline::new(
+            option_env!("CARGO_PKG_NAME"),
+            option_env!("CARGO_PKG_VERSION"),
+            client_options,
+            Vec::default(),
+            vec![auth_policy],
+            None,
+        );
+
+        for _ in 0..2 {
+            let mut request = Request::new(
+                Url::parse("https://vault.c.d/keys/foo").unwrap(),
+                Method::Put,
+            );
+            request.insert_header("content-type", "application/json");
+            request.set_body(Bytes::from_static(b"{\"value\":\"secret\"}"));
+            pipeline
+                .send(&Context::default(), &mut request, None)
+                .await
+                .expect_err("challenge resource validation should fail");
+        }
+
+        assert_eq!(requests.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            mock_credential.call_count(),
+            0,
+            "credential should not be called for rejected challenges"
+        );
     }
 
     #[tokio::test]

--- a/sdk/keyvault/azure_security_keyvault_secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure_security_keyvault_secrets/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.1 (2026-08-25)
+
+### Bugs Fixed
+
+- Fixed the challenge authentication policy to cache the challenge scope only after the challenge resource is verified, so that a rejected challenge is not cached and reused by subsequent requests.
+
 ## 1.0.0 (2026-05-12)
 
 ### Features Added

--- a/sdk/keyvault/azure_security_keyvault_secrets/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_secrets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_security_keyvault_secrets"
-version = "1.0.0"
+version = "1.0.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Azure Key Vault Secrets"
 readme = "README.md"
 authors.workspace = true


### PR DESCRIPTION
## Summary
Security hotfix backporting the Key Vault challenge-cache-after-validation fix to the **1.0.0** release line (MSRC / ICM 31000000679759). Targets the `hotfix/keyvault` branch per the [hotfix policy](https://azure.github.io/azure-sdk/policies_repobranching.html#hotfix-branches).

The challenge scope is now cached **only after** the challenge resource is verified, so a rejected challenge is not cached and reused by later requests.

## Packages (1.0.0 -> 1.0.1)
- `azure_security_keyvault_keys`
- `azure_security_keyvault_secrets`
- `azure_security_keyvault_certificates`

(secrets and certificates use the keys `authorizer.rs` via symlink, so the single source edit covers all three crates.)

## Changes
- Move the challenge-scope cache write in `on_challenge` to after `verify_challenge_resource` succeeds.
- Add a `rejected_challenge_is_not_cached` regression test.
- Bump each crate to 1.0.1 with a CHANGELOG entry.

## Tests
`cargo test -p azure_security_keyvault_keys --lib` -> 13 passed (incl. the new regression test). secrets/certificates build verified.

The same fix is already going into `main` via #5121.