### PR TITLE
Exclude non-shipping code from CG

### DIFF
--- a/eng/pipelines/templates/jobs/pack.yml
+++ b/eng/pipelines/templates/jobs/pack.yml
@@ -12,6 +12,10 @@ jobs:
 - job: Pack
   displayName: "Pack Crates"
   timeoutInMinutes: 90
+  variables:
+    ComponentDetection.SourcePath: $(Build.SourcesDirectory)
+    # Exclude non-shipping samples and tests.
+    ComponentDetection.DirectoryExclusionPatterns: '$(Build.SourcesDirectory)/samples/**;$(Build.SourcesDirectory)/**/tests/**'
 
   pool:
     name: $(LINUXPOOL)

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -3,5 +3,3 @@ variables:
   # Disable CodeQL injections except for where we specifically enable it
   Codeql.SkipTaskAutoInjection: true
   ComponentDetection.Timeout: 1200
-  # Exclude non-shipping samples and tests.
-  ComponentDetection.DirectoryExclusionPatterns: '$(Build.SourcesDirectory)/samples/**;$(Build.SourcesDirectory)/**/tests/**'

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -3,3 +3,5 @@ variables:
   # Disable CodeQL injections except for where we specifically enable it
   Codeql.SkipTaskAutoInjection: true
   ComponentDetection.Timeout: 1200
+  # Exclude non-shipping samples and tests.
+  ComponentDetection.DirectoryExclusionPatterns: '$(Build.SourcesDirectory)/samples/**;$(Build.SourcesDirectory)/**/tests/**'


### PR DESCRIPTION
Ignore sample and test directories so Component Governance reports only dependencies relevant to shipping SDK code.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: 900fd06f-19a5-4914-a9ca-8d9f6ee3b327
