### PR TITLE
Fix Cosmos container client call sites

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/binary_round_trip.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/binary_round_trip.rs
@@ -162,7 +162,7 @@ async fn build_multi_partition_container_with_recorder(
 
     let container = client
         .database_client(db_name)
-        .container_client("items")
+        .container_client("items", None)
         .await
         .unwrap();
     (container, recorder)
@@ -527,7 +527,7 @@ async fn binary_query_negotiates_response_and_round_trips() {
         .unwrap();
     let container = client
         .database_client("bin-query")
-        .container_client("items")
+        .container_client("items", None)
         .await
         .unwrap();
 

--- a/sdk/cosmos/azure_data_cosmos_perf/src/bin/binary_payload_ab.rs
+++ b/sdk/cosmos/azure_data_cosmos_perf/src/bin/binary_payload_ab.rs
@@ -638,7 +638,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let client = build_client(&args, Arc::clone(&recorder), *mode).await?;
         let container = client
             .database_client(&args.database)
-            .container_client(&args.container)
+            .container_client(&args.container, None)
             .await?;
         // Warm up connections, routing caches, and query plans outside of any
         // recording phase so the first measured round is not penalized.
@@ -817,7 +817,7 @@ async fn ensure_container(
         Err(err) => return Err(err.into()),
     }
 
-    Ok(database.container_client(&args.container).await?)
+    Ok(database.container_client(&args.container, None).await?)
 }
 
 /// Identifies one seeded document.


### PR DESCRIPTION
Update stale Cosmos call sites after `DatabaseClient::container_client` gained an options parameter.

- Pass default options from the binary payload benchmark.
- Pass default options from binary in-memory emulator tests.