### PR TITLE
Harden emulator region transitions

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/topology_parity.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/topology_parity.rs
@@ -156,7 +156,7 @@ async fn create_client(
 async fn container(client: &CosmosClient) -> azure_data_cosmos::ContainerClient {
     client
         .database_client(DATABASE)
-        .container_client(CONTAINER)
+        .container_client(CONTAINER, None)
         .await
         .expect("container resolves")
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/config.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/config.rs
@@ -381,7 +381,7 @@ impl VirtualAccountConfig {
     ///
     /// Construct each config with [`Self::new`] instead of cloning a base.
     pub fn with_write_mode(self, mode: WriteMode) -> Self {
-        self.topology.write().unwrap().write_mode = mode;
+        self.set_write_mode(mode);
         self
     }
 
@@ -826,6 +826,10 @@ impl VirtualAccountConfig {
     /// on a normal account, not a one-way door.
     pub(crate) fn set_write_mode(&self, mode: WriteMode) {
         let mut topology = self.topology.write().unwrap();
+        if topology.write_mode != mode {
+            topology.failing_over_from = None;
+            topology.next_write_region = None;
+        }
         topology.write_mode = mode;
     }
 
@@ -993,11 +997,14 @@ impl VirtualAccountConfig {
         };
 
         if topology.write_region == region_name {
-            topology.write_region = next_online;
+            topology.write_region = next_online.clone();
             // The service renumbers priorities during an offline-triggered
             // failover: surviving regions move up and the offlined former hub
             // moves to the lowest-priority position.
-            topology.priority_order.retain(|name| name != region_name);
+            topology
+                .priority_order
+                .retain(|name| name != region_name && name != &next_online);
+            topology.priority_order.insert(0, next_online);
             topology.priority_order.push(region_name.to_string());
             // No `failing_over_from`: the outgoing region is offline, and an
             // offline region is filtered out of the advertised lists entirely,
@@ -1761,5 +1768,55 @@ mod tests {
         assert!(error
             .to_string()
             .contains("partition key range page size must be > 0"));
+    }
+
+    #[test]
+    fn write_mode_change_clears_failover_transition() {
+        let announced = VirtualAccountConfig::new(vec![region("East"), region("West")]).unwrap();
+        announced.announce_failover("West").unwrap();
+        announced.set_write_mode(WriteMode::Multi);
+        announced.set_write_mode(WriteMode::Single);
+
+        let snapshot = announced.topology_snapshot();
+        assert_eq!(
+            snapshot
+                .writable(true)
+                .iter()
+                .map(|region| region.name())
+                .collect::<Vec<_>>(),
+            vec!["East"]
+        );
+        assert_eq!(snapshot.next_write_region, None);
+        assert_eq!(snapshot.failing_over_from, None);
+
+        let begun = VirtualAccountConfig::new(vec![region("East"), region("West")]).unwrap();
+        begun.begin_failover("West").unwrap();
+        begun.set_write_mode(WriteMode::Multi);
+        begun.set_write_mode(WriteMode::Single);
+
+        let snapshot = begun.topology_snapshot();
+        assert_eq!(
+            snapshot
+                .writable(true)
+                .iter()
+                .map(|region| region.name())
+                .collect::<Vec<_>>(),
+            vec!["West"]
+        );
+        assert_eq!(snapshot.next_write_region, None);
+        assert_eq!(snapshot.failing_over_from, None);
+    }
+
+    #[test]
+    fn offline_failover_hoists_first_online_priority() {
+        let config =
+            VirtualAccountConfig::new(vec![region("East"), region("West"), region("Central")])
+                .unwrap();
+        config.set_region_offline("West").unwrap();
+        config.set_region_offline("East").unwrap();
+
+        let topology = config.topology.read().unwrap();
+        assert_eq!(topology.write_region, "Central");
+        assert_eq!(topology.priority_order, vec!["Central", "West", "East"]);
     }
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/operations.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/operations.rs
@@ -997,7 +997,7 @@ pub(crate) async fn handle_operation(
         let write_lock = store.document_write_lock();
         let _write_guard = write_lock.lock().await;
         let replication_barrier = store.replication_barrier();
-        let _replication_guard = replication_barrier.lock().await;
+        let _replication_guard = replication_barrier.read().await;
         handle_dtx_write_transaction_locked(store, region_name, operations, start).await
     }
 
@@ -3955,7 +3955,7 @@ async fn handle_batch(
     #[cfg(feature = "preview_dtx")]
     let _write_guard = write_lock.lock().await;
     let replication_barrier = store.replication_barrier();
-    let _replication_guard = replication_barrier.lock().await;
+    let _replication_guard = replication_barrier.read().await;
 
     const MAX_BATCH_OPERATIONS: usize = 100;
     const MAX_BATCH_PAYLOAD_BYTES: usize = 2 * 1024 * 1024;
@@ -4598,7 +4598,7 @@ async fn handle_create(
     #[cfg(feature = "preview_dtx")]
     let _write_guard = write_lock.lock().await;
     let replication_barrier = store.replication_barrier();
-    let _replication_guard = replication_barrier.lock().await;
+    let _replication_guard = replication_barrier.read().await;
 
     handle_create_locked(store, region_name, parsed, request_body, start).await
 }
@@ -5082,7 +5082,7 @@ async fn handle_replace(
     #[cfg(feature = "preview_dtx")]
     let _write_guard = write_lock.lock().await;
     let replication_barrier = store.replication_barrier();
-    let _replication_guard = replication_barrier.lock().await;
+    let _replication_guard = replication_barrier.read().await;
 
     handle_replace_locked(store, region_name, parsed, request_body, start).await
 }
@@ -5099,7 +5099,7 @@ async fn handle_patch(
     #[cfg(feature = "preview_dtx")]
     let _write_guard = write_lock.lock().await;
     let replication_barrier = store.replication_barrier();
-    let _replication_guard = replication_barrier.lock().await;
+    let _replication_guard = replication_barrier.read().await;
 
     handle_patch_locked(store, region_name, parsed, request_body, start).await
 }
@@ -5748,7 +5748,7 @@ async fn handle_upsert(
     #[cfg(feature = "preview_dtx")]
     let _write_guard = write_lock.lock().await;
     let replication_barrier = store.replication_barrier();
-    let _replication_guard = replication_barrier.lock().await;
+    let _replication_guard = replication_barrier.read().await;
 
     handle_upsert_locked(store, region_name, parsed, request_body, start).await
 }
@@ -5982,7 +5982,7 @@ async fn handle_delete(
     #[cfg(feature = "preview_dtx")]
     let _write_guard = write_lock.lock().await;
     let replication_barrier = store.replication_barrier();
-    let _replication_guard = replication_barrier.lock().await;
+    let _replication_guard = replication_barrier.read().await;
 
     handle_delete_locked(store, region_name, parsed, start).await
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/operations.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/operations.rs
@@ -996,6 +996,8 @@ pub(crate) async fn handle_operation(
     ) -> AsyncRawResponse {
         let write_lock = store.document_write_lock();
         let _write_guard = write_lock.lock().await;
+        let replication_barrier = store.replication_barrier();
+        let _replication_guard = replication_barrier.lock().await;
         handle_dtx_write_transaction_locked(store, region_name, operations, start).await
     }
 
@@ -3952,6 +3954,8 @@ async fn handle_batch(
     let write_lock = store.document_write_lock();
     #[cfg(feature = "preview_dtx")]
     let _write_guard = write_lock.lock().await;
+    let replication_barrier = store.replication_barrier();
+    let _replication_guard = replication_barrier.lock().await;
 
     const MAX_BATCH_OPERATIONS: usize = 100;
     const MAX_BATCH_PAYLOAD_BYTES: usize = 2 * 1024 * 1024;
@@ -4593,6 +4597,8 @@ async fn handle_create(
     let write_lock = store.document_write_lock();
     #[cfg(feature = "preview_dtx")]
     let _write_guard = write_lock.lock().await;
+    let replication_barrier = store.replication_barrier();
+    let _replication_guard = replication_barrier.lock().await;
 
     handle_create_locked(store, region_name, parsed, request_body, start).await
 }
@@ -5075,6 +5081,8 @@ async fn handle_replace(
     let write_lock = store.document_write_lock();
     #[cfg(feature = "preview_dtx")]
     let _write_guard = write_lock.lock().await;
+    let replication_barrier = store.replication_barrier();
+    let _replication_guard = replication_barrier.lock().await;
 
     handle_replace_locked(store, region_name, parsed, request_body, start).await
 }
@@ -5090,6 +5098,8 @@ async fn handle_patch(
     let write_lock = store.document_write_lock();
     #[cfg(feature = "preview_dtx")]
     let _write_guard = write_lock.lock().await;
+    let replication_barrier = store.replication_barrier();
+    let _replication_guard = replication_barrier.lock().await;
 
     handle_patch_locked(store, region_name, parsed, request_body, start).await
 }
@@ -5737,6 +5747,8 @@ async fn handle_upsert(
     let write_lock = store.document_write_lock();
     #[cfg(feature = "preview_dtx")]
     let _write_guard = write_lock.lock().await;
+    let replication_barrier = store.replication_barrier();
+    let _replication_guard = replication_barrier.lock().await;
 
     handle_upsert_locked(store, region_name, parsed, request_body, start).await
 }
@@ -5969,6 +5981,8 @@ async fn handle_delete(
     let write_lock = store.document_write_lock();
     #[cfg(feature = "preview_dtx")]
     let _write_guard = write_lock.lock().await;
+    let replication_barrier = store.replication_barrier();
+    let _replication_guard = replication_barrier.lock().await;
 
     handle_delete_locked(store, region_name, parsed, start).await
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/store.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/store.rs
@@ -18,8 +18,9 @@ use super::session::SessionState;
 use crate::models::{PartitionKeyDefinition, PartitionKeyKind, PartitionKeyVersion};
 
 type SplitMergeLocks = HashMap<(String, String), Arc<async_lock::Mutex<()>>>;
-type InFlightReplications = Arc<std::sync::Mutex<HashMap<u64, PendingReplication>>>;
+type ReplicationTrackerHandle = Arc<std::sync::Mutex<ReplicationTracker>>;
 type CatchUpJournals = Arc<std::sync::Mutex<HashMap<(String, u64), Vec<PendingReplication>>>>;
+type ReplicationRegistrationHook = Arc<dyn Fn() + Send + Sync>;
 /// Sentinel pkrange id used for control-plane (database/container/offer) session
 /// tokens. Chosen as `u32::MAX` so it cannot collide with any user pkrange id,
 /// since real Cosmos partition counts are bounded far below this value.
@@ -233,13 +234,16 @@ pub struct EmulatorStore {
     dtx_replication_capture: std::sync::Mutex<Option<Vec<CapturedReplication>>>,
     /// Tracks spawned replication tasks so tests can drain them.
     replication_tasks: std::sync::Mutex<tokio::task::JoinSet<()>>,
+    /// Serializes a local mutation through replication registration against
+    /// delayed catch-up snapshot and finalization.
+    replication_barrier: Arc<async_lock::Mutex<()>>,
     /// Delayed replications that have been scheduled but not yet applied.
     ///
     /// Region enrollment replays this bounded set into the joining replica so
     /// a mutation already queued for the seed hub cannot fall between the
-    /// source snapshot and target enrollment. Entries are removed immediately
-    /// after their task applies.
-    in_flight_replications: InFlightReplications,
+    /// source snapshot and target enrollment. The tracker retains the newest
+    /// mutation for an item until every older in-flight mutation completes.
+    replication_tracker: ReplicationTrackerHandle,
     next_replication_operation_id: AtomicU64,
     /// Per-incarnation mutation journals for regions using delayed catch-up.
     ///
@@ -249,6 +253,8 @@ pub struct EmulatorStore {
     /// enrollment-time create from being resurrected.
     catch_up_journals: CatchUpJournals,
     next_catch_up_journal_id: AtomicU64,
+    /// Optional deterministic interleaving hook for emulator regression tests.
+    before_replication_registration: std::sync::Mutex<Option<ReplicationRegistrationHook>>,
     /// Tracks spawned split/merge tasks separately from replication so a
     /// control-plane panic does not surface inside an unrelated point-write
     /// handler that happens to call `replicate()`.
@@ -319,10 +325,12 @@ impl EmulatorStore {
             #[cfg(feature = "preview_dtx")]
             dtx_replication_capture: std::sync::Mutex::new(None),
             replication_tasks: std::sync::Mutex::new(tokio::task::JoinSet::new()),
-            in_flight_replications: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            replication_barrier: Arc::new(async_lock::Mutex::new(())),
+            replication_tracker: Arc::new(std::sync::Mutex::new(ReplicationTracker::default())),
             next_replication_operation_id: AtomicU64::new(0),
             catch_up_journals: Arc::new(std::sync::Mutex::new(HashMap::new())),
             next_catch_up_journal_id: AtomicU64::new(0),
+            before_replication_registration: std::sync::Mutex::new(None),
             control_plane_tasks: std::sync::Mutex::new(Vec::new()),
             transport_request_counter: AtomicU32::new(0),
             replication_semaphore: Arc::new(tokio::sync::Semaphore::new(
@@ -501,6 +509,19 @@ impl EmulatorStore {
     #[cfg(feature = "preview_dtx")]
     pub(crate) fn document_write_lock(&self) -> Arc<async_lock::Mutex<()>> {
         self.document_write_lock.clone()
+    }
+
+    pub(crate) fn replication_barrier(&self) -> Arc<async_lock::Mutex<()>> {
+        Arc::clone(&self.replication_barrier)
+    }
+
+    /// Sets a hook invoked after local commit and before replication registration.
+    #[doc(hidden)]
+    pub fn set_before_replication_registration_hook_for_tests(
+        &self,
+        hook: Option<Arc<dyn Fn() + Send + Sync>>,
+    ) {
+        *self.before_replication_registration.lock().unwrap() = hook;
     }
 
     /// Returns the preview-DTX document write lock for internal emulator tests.
@@ -925,17 +946,17 @@ impl EmulatorStore {
 
             // Replay mutations that were committed before enrollment but have
             // not reached every existing replica yet. Delayed tasks remain in
-            // `in_flight_replications` until apply; paused targets retain their
+            // the replication tracker until apply; paused targets retain their
             // entries in per-region buffers. A write beginning after this
             // snapshot blocks on the regions read lock and will discover the
             // newly inserted target normally.
             let mut pending: Vec<PendingReplication> = {
-                // Keep the same in-flight -> journals lock order as
+                // Keep the same tracker -> journals lock order as
                 // `replicate`. Journal creation and replication registration
                 // are atomic relative to each other: a mutation is either in
                 // this initial snapshot or appended to the new journal.
-                let in_flight = self.in_flight_replications.lock().unwrap();
-                let pending: Vec<_> = in_flight.values().cloned().collect();
+                let tracker = self.replication_tracker.lock().unwrap();
+                let pending = tracker.replay_snapshot();
                 if let Some(journal_id) = catch_up_journal_id {
                     self.catch_up_journals
                         .lock()
@@ -998,7 +1019,8 @@ impl EmulatorStore {
             // Delayed intentionally starts empty, then takes a later snapshot.
             // This preserves the original policy's observable lag behavior.
             let target = Arc::clone(&region_store);
-            let in_flight = Arc::clone(&self.in_flight_replications);
+            let barrier = Arc::clone(&self.replication_barrier);
+            let tracker = Arc::clone(&self.replication_tracker);
             let journals = Arc::clone(&self.catch_up_journals);
             let journal_key = (
                 region_name.clone(),
@@ -1006,11 +1028,12 @@ impl EmulatorStore {
             );
             tokio::spawn(async move {
                 tokio::time::sleep(delay).await;
+                let _replication_guard = barrier.lock().await;
                 target.catch_up_from(&seed_source);
-                // Match replication registration's in-flight -> journals lock
+                // Match replication registration's tracker -> journals lock
                 // order. A mutation registered before finalization either
                 // appends before removal or blocks finalization at in-flight.
-                let in_flight_guard = in_flight.lock().unwrap();
+                let tracker_guard = tracker.lock().unwrap();
                 let mut journals_guard = journals.lock().unwrap();
                 let mut pending = journals_guard.remove(&journal_key).unwrap_or_default();
                 sort_pending_replications(&mut pending);
@@ -1021,7 +1044,7 @@ impl EmulatorStore {
                 // no mutation can apply to the target between journal removal
                 // and replay.
                 drop(journals_guard);
-                drop(in_flight_guard);
+                drop(tracker_guard);
             });
         } else if let SeedingPolicy::HiddenUntilReady(delay) = seeding {
             // Hidden buildout is already internally seeded and participates in
@@ -1110,9 +1133,9 @@ impl EmulatorStore {
         self.advance_vector_clock_versions();
         self.config.remove_region(region_name)?;
         {
-            // Match replication registration's in-flight -> journals order so
+            // Match replication registration's tracker -> journals order so
             // no mutation can append to an orphaned journal during cleanup.
-            let _in_flight = self.in_flight_replications.lock().unwrap();
+            let _tracker = self.replication_tracker.lock().unwrap();
             self.catch_up_journals
                 .lock()
                 .unwrap()
@@ -1370,11 +1393,15 @@ impl EmulatorStore {
             doc: doc.clone(),
             is_delete,
         };
+        let registration_hook = self.before_replication_registration.lock().unwrap().clone();
+        if let Some(hook) = registration_hook {
+            hook();
+        }
         {
-            // Match add_region's in-flight -> journals lock order.
-            let mut in_flight = self.in_flight_replications.lock().unwrap();
+            // Match add_region's tracker -> journals lock order.
+            let mut tracker = self.replication_tracker.lock().unwrap();
             let mut journals = self.catch_up_journals.lock().unwrap();
-            in_flight.insert(operation_id, pending_replication.clone());
+            tracker.register(operation_id, pending_replication.clone());
             for journal in journals.values_mut() {
                 journal.push(pending_replication.clone());
             }
@@ -1389,10 +1416,10 @@ impl EmulatorStore {
         drop(regions);
 
         if region_names.is_empty() {
-            self.in_flight_replications
+            self.replication_tracker
                 .lock()
                 .unwrap()
-                .remove(&operation_id);
+                .complete(operation_id);
             return;
         }
         let remaining_targets = Arc::new(AtomicUsize::new(region_names.len()));
@@ -1434,10 +1461,10 @@ impl EmulatorStore {
 
     fn complete_replication_target(&self, operation_id: u64, remaining_targets: &AtomicUsize) {
         if remaining_targets.fetch_sub(1, Ordering::SeqCst) == 1 {
-            self.in_flight_replications
+            self.replication_tracker
                 .lock()
                 .unwrap()
-                .remove(&operation_id);
+                .complete(operation_id);
         }
     }
 
@@ -1811,6 +1838,89 @@ pub(crate) struct PendingReplication {
     pub source_region: String,
     pub doc: StoredDocument,
     pub is_delete: bool,
+}
+
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+struct ReplicationKey {
+    db_id: String,
+    coll_id: String,
+    epk: Epk,
+    id: String,
+}
+
+struct TrackedReplication {
+    operation_id: u64,
+    pending: PendingReplication,
+}
+
+#[derive(Default)]
+struct ReplicationTracker {
+    in_flight: HashMap<u64, PendingReplication>,
+    in_flight_counts: BTreeMap<ReplicationKey, usize>,
+    latest_by_item: BTreeMap<ReplicationKey, TrackedReplication>,
+}
+
+impl ReplicationTracker {
+    fn register(&mut self, operation_id: u64, pending: PendingReplication) {
+        let key = pending.key();
+        *self.in_flight_counts.entry(key.clone()).or_default() += 1;
+        let should_replace = self
+            .latest_by_item
+            .get(&key)
+            .is_none_or(|tracked| pending.lww_order() > tracked.pending.lww_order());
+        if should_replace {
+            self.latest_by_item.insert(
+                key,
+                TrackedReplication {
+                    operation_id,
+                    pending: pending.clone(),
+                },
+            );
+        }
+        self.in_flight.insert(operation_id, pending);
+    }
+
+    fn complete(&mut self, operation_id: u64) {
+        let Some(pending) = self.in_flight.remove(&operation_id) else {
+            return;
+        };
+        let key = pending.key();
+        let count = self
+            .in_flight_counts
+            .get_mut(&key)
+            .expect("registered replication must have an in-flight count");
+        *count -= 1;
+        if *count == 0 {
+            self.in_flight_counts.remove(&key);
+            self.latest_by_item.remove(&key);
+        }
+    }
+
+    fn replay_snapshot(&self) -> Vec<PendingReplication> {
+        let mut pending: Vec<_> = self.in_flight.values().cloned().collect();
+        pending.extend(
+            self.latest_by_item
+                .values()
+                .filter(|tracked| !self.in_flight.contains_key(&tracked.operation_id))
+                .map(|tracked| tracked.pending.clone()),
+        );
+        pending
+    }
+}
+
+impl PendingReplication {
+    fn key(&self) -> ReplicationKey {
+        ReplicationKey {
+            db_id: self.db_id.clone(),
+            coll_id: self.coll_id.clone(),
+            epk: self.doc.epk.clone(),
+            id: self.doc.id.clone(),
+        }
+    }
+
+    fn lww_order(&self) -> (u64, u64) {
+        (self.doc.ts, self.doc.lsn)
+    }
 }
 
 fn sort_pending_replications(pending: &mut [PendingReplication]) {
@@ -3576,6 +3686,170 @@ fn decode_v1_number_hex_to_u32(hex: &str) -> Result<u32, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_store(config: VirtualAccountConfig) -> Arc<EmulatorStore> {
+        let store = EmulatorStore::new(config);
+        store.create_database("db");
+        let partition_key: PartitionKeyDefinition = serde_json::from_value(serde_json::json!({
+            "paths": ["/pk"], "kind": "Hash", "version": 2
+        }))
+        .unwrap();
+        store.create_container_with_config(
+            "db",
+            "c",
+            partition_key,
+            ContainerConfig::new()
+                .with_partition_count(1)
+                .build()
+                .unwrap(),
+        );
+        store
+    }
+
+    fn test_document(id: &str, ts: u64, lsn: u64) -> StoredDocument {
+        StoredDocument {
+            body: serde_json::json!({"id": id, "pk": "value"}),
+            id: id.to_string(),
+            rid: format!("rid-{id}"),
+            etag: format!("etag-{lsn}"),
+            ts,
+            self_link: format!("dbs/db/colls/c/docs/{id}/"),
+            lsn,
+            epk: Epk::MIN,
+            body_size_bytes: 32,
+            source_region: "West".to_string(),
+        }
+    }
+
+    fn apply_local_document(
+        store: &EmulatorStore,
+        region_name: &str,
+        doc: &StoredDocument,
+        is_delete: bool,
+    ) {
+        let region = Arc::clone(
+            store
+                .regions
+                .read()
+                .unwrap()
+                .get(region_name)
+                .expect("test region must exist"),
+        );
+        let containers = region.containers.read().unwrap();
+        let state = containers
+            .get(&("db".to_string(), "c".to_string()))
+            .expect("test container must exist");
+        let partition = state
+            .find_partition(&doc.epk)
+            .expect("test partition must exist");
+        apply_doc_to_partition(partition, doc, is_delete);
+    }
+
+    fn contains_document(store: &EmulatorStore, region_name: &str, epk: &Epk, id: &str) -> bool {
+        let region = Arc::clone(
+            store
+                .regions
+                .read()
+                .unwrap()
+                .get(region_name)
+                .expect("test region must exist"),
+        );
+        let containers = region.containers.read().unwrap();
+        let state = containers
+            .get(&("db".to_string(), "c".to_string()))
+            .expect("test container must exist");
+        let partition = state
+            .find_partition(epk)
+            .expect("test partition must exist");
+        let documents = partition.documents.read().unwrap();
+        documents.get(epk).is_some_and(|docs| docs.contains_key(id))
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn region_add_replays_completed_delete_after_older_create() {
+        let delay_call = Arc::new(AtomicUsize::new(0));
+        let delay_call_clone = Arc::clone(&delay_call);
+        let replication = super::super::config::ReplicationConfig::immediate()
+            .with_replication_delay_fn(Arc::new(move || {
+                if delay_call_clone.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Duration::from_secs(3_600)
+                } else {
+                    Duration::ZERO
+                }
+            }));
+        let config = VirtualAccountConfig::new(vec![
+            VirtualRegion::new("East", url::Url::parse("https://east.local").unwrap()),
+            VirtualRegion::new("West", url::Url::parse("https://west.local").unwrap()),
+        ])
+        .unwrap()
+        .with_replication_config(replication);
+        let store = test_store(config);
+        let mut create = test_document("item", 1, 1);
+        create.source_region = "East".to_string();
+        let mut delete = test_document("item", 2, 2);
+        delete.body = serde_json::Value::Null;
+        delete.source_region = "East".to_string();
+
+        apply_local_document(&store, "East", &create, false);
+        store.replicate("East", "db", "c", &create, false);
+        apply_local_document(&store, "East", &delete, true);
+        store.replicate("East", "db", "c", &delete, true);
+
+        store
+            .add_region(
+                VirtualRegion::new("Central", url::Url::parse("https://central.local").unwrap()),
+                SeedingPolicy::Immediate,
+            )
+            .unwrap();
+
+        assert!(!contains_document(&store, "Central", &Epk::MIN, "item"));
+        tokio::time::advance(Duration::from_secs(3_600)).await;
+        store.drain_pending_replications().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn delayed_catch_up_waits_for_local_replication_registration() {
+        let config = VirtualAccountConfig::new(vec![VirtualRegion::new(
+            "East",
+            url::Url::parse("https://east.local").unwrap(),
+        )])
+        .unwrap()
+        .with_write_mode(WriteMode::Multi)
+        .with_replication_config(super::super::config::ReplicationConfig::fixed(
+            Duration::from_secs(3_600),
+        ));
+        let store = test_store(config);
+        store
+            .add_region(
+                VirtualRegion::new("West", url::Url::parse("https://west.local").unwrap()),
+                SeedingPolicy::Delayed(Duration::from_secs(10)),
+            )
+            .unwrap();
+        tokio::task::yield_now().await;
+
+        let barrier = store.replication_barrier();
+        let replication_guard = barrier.lock().await;
+        let document = test_document("item", 1, 1);
+        apply_local_document(&store, "West", &document, false);
+
+        tokio::time::advance(Duration::from_secs(10)).await;
+        tokio::task::yield_now().await;
+        store.replicate("West", "db", "c", &document, false);
+        drop(replication_guard);
+
+        for _ in 0..10 {
+            if store.catch_up_journals.lock().unwrap().is_empty() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        assert!(
+            store.catch_up_journals.lock().unwrap().is_empty(),
+            "catch-up must finish after the replication barrier is released"
+        );
+        assert!(contains_document(&store, "West", &Epk::MIN, "item"));
+    }
 
     #[tokio::test(start_paused = true)]
     async fn removing_delayed_region_clears_catch_up_journal() {

--- a/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/store.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/in_memory_emulator/store.rs
@@ -234,9 +234,11 @@ pub struct EmulatorStore {
     dtx_replication_capture: std::sync::Mutex<Option<Vec<CapturedReplication>>>,
     /// Tracks spawned replication tasks so tests can drain them.
     replication_tasks: std::sync::Mutex<tokio::task::JoinSet<()>>,
-    /// Serializes a local mutation through replication registration against
-    /// delayed catch-up snapshot and finalization.
-    replication_barrier: Arc<async_lock::Mutex<()>>,
+    /// Coordinates local mutation registration with delayed catch-up.
+    ///
+    /// Writes share the barrier; catch-up takes it exclusively across snapshot
+    /// and finalization.
+    replication_barrier: Arc<async_lock::RwLock<()>>,
     /// Delayed replications that have been scheduled but not yet applied.
     ///
     /// Region enrollment replays this bounded set into the joining replica so
@@ -325,7 +327,7 @@ impl EmulatorStore {
             #[cfg(feature = "preview_dtx")]
             dtx_replication_capture: std::sync::Mutex::new(None),
             replication_tasks: std::sync::Mutex::new(tokio::task::JoinSet::new()),
-            replication_barrier: Arc::new(async_lock::Mutex::new(())),
+            replication_barrier: Arc::new(async_lock::RwLock::new(())),
             replication_tracker: Arc::new(std::sync::Mutex::new(ReplicationTracker::default())),
             next_replication_operation_id: AtomicU64::new(0),
             catch_up_journals: Arc::new(std::sync::Mutex::new(HashMap::new())),
@@ -511,7 +513,7 @@ impl EmulatorStore {
         self.document_write_lock.clone()
     }
 
-    pub(crate) fn replication_barrier(&self) -> Arc<async_lock::Mutex<()>> {
+    pub(crate) fn replication_barrier(&self) -> Arc<async_lock::RwLock<()>> {
         Arc::clone(&self.replication_barrier)
     }
 
@@ -1028,7 +1030,7 @@ impl EmulatorStore {
             );
             tokio::spawn(async move {
                 tokio::time::sleep(delay).await;
-                let _replication_guard = barrier.lock().await;
+                let _replication_guard = barrier.write().await;
                 target.catch_up_from(&seed_source);
                 // Match replication registration's tracker -> journals lock
                 // order. A mutation registered before finalization either
@@ -3828,7 +3830,7 @@ mod tests {
         tokio::task::yield_now().await;
 
         let barrier = store.replication_barrier();
-        let replication_guard = barrier.lock().await;
+        let replication_guard = barrier.read().await;
         let document = test_document("item", 1, 1);
         apply_local_document(&store, "West", &document, false);
 

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/in_memory_emulator_tests/region_online_offline.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/in_memory_emulator_tests/region_online_offline.rs
@@ -27,7 +27,7 @@
 //! the production account-refresh interval is five minutes.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
 
 use azure_core::http::{Method, Request, StatusCode, Url};
@@ -221,7 +221,7 @@ async fn build_driver_at_with_options(
 
 async fn seed_item(driver: &CosmosDriver, item_id: &str) {
     let container = driver
-        .resolve_container("testdb", "testcoll")
+        .resolve_container("testdb", "testcoll", OperationOptions::default())
         .await
         .expect("container should resolve");
     let body = serde_json::json!({"id": item_id, "pk": "pk1", "value": 1}).to_string();
@@ -242,7 +242,7 @@ async fn read_and_capture_hosts(
     item_id: &str,
 ) -> Vec<String> {
     let container = driver
-        .resolve_container("testdb", "testcoll")
+        .resolve_container("testdb", "testcoll", OperationOptions::default())
         .await
         .expect("container should resolve");
     recorder.clear();
@@ -264,7 +264,7 @@ async fn write_and_capture_hosts(
     item_id: &str,
 ) -> Vec<String> {
     let container = driver
-        .resolve_container("testdb", "testcoll")
+        .resolve_container("testdb", "testcoll", OperationOptions::default())
         .await
         .expect("container should resolve");
     recorder.clear();
@@ -1556,6 +1556,137 @@ async fn delayed_region_remains_advertised_during_buildout() {
     );
 }
 
+/// A real point-write handler must hold catch-up behind replication registration.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delayed_catch_up_cannot_overwrite_handler_write_before_registration() {
+    let recorder = HostRecorder::new();
+    let emulator = build_emulator(vec![east()], WriteMode::Multi, recorder);
+    let store = emulator.store();
+
+    let mut seed = Request::new(
+        Url::parse(&format!("{EAST_URL}/dbs/testdb/colls/testcoll/docs")).unwrap(),
+        Method::Post,
+    );
+    seed.set_body(serde_json::json!({"id": "catch-up-sentinel", "pk": "pk1"}).to_string());
+    seed.headers_mut().insert(
+        super::PARTITION_KEY.clone(),
+        azure_core::http::headers::HeaderValue::from_static("[\"pk1\"]"),
+    );
+    let (status, _, _) = collect_response(emulator.execute_request(&seed).await.unwrap()).await;
+    assert_eq!(status, StatusCode::Created);
+
+    let (registration_tx, registration_rx) = tokio::sync::oneshot::channel();
+    let registration_tx = Arc::new(Mutex::new(Some(registration_tx)));
+    let release_registration = Arc::new((Mutex::new(false), Condvar::new()));
+    let registration_tx_clone = Arc::clone(&registration_tx);
+    let release_registration_clone = Arc::clone(&release_registration);
+    store.set_before_replication_registration_hook_for_tests(Some(Arc::new(move || {
+        if let Some(tx) = registration_tx_clone.lock().unwrap().take() {
+            tx.send(()).expect("test must wait for registration hook");
+            let (released, wake) = &*release_registration_clone;
+            let mut released = released.lock().unwrap();
+            while !*released {
+                released = wake.wait(released).unwrap();
+            }
+        }
+    })));
+    drop(registration_tx);
+
+    struct RegistrationRelease(Arc<(Mutex<bool>, Condvar)>);
+
+    impl RegistrationRelease {
+        fn release(&self) {
+            let (released, wake) = &*self.0;
+            *released.lock().unwrap() = true;
+            wake.notify_all();
+        }
+    }
+
+    impl Drop for RegistrationRelease {
+        fn drop(&mut self) {
+            self.release();
+        }
+    }
+
+    let registration_release = RegistrationRelease(Arc::clone(&release_registration));
+    let catch_up_started = std::time::Instant::now();
+    store
+        .add_region(west(), SeedingPolicy::Delayed(Duration::from_secs(1)))
+        .unwrap();
+
+    let mut create = Request::new(
+        Url::parse(&format!("{WEST_URL}/dbs/testdb/colls/testcoll/docs")).unwrap(),
+        Method::Post,
+    );
+    create.set_body(serde_json::json!({"id": "handler-race", "pk": "pk1"}).to_string());
+    create.headers_mut().insert(
+        super::PARTITION_KEY.clone(),
+        azure_core::http::headers::HeaderValue::from_static("[\"pk1\"]"),
+    );
+
+    let emulator_clone = Arc::clone(&emulator);
+    let write = tokio::spawn(async move {
+        let response = emulator_clone.execute_request(&create).await.unwrap();
+        collect_response(response).await.0
+    });
+    tokio::time::timeout(Duration::from_secs(5), registration_rx)
+        .await
+        .expect("handler must reach replication registration before timeout")
+        .expect("handler must reach replication registration");
+    assert!(
+        catch_up_started.elapsed() < Duration::from_secs(1),
+        "handler must commit before delayed catch-up starts"
+    );
+
+    tokio::time::sleep(Duration::from_millis(1_100)).await;
+    registration_release.release();
+
+    assert_eq!(write.await.unwrap(), StatusCode::Created);
+    store.set_before_replication_registration_hook_for_tests(None);
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let mut read = Request::new(
+                Url::parse(&format!(
+                    "{WEST_URL}/dbs/testdb/colls/testcoll/docs/catch-up-sentinel"
+                ))
+                .unwrap(),
+                Method::Get,
+            );
+            read.headers_mut().insert(
+                super::PARTITION_KEY.clone(),
+                azure_core::http::headers::HeaderValue::from_static("[\"pk1\"]"),
+            );
+            let (status, _, _) =
+                collect_response(emulator.execute_request(&read).await.unwrap()).await;
+            if status == StatusCode::Ok {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("delayed catch-up must complete");
+
+    let mut read = Request::new(
+        Url::parse(&format!(
+            "{WEST_URL}/dbs/testdb/colls/testcoll/docs/handler-race"
+        ))
+        .unwrap(),
+        Method::Get,
+    );
+    read.headers_mut().insert(
+        super::PARTITION_KEY.clone(),
+        azure_core::http::headers::HeaderValue::from_static("[\"pk1\"]"),
+    );
+    let (status, _, _) = collect_response(emulator.execute_request(&read).await.unwrap()).await;
+    assert_eq!(
+        status,
+        StatusCode::Ok,
+        "delayed catch-up must not erase a local write before registration"
+    );
+}
+
 /// A mutation already pending at enrollment stays out of a `Delayed` region
 /// until its catch-up timer fires.
 #[tokio::test(start_paused = true)]
@@ -1918,7 +2049,7 @@ async fn offline_region_plus_exclusion_uses_nonpreferred_region() {
     advance_past_refresh().await;
 
     let container = driver
-        .resolve_container("testdb", "testcoll")
+        .resolve_container("testdb", "testcoll", OperationOptions::default())
         .await
         .unwrap();
     let item = ItemReference::from_name(
@@ -2031,7 +2162,7 @@ async fn operation_racing_offline_transition_retries_next_region() {
 
     observer.arm();
     let container = driver
-        .resolve_container("testdb", "testcoll")
+        .resolve_container("testdb", "testcoll", OperationOptions::default())
         .await
         .unwrap();
     let item = ItemReference::from_name(&container, PartitionKey::from("pk1"), "race-offline-item");

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/in_memory_emulator_tests/region_online_offline.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/in_memory_emulator_tests/region_online_offline.rs
@@ -26,6 +26,8 @@
 //! Time is virtualized with `tokio::time::pause()` (via `start_paused`) because
 //! the production account-refresh interval is five minutes.
 
+#[cfg(not(feature = "preview_dtx"))]
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
@@ -1685,6 +1687,96 @@ async fn delayed_catch_up_cannot_overwrite_handler_write_before_registration() {
         StatusCode::Ok,
         "delayed catch-up must not erase a local write before registration"
     );
+}
+
+/// Independent handlers share the replication barrier through registration.
+#[cfg(not(feature = "preview_dtx"))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn replication_registration_preserves_concurrent_handler_writes() {
+    let recorder = HostRecorder::new();
+    let emulator = build_emulator(vec![east(), west()], WriteMode::Multi, recorder);
+    let store = emulator.store();
+
+    let registrations = Arc::new(AtomicUsize::new(0));
+    let (both_registered_tx, both_registered_rx) = tokio::sync::oneshot::channel();
+    let both_registered_tx = Arc::new(Mutex::new(Some(both_registered_tx)));
+    let release_registration = Arc::new((Mutex::new(false), Condvar::new()));
+    let registrations_clone = Arc::clone(&registrations);
+    let both_registered_tx_clone = Arc::clone(&both_registered_tx);
+    let release_registration_clone = Arc::clone(&release_registration);
+    store.set_before_replication_registration_hook_for_tests(Some(Arc::new(move || {
+        if registrations_clone.fetch_add(1, Ordering::SeqCst) + 1 == 2 {
+            if let Some(tx) = both_registered_tx_clone.lock().unwrap().take() {
+                let _ = tx.send(());
+            }
+        }
+        let (released, wake) = &*release_registration_clone;
+        let mut released = released.lock().unwrap();
+        while !*released {
+            released = wake.wait(released).unwrap();
+        }
+    })));
+    drop(both_registered_tx);
+
+    struct RegistrationRelease(Arc<(Mutex<bool>, Condvar)>);
+
+    impl RegistrationRelease {
+        fn release(&self) {
+            let (released, wake) = &*self.0;
+            *released.lock().unwrap() = true;
+            wake.notify_all();
+        }
+    }
+
+    impl Drop for RegistrationRelease {
+        fn drop(&mut self) {
+            self.release();
+        }
+    }
+
+    let registration_release = RegistrationRelease(release_registration);
+    let write = |region_url: &str, id: &str| {
+        let mut request = Request::new(
+            Url::parse(&format!("{region_url}/dbs/testdb/colls/testcoll/docs")).unwrap(),
+            Method::Post,
+        );
+        request.set_body(serde_json::json!({"id": id, "pk": id}).to_string());
+        request.headers_mut().insert(
+            super::PARTITION_KEY.clone(),
+            azure_core::http::headers::HeaderValue::from(format!("[\"{id}\"]")),
+        );
+        request
+    };
+
+    let east_write = {
+        let emulator = Arc::clone(&emulator);
+        let request = write(EAST_URL, "east-concurrent");
+        tokio::spawn(async move {
+            collect_response(emulator.execute_request(&request).await.unwrap())
+                .await
+                .0
+        })
+    };
+    let west_write = {
+        let emulator = Arc::clone(&emulator);
+        let request = write(WEST_URL, "west-concurrent");
+        tokio::spawn(async move {
+            collect_response(emulator.execute_request(&request).await.unwrap())
+                .await
+                .0
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), both_registered_rx)
+        .await
+        .expect("independent handlers must register replication concurrently")
+        .expect("registration hook must remain installed");
+    registration_release.release();
+
+    assert_eq!(east_write.await.unwrap(), StatusCode::Created);
+    assert_eq!(west_write.await.unwrap(), StatusCode::Created);
+    assert_eq!(registrations.load(Ordering::SeqCst), 2);
+    store.set_before_replication_registration_hook_for_tests(None);
 }
 
 /// A mutation already pending at enrollment stays out of a `Delayed` region


### PR DESCRIPTION
Follow-up to #5134 addressing post-merge concurrency and topology review findings.

## Summary

- preserve last-writer-wins mutation order when a region enrolls while older replication is still in flight
- serialize local writes with delayed catch-up so a late snapshot cannot erase a committed regional write
- clear stale failover transition slots when write mode changes and repair priority ordering during offline-triggered failover
- add focused unit and handler-driven race regressions, including explicit catch-up completion coverage
- repair the public SDK topology parity test for the current container client options API