### PR TITLE
Add API generation check mode

### DIFF
--- a/eng/tools/Cargo.toml
+++ b/eng/tools/Cargo.toml
@@ -17,4 +17,5 @@ clap = { version = "4.5.58", features = ["derive"] }
 rustdoc-types = "0.57.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 toml = "0.8.20"

--- a/eng/tools/generate_api/AGENTS.md
+++ b/eng/tools/generate_api/AGENTS.md
@@ -23,6 +23,7 @@ The tool exposes:
 - `--manifest-path <path/to/Cargo.toml>`
 - `--format <markdown|apiview>` default `markdown`
 - `--no-docs` suppresses doc comments in `apiview` and skips `API.comments.patch`
+- `--check` compares generated content with existing files without writing; missing files pass
 - `--output <directory>`
 
 Behavior:
@@ -30,6 +31,7 @@ Behavior:
 - default `markdown` writes `API.md` and `API.comments.patch`
 - `--format apiview` writes `apiview.json`
 - `--no-docs` suppresses APIView doc comment tokens and the Markdown comments patch
+- check comparisons ignore line-ending differences and mismatches exit `1`
 - progress goes to stdout
 - fatal errors go to stderr and exit `1`
 
@@ -38,7 +40,8 @@ Behavior:
 - Standalone bin crate in the `eng/tools` workspace
 - Uses `eng/tools/rust-toolchain.toml` toolchain `nightly-2026-04-14`
 - Keep rustdoc schema compatibility logic isolated from the tool-owned model and renderers
-- Current deps: `rustdoc-types`, `serde`, `serde_json`, `clap`
+- Current deps: `rustdoc-types`, `serde`, `serde_json`, `clap`, `sha2`
+- Add common dependencies to the `eng/tools` workspace using versions already used by the repository
 - `rustc-dev` stays included because long-term direction remains closer to librustdoc/HIR
 - Keep implementation and tests separate when practical. Prefer sibling `tests.rs` files over nested `mod tests` blocks. Tiny local `#[test]` items may stay inline
 

--- a/eng/tools/generate_api/Cargo.toml
+++ b/eng/tools/generate_api/Cargo.toml
@@ -17,6 +17,7 @@ clap = { workspace = true }
 rustdoc-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 diffy = "0.5.2"

--- a/eng/tools/generate_api/README.md
+++ b/eng/tools/generate_api/README.md
@@ -17,6 +17,7 @@ cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- \
 - `--manifest-path <path>`: path to the target crate's `Cargo.toml`
 - `--format <markdown|apiview>`: optional output format to generate; defaults to `markdown`
 - `--no-docs`: omit documentation comments: APIView doc tokens, or the Markdown comments patch
+- `--check`: compare generated content with existing output files without writing them
 - `--output <dir>`: directory where generated files are written
 
 ### Outputs
@@ -25,6 +26,8 @@ cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- \
 - `--no-docs` writes only `API.md`
 - `--format apiview` writes `apiview.json`
 - `--format apiview --no-docs` writes `apiview.json` without doc comment tokens
+- `--check` succeeds when output files are absent or match after normalizing line endings; a mismatch
+  writes an error to stderr and exits with code `1`
 
 Both formats include available Cargo metadata (`description`, `edition`, and `rust-version`) and
 the crate's default and docs.rs feature list (or all features when not configured). Markdown also

--- a/eng/tools/generate_api/src/cli.rs
+++ b/eng/tools/generate_api/src/cli.rs
@@ -23,6 +23,10 @@ struct Args {
     #[arg(long)]
     no_docs: bool,
 
+    /// Check generated content against existing files without writing them.
+    #[arg(long)]
+    check: bool,
+
     /// Directory where generated files will be written.
     #[arg(long, value_name = "DIR")]
     output: PathBuf,
@@ -33,6 +37,7 @@ pub(crate) struct Request {
     pub(crate) manifest_path: PathBuf,
     pub(crate) format: OutputFormat,
     pub(crate) no_docs: bool,
+    pub(crate) check: bool,
     pub(crate) output_dir: PathBuf,
 }
 
@@ -60,6 +65,7 @@ pub(crate) fn parse() -> Request {
         manifest_path: args.manifest_path,
         format: args.format,
         no_docs: args.no_docs,
+        check: args.check,
         output_dir: args.output,
     }
 }

