### PR TITLE
Add default-feature legs to the Rust PR build matrix

### DIFF
--- a/doc/checks.md
+++ b/doc/checks.md
@@ -8,6 +8,18 @@ The Engineering System provides a set of [standard checks](https://dev.azure.com
 
 ## Rust-specific checks
 
+### Pull request Cargo feature coverage
+
+The pull request test matrix validates changed packages with all Cargo features on
+the existing platform and toolchain legs. It also has stable-toolchain legs for
+Linux amd64 and macOS arm64 that validate Cargo's default feature set. Those two
+legs omit `--all-features` from the package build, doctest, target test, and
+benchmark test commands.
+
+Source analysis remains a separate Linux job and continues to run check, Clippy,
+dependency policy, and documentation commands with all features enabled. The
+default-feature matrix legs do not duplicate source analysis.
+
 ### Checks included in `cargo`
 
 The following checks are included in the Rust toolchain or are part of cargo.

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -43,6 +43,9 @@ jobs:
       image: $(OSVmImage)
     os: ${{ parameters.OSName }}
 
+  variables:
+    TestFeatureSet: $[ coalesce(variables['TestFeatureSet'], 'All') ]
+
   steps:
   - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
     parameters:
@@ -83,6 +86,7 @@ jobs:
       filePath: $(Build.SourcesDirectory)/eng/scripts/Test-Packages.ps1
       arguments: >
         -PackageInfoDirectory '$(Build.ArtifactStagingDirectory)/PackageInfo'
+        -FeatureSet '$(TestFeatureSet)'
 
   - task: Powershell@2
     displayName: Convert Test Results to JUnit XML

--- a/eng/pipelines/templates/stages/pr-platform-matrix.json
+++ b/eng/pipelines/templates/stages/pr-platform-matrix.json
@@ -1,5 +1,9 @@
 {
-  "displayNames": {},
+  "displayNames": {
+    "TestFeatureSet": {
+      "Default": "Default Features"
+    }
+  },
   "matrix": {
     "Agent": {
       "ubuntu": {
@@ -37,6 +41,20 @@
     {
       "OSVmImage": "env:WINDOWSVMIMAGE",
       "RustToolchainName": "nightly"
+    }
+  ],
+  "include": [
+    {
+      "OSVmImage": "env:LINUXVMIMAGE",
+      "Pool": "env:LINUXPOOL",
+      "RustToolchainName": "stable",
+      "TestFeatureSet": "Default"
+    },
+    {
+      "OSVmImage": "env:MACVMIMAGEM1",
+      "Pool": "env:MACPOOL",
+      "RustToolchainName": "stable",
+      "TestFeatureSet": "Default"
     }
   ]
 }

--- a/eng/pipelines/templates/stages/pr-platform-matrix.json
+++ b/eng/pipelines/templates/stages/pr-platform-matrix.json
@@ -1,8 +1,7 @@
 {
   "displayNames": {
-    "TestFeatureSet": {
-      "Default": "Default Features"
-    }
+    "All": "AllFeatures",
+    "Default": "DefaultFeatures"
   },
   "matrix": {
     "Agent": {
@@ -23,6 +22,9 @@
       "stable",
       "msrv",
       "nightly"
+    ],
+    "TestFeatureSet": [
+      "All"
     ]
   },
   "exclude": [
@@ -45,14 +47,22 @@
   ],
   "include": [
     {
-      "OSVmImage": "env:LINUXVMIMAGE",
-      "Pool": "env:LINUXPOOL",
+      "Agent": {
+        "ubuntu": {
+          "OSVmImage": "env:LINUXVMIMAGE",
+          "Pool": "env:LINUXPOOL"
+        }
+      },
       "RustToolchainName": "stable",
       "TestFeatureSet": "Default"
     },
     {
-      "OSVmImage": "env:MACVMIMAGEM1",
-      "Pool": "env:MACPOOL",
+      "Agent": {
+        "macos": {
+          "OSVmImage": "env:MACVMIMAGEM1",
+          "Pool": "env:MACPOOL"
+        }
+      },
       "RustToolchainName": "stable",
       "TestFeatureSet": "Default"
     }

--- a/eng/scripts/Test-Packages.ps1
+++ b/eng/scripts/Test-Packages.ps1
@@ -5,7 +5,9 @@
 
 #Requires -Version 7.0
 param(
-  [string]$PackageInfoDirectory
+  [string]$PackageInfoDirectory,
+  [ValidateSet('All', 'Default')]
+  [string]$FeatureSet = 'All'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -15,6 +17,7 @@ Set-StrictMode -Version 2.0
 
 $activeToolchain = Get-ResolvedRustToolchain
 $usesJsonTestOutput = Test-IsNightlyRustToolchain
+$cargoFeatureArgs = if ($FeatureSet -eq 'All') { @('--all-features') } else { @() }
 
 # Helper function to run cargo test, capturing JSON output only when the active
 # toolchain supports `--format json -Z unstable-options`.
@@ -25,7 +28,8 @@ function Invoke-CargoTest (
   [string]$OutputFile
 ) {
   Write-Host "Running tests for $PackageName"
-  $command = "cargo test $TestParams --manifest-path $ManifestPath --all-features --no-fail-fast"
+  $commandParts = @('cargo', 'test', $TestParams, '--manifest-path', $ManifestPath) + $cargoFeatureArgs + @('--no-fail-fast')
+  $command = $commandParts -join ' '
 
   if ($usesJsonTestOutput) {
     $result = Invoke-LoggedCommand `
@@ -61,6 +65,7 @@ Testing packages with
     SYSTEM_ACCESSTOKEN: $($env:SYSTEM_ACCESSTOKEN ? 'present' : 'not present')
     ARM_OIDC_TOKEN: $($env:ARM_OIDC_TOKEN ? 'present' : 'not present')
     Active Rust toolchain: '$activeToolchain'
+    Cargo feature set: '$FeatureSet'
 "@
 
 $testResultsDir = ([System.IO.Path]::Combine($RepoRoot, 'test-results'))
@@ -108,7 +113,8 @@ foreach ($package in $packagesToTest) {
 
   Write-Host "`n`nTesting package: '$($package.Name)'`n"
 
-  Invoke-LoggedCommand "cargo build --all-features --keep-going" -GroupOutput
+  $buildCommand = (@('cargo', 'build') + $cargoFeatureArgs + @('--keep-going')) -join ' '
+  Invoke-LoggedCommand $buildCommand -GroupOutput
   Write-Host "`n`n"
 
   $manifestPath = [System.IO.Path]::Combine($packageDirectory, 'Cargo.toml')
@@ -128,9 +134,8 @@ foreach ($package in $packagesToTest) {
     -ManifestPath $manifestPath `
     -OutputFile $allTargetsOutput
 
-  Invoke-LoggedCommand `
-    "cargo test --benches --manifest-path $manifestPath --all-features --no-fail-fast" `
-    -GroupOutput
+  $benchCommand = (@('cargo', 'test', '--benches', '--manifest-path', $manifestPath) + $cargoFeatureArgs + @('--no-fail-fast')) -join ' '
+  Invoke-LoggedCommand $benchCommand -GroupOutput
 
   $cleanupScript = ([System.IO.Path]::Combine($packageDirectory, 'Test-Cleanup.ps1'))
   if (Test-Path $cleanupScript) {


### PR DESCRIPTION
Add two blocking stable-toolchain PR package-test legs for Linux amd64 and macOS arm64 that validate Cargo's default feature set, in addition to the existing five all-feature legs.