### PR TITLE
Expose latest committed through C ABI

### DIFF
--- a/sdk/cosmos/azure_data_cosmos_driver_native/c_tests/operation_construction.c
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/c_tests/operation_construction.c
@@ -25,6 +25,12 @@ static int test_options_default_is_all_unset(void)
     int result = TEST_PASS;
     cosmos_operation_options_t opts = cosmos_operation_options_default();
 
+    ASSERT(COSMOS_READ_CONSISTENCY_STRATEGY_GLOBAL_STRONG == 4,
+           "global strong ABI value (=%d)",
+           COSMOS_READ_CONSISTENCY_STRATEGY_GLOBAL_STRONG);
+    ASSERT(COSMOS_READ_CONSISTENCY_STRATEGY_LATEST_COMMITTED == 5,
+           "latest committed ABI value (=%d)",
+           COSMOS_READ_CONSISTENCY_STRATEGY_LATEST_COMMITTED);
     ASSERT(opts.read_consistency_strategy == 0,
            "read_consistency unset (=%d)", opts.read_consistency_strategy);
     ASSERT(opts.content_response_on_write == 0,

--- a/sdk/cosmos/azure_data_cosmos_driver_native/include/azurecosmosdriver.h
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/include/azurecosmosdriver.h
@@ -435,6 +435,10 @@ enum cosmos_CosmosReadConsistencyStrategy
    * Read the latest version across all regions (single-master / Strong).
    */
   COSMOS_READ_CONSISTENCY_STRATEGY_GLOBAL_STRONG = 4,
+  /**
+   * Read the latest committed version using a quorum read.
+   */
+  COSMOS_READ_CONSISTENCY_STRATEGY_LATEST_COMMITTED = 5,
 };
 #ifndef __cplusplus
 #if __STDC_VERSION__ >= 202311L

--- a/sdk/cosmos/azure_data_cosmos_driver_native/src/op_request.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/src/op_request.rs
@@ -135,6 +135,8 @@ pub enum CosmosReadConsistencyStrategy {
     CosmosReadConsistencyStrategySession = 3,
     /// Read the latest version across all regions (single-master / Strong).
     CosmosReadConsistencyStrategyGlobalStrong = 4,
+    /// Read the latest committed version using a quorum read.
+    CosmosReadConsistencyStrategyLatestCommitted = 5,
 }
 
 impl CosmosReadConsistencyStrategy {
@@ -153,6 +155,7 @@ impl CosmosReadConsistencyStrategy {
             2 => Self::CosmosReadConsistencyStrategyEventual,
             3 => Self::CosmosReadConsistencyStrategySession,
             4 => Self::CosmosReadConsistencyStrategyGlobalStrong,
+            5 => Self::CosmosReadConsistencyStrategyLatestCommitted,
             _ => return Err(CosmosErrorCode::CosmosErrorCodeInvalidOptionValue),
         })
     }
@@ -165,6 +168,9 @@ impl CosmosReadConsistencyStrategy {
             Self::CosmosReadConsistencyStrategySession => Some(ReadConsistencyStrategy::Session),
             Self::CosmosReadConsistencyStrategyGlobalStrong => {
                 Some(ReadConsistencyStrategy::GlobalStrong)
+            }
+            Self::CosmosReadConsistencyStrategyLatestCommitted => {
+                Some(ReadConsistencyStrategy::LatestCommitted)
             }
         })
     }
@@ -1156,6 +1162,10 @@ mod tests {
             S::CosmosReadConsistencyStrategyGlobalStrong.to_driver(),
             Ok(Some(ReadConsistencyStrategy::GlobalStrong))
         );
+        assert_eq!(
+            S::CosmosReadConsistencyStrategyLatestCommitted.to_driver(),
+            Ok(Some(ReadConsistencyStrategy::LatestCommitted))
+        );
     }
 
     #[test]
@@ -1185,6 +1195,10 @@ mod tests {
         );
         assert_eq!(
             S::from_i32(5),
+            Ok(S::CosmosReadConsistencyStrategyLatestCommitted)
+        );
+        assert_eq!(
+            S::from_i32(6),
             Err(CosmosErrorCode::CosmosErrorCodeInvalidOptionValue)
         );
         assert_eq!(


### PR DESCRIPTION
## Summary

- append `LatestCommitted = 5` to the native read-consistency ABI without renumbering `GlobalStrong = 4`
- map the new host value to the Rust driver's `ReadConsistencyStrategy::LatestCommitted`
- regenerate the checked-in C header and cover the discriminant in Rust and C tests

Addresses Azure/azure-sdk-for-go#27351.