--- a/eng/tools/generate_api/src/cli/tests.rs
+++ b/eng/tools/generate_api/src/cli/tests.rs
@@ -15,6 +15,7 @@ fn defaults_to_markdown_format() {
 
     assert_eq!(args.format, OutputFormat::Markdown);
     assert!(!args.no_docs);
+    assert!(!args.check);
 }
 
 #[test]
@@ -46,4 +47,18 @@ fn accepts_no_docs_switch() {
     ]);
 
     assert!(args.no_docs);
+}
+
+#[test]
+fn accepts_check_switch() {
+    let args = Args::parse_from([
+        "generate_api",
+        "--manifest-path",
+        "sdk/core/azure_core/Cargo.toml",
+        "--check",
+        "--output",
+        "/tmp/generate_api",
+    ]);
+
+    assert!(args.check);
 }

--- a/eng/tools/generate_api/src/main.rs
+++ b/eng/tools/generate_api/src/main.rs
@@ -34,30 +34,42 @@ fn run() -> Result<(), String> {
     ));
 
     let model = driver::load_model(&request)?;
-    let output_path = output::output_path(&request)?;
+    let output_path = output::output_path(&request);
     diagnostics::info(format!("Generating file: {}", output_path.display()));
 
     match request.format {
         cli::OutputFormat::Markdown => {
             let lines = render::markdown::render_lines(&model);
             let rendered = render::markdown::render_from_lines(&lines);
-            output::write_file(&output_path, &rendered)?;
-            diagnostics::info(format!("Wrote file: {}", output_path.display()));
+            save_or_check(&request, &output_path, &rendered)?;
 
             if !request.no_docs {
                 let patch_path = output::output_file_path(&request, cli::COMMENTS_PATCH_FILE_NAME);
                 let file_name = request.format.default_file_name();
                 let patch = render::patch::render(&lines, file_name);
-                output::write_file(&patch_path, &patch)?;
-                diagnostics::info(format!("Wrote file: {}", patch_path.display()));
+                save_or_check(&request, &patch_path, &patch)?;
             }
         }
         cli::OutputFormat::Apiview => {
             let options = render::apiview::RenderOptions::new(!request.no_docs);
             let rendered = render::apiview::render(&model, &options)?;
-            output::write_file(&output_path, &rendered)?;
-            diagnostics::info(format!("Wrote file: {}", output_path.display()));
+            save_or_check(&request, &output_path, &rendered)?;
         }
+    }
+
+    Ok(())
+}
+
+fn save_or_check(request: &cli::Request, path: &Path, contents: &str) -> Result<(), String> {
+    if request.check {
+        if output::check_file(path, contents)? {
+            diagnostics::info(format!("Generated content matches: {}", path.display()));
+        } else {
+            diagnostics::info(format!("No existing file to check: {}", path.display()));
+        }
+    } else {
+        output::write_file(path, contents)?;
+        diagnostics::info(format!("Wrote file: {}", path.display()));
     }
 
     Ok(())

--- a/eng/tools/generate_api/src/output.rs
+++ b/eng/tools/generate_api/src/output.rs
@@ -2,20 +2,15 @@
 // Licensed under the MIT License.
 
 use crate::cli::Request;
+use sha2::{Digest, Sha256};
 use std::{
-    fs,
+    fs::{self, File},
+    io::{self, Read},
     path::{Path, PathBuf},
 };
 
-pub(crate) fn output_path(request: &Request) -> Result<PathBuf, String> {
-    fs::create_dir_all(&request.output_dir).map_err(|error| {
-        format!(
-            "Failed to create output directory '{}': {error}",
-            request.output_dir.display()
-        )
-    })?;
-
-    Ok(request.output_dir.join(request.format.default_file_name()))
+pub(crate) fn output_path(request: &Request) -> PathBuf {
+    request.output_dir.join(request.format.default_file_name())
 }
 
 pub(crate) fn output_file_path(request: &Request, file_name: &str) -> PathBuf {
@@ -23,6 +18,64 @@ pub(crate) fn output_file_path(request: &Request, file_name: &str) -> PathBuf {
 }
 
 pub(crate) fn write_file(path: &Path, contents: &str) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("Output file '{}' has no parent directory", path.display()))?;
+    fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "Failed to create output directory '{}': {error}",
+            parent.display()
+        )
+    })?;
     fs::write(path, contents)
         .map_err(|error| format!("Failed to write output file '{}': {error}", path.display()))
 }
