### PR TITLE
Add crate metadata to API reviews

### DIFF
--- a/eng/tools/generate_api/AGENTS.md
+++ b/eng/tools/generate_api/AGENTS.md
@@ -60,7 +60,7 @@ The shared model is the boundary between extraction and rendering.
 
 It currently models:
 
-- package name, version, description, edition, rust-version, and features
+- package name, version, edition, rust-version, and features
 - modules
 - item doc comments
 - item attributes
@@ -177,11 +177,12 @@ Documentation handling:
 Package metadata rendering:
 
 - Markdown renders the crate name first; APIView uses only the top-level `PackageName`
-- missing description, edition, or rust-version values are omitted
+- missing edition or rust-version values are omitted
 - features use `default` plus `package.metadata.docs.rs.features` when present
 - without docs.rs feature metadata, all Cargo features render
 - crates without defined features render an empty `default` feature
 - `default` renders first, followed by other visible features in lexical order
+- render feature names only, except for the `default` feature's lexically sorted children
 - Markdown renders the crate name as H1, metadata as a list, and features under an H2
 - APIView renders metadata and features as leading text-token lines followed by a blank text line
 

--- a/eng/tools/generate_api/AGENTS.md
+++ b/eng/tools/generate_api/AGENTS.md
@@ -177,13 +177,14 @@ Documentation handling:
 Package metadata rendering:
 
 - Markdown renders the crate name first; APIView uses only the top-level `PackageName`
-- missing edition or rust-version values are omitted
+- missing description, edition, or rust-version values are omitted
+- multiline descriptions render with the `Description` label on its own line
 - features use `default` plus `package.metadata.docs.rs.features` when present
 - without docs.rs feature metadata, all Cargo features render
 - crates without defined features render an empty `default` feature
 - `default` renders first, followed by other visible features in lexical order
 - render feature names only, except for the `default` feature's lexically sorted children
-- Markdown renders the crate name as H1, metadata as a list, and features under an H2
+- Markdown renders the crate name as H1, metadata before features, and features under an H2
 - APIView renders metadata and features as leading text-token lines followed by a blank text line
 
 Signature normalization:

--- a/eng/tools/generate_api/AGENTS.md
+++ b/eng/tools/generate_api/AGENTS.md
@@ -176,11 +176,14 @@ Documentation handling:
 
 Package metadata rendering:
 
-- both formats render the crate name first
+- Markdown renders the crate name first; APIView uses only the top-level `PackageName`
 - missing description, edition, or rust-version values are omitted
-- features render in lexical order with their enabled features and dependencies as children
+- features use `default` plus `package.metadata.docs.rs.features` when present
+- without docs.rs feature metadata, all Cargo features render
+- crates without defined features render an empty `default` feature
+- `default` renders first, followed by other visible features in lexical order
 - Markdown renders the crate name as H1, metadata as a list, and features under an H2
-- APIView renders crate metadata and features as leading text-token lines
+- APIView renders metadata and features as leading text-token lines followed by a blank text line
 
 Signature normalization:
 

--- a/eng/tools/generate_api/AGENTS.md
+++ b/eng/tools/generate_api/AGENTS.md
@@ -60,7 +60,7 @@ The shared model is the boundary between extraction and rendering.
 
 It currently models:
 
-- package metadata
+- package name, version, description, edition, rust-version, and features
 - modules
 - item doc comments
 - item attributes
@@ -173,6 +173,14 @@ Documentation handling:
 - rustdoc docs stay separate from attrs in the shared model
 - markdown output omits doc comments and emits them as a companion patch
 - APIView renders comment tokens with documentation markers
+
+Package metadata rendering:
+
+- both formats render the crate name first
+- missing description, edition, or rust-version values are omitted
+- features render in lexical order with their enabled features and dependencies as children
+- Markdown renders the crate name as H1, metadata as a list, and features under an H2
+- APIView renders crate metadata and features as leading text-token lines
 
 Signature normalization:
 

--- a/eng/tools/generate_api/Cargo.toml
+++ b/eng/tools/generate_api/Cargo.toml
@@ -17,3 +17,6 @@ clap = { workspace = true }
 rustdoc-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+
+[dev-dependencies]
+diffy = "0.5.2"

--- a/eng/tools/generate_api/README.md
+++ b/eng/tools/generate_api/README.md
@@ -26,8 +26,9 @@ cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- \
 - `--format apiview` writes `apiview.json`
 - `--format apiview --no-docs` writes `apiview.json` without doc comment tokens
 
-Both formats start with the crate name, available Cargo metadata (`description`, `edition`, and
-`rust-version`), and the crate's feature graph. `API.md` never contains documentation comments.
+Both formats include available Cargo metadata (`description`, `edition`, and `rust-version`) and
+the crate's default and docs.rs feature graph (or all features when not configured). Markdown also
+starts with the crate name. `API.md` never contains documentation comments.
 `API.comments.patch` is a unified diff that adds them back, so it can be applied to toggle
 documentation comments on:
 

--- a/eng/tools/generate_api/README.md
+++ b/eng/tools/generate_api/README.md
@@ -26,9 +26,10 @@ cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- \
 - `--format apiview` writes `apiview.json`
 - `--format apiview --no-docs` writes `apiview.json` without doc comment tokens
 
-Both formats include available Cargo metadata (`description`, `edition`, and `rust-version`) and
-the crate's default and docs.rs feature graph (or all features when not configured). Markdown also
-starts with the crate name. `API.md` never contains documentation comments.
+Both formats include available Cargo metadata (`edition` and `rust-version`) and the crate's
+default and docs.rs feature list (or all features when not configured). Markdown also starts with
+the crate name. Children of the `default` feature are also listed. `API.md` never contains
+documentation comments.
 `API.comments.patch` is a unified diff that adds them back, so it can be applied to toggle
 documentation comments on:
 

--- a/eng/tools/generate_api/README.md
+++ b/eng/tools/generate_api/README.md
@@ -26,8 +26,10 @@ cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- \
 - `--format apiview` writes `apiview.json`
 - `--format apiview --no-docs` writes `apiview.json` without doc comment tokens
 
