### PR TITLE
Update emitter skill tsp-client usage

### DIFF
--- a/.github/skills/create-crate/SKILL.md
+++ b/.github/skills/create-crate/SKILL.md
@@ -8,9 +8,15 @@ description: Create a new Azure SDK crate from a TypeSpec specification.
 All new service crates must be generated from TypeSpec specifications in [Azure/azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). Do not hand-write client libraries from scratch.
 
 1. **Install tsp-client**
-   - Follow `eng/common/tsp-client/README.md` to install dependencies
-   - Run `npm ci` from `eng/common/tsp-client/`
-   - Use `npm exec --prefix eng/common/tsp-client -- tsp-client {command}` to invoke it from the repository root
+   - Use the repository-pinned CLI; do not invoke a globally installed binary:
+
+     ```bash
+     _TspClientDir="$(pwd)/eng/common/tsp-client"
+     npm ci --prefix "$_TspClientDir"
+     ```
+
+   - Run commands with `npm exec --prefix "$_TspClientDir" --no -- tsp-client`
+   - See [`eng/common/tsp-client/README.md`](../../../eng/common/tsp-client/README.md) for prerequisites and more context
 
 2. **Find the TypeSpec spec**
    - Look for a `tspconfig.yaml` under `specification/{service}/` in [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs)
@@ -18,14 +24,14 @@ All new service crates must be generated from TypeSpec specifications in [Azure/
    - If no emitter configuration exists, stop and report an error indicating that the TypeSpec specification in [Azure/azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs) must be updated before generating the client
 
 3. **Initialize the crate**
-   - Run `npm exec --prefix eng/common/tsp-client -- tsp-client init --tsp-config {url}` from the repository root
+   - From the repository root, run `npm exec --prefix "$_TspClientDir" --no -- tsp-client init --tsp-config {url}`
    - `{url}` is the GitHub URL to the `tspconfig.yaml`
    - Always use a specific commit SHA in the URL — never a branch or tag, which can move
    - Example: `https://github.com/Azure/azure-rest-api-specs/blob/{commit-sha}/specification/{service}/{rp}/tspconfig.yaml`
 
 4. **Generate the client**
    - Use the `azsdk_package_generate_code` MCP tool, or
-   - Run `npm exec --prefix eng/common/tsp-client -- tsp-client update` from the crate directory
+   - From the crate directory, run `npm exec --prefix "$_TspClientDir" --no -- tsp-client update`
 
 5. **Add hand-written wrappers**
    - Create `clients.rs` (or similar) for custom client constructors, authentication setup, and convenience methods

--- a/.github/skills/update-emitter/SKILL.md
+++ b/.github/skills/update-emitter/SKILL.md
@@ -3,24 +3,38 @@ name: update-emitter
 description: Update the TypeSpec emitter for Rust and optionally regenerate all clients
 ---
 
+# Update the TypeSpec emitter
+
 Run `eng/scripts/Update-Emitter.ps1` to update `eng/emitter-package.json` to the latest `@azure-tools/typespec-rust` version and regenerate the lock file.
 
 ## Regenerating clients
 
 After updating the emitter, service crates should be regenerated to pick up the new version.
 
-Service owners should regenerate only their own service crates. To regenerate a single crate, run `tsp-client update` from within the crate directory:
+Use the repository-pinned `tsp-client`; do not invoke a globally installed binary. From the repository root, install its locked dependencies:
+
+```bash
+_TspClientDir="$(pwd)/eng/common/tsp-client"
+npm ci --prefix "$_TspClientDir"
+```
+
+Run `tsp-client` with `npm exec --prefix "$_TspClientDir" --no --` while the current directory is the client library root. Service owners should regenerate only their own service crates.
+
+To regenerate a single crate:
 
 ```bash
 cd sdk/{service-directory}/{crate-directory}
-tsp-client update
+npm exec --prefix "$_TspClientDir" --no -- tsp-client update
 ```
 
-To regenerate all crates under a service directory:
+To regenerate all crates under a service directory from the repository root:
 
 ```bash
-find sdk/{service-directory} -name tsp-location.yaml -execdir tsp-client update \;
+find sdk/{service-directory} -name tsp-location.yaml -execdir \
+  npm exec --prefix "$_TspClientDir" --no -- tsp-client update \;
 ```
+
+See [`eng/common/tsp-client/README.md`](../../../eng/common/tsp-client/README.md) for prerequisites, additional commands, and package management details.
 
 ## After regenerating
 


### PR DESCRIPTION
Document how to install and run the repository-pinned tsp-client so client regeneration uses reproducible tooling from the correct working directory. Link to the canonical README for less common commands and package maintenance details.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: c2c591f7-a390-4422-a58b-d2ed7fb43c32