+
+pub(crate) fn check_file(path: &Path, contents: &str) -> Result<bool, String> {
+    let existing = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(format!(
+                "Failed to read output file '{}': {error}",
+                path.display()
+            ));
+        }
+    };
+
+    let existing_hash = sha256(existing)
+        .map_err(|error| format!("Failed to read output file '{}': {error}", path.display()))?;
+    let generated_hash = sha256(contents.as_bytes())
+        .map_err(|error| format!("Failed to hash generated content: {error}"))?;
+
+    if existing_hash == generated_hash {
+        Ok(true)
+    } else {
+        Err(format!(
+            "Generated content does not match existing file '{}'",
+            path.display()
+        ))
+    }
+}
+
+fn sha256(mut reader: impl Read) -> io::Result<[u8; 32]> {
+    let mut contents = Vec::new();
+    reader.read_to_end(&mut contents)?;
+
+    let mut normalized = Vec::with_capacity(contents.len());
+    let mut index = 0;
+    while index < contents.len() {
+        if contents[index] == b'\r' {
+            normalized.push(b'\n');
+            index += usize::from(contents.get(index + 1) == Some(&b'\n'));
+        } else {
+            normalized.push(contents[index]);
+        }
+        index += 1;
+    }
+
+    Ok(Sha256::digest(normalized).into())
+}
+
+#[cfg(test)]
+mod tests;

--- a/eng/tools/generate_api/src/output/tests.rs
+++ b/eng/tools/generate_api/src/output/tests.rs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use super::*;
+use std::io::Cursor;
+
+#[test]
+fn sha256_matches_sha256sum() {
+    assert_eq!(
+        sha256(Cursor::new(b"one\ntwo\n")).unwrap(),
+        [
+            0xc3, 0xf9, 0xc8, 0xc2, 0x83, 0xa2, 0xb1, 0xf2, 0xf1, 0x89, 0x6f, 0x27, 0xa0, 0x1c,
+            0xbe, 0x3c, 0xdd, 0xc0, 0xc9, 0xd9, 0x3f, 0x75, 0x2e, 0x46, 0x39, 0x03, 0x5a, 0x0f,
+            0x5b, 0x36, 0xf6, 0xe8,
+        ]
+    );
+}
+
+#[test]
+fn sha256_ignores_windows_line_endings() {
+    let lf = sha256(Cursor::new(b"one\ntwo\n")).unwrap();
+    let crlf = sha256(Cursor::new(b"one\r\ntwo\r\n")).unwrap();
+
+    assert_eq!(lf, crlf);
+}
+
+#[test]
+fn sha256_ignores_legacy_mac_line_endings() {
+    let lf = sha256(Cursor::new(b"one\ntwo\n")).unwrap();
+    let cr = sha256(Cursor::new(b"one\rtwo\r")).unwrap();
+
+    assert_eq!(lf, cr);
+}
+
+#[test]
+fn missing_file_is_positive() {
+    let path = test_path("missing", line!());
+    let _ = fs::remove_file(&path);
+
+    assert!(!check_file(&path, "generated").unwrap());
+}
+
+#[test]
+fn matching_file_is_positive_with_different_line_endings() {
+    let path = test_path("matching", line!());
+    fs::write(&path, "one\r\ntwo\r\n").unwrap();
+
+    assert!(check_file(&path, "one\ntwo\n").unwrap());
+
+    fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn mismatched_file_is_an_error() {
+    let path = test_path("mismatched", line!());
+    fs::write(&path, "existing\n").unwrap();
+
+    let error = check_file(&path, "generated\n").unwrap_err();
+
+    fs::remove_file(&path).unwrap();
+    assert!(error.contains(&path.display().to_string()));
+}
+
+fn test_path(name: &str, line: u32) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "generate_api_{name}_{}_{}",
+        std::process::id(),
+        line
+    ))
+}


### PR DESCRIPTION
Add a --check switch for Markdown and APIView output that compares generated content without writing files. Missing files pass, while mismatches report an error and exit unsuccessfully.

Normalize line endings before SHA-256 comparison and cover LF, Windows CRLF, legacy CR, missing, matching, and mismatched file cases.

Document the new behavior and manage sha2 through the shared engineering tools workspace dependencies.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: c1ffe5f5-11d9-4758-a0f0-185a3019b52c

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>