-`API.md` never contains documentation comments. `API.comments.patch` is a unified diff that adds
-them back, so it can be applied to toggle documentation comments on:
+Both formats start with the crate name, available Cargo metadata (`description`, `edition`, and
+`rust-version`), and the crate's feature graph. `API.md` never contains documentation comments.
+`API.comments.patch` is a unified diff that adds them back, so it can be applied to toggle
+documentation comments on:
 
 ```sh
 patch -p1 < API.comments.patch

--- a/eng/tools/generate_api/README.md
+++ b/eng/tools/generate_api/README.md
@@ -26,9 +26,11 @@ cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- \
 - `--format apiview` writes `apiview.json`
 - `--format apiview --no-docs` writes `apiview.json` without doc comment tokens
 
-Both formats include available Cargo metadata (`edition` and `rust-version`) and the crate's
-default and docs.rs feature list (or all features when not configured). Markdown also starts with
-the crate name. Children of the `default` feature are also listed. `API.md` never contains
+Both formats include available Cargo metadata (`description`, `edition`, and `rust-version`) and
+the crate's default and docs.rs feature list (or all features when not configured). Markdown also
+starts with the crate name. Multiline descriptions render with the `Description` label on its own
+line before the description text. Children of the `default` feature are also listed. `API.md` never
+contains
 documentation comments.
 `API.comments.patch` is a unified diff that adds them back, so it can be applied to toggle
 documentation comments on:

--- a/eng/tools/generate_api/src/driver.rs
+++ b/eng/tools/generate_api/src/driver.rs
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use crate::{cli::Request, diagnostics, extract, model::ApiModel};
+use crate::{
+    cli::Request,
+    diagnostics, extract,
+    model::{ApiModel, PackageMetadata as ApiPackageMetadata},
+};
 use rustdoc_types::{Crate, FORMAT_VERSION};
 use serde::Deserialize;
 use std::{
@@ -77,6 +81,11 @@ struct CargoPackage {
     manifest_path: String,
     version: String,
     name: String,
+    description: Option<String>,
+    edition: Option<String>,
+    rust_version: Option<String>,
+    #[serde(default)]
+    features: BTreeMap<String, Vec<String>>,
     targets: Vec<CargoTarget>,
 }
 
@@ -154,6 +163,12 @@ fn load_workspace_metadata(request: &Request) -> Result<WorkspaceMetadata, Strin
                 version: package.version,
                 manifest_path,
                 has_library_target,
+                api: ApiPackageMetadata {
+                    description: package.description,
+                    edition: package.edition,
+                    rust_version: package.rust_version,
+                    features: package.features,
+                },
             },
         );
     }
@@ -288,6 +303,7 @@ pub(crate) struct PackageMetadata {
     pub(crate) version: String,
     pub(crate) manifest_path: PathBuf,
     pub(crate) has_library_target: bool,
+    pub(crate) api: ApiPackageMetadata,
 }
 
 impl PackageMetadata {
@@ -302,7 +318,7 @@ impl PackageMetadata {
 
 #[cfg(test)]
 mod tests {
-    use super::{crate_target_name, CargoTarget};
+    use super::{crate_target_name, CargoPackage, CargoTarget};
     use std::path::PathBuf;
 
     #[test]
@@ -350,6 +366,7 @@ mod tests {
             version: "0.1.0".to_string(),
             manifest_path: PathBuf::from("sdk/cosmos/azure_data_cosmos_driver_native/Cargo.toml"),
             has_library_target: true,
+            api: Default::default(),
         };
 
         assert_eq!(package.rustdoc_selector_args(), ["--lib"]);
@@ -362,8 +379,53 @@ mod tests {
             version: "0.1.0".to_string(),
             manifest_path: PathBuf::from("sdk/cosmos/azure_data_cosmos_benchmarks/Cargo.toml"),
             has_library_target: false,
+            api: Default::default(),
         };
 
         assert!(package.rustdoc_selector_args().is_empty());
+    }
+
+    #[test]
+    fn reads_api_metadata_from_cargo_metadata() {
+        let package: CargoPackage = serde_json::from_value(serde_json::json!({
+            "id": "demo 1.0.0 (path+file:///demo)",
+            "manifest_path": "/demo/Cargo.toml",
+            "version": "1.0.0",
+            "name": "demo",
+            "description": "Demo crate",
+            "edition": "2021",
+            "rust_version": "1.88",
+            "features": {
+                "default": ["dep:foo", "foo/std"],
+                "test": ["default"]
+            },
+            "targets": []
+        }))
+        .expect("package metadata should deserialize");
+
+        assert_eq!(package.description.as_deref(), Some("Demo crate"));
+        assert_eq!(package.edition.as_deref(), Some("2021"));
+        assert_eq!(package.rust_version.as_deref(), Some("1.88"));
+        assert_eq!(
+            package.features["default"],
+            ["dep:foo".to_string(), "foo/std".to_string()]
+        );
+    }
+
+    #[test]
+    fn allows_missing_optional_api_metadata() {
+        let package: CargoPackage = serde_json::from_value(serde_json::json!({
+            "id": "demo 1.0.0 (path+file:///demo)",
+            "manifest_path": "/demo/Cargo.toml",
+            "version": "1.0.0",
+            "name": "demo",
+            "targets": []
+        }))
+        .expect("package metadata should deserialize");
+
+        assert!(package.description.is_none());
+        assert!(package.edition.is_none());
+        assert!(package.rust_version.is_none());
+        assert!(package.features.is_empty());
     }
 }

--- a/eng/tools/generate_api/src/driver.rs
+++ b/eng/tools/generate_api/src/driver.rs
@@ -81,7 +81,6 @@ struct CargoPackage {
     manifest_path: String,
     version: String,
     name: String,
-    description: Option<String>,
     edition: Option<String>,
     rust_version: Option<String>,
     #[serde(default)]
@@ -189,7 +188,6 @@ fn load_workspace_metadata(request: &Request) -> Result<WorkspaceMetadata, Strin
                 manifest_path,
                 has_library_target,
                 api: ApiPackageMetadata {
-                    description: package.description,
                     edition: package.edition,
                     rust_version: package.rust_version,
                     features,
@@ -442,7 +440,6 @@ mod tests {
             "manifest_path": "/demo/Cargo.toml",
             "version": "1.0.0",
             "name": "demo",
-            "description": "Demo crate",
             "edition": "2021",
             "rust_version": "1.88",
             "features": {
@@ -460,7 +457,6 @@ mod tests {
         }))
         .expect("package metadata should deserialize");
 
-        assert_eq!(package.description.as_deref(), Some("Demo crate"));
         assert_eq!(package.edition.as_deref(), Some("2021"));
         assert_eq!(package.rust_version.as_deref(), Some("1.88"));
         assert_eq!(
@@ -486,7 +482,6 @@ mod tests {
         }))
         .expect("package metadata should deserialize");
 
-        assert!(package.description.is_none());
         assert!(package.edition.is_none());
         assert!(package.rust_version.is_none());
         assert!(package.features.is_empty());

--- a/eng/tools/generate_api/src/driver.rs
+++ b/eng/tools/generate_api/src/driver.rs
@@ -86,7 +86,25 @@ struct CargoPackage {
     rust_version: Option<String>,
     #[serde(default)]
     features: BTreeMap<String, Vec<String>>,
+    metadata: Option<CargoPackageMetadata>,
     targets: Vec<CargoTarget>,
+}
+
+#[derive(Default, Deserialize)]
+struct CargoPackageMetadata {
+    #[serde(default)]
+    docs: CargoDocsMetadata,
+}
+
+#[derive(Default, Deserialize)]
+struct CargoDocsMetadata {
+    #[serde(default)]
+    rs: CargoDocsRsMetadata,
+}
+
+#[derive(Default, Deserialize)]
+struct CargoDocsRsMetadata {
+    features: Option<Vec<String>>,
 }
 
 #[derive(Deserialize)]
@@ -156,6 +174,13 @@ fn load_workspace_metadata(request: &Request) -> Result<WorkspaceMetadata, Strin
             .iter()
             .any(|target| target.kind.iter().any(|kind| is_library_target_kind(kind)));
 
+        let features = select_features(
+            package.features,
+            package
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.docs.rs.features.as_deref()),
+        );
         workspace_packages.insert(
             name.clone(),
             PackageMetadata {
@@ -167,7 +192,7 @@ fn load_workspace_metadata(request: &Request) -> Result<WorkspaceMetadata, Strin
                     description: package.description,
                     edition: package.edition,
                     rust_version: package.rust_version,
-                    features: package.features,
+                    features,
                 },
             },
         );
@@ -184,6 +209,31 @@ fn load_workspace_metadata(request: &Request) -> Result<WorkspaceMetadata, Strin
         current_package,
         packages: workspace_packages,
     })
+}
+
+fn select_features(
+    features: BTreeMap<String, Vec<String>>,
+    docs_rs_features: Option<&[String]>,
+) -> BTreeMap<String, Vec<String>> {
+    if features.is_empty() {
+        return BTreeMap::from([("default".to_string(), Vec::new())]);
+    }
+
+    match docs_rs_features {
+        Some(visible_features) => {
+            let mut selected = BTreeMap::new();
+            if let Some(enabled) = features.get("default") {
+                selected.insert("default".to_string(), enabled.clone());
+            }
+            selected.extend(visible_features.iter().filter_map(|feature| {
+                features
+                    .get(feature)
+                    .map(|enabled| (feature.clone(), enabled.clone()))
+            }));
+            selected
+        }
+        None => features,
+    }
 }
 
 struct WorkspaceMetadata {
@@ -318,8 +368,8 @@ impl PackageMetadata {
 
 #[cfg(test)]
 mod tests {
-    use super::{crate_target_name, CargoPackage, CargoTarget};
-    use std::path::PathBuf;
+    use super::{crate_target_name, select_features, CargoPackage, CargoTarget};
+    use std::{collections::BTreeMap, path::PathBuf};
 
     #[test]
     fn prefers_library_like_target_names() {
@@ -399,6 +449,13 @@ mod tests {
                 "default": ["dep:foo", "foo/std"],
                 "test": ["default"]
             },
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": ["test"]
+                    }
+                }
+            },
             "targets": []
         }))
         .expect("package metadata should deserialize");
@@ -409,6 +466,12 @@ mod tests {
         assert_eq!(
             package.features["default"],
             ["dep:foo".to_string(), "foo/std".to_string()]
+        );
+        assert_eq!(
+            package
+                .metadata
+                .and_then(|metadata| metadata.docs.rs.features),
+            Some(vec!["test".to_string()])
         );
     }
 
@@ -427,5 +490,60 @@ mod tests {
         assert!(package.edition.is_none());
         assert!(package.rust_version.is_none());
         assert!(package.features.is_empty());
+        assert!(package.metadata.is_none());
+    }
+
+    #[test]
+    fn selects_default_and_docs_rs_features() {
+        let features = BTreeMap::from([
+            ("alpha".to_string(), vec!["dep:alpha".to_string()]),
+            ("default".to_string(), vec!["alpha".to_string()]),
+            ("test".to_string(), vec!["default".to_string()]),
+        ]);
+
+        assert_eq!(
+            select_features(features, Some(&["alpha".to_string()])),
+            BTreeMap::from([
+                ("alpha".to_string(), vec!["dep:alpha".to_string()]),
+                ("default".to_string(), vec!["alpha".to_string()]),
+            ])
+        );
+    }
+
+    #[test]
+    fn does_not_duplicate_default_from_docs_rs_features() {
+        let features = BTreeMap::from([
+            ("alpha".to_string(), Vec::new()),
+            ("default".to_string(), vec!["alpha".to_string()]),
+        ]);
+
+        assert_eq!(
+            select_features(
+                features,
+                Some(&["default".to_string(), "alpha".to_string()])
+            ),
+            BTreeMap::from([
+                ("alpha".to_string(), Vec::new()),
+                ("default".to_string(), vec!["alpha".to_string()]),
+            ])
+        );
+    }
+
+    #[test]
+    fn selects_all_features_without_docs_rs_features() {
+        let features = BTreeMap::from([
+            ("alpha".to_string(), Vec::new()),
+            ("default".to_string(), vec!["alpha".to_string()]),
+        ]);
+
+        assert_eq!(select_features(features.clone(), None), features);
+    }
+
+    #[test]
+    fn declares_default_when_no_features_are_defined() {
+        assert_eq!(
+            select_features(BTreeMap::new(), Some(&["test".to_string()])),
+            BTreeMap::from([("default".to_string(), Vec::new())])
+        );
     }
 }

--- a/eng/tools/generate_api/src/driver.rs
+++ b/eng/tools/generate_api/src/driver.rs
@@ -440,6 +440,7 @@ mod tests {
             "manifest_path": "/demo/Cargo.toml",
             "version": "1.0.0",
             "name": "demo",
+            "description": "First line\nSecond line",
             "edition": "2021",
             "rust_version": "1.88",
             "features": {

--- a/eng/tools/generate_api/src/driver.rs
+++ b/eng/tools/generate_api/src/driver.rs
@@ -81,6 +81,7 @@ struct CargoPackage {
     manifest_path: String,
     version: String,
     name: String,
+    description: Option<String>,
     edition: Option<String>,
     rust_version: Option<String>,
     #[serde(default)]
@@ -188,6 +189,7 @@ fn load_workspace_metadata(request: &Request) -> Result<WorkspaceMetadata, Strin
                 manifest_path,
                 has_library_target,
                 api: ApiPackageMetadata {
+                    description: package.description,
                     edition: package.edition,
                     rust_version: package.rust_version,
                     features,
@@ -458,6 +460,10 @@ mod tests {
         }))
         .expect("package metadata should deserialize");
 
+        assert_eq!(
+            package.description.as_deref(),
+            Some("First line\nSecond line")
+        );
         assert_eq!(package.edition.as_deref(), Some("2021"));
         assert_eq!(package.rust_version.as_deref(), Some("1.88"));
         assert_eq!(

--- a/eng/tools/generate_api/src/extract.rs
+++ b/eng/tools/generate_api/src/extract.rs
@@ -78,7 +78,11 @@ pub(crate) fn extract_model(
         return Err("rustdoc JSON root item was not a module".to_string());
     };
 
-    let mut model = ApiModel::new(package.name.clone(), package.version.clone());
+    let mut model = ApiModel::new(
+        package.name.clone(),
+        package.version.clone(),
+        package.api.clone(),
+    );
     model.root_module = extract_module(krate, root, package.name.clone(), resolver)?;
     Ok(model)
 }

--- a/eng/tools/generate_api/src/extract/tests.rs
+++ b/eng/tools/generate_api/src/extract/tests.rs
@@ -2531,6 +2531,7 @@ fn package_metadata(name: &str) -> PackageMetadata {
         version: "1.0.0".to_string(),
         manifest_path: std::path::PathBuf::from("Cargo.toml"),
         has_library_target: true,
+        api: Default::default(),
     }
 }
 

--- a/eng/tools/generate_api/src/model.rs
+++ b/eng/tools/generate_api/src/model.rs
@@ -36,12 +36,33 @@ impl ApiModel {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub(crate) struct PackageMetadata {
     pub(crate) description: Option<String>,
     pub(crate) edition: Option<String>,
     pub(crate) rust_version: Option<String>,
     pub(crate) features: BTreeMap<String, Vec<String>>,
+}
+
+impl Default for PackageMetadata {
+    fn default() -> Self {
+        Self {
+            description: None,
+            edition: None,
+            rust_version: None,
+            features: BTreeMap::from([("default".to_string(), Vec::new())]),
+        }
+    }
+}
+
+impl PackageMetadata {
+    pub(crate) fn features(&self) -> impl Iterator<Item = (&String, &Vec<String>)> {
+        self.features.get_key_value("default").into_iter().chain(
+            self.features
+                .iter()
+                .filter(|(feature, _)| feature.as_str() != "default"),
+        )
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/eng/tools/generate_api/src/model.rs
+++ b/eng/tools/generate_api/src/model.rs
@@ -1,16 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+use std::collections::BTreeMap;
+
 #[derive(Debug, Clone)]
 pub(crate) struct ApiModel {
     pub(crate) package_name: String,
     pub(crate) package_version: String,
     pub(crate) parser_version: String,
+    pub(crate) package_metadata: PackageMetadata,
     pub(crate) root_module: ApiModule,
 }
 
 impl ApiModel {
-    pub(crate) fn new(package_name: String, package_version: String) -> Self {
+    pub(crate) fn new(
+        package_name: String,
+        package_version: String,
+        package_metadata: PackageMetadata,
+    ) -> Self {
         let root_module = ApiModule {
             path: package_name.clone(),
             doc_comments: Vec::new(),
@@ -23,9 +30,18 @@ impl ApiModel {
             package_name,
             package_version,
             parser_version: env!("CARGO_PKG_VERSION").to_string(),
+            package_metadata,
             root_module,
         }
     }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PackageMetadata {
+    pub(crate) description: Option<String>,
+    pub(crate) edition: Option<String>,
+    pub(crate) rust_version: Option<String>,
+    pub(crate) features: BTreeMap<String, Vec<String>>,
 }
 
 #[derive(Debug, Clone)]

--- a/eng/tools/generate_api/src/model.rs
+++ b/eng/tools/generate_api/src/model.rs
@@ -38,7 +38,6 @@ impl ApiModel {
 
 #[derive(Debug, Clone)]
 pub(crate) struct PackageMetadata {
-    pub(crate) description: Option<String>,
     pub(crate) edition: Option<String>,
     pub(crate) rust_version: Option<String>,
     pub(crate) features: BTreeMap<String, Vec<String>>,
@@ -47,7 +46,6 @@ pub(crate) struct PackageMetadata {
 impl Default for PackageMetadata {
     fn default() -> Self {
         Self {
-            description: None,
             edition: None,
             rust_version: None,
             features: BTreeMap::from([("default".to_string(), Vec::new())]),
@@ -56,12 +54,28 @@ impl Default for PackageMetadata {
 }
 
 impl PackageMetadata {
-    pub(crate) fn features(&self) -> impl Iterator<Item = (&String, &Vec<String>)> {
-        self.features.get_key_value("default").into_iter().chain(
-            self.features
-                .iter()
-                .filter(|(feature, _)| feature.as_str() != "default"),
-        )
+    pub(crate) fn feature_names(&self) -> impl Iterator<Item = &String> {
+        self.features
+            .get_key_value("default")
+            .map(|(name, _)| name)
+            .into_iter()
+            .chain(
+                self.features
+                    .iter()
+                    .filter(|(feature, _)| feature.as_str() != "default")
+                    .map(|(name, _)| name),
+            )
+    }
+
+    pub(crate) fn default_feature_children(&self) -> Vec<&String> {
+        let mut children = self
+            .features
+            .get("default")
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        children.sort_unstable();
+        children
     }
 }
 

--- a/eng/tools/generate_api/src/model.rs
+++ b/eng/tools/generate_api/src/model.rs
@@ -38,6 +38,7 @@ impl ApiModel {
 
 #[derive(Debug, Clone)]
 pub(crate) struct PackageMetadata {
+    pub(crate) description: Option<String>,
     pub(crate) edition: Option<String>,
     pub(crate) rust_version: Option<String>,
     pub(crate) features: BTreeMap<String, Vec<String>>,
@@ -46,6 +47,7 @@ pub(crate) struct PackageMetadata {
 impl Default for PackageMetadata {
     fn default() -> Self {
         Self {
+            description: None,
             edition: None,
             rust_version: None,
             features: BTreeMap::from([("default".to_string(), Vec::new())]),
@@ -54,6 +56,21 @@ impl Default for PackageMetadata {
 }
 
 impl PackageMetadata {
+    pub(crate) fn description_lines(&self) -> Option<Vec<&str>> {
+        let description = self.description.as_deref()?;
+        let description = description
+            .strip_suffix("\r\n")
+            .or_else(|| description.strip_suffix('\n'))
+            .unwrap_or(description);
+
+        Some(
+            description
+                .split('\n')
+                .map(|line| line.strip_suffix('\r').unwrap_or(line))
+                .collect(),
+        )
+    }
+
     pub(crate) fn feature_names(&self) -> impl Iterator<Item = &String> {
         self.features
             .get_key_value("default")

--- a/eng/tools/generate_api/src/model/tests.rs
+++ b/eng/tools/generate_api/src/model/tests.rs
@@ -24,6 +24,7 @@ fn item(name: &str, kind: ApiItemKind, declaration: &str) -> ApiItem {
 #[test]
 fn orders_feature_names_and_default_children() {
     let metadata = PackageMetadata {
+        description: None,
         edition: None,
         rust_version: None,
         features: BTreeMap::from([
@@ -50,6 +51,27 @@ fn orders_feature_names_and_default_children() {
             .map(String::as_str)
             .collect::<Vec<_>>(),
         vec!["alpha", "zeta"]
+    );
+}
+
+#[test]
+fn splits_description_lines_after_ignoring_one_final_newline() {
+    let single_line = PackageMetadata {
+        description: Some("Single-line comment\n".to_string()),
+        ..Default::default()
+    };
+    assert_eq!(
+        single_line.description_lines(),
+        Some(vec!["Single-line comment"])
+    );
+
+    let multi_line = PackageMetadata {
+        description: Some("Multi-line\ncomment\n".to_string()),
+        ..Default::default()
+    };
+    assert_eq!(
+        multi_line.description_lines(),
+        Some(vec!["Multi-line", "comment"])
     );
 }
 

--- a/eng/tools/generate_api/src/model/tests.rs
+++ b/eng/tools/generate_api/src/model/tests.rs
@@ -22,6 +22,38 @@ fn item(name: &str, kind: ApiItemKind, declaration: &str) -> ApiItem {
 }
 
 #[test]
+fn orders_feature_names_and_default_children() {
+    let metadata = PackageMetadata {
+        edition: None,
+        rust_version: None,
+        features: BTreeMap::from([
+            ("alpha".to_string(), vec!["ignored".to_string()]),
+            (
+                "default".to_string(),
+                vec!["zeta".to_string(), "alpha".to_string()],
+            ),
+            ("zeta".to_string(), Vec::new()),
+        ]),
+    };
+
+    assert_eq!(
+        metadata
+            .feature_names()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        vec!["default", "alpha", "zeta"]
+    );
+    assert_eq!(
+        metadata
+            .default_feature_children()
+            .into_iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        vec!["alpha", "zeta"]
+    );
+}
+
+#[test]
 fn sorts_inherent_impls_by_type_parameter_then_infer_then_explicit_type() {
     let mut explicit = item(
         "Builder",

--- a/eng/tools/generate_api/src/render/apiview.rs
+++ b/eng/tools/generate_api/src/render/apiview.rs
@@ -159,7 +159,7 @@ fn render_all_review_lines(
 }
 
 fn render_package_metadata(model: &ApiModel) -> Vec<ReviewLine> {
-    let mut lines = vec![metadata_line(&model.package_name)];
+    let mut lines = Vec::new();
     let metadata = &model.package_metadata;
     if let Some(description) = &metadata.description {
         lines.push(metadata_line(&format!("Description: {description}")));
@@ -172,12 +172,13 @@ fn render_package_metadata(model: &ApiModel) -> Vec<ReviewLine> {
     }
 
     lines.push(metadata_line("Features:"));
-    for (feature, enabled_features) in &metadata.features {
+    for (feature, enabled_features) in metadata.features() {
         lines.push(metadata_line(&format!("- {feature}")));
         for enabled_feature in enabled_features {
             lines.push(metadata_line(&format!("  - {enabled_feature}")));
         }
     }
+    lines.push(metadata_line(""));
     lines
 }
 

--- a/eng/tools/generate_api/src/render/apiview.rs
+++ b/eng/tools/generate_api/src/render/apiview.rs
@@ -161,9 +161,6 @@ fn render_all_review_lines(
 fn render_package_metadata(model: &ApiModel) -> Vec<ReviewLine> {
     let mut lines = Vec::new();
     let metadata = &model.package_metadata;
-    if let Some(description) = &metadata.description {
-        lines.push(metadata_line(&format!("Description: {description}")));
-    }
     if let Some(edition) = &metadata.edition {
         lines.push(metadata_line(&format!("Edition: {edition}")));
     }
@@ -172,10 +169,12 @@ fn render_package_metadata(model: &ApiModel) -> Vec<ReviewLine> {
     }
 
     lines.push(metadata_line("Features:"));
-    for (feature, enabled_features) in metadata.features() {
+    for feature in metadata.feature_names() {
         lines.push(metadata_line(&format!("- {feature}")));
-        for enabled_feature in enabled_features {
-            lines.push(metadata_line(&format!("  - {enabled_feature}")));
+        if feature == "default" {
+            for child in metadata.default_feature_children() {
+                lines.push(metadata_line(&format!("  - {child}")));
+            }
         }
     }
     lines.push(metadata_line(""));

--- a/eng/tools/generate_api/src/render/apiview.rs
+++ b/eng/tools/generate_api/src/render/apiview.rs
@@ -95,7 +95,7 @@ pub(crate) fn render(model: &ApiModel, options: &RenderOptions) -> Result<String
         package_version: &model.package_version,
         parser_version: &model.parser_version,
         language: "Rust",
-        review_lines: render_review_lines(model, options, &navigation_lookup),
+        review_lines: render_all_review_lines(model, options, &navigation_lookup),
     };
     validate_code_file(&document)?;
 
@@ -146,6 +146,58 @@ fn render_review_lines(
     navigation_lookup: &NavigationLookup,
 ) -> Vec<ReviewLine> {
     render_root_module(&model.root_module, options, navigation_lookup)
+}
+
+fn render_all_review_lines(
+    model: &ApiModel,
+    options: &RenderOptions,
+    navigation_lookup: &NavigationLookup,
+) -> Vec<ReviewLine> {
+    let mut lines = render_package_metadata(model);
+    lines.extend(render_review_lines(model, options, navigation_lookup));
+    lines
+}
+
+fn render_package_metadata(model: &ApiModel) -> Vec<ReviewLine> {
+    let mut lines = vec![metadata_line(&model.package_name)];
+    let metadata = &model.package_metadata;
+    if let Some(description) = &metadata.description {
+        lines.push(metadata_line(&format!("Description: {description}")));
+    }
+    if let Some(edition) = &metadata.edition {
+        lines.push(metadata_line(&format!("Edition: {edition}")));
+    }
+    if let Some(rust_version) = &metadata.rust_version {
+        lines.push(metadata_line(&format!("Rust version: {rust_version}")));
+    }
+
+    lines.push(metadata_line("Features:"));
+    for (feature, enabled_features) in &metadata.features {
+        lines.push(metadata_line(&format!("- {feature}")));
+        for enabled_feature in enabled_features {
+            lines.push(metadata_line(&format!("  - {enabled_feature}")));
+        }
+    }
+    lines
+}
+
+fn metadata_line(value: &str) -> ReviewLine {
+    ReviewLine {
+        line_id: None,
+        tokens: vec![ReviewToken {
+            kind: token_kind::TEXT,
+            value: value.to_string(),
+            has_prefix_space: false,
+            has_suffix_space: false,
+            is_documentation: false,
+            navigation_display_name: None,
+            navigate_to_id: None,
+            render_classes: None,
+        }],
+        children: Vec::new(),
+        is_context_end_line: None,
+        related_to_line: None,
+    }
 }
 
 fn render_module_contents(

--- a/eng/tools/generate_api/src/render/apiview.rs
+++ b/eng/tools/generate_api/src/render/apiview.rs
@@ -161,6 +161,16 @@ fn render_all_review_lines(
 fn render_package_metadata(model: &ApiModel) -> Vec<ReviewLine> {
     let mut lines = Vec::new();
     let metadata = &model.package_metadata;
+    if let Some(description) = metadata.description_lines() {
+        if description.len() == 1 {
+            lines.push(metadata_line(&format!("Description: {}", description[0])));
+        } else {
+            lines.push(metadata_line("Description:"));
+            for line in description {
+                lines.push(metadata_line(line));
+            }
+        }
+    }
     if let Some(edition) = &metadata.edition {
         lines.push(metadata_line(&format!("Edition: {edition}")));
     }

--- a/eng/tools/generate_api/src/render/apiview/tests.rs
+++ b/eng/tools/generate_api/src/render/apiview/tests.rs
@@ -115,6 +115,7 @@ fn renders_package_metadata_and_features_as_leading_text_tokens() {
             edition: Some("2021".to_string()),
             rust_version: Some("1.88".to_string()),
             features: BTreeMap::from([
+                ("alpha".to_string(), vec!["dep:alpha".to_string()]),
                 (
                     "default".to_string(),
                     vec!["azure_core/default".to_string(), "hmac".to_string()],
@@ -137,7 +138,6 @@ fn renders_package_metadata_and_features_as_leading_text_tokens() {
     assert_eq!(
         lines.iter().map(line_text).collect::<Vec<_>>(),
         vec![
-            "azure_security_keyvault_secrets",
             "Description: Azure Key Vault secrets client library",
             "Edition: 2021",
             "Rust version: 1.88",
@@ -145,8 +145,11 @@ fn renders_package_metadata_and_features_as_leading_text_tokens() {
             "- default",
             "  - azure_core/default",
             "  - hmac",
+            "- alpha",
+            "  - dep:alpha",
             "- test",
             "  - default",
+            "",
         ]
     );
     assert!(lines
@@ -180,7 +183,7 @@ fn omits_missing_package_metadata() {
         .iter()
         .map(line_text)
         .collect::<Vec<_>>(),
-        vec!["demo", "Features:"]
+        vec!["Features:", "- default", ""]
     );
 }
 

--- a/eng/tools/generate_api/src/render/apiview/tests.rs
+++ b/eng/tools/generate_api/src/render/apiview/tests.rs
@@ -111,14 +111,13 @@ fn renders_package_metadata_and_features_as_leading_text_tokens() {
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
         package_metadata: PackageMetadata {
-            description: Some("Azure Key Vault secrets client library".to_string()),
             edition: Some("2021".to_string()),
             rust_version: Some("1.88".to_string()),
             features: BTreeMap::from([
                 ("alpha".to_string(), vec!["dep:alpha".to_string()]),
                 (
                     "default".to_string(),
-                    vec!["azure_core/default".to_string(), "hmac".to_string()],
+                    vec!["hmac".to_string(), "azure_core/default".to_string()],
                 ),
                 ("test".to_string(), vec!["default".to_string()]),
             ]),
@@ -138,7 +137,6 @@ fn renders_package_metadata_and_features_as_leading_text_tokens() {
     assert_eq!(
         lines.iter().map(line_text).collect::<Vec<_>>(),
         vec![
-            "Description: Azure Key Vault secrets client library",
             "Edition: 2021",
             "Rust version: 1.88",
             "Features:",
@@ -146,9 +144,7 @@ fn renders_package_metadata_and_features_as_leading_text_tokens() {
             "  - azure_core/default",
             "  - hmac",
             "- alpha",
-            "  - dep:alpha",
             "- test",
-            "  - default",
             "",
         ]
     );

--- a/eng/tools/generate_api/src/render/apiview/tests.rs
+++ b/eng/tools/generate_api/src/render/apiview/tests.rs
@@ -111,6 +111,7 @@ fn renders_package_metadata_and_features_as_leading_text_tokens() {
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
         package_metadata: PackageMetadata {
+            description: Some("Multi-line\ncomment\n".to_string()),
             edition: Some("2021".to_string()),
             rust_version: Some("1.88".to_string()),
             features: BTreeMap::from([
@@ -137,6 +138,9 @@ fn renders_package_metadata_and_features_as_leading_text_tokens() {
     assert_eq!(
         lines.iter().map(line_text).collect::<Vec<_>>(),
         vec![
+            "Description:",
+            "Multi-line",
+            "comment",
             "Edition: 2021",
             "Rust version: 1.88",
             "Features:",

--- a/eng/tools/generate_api/src/render/apiview/tests.rs
+++ b/eng/tools/generate_api/src/render/apiview/tests.rs
@@ -4,8 +4,9 @@
 use super::*;
 use crate::model::{
     ApiAttribute, ApiItem, ApiItemKind, ApiMember, ApiMemberKind, ApiModel, ApiModule,
-    ApiNavigationPath, ApiPathReference, InherentImplSortKey,
+    ApiNavigationPath, ApiPathReference, InherentImplSortKey, PackageMetadata,
 };
+use std::collections::BTreeMap;
 
 fn item(name: &str, kind: ApiItemKind, declaration: &str) -> ApiItem {
     ApiItem {
@@ -64,6 +65,7 @@ fn navigation_lookup(root_module: &ApiModule) -> NavigationLookup {
         package_name: root_module.local_name().to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: root_module.clone(),
     })
 }
@@ -100,6 +102,86 @@ fn line_text(line: &ReviewLine) -> String {
         .iter()
         .map(|token| token.value.as_str())
         .collect()
+}
+
+#[test]
+fn renders_package_metadata_and_features_as_leading_text_tokens() {
+    let model = ApiModel {
+        package_name: "azure_security_keyvault_secrets".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        package_metadata: PackageMetadata {
+            description: Some("Azure Key Vault secrets client library".to_string()),
+            edition: Some("2021".to_string()),
+            rust_version: Some("1.88".to_string()),
+            features: BTreeMap::from([
+                (
+                    "default".to_string(),
+                    vec!["azure_core/default".to_string(), "hmac".to_string()],
+                ),
+                ("test".to_string(), vec!["default".to_string()]),
+            ]),
+        },
+        root_module: ApiModule {
+            path: "azure_security_keyvault_secrets".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: Vec::new(),
+            modules: Vec::new(),
+        },
+    };
+
+    let lookup = NavigationLookup::new(&model);
+    let lines = render_all_review_lines(&model, &RenderOptions::default(), &lookup);
+
+    assert_eq!(
+        lines.iter().map(line_text).collect::<Vec<_>>(),
+        vec![
+            "azure_security_keyvault_secrets",
+            "Description: Azure Key Vault secrets client library",
+            "Edition: 2021",
+            "Rust version: 1.88",
+            "Features:",
+            "- default",
+            "  - azure_core/default",
+            "  - hmac",
+            "- test",
+            "  - default",
+        ]
+    );
+    assert!(lines
+        .iter()
+        .flat_map(|line| &line.tokens)
+        .all(|token| token.kind == token_kind::TEXT && !token.is_documentation));
+}
+
+#[test]
+fn omits_missing_package_metadata() {
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: Vec::new(),
+            modules: Vec::new(),
+        },
+    };
+
+    assert_eq!(
+        render_all_review_lines(
+            &model,
+            &RenderOptions::default(),
+            &NavigationLookup::new(&model),
+        )
+        .iter()
+        .map(line_text)
+        .collect::<Vec<_>>(),
+        vec!["demo", "Features:"]
+    );
 }
 
 #[test]
@@ -183,6 +265,7 @@ fn renders_root_inner_attrs_and_child_module_outer_attrs() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: Vec::new(),
@@ -416,6 +499,7 @@ fn links_trait_impl_owner_to_local_definition() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: Vec::new(),
@@ -472,6 +556,7 @@ fn links_trait_impl_owner_to_public_reexport() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: Vec::new(),
@@ -529,6 +614,7 @@ fn links_trait_impl_owner_to_declaration_over_visible_reexport() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: Vec::new(),
@@ -578,6 +664,7 @@ fn keeps_trait_impl_owner_unlinked_without_visible_target() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: Vec::new(),
@@ -633,6 +720,7 @@ fn links_associated_error_type_to_visible_error_target() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: Vec::new(),
@@ -703,6 +791,7 @@ fn links_bare_result_to_public_reexport_when_resolved_path_matches() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: Vec::new(),
@@ -745,6 +834,7 @@ fn links_crate_result_with_resolved_path_metadata() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: Vec::new(),
@@ -794,6 +884,7 @@ fn links_where_clause_references_after_signature_types() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: Vec::new(),
@@ -866,6 +957,7 @@ fn keeps_std_result_references_unlinked_without_current_crate_reexport() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: Vec::new(),
@@ -912,6 +1004,7 @@ fn prefers_original_definition_over_public_reexport_for_bare_result_links() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: Vec::new(),
@@ -1072,6 +1165,7 @@ fn orders_modules_after_non_module_navigation_items() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: Vec::new(),
@@ -1290,6 +1384,7 @@ fn same_crate_reexport_links_to_nested_declaration() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: Vec::new(),

--- a/eng/tools/generate_api/src/render/markdown.rs
+++ b/eng/tools/generate_api/src/render/markdown.rs
@@ -52,11 +52,16 @@ fn render_package_metadata(output: &mut Vec<RenderedLine>, model: &ApiModel) {
     let metadata = &model.package_metadata;
     if let Some(description) = metadata.description_lines() {
         if description.len() == 1 {
-            push_code(output, 0, &format!("**Description**: {}", description[0]));
+            push_code(output, 0, &format!("- **Description**: {}", description[0]));
         } else {
-            push_code(output, 0, "**Description:**");
+            push_code(output, 0, "- **Description:**");
+            push_code(output, 0, "");
             for line in description {
-                push_code(output, 0, line);
+                if line.is_empty() {
+                    push_code(output, 0, "");
+                } else {
+                    push_code(output, 0, &format!("  {line}"));
+                }
             }
         }
     }

--- a/eng/tools/generate_api/src/render/markdown.rs
+++ b/eng/tools/generate_api/src/render/markdown.rs
@@ -50,13 +50,26 @@ pub(crate) fn render_lines(model: &ApiModel) -> Vec<RenderedLine> {
 
 fn render_package_metadata(output: &mut Vec<RenderedLine>, model: &ApiModel) {
     let metadata = &model.package_metadata;
+    if let Some(description) = metadata.description_lines() {
+        if description.len() == 1 {
+            push_code(output, 0, &format!("**Description**: {}", description[0]));
+        } else {
+            push_code(output, 0, "**Description:**");
+            for line in description {
+                push_code(output, 0, line);
+            }
+        }
+    }
     if let Some(edition) = &metadata.edition {
         push_code(output, 0, &format!("- **Edition**: {edition}"));
     }
     if let Some(rust_version) = &metadata.rust_version {
         push_code(output, 0, &format!("- **Rust version**: {rust_version}"));
     }
-    if metadata.edition.is_some() || metadata.rust_version.is_some() {
+    if metadata.description.is_some()
+        || metadata.edition.is_some()
+        || metadata.rust_version.is_some()
+    {
         push_code(output, 0, "");
     }
 }

--- a/eng/tools/generate_api/src/render/markdown.rs
+++ b/eng/tools/generate_api/src/render/markdown.rs
@@ -31,7 +31,7 @@ pub(crate) fn render_lines(model: &ApiModel) -> Vec<RenderedLine> {
     render_package_metadata(&mut output, model);
     push_code(&mut output, 0, "## Features");
     push_code(&mut output, 0, "");
-    for (feature, enabled_features) in &model.package_metadata.features {
+    for (feature, enabled_features) in model.package_metadata.features() {
         push_code(&mut output, 0, &format!("- `{feature}`"));
         for enabled_feature in enabled_features {
             push_code(&mut output, 0, &format!("  - `{enabled_feature}`"));

--- a/eng/tools/generate_api/src/render/markdown.rs
+++ b/eng/tools/generate_api/src/render/markdown.rs
@@ -31,10 +31,12 @@ pub(crate) fn render_lines(model: &ApiModel) -> Vec<RenderedLine> {
     render_package_metadata(&mut output, model);
     push_code(&mut output, 0, "## Features");
     push_code(&mut output, 0, "");
-    for (feature, enabled_features) in model.package_metadata.features() {
+    for feature in model.package_metadata.feature_names() {
         push_code(&mut output, 0, &format!("- `{feature}`"));
-        for enabled_feature in enabled_features {
-            push_code(&mut output, 0, &format!("  - `{enabled_feature}`"));
+        if feature == "default" {
+            for child in model.package_metadata.default_feature_children() {
+                push_code(&mut output, 0, &format!("  - `{child}`"));
+            }
         }
     }
     if !model.package_metadata.features.is_empty() {
@@ -48,19 +50,13 @@ pub(crate) fn render_lines(model: &ApiModel) -> Vec<RenderedLine> {
 
 fn render_package_metadata(output: &mut Vec<RenderedLine>, model: &ApiModel) {
     let metadata = &model.package_metadata;
-    if let Some(description) = &metadata.description {
-        push_code(output, 0, &format!("- **Description**: {description}"));
-    }
     if let Some(edition) = &metadata.edition {
         push_code(output, 0, &format!("- **Edition**: {edition}"));
     }
     if let Some(rust_version) = &metadata.rust_version {
         push_code(output, 0, &format!("- **Rust version**: {rust_version}"));
     }
-    if metadata.description.is_some()
-        || metadata.edition.is_some()
-        || metadata.rust_version.is_some()
-    {
+    if metadata.edition.is_some() || metadata.rust_version.is_some() {
         push_code(output, 0, "");
     }
 }

--- a/eng/tools/generate_api/src/render/markdown.rs
+++ b/eng/tools/generate_api/src/render/markdown.rs
@@ -26,10 +26,43 @@ pub(crate) fn render_from_lines(lines: &[RenderedLine]) -> String {
 /// without them and still generate a patch that adds them back.
 pub(crate) fn render_lines(model: &ApiModel) -> Vec<RenderedLine> {
     let mut output = Vec::new();
+    push_code(&mut output, 0, &format!("# {}", model.package_name));
+    push_code(&mut output, 0, "");
+    render_package_metadata(&mut output, model);
+    push_code(&mut output, 0, "## Features");
+    push_code(&mut output, 0, "");
+    for (feature, enabled_features) in &model.package_metadata.features {
+        push_code(&mut output, 0, &format!("- `{feature}`"));
+        for enabled_feature in enabled_features {
+            push_code(&mut output, 0, &format!("  - `{enabled_feature}`"));
+        }
+    }
+    if !model.package_metadata.features.is_empty() {
+        push_code(&mut output, 0, "");
+    }
     push_code(&mut output, 0, "```rust");
     render_module(&mut output, &model.root_module, true, 0);
     push_code(&mut output, 0, "```");
     output
