### PR TITLE
Add create-hotfix skill

### DIFF
--- a/.github/skills/create-hotfix/SKILL.md
+++ b/.github/skills/create-hotfix/SKILL.md
@@ -33,7 +33,23 @@ Use the bundled script for deterministic discovery and git operations. Run all c
    python3 .github/skills/create-hotfix/create_hotfix.py cherry-pick <sha>...
    ```
 
-   If cherry-picking conflicts, stop and report the conflict without aborting or skipping it.
+   The script automatically resolves `Cargo.lock` conflicts by taking `--ours`,
+   then regenerating it with:
+
+   ```bash
+   cargo generate-lockfile --manifest-path Cargo.toml
+   ```
+
+   If the JSON result has a `waiting` status, prompt the user to resolve and
+   stage the listed conflicts. Remain waiting for the user to confirm they are
+   ready, then run:
+
+   ```bash
+   python3 .github/skills/create-hotfix/create_hotfix.py continue
+   ```
+
+   Repeat this step if another commit conflicts. Do not abort or skip commits.
+   Only show the final message after the script returns a `complete` status.
 
 5. Report the selected crate, base tag, patch version, branch, and cherry-picked commits. Tell the user:
 

--- a/.github/skills/create-hotfix/SKILL.md
+++ b/.github/skills/create-hotfix/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: create-hotfix
+description: Create a hotfix (patch) release branch for an Azure SDK Rust crate.
+---
+
+# Create a Hotfix
+
+Use the bundled script for deterministic discovery and git operations. Run all commands from the repository root.
+
+1. List workspace crates:
+
+   ```bash
+   python3 .github/skills/create-hotfix/create_hotfix.py list-crates
+   ```
+
+   Use a single-select prompt to ask the user which crate to patch, using the
+   crate names from the JSON output.
+
+2. Prepare the hotfix:
+
+   ```bash
+   python3 .github/skills/create-hotfix/create_hotfix.py prepare <crate-name>
+   ```
+
+   The command fetches tags and `main` directly from `https://github.com/Azure/azure-sdk-for-rust`, finds the latest stable `<crate-name>@<version>` tag, calculates the next patch version, creates `hotfix/<crate-name>-<version>` from that tag unless already on a `hotfix/` branch, and returns candidate commits from `main` as JSON.
+
+3. If candidates were returned, prompt the user with a multiselect containing
+   each candidate's SHA and deterministic summary. Allow selecting none.
+
+4. If commits are selected, preserve their displayed order and run:
+
+   ```bash
+   python3 .github/skills/create-hotfix/create_hotfix.py cherry-pick <sha>...
+   ```
+
+   If cherry-picking conflicts, stop and report the conflict without aborting or skipping it.
+
+5. Report the selected crate, base tag, patch version, branch, and cherry-picked commits. Tell the user:
+
+   > Make any additional hotfix changes on this branch. Do not merge this branch
+   > into `main`; cherry-pick any new fixes into `main` separately. See the
+   > [Azure SDK hotfix branch policy](https://azure.github.io/azure-sdk/policies_repobranching.html#hotfix-branches)
+   > for more information.

--- a/.github/skills/create-hotfix/create_hotfix.py
+++ b/.github/skills/create-hotfix/create_hotfix.py
@@ -54,7 +54,7 @@ def workspace_crates(root: Path) -> list[dict[str, str]]:
     crates = []
 
     for package in metadata["packages"]:
-        if package["id"] not in workspace_members:
+        if package["id"] not in workspace_members or package["publish"] == []:
             continue
 
         manifest = Path(package["manifest_path"]).resolve()
@@ -285,15 +285,17 @@ def summarize_files(files: list[dict[str, object]]) -> str:
     return ", ".join(summaries)
 
 
-def candidate_commits(base_tag: str, crate_path: str) -> list[dict[str, object]]:
+def candidate_commits(crate_path: str) -> list[dict[str, object]]:
     output = run(
         "git",
         "log",
         "--no-color",
         "--reverse",
         "--no-merges",
+        "--cherry-pick",
+        "--right-only",
         "--format=%H%x09%s",
-        f"{base_tag}..FETCH_HEAD",
+        "HEAD...FETCH_HEAD",
         "--",
         crate_path,
     )
@@ -327,7 +329,7 @@ def prepare(args: argparse.Namespace) -> dict[str, object]:
     run("git", "fetch", UPSTREAM_URL)
     if run("git", "rev-parse", "FETCH_HEAD").strip() != upstream_main_commit():
         raise CommandError(f"{UPSTREAM_URL} HEAD does not point to main")
-    commits = candidate_commits(base_tag, crate["path"])
+    commits = candidate_commits(crate["path"])
     return {
         "crate": crate,
         "base_tag": base_tag,
@@ -358,10 +360,12 @@ def cherry_pick(args: argparse.Namespace) -> dict[str, object]:
     branch = current_branch()
     if not branch.startswith("hotfix/"):
         raise CommandError("cherry-pick must run from a hotfix/ branch")
+    if cherry_pick_in_progress():
+        raise CommandError(
+            "a cherry-pick is already in progress; use the continue command"
+        )
 
-    if not cherry_pick_in_progress():
-        lock_conflict_marker().unlink(missing_ok=True)
-
+    lock_conflict_marker().unlink(missing_ok=True)
     command = ("git", "cherry-pick", *args.commits)
     result = run_process(*command)
     if result.returncode == 0:

--- a/.github/skills/create-hotfix/create_hotfix.py
+++ b/.github/skills/create-hotfix/create_hotfix.py
@@ -18,17 +18,27 @@ class CommandError(RuntimeError):
     pass
 
 
-def run(*args: str) -> str:
-    result = subprocess.run(
+def run_process(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
         args,
         check=False,
         encoding="utf-8",
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
+
+
+def command_error(
+    args: tuple[str, ...], result: subprocess.CompletedProcess[str]
+) -> CommandError:
+    detail = result.stderr.strip() or result.stdout.strip()
+    return CommandError(f"{' '.join(args)} failed: {detail}")
+
+
+def run(*args: str) -> str:
+    result = run_process(*args)
     if result.returncode:
-        detail = result.stderr.strip() or result.stdout.strip()
-        raise CommandError(f"{' '.join(args)} failed: {detail}")
+        raise command_error(args, result)
     return result.stdout
 
 
@@ -137,6 +147,44 @@ def current_branch() -> str:
 
 def worktree_is_clean() -> bool:
     return not run("git", "status", "--porcelain").strip()
+
+
+def git_path(name: str) -> Path:
+    return Path(run("git", "rev-parse", "--git-path", name).strip())
+
+
+def cherry_pick_in_progress() -> bool:
+    return git_path("CHERRY_PICK_HEAD").exists()
+
+
+def lock_conflict_marker() -> Path:
+    return git_path("create-hotfix-cargo-lock-conflict")
+
+
+def conflicted_files() -> list[str]:
+    output = run("git", "diff", "--name-only", "--diff-filter=U", "-z")
+    return sorted(path for path in output.split("\0") if path)
+
+
+def resolve_cargo_lock_conflict() -> list[str]:
+    conflicts = conflicted_files()
+    if "Cargo.lock" not in conflicts:
+        return conflicts
+
+    run("git", "checkout", "--ours", "--", "Cargo.lock")
+    run("git", "add", "Cargo.lock")
+    lock_conflict_marker().touch()
+    return [path for path in conflicts if path != "Cargo.lock"]
+
+
+def regenerate_cargo_lock() -> None:
+    marker = lock_conflict_marker()
+    if not marker.exists():
+        return
+
+    run("cargo", "generate-lockfile", "--manifest-path", "Cargo.toml")
+    run("git", "add", "Cargo.lock")
+    marker.unlink()
 
 
 def is_ancestor(ancestor: str, descendant: str) -> bool:
@@ -289,12 +337,54 @@ def prepare(args: argparse.Namespace) -> dict[str, object]:
     }
 
 
+def advance_cherry_pick(branch: str) -> dict[str, object]:
+    while True:
+        conflicts = resolve_cargo_lock_conflict()
+        if conflicts:
+            return {"status": "waiting", "branch": branch, "conflicts": conflicts}
+
+        regenerate_cargo_lock()
+        command = ("git", "-c", "core.editor=true", "cherry-pick", "--continue")
+        result = run_process(*command)
+        if result.returncode == 0:
+            return {"status": "complete", "branch": branch}
+        if not cherry_pick_in_progress():
+            raise command_error(command, result)
+        if not conflicted_files():
+            raise command_error(command, result)
+
+
 def cherry_pick(args: argparse.Namespace) -> dict[str, object]:
     branch = current_branch()
     if not branch.startswith("hotfix/"):
         raise CommandError("cherry-pick must run from a hotfix/ branch")
-    run("git", "cherry-pick", *args.commits)
-    return {"branch": branch, "cherry_picked": args.commits}
+
+    if not cherry_pick_in_progress():
+        lock_conflict_marker().unlink(missing_ok=True)
+
+    command = ("git", "cherry-pick", *args.commits)
+    result = run_process(*command)
+    if result.returncode == 0:
+        return {
+            "status": "complete",
+            "branch": branch,
+            "cherry_picked": args.commits,
+        }
+    if not cherry_pick_in_progress():
+        raise command_error(command, result)
+    if not conflicted_files():
+        raise command_error(command, result)
+    return advance_cherry_pick(branch)
+
+
+def continue_cherry_pick(_: argparse.Namespace) -> dict[str, object]:
+    branch = current_branch()
+    if not branch.startswith("hotfix/"):
+        raise CommandError("continue must run from a hotfix/ branch")
+    if not cherry_pick_in_progress():
+        lock_conflict_marker().unlink(missing_ok=True)
+        raise CommandError("no cherry-pick is in progress")
+    return advance_cherry_pick(branch)
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -319,6 +409,11 @@ def create_parser() -> argparse.ArgumentParser:
     )
     cherry_pick_parser.add_argument("commits", nargs="+", help="Commit SHAs.")
     cherry_pick_parser.set_defaults(handler=cherry_pick)
+
+    continue_parser = subparsers.add_parser(
+        "continue", help="Continue after resolving and staging other conflicts."
+    )
+    continue_parser.set_defaults(handler=continue_cherry_pick)
     return parser
 
 

--- a/.github/skills/create-hotfix/create_hotfix.py
+++ b/.github/skills/create-hotfix/create_hotfix.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+UPSTREAM_URL = "https://github.com/Azure/azure-sdk-for-rust"
+STABLE_VERSION = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)")
+
+
+class CommandError(RuntimeError):
+    pass
+
+
+def run(*args: str) -> str:
+    result = subprocess.run(
+        args,
+        check=False,
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise CommandError(f"{' '.join(args)} failed: {detail}")
+    return result.stdout
+
+
+def repository_root() -> Path:
+    return Path(run("git", "rev-parse", "--show-toplevel").strip()).resolve()
+
+
+def workspace_crates(root: Path) -> list[dict[str, str]]:
+    metadata = json.loads(
+        run("cargo", "metadata", "--no-deps", "--format-version", "1")
+    )
+    workspace_members = set(metadata["workspace_members"])
+    crates = []
+
+    for package in metadata["packages"]:
+        if package["id"] not in workspace_members:
+            continue
+
+        manifest = Path(package["manifest_path"]).resolve()
+        crate_dir = manifest.parent
+        try:
+            relative_dir = crate_dir.relative_to(root)
+        except ValueError:
+            continue
+
+        crates.append(
+            {
+                "name": package["name"],
+                "path": relative_dir.as_posix(),
+                "version": package["version"],
+            }
+        )
+
+    return sorted(crates, key=lambda crate: (crate["name"], crate["path"]))
+
+
+def find_crate(root: Path, crate_name: str) -> dict[str, str]:
+    matches = [crate for crate in workspace_crates(root) if crate["name"] == crate_name]
+    if not matches:
+        raise CommandError(f"crate is not a workspace member: {crate_name}")
+    if len(matches) > 1:
+        paths = ", ".join(crate["path"] for crate in matches)
+        raise CommandError(f"crate name is ambiguous ({crate_name}): {paths}")
+    return matches[0]
+
+
+def parse_stable_tag(crate_name: str, tag: str) -> tuple[int, int, int] | None:
+    prefix = f"{crate_name}@"
+    if not tag.startswith(prefix):
+        return None
+
+    match = STABLE_VERSION.fullmatch(tag[len(prefix) :])
+    if not match:
+        return None
+
+    return tuple(int(part) for part in match.groups())
+
+
+def resolve_base_tag(crate_name: str, tags: list[str]) -> tuple[str, str]:
+    stable_tags = []
+    for tag in tags:
+        version = parse_stable_tag(crate_name, tag)
+        if version is not None:
+            stable_tags.append((version, tag))
+
+    if not stable_tags:
+        raise CommandError(
+            f"no stable release tag found matching {crate_name}@<major>.<minor>.<patch>"
+        )
+
+    version, tag = max(stable_tags)
+    next_version = f"{version[0]}.{version[1]}.{version[2] + 1}"
+    return tag, next_version
+
+
+def upstream_tags(crate_name: str) -> list[str]:
+    output = run(
+        "git",
+        "ls-remote",
+        "--refs",
+        "--tags",
+        UPSTREAM_URL,
+        f"refs/tags/{crate_name}@*",
+    )
+    return [
+        line.split("\t", 1)[1].removeprefix("refs/tags/")
+        for line in output.splitlines()
+    ]
+
+
+def upstream_main_commit() -> str:
+    output = run(
+        "git", "ls-remote", "--heads", UPSTREAM_URL, "refs/heads/main"
+    ).strip()
+    if not output:
+        raise CommandError(f"main branch not found at {UPSTREAM_URL}")
+    return output.split("\t", 1)[0]
+
+
+def current_branch() -> str:
+    branch = run("git", "branch", "--show-current").strip()
+    if not branch:
+        raise CommandError("HEAD is detached")
+    return branch
+
+
+def worktree_is_clean() -> bool:
+    return not run("git", "status", "--porcelain").strip()
+
+
+def is_ancestor(ancestor: str, descendant: str) -> bool:
+    result = subprocess.run(
+        ("git", "merge-base", "--is-ancestor", ancestor, descendant),
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+    )
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    raise CommandError(
+        f"git merge-base --is-ancestor failed: {result.stderr.strip()}"
+    )
+
+
+def ensure_hotfix_branch(crate_name: str, version: str, base_tag: str) -> str:
+    branch = current_branch()
+    if branch.startswith("hotfix/"):
+        return branch
+
+    if not worktree_is_clean():
+        raise CommandError(
+            "working tree must be clean before creating or switching hotfix branches"
+        )
+
+    branch = f"hotfix/{crate_name}-{version}"
+    existing = run("git", "branch", "--list", branch).strip()
+    if existing:
+        if not is_ancestor(base_tag, branch):
+            raise CommandError(
+                f"existing branch {branch} is not based on {base_tag}"
+            )
+        run("git", "switch", branch)
+    else:
+        run("git", "switch", "--create", branch, base_tag)
+    return branch
+
+
+def changed_files(commit: str, crate_path: str) -> list[dict[str, object]]:
+    name_status = run(
+        "git",
+        "diff-tree",
+        "--no-commit-id",
+        "--name-status",
+        "--no-renames",
+        "-r",
+        commit,
+        "--",
+        crate_path,
+    )
+    numstat = run(
+        "git",
+        "diff-tree",
+        "--no-commit-id",
+        "--numstat",
+        "--no-renames",
+        "-r",
+        commit,
+        "--",
+        crate_path,
+    )
+
+    stats = {}
+    for line in numstat.splitlines():
+        additions, deletions, path = line.split("\t", 2)
+        stats[path] = {
+            "additions": None if additions == "-" else int(additions),
+            "deletions": None if deletions == "-" else int(deletions),
+        }
+
+    files = []
+    for line in name_status.splitlines():
+        parts = line.split("\t")
+        status = parts[0]
+        path = parts[-1]
+        file_change = {"path": path, "status": status}
+        file_change.update(stats.get(path, {"additions": None, "deletions": None}))
+        files.append(file_change)
+    return files
+
+
+def summarize_files(files: list[dict[str, object]]) -> str:
+    summaries = []
+    for file_change in files:
+        additions = file_change["additions"]
+        deletions = file_change["deletions"]
+        if additions is None or deletions is None:
+            stats = "binary"
+        else:
+            stats = f"+{additions}/-{deletions}"
+        summaries.append(
+            f"{file_change['status']} {file_change['path']} ({stats})"
+        )
+    return ", ".join(summaries)
+
+
+def candidate_commits(base_tag: str, crate_path: str) -> list[dict[str, object]]:
+    output = run(
+        "git",
+        "log",
+        "--no-color",
+        "--reverse",
+        "--no-merges",
+        "--format=%H%x09%s",
+        f"{base_tag}..FETCH_HEAD",
+        "--",
+        crate_path,
+    )
+    commits = []
+    for line in output.splitlines():
+        full_sha, subject = line.split("\t", 1)
+        files = changed_files(full_sha, crate_path)
+        commits.append(
+            {
+                "sha": full_sha,
+                "summary": f"{full_sha[:12]} {subject}: {summarize_files(files)}",
+            }
+        )
+    return commits
+
+
+def list_crates(_: argparse.Namespace) -> dict[str, object]:
+    root = repository_root()
+    return {"crates": workspace_crates(root)}
+
+
+def prepare(args: argparse.Namespace) -> dict[str, object]:
+    root = repository_root()
+    crate = find_crate(root, args.crate)
+
+    run("git", "fetch", UPSTREAM_URL, "--tags")
+    tags = upstream_tags(args.crate)
+    base_tag, patch_version = resolve_base_tag(args.crate, tags)
+    branch = ensure_hotfix_branch(args.crate, patch_version, base_tag)
+
+    run("git", "fetch", UPSTREAM_URL)
+    if run("git", "rev-parse", "FETCH_HEAD").strip() != upstream_main_commit():
+        raise CommandError(f"{UPSTREAM_URL} HEAD does not point to main")
+    commits = candidate_commits(base_tag, crate["path"])
+    return {
+        "crate": crate,
+        "base_tag": base_tag,
+        "patch_version": patch_version,
+        "branch": branch,
+        "candidates": commits,
+    }
+
+
+def cherry_pick(args: argparse.Namespace) -> dict[str, object]:
+    branch = current_branch()
+    if not branch.startswith("hotfix/"):
+        raise CommandError("cherry-pick must run from a hotfix/ branch")
+    run("git", "cherry-pick", *args.commits)
+    return {"branch": branch, "cherry_picked": args.commits}
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Prepare a crate hotfix branch from its latest stable release tag."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser(
+        "list-crates", help="List workspace crates as JSON."
+    )
+    list_parser.set_defaults(handler=list_crates)
+
+    prepare_parser = subparsers.add_parser(
+        "prepare", help="Create or reuse a hotfix branch and list candidate fixes."
+    )
+    prepare_parser.add_argument("crate", help="Workspace crate name.")
+    prepare_parser.set_defaults(handler=prepare)
+
+    cherry_pick_parser = subparsers.add_parser(
+        "cherry-pick", help="Cherry-pick selected commits in the given order."
+    )
+    cherry_pick_parser.add_argument("commits", nargs="+", help="Commit SHAs.")
+    cherry_pick_parser.set_defaults(handler=cherry_pick)
+    return parser
+
+
+def main() -> int:
+    try:
+        args = create_parser().parse_args()
+        print(json.dumps(args.handler(args), indent=2))
+        return 0
+    except (CommandError, json.JSONDecodeError) as error:
+        print(json.dumps({"error": str(error)}), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skills/create-hotfix/test_create_hotfix.py
+++ b/.github/skills/create-hotfix/test_create_hotfix.py
@@ -107,39 +107,46 @@ class StableTagTests(unittest.TestCase):
 
     @mock.patch.object(CREATE_HOTFIX, "run")
     def test_excludes_non_publishable_workspace_crates(self, run):
-        root = Path("/repo")
-        run.return_value = json.dumps(
-            {
-                "workspace_members": ["publishable", "private"],
-                "packages": [
-                    {
-                        "id": "publishable",
-                        "name": "azure_identity",
-                        "version": "1.0.0",
-                        "manifest_path": "/repo/sdk/identity/azure_identity/Cargo.toml",
-                        "publish": None,
-                    },
-                    {
-                        "id": "private",
-                        "name": "azure_core_test",
-                        "version": "0.1.0",
-                        "manifest_path": "/repo/sdk/core/azure_core_test/Cargo.toml",
-                        "publish": [],
-                    },
-                ],
-            }
-        )
-
-        self.assertEqual(
-            [
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            identity_manifest = (
+                root / "sdk" / "identity" / "azure_identity" / "Cargo.toml"
+            )
+            core_test_manifest = (
+                root / "sdk" / "core" / "azure_core_test" / "Cargo.toml"
+            )
+            run.return_value = json.dumps(
                 {
-                    "name": "azure_identity",
-                    "path": "sdk/identity/azure_identity",
-                    "version": "1.0.0",
+                    "workspace_members": ["publishable", "private"],
+                    "packages": [
+                        {
+                            "id": "publishable",
+                            "name": "azure_identity",
+                            "version": "1.0.0",
+                            "manifest_path": str(identity_manifest),
+                            "publish": None,
+                        },
+                        {
+                            "id": "private",
+                            "name": "azure_core_test",
+                            "version": "0.1.0",
+                            "manifest_path": str(core_test_manifest),
+                            "publish": [],
+                        },
+                    ],
                 }
-            ],
-            CREATE_HOTFIX.workspace_crates(root),
-        )
+            )
+
+            self.assertEqual(
+                [
+                    {
+                        "name": "azure_identity",
+                        "path": "sdk/identity/azure_identity",
+                        "version": "1.0.0",
+                    }
+                ],
+                CREATE_HOTFIX.workspace_crates(root),
+            )
 
 
 class ConflictTests(unittest.TestCase):

--- a/.github/skills/create-hotfix/test_create_hotfix.py
+++ b/.github/skills/create-hotfix/test_create_hotfix.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import importlib.util
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -104,6 +105,42 @@ class StableTagTests(unittest.TestCase):
             "refs/tags/azure_identity@*",
         )
 
+    @mock.patch.object(CREATE_HOTFIX, "run")
+    def test_excludes_non_publishable_workspace_crates(self, run):
+        root = Path("/repo")
+        run.return_value = json.dumps(
+            {
+                "workspace_members": ["publishable", "private"],
+                "packages": [
+                    {
+                        "id": "publishable",
+                        "name": "azure_identity",
+                        "version": "1.0.0",
+                        "manifest_path": "/repo/sdk/identity/azure_identity/Cargo.toml",
+                        "publish": None,
+                    },
+                    {
+                        "id": "private",
+                        "name": "azure_core_test",
+                        "version": "0.1.0",
+                        "manifest_path": "/repo/sdk/core/azure_core_test/Cargo.toml",
+                        "publish": [],
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual(
+            [
+                {
+                    "name": "azure_identity",
+                    "path": "sdk/identity/azure_identity",
+                    "version": "1.0.0",
+                }
+            ],
+            CREATE_HOTFIX.workspace_crates(root),
+        )
+
 
 class ConflictTests(unittest.TestCase):
     def test_resolves_cargo_lock_and_returns_other_conflicts(self):
@@ -147,6 +184,21 @@ class ConflictTests(unittest.TestCase):
                 CREATE_HOTFIX.CommandError, "no cherry-pick is in progress"
             ):
                 CREATE_HOTFIX.continue_cherry_pick(args)
+
+    def test_cherry_pick_rejects_an_active_sequence(self):
+        args = mock.Mock(commits=["abc"])
+        with (
+            mock.patch.object(
+                CREATE_HOTFIX, "current_branch", return_value="hotfix/fixture"
+            ),
+            mock.patch.object(
+                CREATE_HOTFIX, "cherry_pick_in_progress", return_value=True
+            ),
+        ):
+            with self.assertRaisesRegex(
+                CREATE_HOTFIX.CommandError, "use the continue command"
+            ):
+                CREATE_HOTFIX.cherry_pick(args)
 
     def test_advance_stops_on_non_conflict_failure(self):
         result = CREATE_HOTFIX.subprocess.CompletedProcess(

--- a/.github/skills/create-hotfix/test_create_hotfix.py
+++ b/.github/skills/create-hotfix/test_create_hotfix.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import importlib.util
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -101,6 +102,104 @@ class StableTagTests(unittest.TestCase):
             "--tags",
             CREATE_HOTFIX.UPSTREAM_URL,
             "refs/tags/azure_identity@*",
+        )
+
+
+class ConflictTests(unittest.TestCase):
+    def test_resolves_cargo_lock_and_returns_other_conflicts(self):
+        with tempfile.TemporaryDirectory() as directory:
+            marker = Path(directory) / "lock-conflict"
+            with (
+                mock.patch.object(
+                    CREATE_HOTFIX,
+                    "conflicted_files",
+                    return_value=["Cargo.lock", "src/lib.rs"],
+                ),
+                mock.patch.object(CREATE_HOTFIX, "lock_conflict_marker") as get_marker,
+                mock.patch.object(CREATE_HOTFIX, "run") as run,
+            ):
+                get_marker.return_value = marker
+                conflicts = CREATE_HOTFIX.resolve_cargo_lock_conflict()
+
+            self.assertEqual(["src/lib.rs"], conflicts)
+            self.assertTrue(marker.exists())
+        self.assertEqual(
+            [
+                mock.call("git", "checkout", "--ours", "--", "Cargo.lock"),
+                mock.call("git", "add", "Cargo.lock"),
+            ],
+            run.call_args_list,
+        )
+
+    def test_continue_requires_an_active_cherry_pick(self):
+        args = mock.Mock()
+        with (
+            mock.patch.object(
+                CREATE_HOTFIX, "current_branch", return_value="hotfix/fixture"
+            ),
+            mock.patch.object(
+                CREATE_HOTFIX, "cherry_pick_in_progress", return_value=False
+            ),
+            mock.patch.object(CREATE_HOTFIX, "lock_conflict_marker") as get_marker,
+        ):
+            get_marker.return_value = mock.Mock()
+            with self.assertRaisesRegex(
+                CREATE_HOTFIX.CommandError, "no cherry-pick is in progress"
+            ):
+                CREATE_HOTFIX.continue_cherry_pick(args)
+
+    def test_advance_stops_on_non_conflict_failure(self):
+        result = CREATE_HOTFIX.subprocess.CompletedProcess(
+            args=["git", "cherry-pick", "--continue"],
+            returncode=1,
+            stdout="",
+            stderr="the previous cherry-pick is now empty",
+        )
+        with (
+            mock.patch.object(
+                CREATE_HOTFIX, "resolve_cargo_lock_conflict", return_value=[]
+            ),
+            mock.patch.object(CREATE_HOTFIX, "regenerate_cargo_lock"),
+            mock.patch.object(CREATE_HOTFIX, "run_process", return_value=result) as run,
+            mock.patch.object(
+                CREATE_HOTFIX, "cherry_pick_in_progress", return_value=True
+            ),
+            mock.patch.object(CREATE_HOTFIX, "conflicted_files", return_value=[]),
+        ):
+            with self.assertRaisesRegex(
+                CREATE_HOTFIX.CommandError, "cherry-pick is now empty"
+            ):
+                CREATE_HOTFIX.advance_cherry_pick("hotfix/fixture")
+
+        run.assert_called_once()
+
+    def test_regenerates_cargo_lock_after_conflicts_are_resolved(self):
+        with tempfile.TemporaryDirectory() as directory:
+            marker = Path(directory) / "lock-conflict"
+            marker.touch()
+            with (
+                mock.patch.object(
+                    CREATE_HOTFIX,
+                    "lock_conflict_marker",
+                    return_value=marker,
+                ),
+                mock.patch.object(CREATE_HOTFIX, "run") as run,
+            ):
+                CREATE_HOTFIX.regenerate_cargo_lock()
+
+            self.assertFalse(marker.exists())
+
+        self.assertEqual(
+            [
+                mock.call(
+                    "cargo",
+                    "generate-lockfile",
+                    "--manifest-path",
+                    "Cargo.toml",
+                ),
+                mock.call("git", "add", "Cargo.lock"),
+            ],
+            run.call_args_list,
         )
 
 

--- a/.github/skills/create-hotfix/test_create_hotfix.py
+++ b/.github/skills/create-hotfix/test_create_hotfix.py
@@ -1,0 +1,108 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest import mock
+
+MODULE_PATH = Path(__file__).with_name("create_hotfix.py")
+SPEC = importlib.util.spec_from_file_location("create_hotfix", MODULE_PATH)
+assert SPEC and SPEC.loader
+CREATE_HOTFIX = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CREATE_HOTFIX)
+
+
+class StableTagTests(unittest.TestCase):
+    def test_parses_stable_tag(self):
+        self.assertEqual(
+            (1, 2, 3),
+            CREATE_HOTFIX.parse_stable_tag("azure_identity", "azure_identity@1.2.3"),
+        )
+
+    def test_rejects_prerelease_and_other_formats(self):
+        tags = [
+            "azure_identity@1.2.3-beta.1",
+            "azure_identity-1.2.3",
+            "azure_identity_1.2.3",
+            "azure_core@1.2.3",
+        ]
+        self.assertTrue(
+            all(
+                CREATE_HOTFIX.parse_stable_tag("azure_identity", tag) is None
+                for tag in tags
+            )
+        )
+
+    def test_rejects_invalid_semver_leading_zero(self):
+        self.assertIsNone(
+            CREATE_HOTFIX.parse_stable_tag("azure_identity", "azure_identity@1.02.3")
+        )
+
+    def test_resolves_latest_stable_tag_and_patch(self):
+        tag, patch = CREATE_HOTFIX.resolve_base_tag(
+            "azure_identity",
+            [
+                "azure_identity@1.0.0",
+                "azure_identity@1.2.0-beta.1",
+                "azure_identity@1.10.0",
+                "azure_identity@1.9.5",
+                "azure_identity@0.9.5",
+            ],
+        )
+        self.assertEqual("azure_identity@1.10.0", tag)
+        self.assertEqual("1.10.1", patch)
+
+    def test_errors_without_stable_tag(self):
+        with self.assertRaisesRegex(
+            CREATE_HOTFIX.CommandError, "no stable release tag"
+        ):
+            CREATE_HOTFIX.resolve_base_tag(
+                "azure_identity", ["azure_identity@1.1.0-beta.1"]
+            )
+
+    def test_summarizes_text_and_binary_changes(self):
+        summary = CREATE_HOTFIX.summarize_files(
+            [
+                {
+                    "path": "sdk/identity/src/lib.rs",
+                    "status": "M",
+                    "additions": 3,
+                    "deletions": 1,
+                },
+                {
+                    "path": "sdk/identity/test.bin",
+                    "status": "A",
+                    "additions": None,
+                    "deletions": None,
+                },
+            ]
+        )
+        self.assertEqual(
+            "M sdk/identity/src/lib.rs (+3/-1), "
+            "A sdk/identity/test.bin (binary)",
+            summary,
+        )
+
+    @mock.patch.object(CREATE_HOTFIX, "run")
+    def test_reads_tags_from_canonical_upstream(self, run):
+        run.return_value = (
+            "abc\trefs/tags/azure_identity@1.0.0\n"
+            "def\trefs/tags/azure_identity@1.1.0\n"
+        )
+        self.assertEqual(
+            ["azure_identity@1.0.0", "azure_identity@1.1.0"],
+            CREATE_HOTFIX.upstream_tags("azure_identity"),
+        )
+        run.assert_called_once_with(
+            "git",
+            "ls-remote",
+            "--refs",
+            "--tags",
+            CREATE_HOTFIX.UPSTREAM_URL,
+            "refs/tags/azure_identity@*",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a compact skill workflow for preparing crate hotfix and patch branches without relying on configured remotes.

Use a deterministic Python helper to discover workspace crates, resolve canonical stable release tags, create the servicing branch, summarize candidate fixes, and cherry-pick user-selected commits.

Cover stable SemVer filtering and compact change summaries with unit tests.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: d9faf2fa-0b39-40c1-8750-bc14822c1e6f