+}
+
+fn render_package_metadata(output: &mut Vec<RenderedLine>, model: &ApiModel) {
+    let metadata = &model.package_metadata;
+    if let Some(description) = &metadata.description {
+        push_code(output, 0, &format!("- **Description**: {description}"));
+    }
+    if let Some(edition) = &metadata.edition {
+        push_code(output, 0, &format!("- **Edition**: {edition}"));
+    }
+    if let Some(rust_version) = &metadata.rust_version {
+        push_code(output, 0, &format!("- **Rust version**: {rust_version}"));
+    }
+    if metadata.description.is_some()
+        || metadata.edition.is_some()
+        || metadata.rust_version.is_some()
+    {
+        push_code(output, 0, "");
+    }
 }
 
 fn render_module(output: &mut Vec<RenderedLine>, module: &ApiModule, is_root: bool, indent: usize) {

--- a/eng/tools/generate_api/src/render/markdown/tests.rs
+++ b/eng/tools/generate_api/src/render/markdown/tests.rs
@@ -4,7 +4,9 @@
 use super::*;
 use crate::model::{
     ApiAttribute, ApiItem, ApiItemKind, ApiMember, ApiMemberKind, ApiModel, ApiModule,
+    PackageMetadata,
 };
+use std::collections::BTreeMap;
 
 fn render(model: &ApiModel) -> String {
     render_from_lines(&render_lines(model))
@@ -59,6 +61,7 @@ fn renders_explicit_trait_impl_blocks() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: Vec::new(),
@@ -91,6 +94,7 @@ fn renders_inherent_members_inside_impl_blocks() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: Vec::new(),
@@ -116,6 +120,7 @@ fn renders_root_inner_attrs_and_child_module_outer_attrs() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: Vec::new(),
@@ -151,6 +156,7 @@ fn marks_doc_comments_and_omits_them_from_markdown() {
         package_name: "demo".to_string(),
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
         root_module: ApiModule {
             path: "demo".to_string(),
             doc_comments: vec![
@@ -179,5 +185,110 @@ fn marks_doc_comments_and_omits_them_from_markdown() {
             "/// Does foo."
         ]
     );
-    assert_eq!(render_from_lines(&lines), "```rust\npub struct Foo;\n```\n");
+    assert_eq!(
+        render_from_lines(&lines),
+        "# demo\n\n## Features\n\n```rust\npub struct Foo;\n```\n"
+    );
+}
+
+#[test]
+fn renders_package_metadata_and_features_before_api() {
+    let model = ApiModel {
+        package_name: "azure_security_keyvault_secrets".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        package_metadata: PackageMetadata {
+            description: Some("Azure Key Vault secrets client library".to_string()),
+            edition: Some("2021".to_string()),
+            rust_version: Some("1.88".to_string()),
+            features: BTreeMap::from([
+                (
+                    "default".to_string(),
+                    vec!["azure_core/default".to_string(), "hmac".to_string()],
+                ),
+                ("test".to_string(), vec!["default".to_string()]),
+            ]),
+        },
+        root_module: ApiModule {
+            path: "azure_security_keyvault_secrets".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![item(
+                "SecretClient",
+                ApiItemKind::Struct,
+                "pub struct SecretClient;",
+            )],
+            modules: Vec::new(),
+        },
+    };
+
+    assert_eq!(
+        render(&model),
+        "# azure_security_keyvault_secrets\n\
+         \n\
+         - **Description**: Azure Key Vault secrets client library\n\
+         - **Edition**: 2021\n\
+         - **Rust version**: 1.88\n\
+         \n\
+         ## Features\n\
+         \n\
+         - `default`\n\
+         \x20\x20- `azure_core/default`\n\
+         \x20\x20- `hmac`\n\
+         - `test`\n\
+         \x20\x20- `default`\n\
+         \n\
+         ```rust\n\
+         pub struct SecretClient;\n\
+         ```\n"
+    );
+}
+
+#[test]
+fn omits_missing_package_metadata() {
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: Vec::new(),
+            modules: Vec::new(),
+        },
+    };
+
+    assert_eq!(render(&model), "# demo\n\n## Features\n\n```rust\n```\n");
+}
+
+#[test]
+fn comments_patch_accounts_for_package_metadata_lines() {
+    let mut documented = item("Foo", ApiItemKind::Struct, "pub struct Foo;");
+    documented.doc_comments = vec!["/// Does foo.".to_string()];
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        package_metadata: PackageMetadata {
+            description: Some("Demo crate".to_string()),
+            edition: Some("2021".to_string()),
+            rust_version: Some("1.88".to_string()),
+            features: BTreeMap::from([("default".to_string(), vec!["dep:foo".to_string()])]),
+        },
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: vec!["//! Demo docs.".to_string()],
+            attributes: Vec::new(),
+            items: vec![documented],
+            modules: Vec::new(),
+        },
+    };
+
+    let lines = render_lines(&model);
+    let patch = crate::render::patch::render(&lines, "API.md");
+
+    assert!(patch.contains("@@ -10,5 +10,7 @@"));
+    assert!(patch.contains("+//! Demo docs.\n+/// Does foo.\n"));
 }

--- a/eng/tools/generate_api/src/render/markdown/tests.rs
+++ b/eng/tools/generate_api/src/render/markdown/tests.rs
@@ -300,8 +300,12 @@ fn comments_patch_accounts_for_package_metadata_lines() {
     let parsed_patch = diffy::Patch::from_str(&patch).expect("patch should parse");
 
     assert!(api_without_docs.contains("**Description:**\nMulti-line\ncomment\n"));
-    assert!(patch.contains("@@ -12,5 +12,7 @@"));
-    assert!(patch.contains("+//! Demo docs.\n+/// Does foo.\n"));
+    assert!(patch.contains(
+        "@@ -15,1 +15,3 @@\n\
+         +//! Demo docs.\n\
+         +/// Does foo.\n\
+         \x20pub struct Foo;\n"
+    ));
     assert_eq!(
         diffy::apply(&api_without_docs, &parsed_patch).expect("patch should apply"),
         api_with_docs

--- a/eng/tools/generate_api/src/render/markdown/tests.rs
+++ b/eng/tools/generate_api/src/render/markdown/tests.rs
@@ -198,6 +198,7 @@ fn renders_package_metadata_and_features_before_api() {
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
         package_metadata: PackageMetadata {
+            description: Some("Manage secrets.\n".to_string()),
             edition: Some("2021".to_string()),
             rust_version: Some("1.88".to_string()),
             features: BTreeMap::from([
@@ -226,6 +227,7 @@ fn renders_package_metadata_and_features_before_api() {
         render(&model),
         "# azure_security_keyvault_secrets\n\
          \n\
+         **Description**: Manage secrets.\n\
          - **Edition**: 2021\n\
          - **Rust version**: 1.88\n\
          \n\
@@ -274,6 +276,7 @@ fn comments_patch_accounts_for_package_metadata_lines() {
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
         package_metadata: PackageMetadata {
+            description: Some("Multi-line\ncomment\n".to_string()),
             edition: Some("2021".to_string()),
             rust_version: Some("1.88".to_string()),
             features: BTreeMap::from([("default".to_string(), vec!["dep:foo".to_string()])]),
@@ -288,8 +291,19 @@ fn comments_patch_accounts_for_package_metadata_lines() {
     };
 
     let lines = render_lines(&model);
+    let api_without_docs = render_from_lines(&lines);
+    let api_with_docs = lines
+        .iter()
+        .map(|line| format!("{}\n", line.text))
+        .collect::<String>();
     let patch = crate::render::patch::render(&lines, "API.md");
+    let parsed_patch = diffy::Patch::from_str(&patch).expect("patch should parse");
 
-    assert!(patch.contains("@@ -9,5 +9,7 @@"));
+    assert!(api_without_docs.contains("**Description:**\nMulti-line\ncomment\n"));
+    assert!(patch.contains("@@ -12,5 +12,7 @@"));
     assert!(patch.contains("+//! Demo docs.\n+/// Does foo.\n"));
+    assert_eq!(
+        diffy::apply(&api_without_docs, &parsed_patch).expect("patch should apply"),
+        api_with_docs
+    );
 }

--- a/eng/tools/generate_api/src/render/markdown/tests.rs
+++ b/eng/tools/generate_api/src/render/markdown/tests.rs
@@ -187,7 +187,7 @@ fn marks_doc_comments_and_omits_them_from_markdown() {
     );
     assert_eq!(
         render_from_lines(&lines),
-        "# demo\n\n## Features\n\n```rust\npub struct Foo;\n```\n"
+        "# demo\n\n## Features\n\n- `default`\n\n```rust\npub struct Foo;\n```\n"
     );
 }
 
@@ -202,6 +202,7 @@ fn renders_package_metadata_and_features_before_api() {
             edition: Some("2021".to_string()),
             rust_version: Some("1.88".to_string()),
             features: BTreeMap::from([
+                ("alpha".to_string(), vec!["dep:alpha".to_string()]),
                 (
                     "default".to_string(),
                     vec!["azure_core/default".to_string(), "hmac".to_string()],
@@ -235,6 +236,8 @@ fn renders_package_metadata_and_features_before_api() {
          - `default`\n\
          \x20\x20- `azure_core/default`\n\
          \x20\x20- `hmac`\n\
+         - `alpha`\n\
+         \x20\x20- `dep:alpha`\n\
          - `test`\n\
          \x20\x20- `default`\n\
          \n\
@@ -260,7 +263,10 @@ fn omits_missing_package_metadata() {
         },
     };
 
-    assert_eq!(render(&model), "# demo\n\n## Features\n\n```rust\n```\n");
+    assert_eq!(
+        render(&model),
+        "# demo\n\n## Features\n\n- `default`\n\n```rust\n```\n"
+    );
 }
 
 #[test]

--- a/eng/tools/generate_api/src/render/markdown/tests.rs
+++ b/eng/tools/generate_api/src/render/markdown/tests.rs
@@ -198,14 +198,13 @@ fn renders_package_metadata_and_features_before_api() {
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
         package_metadata: PackageMetadata {
-            description: Some("Azure Key Vault secrets client library".to_string()),
             edition: Some("2021".to_string()),
             rust_version: Some("1.88".to_string()),
             features: BTreeMap::from([
                 ("alpha".to_string(), vec!["dep:alpha".to_string()]),
                 (
                     "default".to_string(),
-                    vec!["azure_core/default".to_string(), "hmac".to_string()],
+                    vec!["hmac".to_string(), "azure_core/default".to_string()],
                 ),
                 ("test".to_string(), vec!["default".to_string()]),
             ]),
@@ -227,7 +226,6 @@ fn renders_package_metadata_and_features_before_api() {
         render(&model),
         "# azure_security_keyvault_secrets\n\
          \n\
-         - **Description**: Azure Key Vault secrets client library\n\
          - **Edition**: 2021\n\
          - **Rust version**: 1.88\n\
          \n\
@@ -237,9 +235,7 @@ fn renders_package_metadata_and_features_before_api() {
          \x20\x20- `azure_core/default`\n\
          \x20\x20- `hmac`\n\
          - `alpha`\n\
-         \x20\x20- `dep:alpha`\n\
          - `test`\n\
-         \x20\x20- `default`\n\
          \n\
          ```rust\n\
          pub struct SecretClient;\n\
@@ -278,7 +274,6 @@ fn comments_patch_accounts_for_package_metadata_lines() {
         package_version: "1.0.0".to_string(),
         parser_version: "0.0.0".to_string(),
         package_metadata: PackageMetadata {
-            description: Some("Demo crate".to_string()),
             edition: Some("2021".to_string()),
             rust_version: Some("1.88".to_string()),
             features: BTreeMap::from([("default".to_string(), vec!["dep:foo".to_string()])]),
@@ -295,6 +290,6 @@ fn comments_patch_accounts_for_package_metadata_lines() {
     let lines = render_lines(&model);
     let patch = crate::render::patch::render(&lines, "API.md");
 
-    assert!(patch.contains("@@ -10,5 +10,7 @@"));
+    assert!(patch.contains("@@ -9,5 +9,7 @@"));
     assert!(patch.contains("+//! Demo docs.\n+/// Does foo.\n"));
 }

--- a/eng/tools/generate_api/src/render/markdown/tests.rs
+++ b/eng/tools/generate_api/src/render/markdown/tests.rs
@@ -227,7 +227,7 @@ fn renders_package_metadata_and_features_before_api() {
         render(&model),
         "# azure_security_keyvault_secrets\n\
          \n\
-         **Description**: Manage secrets.\n\
+         - **Description**: Manage secrets.\n\
          - **Edition**: 2021\n\
          - **Rust version**: 1.88\n\
          \n\
@@ -241,6 +241,47 @@ fn renders_package_metadata_and_features_before_api() {
          \n\
          ```rust\n\
          pub struct SecretClient;\n\
+         ```\n"
+    );
+}
+
+#[test]
+fn preserves_multiline_description_paragraphs() {
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        package_metadata: PackageMetadata {
+            description: Some("Line one\n\nLine two\nAlso line two\n\nLine three\n".to_string()),
+            ..Default::default()
+        },
+        root_module: ApiModule {
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: Vec::new(),
+            modules: Vec::new(),
+        },
+    };
+
+    assert_eq!(
+        render(&model),
+        "# demo\n\
+         \n\
+         - **Description:**\n\
+         \n\
+         \x20\x20Line one\n\
+         \n\
+         \x20\x20Line two\n\
+         \x20\x20Also line two\n\
+         \n\
+         \x20\x20Line three\n\
+         \n\
+         ## Features\n\
+         \n\
+         - `default`\n\
+         \n\
+         ```rust\n\
          ```\n"
     );
 }
@@ -299,13 +340,18 @@ fn comments_patch_accounts_for_package_metadata_lines() {
     let patch = crate::render::patch::render(&lines, "API.md");
     let parsed_patch = diffy::Patch::from_str(&patch).expect("patch should parse");
 
-    assert!(api_without_docs.contains("**Description:**\nMulti-line\ncomment\n"));
-    assert!(patch.contains(
-        "@@ -15,1 +15,3 @@\n\
-         +//! Demo docs.\n\
-         +/// Does foo.\n\
-         \x20pub struct Foo;\n"
-    ));
+    assert!(api_without_docs.contains(concat!(
+        "- **Description:**\n",
+        "\n",
+        "  Multi-line\n",
+        "  comment\n",
+    )));
+    assert!(patch.contains(concat!(
+        "@@ -16,1 +16,3 @@\n",
+        "+//! Demo docs.\n",
+        "+/// Does foo.\n",
+        " pub struct Foo;\n",
+    )));
     assert_eq!(
         diffy::apply(&api_without_docs, &parsed_patch).expect("patch should apply"),
         api_with_docs


### PR DESCRIPTION
Read Cargo package metadata into the shared API model and render it consistently in Markdown and APIView reviews.

## Summary

- Show the crate name, edition, Rust version, and features in Markdown output.
- Add edition, Rust version, and feature text tokens before APIView declarations.
- Use the defined `default` feature plus docs.rs-selected features, falling back to all features when docs.rs metadata is absent.
- Sort `default` first, sort other feature names lexically, and show sorted children only for `default`.
- Synthesize an empty `default` entry for crates without defined features.
- Keep generated documentation-comment patch offsets aligned with the added Markdown header.
- Document the output shape and add extraction, ordering, rendering, omission, and patch regression coverage.

## Checks

- `cargo test --manifest-path eng/tools/Cargo.toml -p generate_api --all-features`
- `cargo clippy --manifest-path eng/tools/Cargo.toml -p generate_api --all-targets --all-features -- -D warnings`
- `npx markdownlint-cli2 --no-globs eng/tools/generate_api/README.md eng/tools/generate_api/AGENTS.md`
