### PR TITLE
Generate Markdown API source maps

### DIFF
--- a/eng/tools/generate_api/AGENTS.md
+++ b/eng/tools/generate_api/AGENTS.md
@@ -5,8 +5,9 @@
 `eng/tools/generate_api` is a Rust CLI that generates the following public API artifacts for a target crate:
 
 1. `API.md` — one fenced `rust` block
-2. `API.comments.patch` — a unified diff that adds doc comments back to `API.md`
-3. `apiview.json` — an APIView tree-style `CodeFile`
+2. `API.md.map` — an ECMA-426 source map for declaration lines in `API.md`
+3. `API.comments.patch` — a unified diff that adds doc comments back to `API.md`
+4. `apiview.json` — an APIView tree-style `CodeFile`
 
 ## Scope
 
@@ -23,12 +24,13 @@ The tool exposes:
 - `--manifest-path <path/to/Cargo.toml>`
 - `--format <markdown|apiview>` default `markdown`
 - `--no-docs` suppresses doc comments in `apiview` and skips `API.comments.patch`
+- `--no-map` skips `API.md.map`; it is a no-op for `apiview`
 - `--check` compares generated content with existing files without writing; missing files pass
 - `--output <directory>`
 
 Behavior:
 
-- default `markdown` writes `API.md` and `API.comments.patch`
+- default `markdown` writes `API.md`, `API.md.map`, and `API.comments.patch`
 - `--format apiview` writes `apiview.json`
 - `--no-docs` suppresses APIView doc comment tokens and the Markdown comments patch
 - check comparisons ignore line-ending differences and mismatches exit `1`
@@ -213,6 +215,14 @@ For traits whose rustdoc-expanded methods carry synthetic async-trait lifetimes:
 - each contiguous doc-comment block becomes its own hunk
 - each hunk includes only the doc comments plus the next non-doc line as context
 - no doc comments means an empty patch file
+
+## Source map output
+
+- `source_map` owns the generic ECMA-426 v3 schema and Base64 VLQ encoding
+- the shared model stores repo-relative zero-based declaration locations
+- Markdown maps item, module, and member declaration lines only
+- headings, metadata, fences, attributes, documentation, and structural closing lines are unmapped
+- `sourceRoot` and `names` are omitted
 
 ## APIView output design
 

--- a/eng/tools/generate_api/AGENTS.md
+++ b/eng/tools/generate_api/AGENTS.md
@@ -220,9 +220,11 @@ For traits whose rustdoc-expanded methods carry synthetic async-trait lifetimes:
 
 - `source_map` owns the generic ECMA-426 v3 schema and Base64 VLQ encoding
 - the shared model stores repo-relative zero-based declaration locations
+- `sourceRoot` points from an in-repo output directory to the repository root
+- output outside the repository omits `sourceRoot`; `sources` always stay repo-relative
 - Markdown maps item, module, and member declaration lines only
 - headings, metadata, fences, attributes, documentation, and structural closing lines are unmapped
-- `sourceRoot` and `names` are omitted
+- `names` is omitted
 
 ## APIView output design
 

--- a/eng/tools/generate_api/README.md
+++ b/eng/tools/generate_api/README.md
@@ -17,13 +17,15 @@ cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- \
 - `--manifest-path <path>`: path to the target crate's `Cargo.toml`
 - `--format <markdown|apiview>`: optional output format to generate; defaults to `markdown`
 - `--no-docs`: omit documentation comments: APIView doc tokens, or the Markdown comments patch
+- `--no-map`: omit the Markdown source map; accepted as a no-op for APIView output
 - `--check`: compare generated content with existing output files without writing them
 - `--output <dir>`: directory where generated files are written
 
 ### Outputs
 
-- default `markdown` output writes `API.md` and `API.comments.patch`
-- `--no-docs` writes only `API.md`
+- default `markdown` output writes `API.md`, `API.md.map`, and `API.comments.patch`
+- `--no-docs` skips `API.comments.patch`
+- `--no-map` skips `API.md.map`
 - `--format apiview` writes `apiview.json`
 - `--format apiview --no-docs` writes `apiview.json` without doc comment tokens
 - `--check` succeeds when output files are absent or match after normalizing line endings; a mismatch
@@ -41,6 +43,9 @@ documentation comments on:
 ```sh
 patch -p1 < API.comments.patch
 ```
+
+`API.md.map` is an ECMA-426 source map with repo-relative Rust source paths. It maps declaration
+lines in the fenced Rust API block back to the corresponding item or member declarations.
 
 ## Workflow
 

--- a/eng/tools/generate_api/README.md
+++ b/eng/tools/generate_api/README.md
@@ -44,8 +44,19 @@ documentation comments on:
 patch -p1 < API.comments.patch
 ```
 
-`API.md.map` is an ECMA-426 source map with repo-relative Rust source paths. It maps declaration
-lines in the fenced Rust API block back to the corresponding item or member declarations.
+`API.md.map` is an ECMA-426 source map that maps declaration lines in the fenced Rust API block
+back to the corresponding item or member declarations. Entries in `sources` are always relative
+to the repository root. The generated `sourceRoot` is the relative path from the `--output`
+directory to the repository root when the output directory is inside the repository. `sourceRoot`
+is omitted when the output directory is outside the repository.
+
+Source-map consumers differ in how they resolve `sourceRoot`. If the application opens the source
+map with the repository root as its base, remove `sourceRoot`. If the application cannot resolve
+the generated relative `sourceRoot`, replace it with the absolute path to the repository root.
+Alternatively, keep the generated relative `sourceRoot` and the source map at the same relative
+location within an unchanged repository directory structure; the source paths will then continue
+to resolve relative to `API.md.map` or a custom map path. Keep the `sources` entries unchanged in
+all cases.
 
 ## Workflow
 

--- a/eng/tools/generate_api/src/cli.rs
+++ b/eng/tools/generate_api/src/cli.rs
@@ -23,6 +23,10 @@ struct Args {
     #[arg(long)]
     no_docs: bool,
 
+    /// Do not emit a source map for Markdown output.
+    #[arg(long)]
+    no_map: bool,
+
     /// Check generated content against existing files without writing them.
     #[arg(long)]
     check: bool,
@@ -37,6 +41,7 @@ pub(crate) struct Request {
     pub(crate) manifest_path: PathBuf,
     pub(crate) format: OutputFormat,
     pub(crate) no_docs: bool,
+    pub(crate) no_map: bool,
     pub(crate) check: bool,
     pub(crate) output_dir: PathBuf,
 }
@@ -49,6 +54,7 @@ pub(crate) enum OutputFormat {
 
 /// File name of the patch that adds documentation comments back to `API.md`.
 pub(crate) const COMMENTS_PATCH_FILE_NAME: &str = "API.comments.patch";
+pub(crate) const SOURCE_MAP_FILE_NAME: &str = "API.md.map";
 
 impl OutputFormat {
     pub(crate) fn default_file_name(self) -> &'static str {
@@ -65,6 +71,7 @@ pub(crate) fn parse() -> Request {
         manifest_path: args.manifest_path,
         format: args.format,
         no_docs: args.no_docs,
+        no_map: args.no_map,
         check: args.check,
         output_dir: args.output,
     }

--- a/eng/tools/generate_api/src/cli/tests.rs
+++ b/eng/tools/generate_api/src/cli/tests.rs
@@ -15,6 +15,7 @@ fn defaults_to_markdown_format() {
 
     assert_eq!(args.format, OutputFormat::Markdown);
     assert!(!args.no_docs);
+    assert!(!args.no_map);
     assert!(!args.check);
 }
 
@@ -61,4 +62,22 @@ fn accepts_check_switch() {
     ]);
 
     assert!(args.check);
+}
+
+#[test]
+fn accepts_no_map_switch_for_any_format() {
+    for format in ["markdown", "apiview"] {
+        let args = Args::parse_from([
+            "generate_api",
+            "--manifest-path",
+            "sdk/core/azure_core/Cargo.toml",
+            "--format",
+            format,
+            "--no-map",
+            "--output",
+            "/tmp/generate_api",
+        ]);
+
+        assert!(args.no_map);
+    }
 }

--- a/eng/tools/generate_api/src/extract.rs
+++ b/eng/tools/generate_api/src/extract.rs
@@ -5,7 +5,7 @@ use crate::{
     driver::PackageMetadata,
     model::{
         ApiAttribute, ApiItem, ApiItemKind, ApiMember, ApiMemberKind, ApiModel, ApiModule,
-        ApiNavigationPath, ApiPathReference, InherentImplSortKey,
+        ApiNavigationPath, ApiPathReference, InherentImplSortKey, SourceLocation,
     },
     rustdoc_compat,
 };
@@ -22,6 +22,69 @@ pub(crate) trait WorkspaceResolver {
     fn is_workspace_crate(&self, crate_name: &str) -> bool;
     fn load_workspace_model(&mut self, crate_name: &str) -> Result<Option<Arc<ApiModel>>, String>;
     fn load_workspace_crate(&mut self, crate_name: &str) -> Result<Option<Arc<Crate>>, String>;
+}
+
+fn source_location_at_offset(item: &Item, source: &str, offset: usize) -> Option<SourceLocation> {
+    let mut location = source_location(item)?;
+    let prefix = source.get(..offset)?;
+    let line_count = prefix.bytes().filter(|byte| *byte == b'\n').count();
+    location.line += line_count;
+    location.column = if line_count == 0 {
+        location.column + prefix.chars().count()
+    } else {
+        prefix
+            .rsplit_once('\n')
+            .map_or(0, |(_, suffix)| suffix.chars().count())
+    };
+    Some(location)
+}
+
+fn proc_macro_helper_location(item: &Item, helper: &str) -> Option<SourceLocation> {
+    let span = item.span.as_ref()?;
+    let source = crate::source_cache::get(&span.filename)?;
+    let lines = source.lines().collect::<Vec<_>>();
+    let item_line = span.begin.0.saturating_sub(1).min(lines.len());
+    let search_start = item_line.saturating_sub(20);
+    let attribute_start = (search_start..item_line)
+        .rev()
+        .find(|index| lines[*index].contains("#[proc_macro_derive"))?;
+
+    let mut in_helpers = false;
+    for (line_index, line) in lines
+        .iter()
+        .enumerate()
+        .take(item_line)
+        .skip(attribute_start)
+    {
+        let search_from = if in_helpers {
+            0
+        } else {
+            let Some(attributes) = line.find("attributes") else {
+                continue;
+            };
+            in_helpers = true;
+            attributes + "attributes".len()
+        };
+        if let Some(column) = find_identifier(&line[search_from..], helper) {
+            return Some(SourceLocation {
+                path: repo_relative_source_path(&span.filename)?,
+                line: line_index,
+                column: search_from + column,
+            });
+        }
+    }
+    None
+}
+
+fn find_identifier(text: &str, identifier: &str) -> Option<usize> {
+    text.match_indices(identifier)
+        .map(|(index, _)| index)
+        .find(|index| {
+            let before = text[..*index].chars().next_back();
+            let after = text[*index + identifier.len()..].chars().next();
+            !before.is_some_and(|character| character == '_' || character.is_alphanumeric())
+                && !after.is_some_and(|character| character == '_' || character.is_alphanumeric())
+        })
 }
 
 fn find_item_entry<'a>(
@@ -99,6 +162,7 @@ fn extract_module(
 
     let mut result = ApiModule {
         path,
+        declaration_location: source_location(item),
         doc_comments: extract_doc_comments(item),
         attributes: extract_module_attributes(item, module.is_crate),
         items: Vec::new(),
@@ -119,7 +183,8 @@ fn extract_module(
                     result.path,
                     child.name.as_deref().unwrap_or("unknown_module")
                 );
-                let module = extract_module(krate, child, child_path, resolver)?;
+                let mut module = extract_module(krate, child, child_path, resolver)?;
+                module.declaration_location = module_declaration_location(item, child);
                 insert_module(&mut result.modules, &mut seen_modules, module);
             }
             ItemEnum::Impl(impl_block) => {
@@ -747,6 +812,7 @@ fn extract_item(krate: &Crate, item: &Item) -> ApiItem {
     ApiItem {
         name: item_name(krate, item),
         kind: item_kind(item),
+        declaration_location: source_location(item),
         source_id: (!matches!(item.inner, ItemEnum::Use(_)))
             .then(|| qualified_source_id(krate, item.id)),
         navigation_paths: item_navigation_paths(krate, item),
@@ -786,8 +852,8 @@ fn item_name(krate: &Crate, item: &Item) -> String {
 
 fn extract_members(krate: &Crate, item: &Item) -> Vec<ApiMember> {
     match &item.inner {
-        ItemEnum::Macro(source) => extract_macro_members(source),
-        ItemEnum::ProcMacro(proc_macro) => extract_proc_macro_members(proc_macro),
+        ItemEnum::Macro(source) => extract_macro_members(item, source),
+        ItemEnum::ProcMacro(proc_macro) => extract_proc_macro_members(item, proc_macro),
         ItemEnum::Struct(struct_item) => extract_struct_members(krate, struct_item),
         ItemEnum::Enum(enum_item) => extract_enum_members(krate, enum_item),
         ItemEnum::Trait(trait_item) => extract_trait_members(krate, trait_item),
@@ -827,6 +893,172 @@ fn qualified_source_id(krate: &Crate, id: Id) -> String {
         .and_then(|summary| summary.path.first())
         .map(|crate_name| format!("{crate_name}::{}", id.0))
         .unwrap_or_else(|| id.0.to_string())
+}
+
+fn source_location(item: &Item) -> Option<SourceLocation> {
+    let span = item.span.as_ref()?;
+    Some(SourceLocation {
+        path: repo_relative_source_path(&span.filename)?,
+        line: span.begin.0.saturating_sub(1),
+        column: span.begin.1.saturating_sub(1),
+    })
+}
+
+fn module_declaration_location(parent: &Item, module: &Item) -> Option<SourceLocation> {
+    let parent_span = parent.span.as_ref()?;
+    let module_span = module.span.as_ref()?;
+    if parent_span.filename == module_span.filename {
+        return source_location(module);
+    }
+
+    let name = module.name.as_deref()?;
+    let source = crate::source_cache::get(&parent_span.filename)?;
+    let (line, column) = find_module_declaration(
+        &source,
+        name,
+        parent_span.begin.0.saturating_sub(1),
+        parent_span.end.0,
+        Some(&module_span.filename),
+        matches!(module.visibility, Visibility::Public),
+    )?;
+    Some(SourceLocation {
+        path: repo_relative_source_path(&parent_span.filename)?,
+        line,
+        column,
+    })
+}
+
+fn find_module_declaration(
+    source: &str,
+    name: &str,
+    start_line: usize,
+    end_line: usize,
+    module_file: Option<&std::path::Path>,
+    is_public: bool,
+) -> Option<(usize, usize)> {
+    let mut candidates = Vec::new();
+    for (line_index, line) in source
+        .lines()
+        .enumerate()
+        .skip(start_line)
+        .take(end_line.saturating_sub(start_line))
+    {
+        for (mod_index, _) in line.match_indices("mod") {
+            let before = &line[..mod_index];
+            let previous = before.chars().next_back();
+            if previous.is_some_and(|character| character == '_' || character.is_alphanumeric()) {
+                continue;
+            }
+
+            let prefix = before.trim();
+            if !is_module_declaration_prefix(prefix) {
+                continue;
+            }
+
+            let after_mod = &line[mod_index + 3..];
+            let after_whitespace = after_mod.trim_start();
+            let Some(after_name) = after_whitespace.strip_prefix(name) else {
+                continue;
+            };
+            if after_name
+                .chars()
+                .next()
+                .is_some_and(|character| character == '_' || character.is_alphanumeric())
+            {
+                continue;
+            }
+            if matches!(after_name.trim_start().chars().next(), Some(';' | '{')) {
+                candidates.push((
+                    line_index,
+                    line.len() - line.trim_start().len(),
+                    path_attribute_before(source, line_index),
+                    is_public_module_declaration_prefix(prefix),
+                ));
+            }
+        }
+    }
+    if candidates.len() == 1 {
+        return candidates.pop().map(|(line, column, _, _)| (line, column));
+    }
+
+    let candidates = candidates
+        .into_iter()
+        .filter(|(_, _, _, candidate_is_public)| *candidate_is_public == is_public)
+        .collect::<Vec<_>>();
+    if candidates.len() == 1 {
+        return candidates
+            .into_iter()
+            .next()
+            .map(|(line, column, _, _)| (line, column));
+    }
+
+    let module_file = module_file?.to_string_lossy().replace('\\', "/");
+    candidates
+        .into_iter()
+        .find(|(_, _, path, _)| {
+            path.as_deref()
+                .is_some_and(|path| module_file.ends_with(&path.replace('\\', "/")))
+        })
+        .map(|(line, column, _, _)| (line, column))
+}
+
+fn is_module_declaration_prefix(prefix: &str) -> bool {
+    let visibility = prefix
+        .strip_suffix("unsafe")
+        .map(str::trim_end)
+        .unwrap_or(prefix);
+    visibility.is_empty()
+        || visibility == "pub"
+        || (visibility.starts_with("pub(") && visibility.ends_with(')'))
+}
+
+fn is_public_module_declaration_prefix(prefix: &str) -> bool {
+    prefix
+        .strip_suffix("unsafe")
+        .map(str::trim_end)
+        .unwrap_or(prefix)
+        == "pub"
+}
+
+fn path_attribute_before(source: &str, line_index: usize) -> Option<String> {
+    for line in source
+        .lines()
+        .collect::<Vec<_>>()
+        .into_iter()
+        .take(line_index)
+        .rev()
+    {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with("///") || line.starts_with("//!") {
+            continue;
+        }
+        if !line.starts_with("#[") {
+            break;
+        }
+        let Some(path) = line.strip_prefix("#[path") else {
+            continue;
+        };
+        let start = path.find('"')? + 1;
+        let end = path[start..].find('"')? + start;
+        return Some(path[start..end].to_string());
+    }
+    None
+}
+
+fn repo_relative_source_path(path: &std::path::Path) -> Option<String> {
+    let path = if path.is_absolute() {
+        path.strip_prefix(std::env::current_dir().ok()?).ok()?
+    } else {
+        path
+    };
+    if path
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return None;
+    }
+
+    Some(path.to_string_lossy().replace('\\', "/"))
 }
 
 fn reexport_navigation_paths(path: &str) -> Vec<String> {
@@ -1686,6 +1918,7 @@ fn extract_trait_impl(
     Some(ApiItem {
         name: self_type,
         kind: ApiItemKind::TraitImpl,
+        declaration_location: source_location(item),
         source_id: Some(qualified_source_id(krate, item.id)),
         navigation_paths: Vec::new(),
         owner_name: owner.map(|owner| {
@@ -1744,6 +1977,7 @@ fn extract_inherent_impl(
             .clone()
             .unwrap_or_else(|| fallback_item_name(target).to_string()),
         kind: ApiItemKind::InherentImpl,
+        declaration_location: source_location(item),
         source_id: Some(qualified_source_id(krate, item.id)),
         navigation_paths: Vec::new(),
         owner_name: Some(
@@ -1812,13 +2046,58 @@ fn extract_trait_members(krate: &Crate, trait_item: &Trait) -> Vec<ApiMember> {
         .collect()
 }
 
-fn extract_macro_members(source: &str) -> Vec<ApiMember> {
-    parse_macro_definition(source)
-        .map(|(_, members)| members)
+fn extract_macro_members(item: &Item, source: &str) -> Vec<ApiMember> {
+    let source = source_text_for_span(item).unwrap_or_else(|| source.to_string());
+    parse_macro_definition(&source)
+        .map(|parsed| {
+            parsed
+                .members
+                .into_iter()
+                .map(|(offset, mut member)| {
+                    member.declaration_location = source_location_at_offset(item, &source, offset);
+                    member
+                })
+                .collect()
+        })
         .unwrap_or_default()
 }
 
-fn extract_proc_macro_members(proc_macro: &rustdoc_types::ProcMacro) -> Vec<ApiMember> {
+fn source_text_for_span(item: &Item) -> Option<String> {
+    let span = item.span.as_ref()?;
+    let source = crate::source_cache::get(&span.filename)?;
+    let lines = source.lines().collect::<Vec<_>>();
+    let start_line = span.begin.0.checked_sub(1)?;
+    let end_line = span.end.0.min(lines.len());
+    let mut selected = lines.get(start_line..end_line)?.to_vec();
+    let start_column = span.begin.1.saturating_sub(1);
+    let end_column = span.end.1.saturating_sub(1);
+    if selected.len() == 1 {
+        let line = *selected.first()?;
+        let start_byte = byte_index_at_character(line, start_column);
+        let end_byte = byte_index_at_character(line, end_column);
+        *selected.first_mut()? = line.get(start_byte..end_byte)?;
+    } else {
+        let first = *selected.first()?;
+        let start_byte = byte_index_at_character(first, start_column);
+        *selected.first_mut()? = first.get(start_byte..)?;
+
+        let last = *selected.last()?;
+        let end_byte = byte_index_at_character(last, end_column);
+        *selected.last_mut()? = last.get(..end_byte)?;
+    }
+    Some(selected.join("\n"))
+}
+
+fn byte_index_at_character(text: &str, character: usize) -> usize {
+    text.char_indices()
+        .nth(character)
+        .map_or(text.len(), |(index, _)| index)
+}
+
+fn extract_proc_macro_members(
+    item: &Item,
+    proc_macro: &rustdoc_types::ProcMacro,
+) -> Vec<ApiMember> {
     if !matches!(proc_macro.kind, MacroKind::Derive) || proc_macro.helpers.is_empty() {
         return Vec::new();
     }
@@ -1830,6 +2109,7 @@ fn extract_proc_macro_members(proc_macro: &rustdoc_types::ProcMacro) -> Vec<ApiM
     members.extend(proc_macro.helpers.iter().map(|helper| ApiMember {
         name: helper.clone(),
         kind: ApiMemberKind::MacroInput,
+        declaration_location: proc_macro_helper_location(item, helper),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
         declaration: format!("#[{helper}]"),
@@ -1867,6 +2147,7 @@ fn extract_enum_members(krate: &Crate, enum_item: &rustdoc_types::Enum) -> Vec<A
         .map(|variant_item| ApiMember {
             name: variant_item.name.clone().unwrap_or_default(),
             kind: ApiMemberKind::Variant,
+            declaration_location: source_location(variant_item),
             doc_comments: extract_doc_comments(variant_item),
             attributes: extract_attributes(variant_item),
             declaration: render_variant(krate, variant_item),
@@ -1882,6 +2163,7 @@ fn extract_field_member(krate: &Crate, field_item: &Item) -> Option<ApiMember> {
     render_named_field(field_item).map(|declaration| ApiMember {
         name: field_item.name.clone().unwrap_or_default(),
         kind: ApiMemberKind::Field,
+        declaration_location: source_location(field_item),
         doc_comments: extract_doc_comments(field_item),
         attributes: extract_attributes(field_item),
         declaration,
@@ -1893,6 +2175,7 @@ fn api_member(krate: &Crate, item: &Item, kind: ApiMemberKind, declaration: Stri
     ApiMember {
         name: item.name.clone().unwrap_or_default(),
         kind,
+        declaration_location: source_location(item),
         doc_comments: extract_doc_comments(item),
         attributes: extract_attributes(item),
         declaration,
@@ -1906,6 +2189,7 @@ fn text_member(name: impl Into<String>, declaration: impl Into<String>) -> ApiMe
     ApiMember {
         name: name.into(),
         kind: ApiMemberKind::Text,
+        declaration_location: None,
         doc_comments: Vec::new(),
         attributes: Vec::new(),
         declaration: declaration.into(),
@@ -2296,7 +2580,7 @@ fn render_item_declaration(krate: &Crate, item: &Item) -> String {
 
 fn render_macro_declaration(source: &str) -> String {
     parse_macro_definition(source)
-        .map(|(declaration, _)| declaration)
+        .map(|parsed| parsed.declaration)
         .unwrap_or_else(|| source.to_string())
 }
 
@@ -2339,7 +2623,13 @@ fn render_proc_macro_declaration(name: &str, proc_macro: &rustdoc_types::ProcMac
     }
 }
 
-fn parse_macro_definition(source: &str) -> Option<(String, Vec<ApiMember>)> {
+struct ParsedMacro {
+    declaration: String,
+    members: Vec<(usize, ApiMember)>,
+}
+
+fn parse_macro_definition(source: &str) -> Option<ParsedMacro> {
+    let leading_whitespace = source.len() - source.trim_start().len();
     let source = source.trim();
     let open_index = source.find('{')?;
     let close_index = find_matching_delimiter(source, open_index, '{', '}')?;
@@ -2352,20 +2642,29 @@ fn parse_macro_definition(source: &str) -> Option<(String, Vec<ApiMember>)> {
     let members = split_macro_arms(body)
         .into_iter()
         .enumerate()
-        .map(|(index, arm)| ApiMember {
-            name: format!("arm_{index}"),
-            kind: ApiMemberKind::MacroInput,
-            doc_comments: Vec::new(),
-            attributes: Vec::new(),
-            declaration: summarize_macro_arm(&arm),
-            declaration_path_references: Vec::new(),
+        .map(|(index, (offset, arm))| {
+            (
+                leading_whitespace + open_index + 1 + offset,
+                ApiMember {
+                    name: format!("arm_{index}"),
+                    kind: ApiMemberKind::MacroInput,
+                    declaration_location: None,
+                    doc_comments: Vec::new(),
+                    attributes: Vec::new(),
+                    declaration: summarize_macro_arm(&arm),
+                    declaration_path_references: Vec::new(),
+                },
+            )
         })
         .collect::<Vec<_>>();
 
-    (!members.is_empty()).then_some((declaration, members))
+    (!members.is_empty()).then_some(ParsedMacro {
+        declaration,
+        members,
+    })
 }
 
-fn split_macro_arms(body: &str) -> Vec<String> {
+fn split_macro_arms(body: &str) -> Vec<(usize, String)> {
     let mut arms = Vec::new();
     let mut start = None;
     let mut paren_depth = 0usize;
@@ -2393,7 +2692,7 @@ fn split_macro_arms(body: &str) -> Vec<String> {
                 if let Some(start_index) = start {
                     let arm = body[start_index..index].trim();
                     if !arm.is_empty() {
-                        arms.push(arm.to_string());
+                        arms.push((start_index, arm.to_string()));
                     }
                 }
                 start = None;
@@ -2408,7 +2707,7 @@ fn split_macro_arms(body: &str) -> Vec<String> {
     if let Some(start_index) = start {
         let arm = body[start_index..].trim();
         if !arm.is_empty() {
-            arms.push(arm.to_string());
+            arms.push((start_index, arm.to_string()));
         }
     }
 

--- a/eng/tools/generate_api/src/extract.rs
+++ b/eng/tools/generate_api/src/extract.rs
@@ -44,8 +44,7 @@ fn proc_macro_helper_location(item: &Item, helper: &str) -> Option<SourceLocatio
     let source = crate::source_cache::get(&span.filename)?;
     let lines = source.lines().collect::<Vec<_>>();
     let item_line = span.begin.0.saturating_sub(1).min(lines.len());
-    let search_start = item_line.saturating_sub(20);
-    let attribute_start = (search_start..item_line)
+    let attribute_start = (0..item_line)
         .rev()
         .find(|index| lines[*index].contains("#[proc_macro_derive"))?;
 

--- a/eng/tools/generate_api/src/extract/tests.rs
+++ b/eng/tools/generate_api/src/extract/tests.rs
@@ -2122,6 +2122,51 @@ fn extracts_derive_macro_helpers_as_members() {
 }
 
 #[test]
+fn locates_derive_macro_helpers_in_long_attributes() {
+    let path = std::path::PathBuf::from(format!(
+        "generate_api_proc_macro_source_test_{}.rs",
+        std::process::id()
+    ));
+    let source = format!(
+        "#[proc_macro_derive(\n    BlobDerive,\n    attributes(\n        blob,\n{}\n    )\n)]\npub fn derive() {{}}\n",
+        "\n".repeat(20)
+    );
+    std::fs::write(&path, source).unwrap();
+
+    let mut macro_item = item(
+        Id(1),
+        Some("BlobDerive"),
+        ItemEnum::ProcMacro(rustdoc_types::ProcMacro {
+            kind: rustdoc_types::MacroKind::Derive,
+            helpers: vec!["blob".to_string()],
+        }),
+    );
+    macro_item.span = Some(rustdoc_types::Span {
+        filename: path.clone(),
+        begin: (28, 1),
+        end: (28, 19),
+    });
+
+    let location = proc_macro_helper_location(&macro_item, "blob");
+
+    std::fs::remove_file(path).unwrap();
+    assert_eq!(
+        location,
+        Some(crate::model::SourceLocation {
+            path: macro_item
+                .span
+                .as_ref()
+                .unwrap()
+                .filename
+                .to_string_lossy()
+                .to_string(),
+            line: 3,
+            column: 8,
+        })
+    );
+}
+
+#[test]
 fn extracts_macro_matcher_arms_as_members() {
     let macro_id = Id(1);
     let krate = crate_with_items(vec![item(

--- a/eng/tools/generate_api/src/extract/tests.rs
+++ b/eng/tools/generate_api/src/extract/tests.rs
@@ -1062,16 +1062,19 @@ fn local_reexport_preserves_synthesized_derives_for_reexported_items() {
 fn model_reexport_collects_nested_impls_by_owner_identity() {
     let expanded = expand_model_item_reexport(
         &ApiModule {
+            declaration_location: None,
             path: "azure_core".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
             items: Vec::new(),
             modules: vec![ApiModule {
+                declaration_location: None,
                 path: "azure_core::credentials".to_string(),
                 doc_comments: Vec::new(),
                 attributes: Vec::new(),
                 items: vec![
                     ApiItem {
+                        declaration_location: None,
                         name: "Secret".to_string(),
                         kind: ApiItemKind::Struct,
                         source_id: Some("secret".to_string()),
@@ -1087,6 +1090,7 @@ fn model_reexport_collects_nested_impls_by_owner_identity() {
                         members: Vec::new(),
                     },
                     ApiItem {
+                        declaration_location: None,
                         name: "Secret".to_string(),
                         kind: ApiItemKind::InherentImpl,
                         source_id: Some("secret-inherent".to_string()),
@@ -1105,6 +1109,7 @@ fn model_reexport_collects_nested_impls_by_owner_identity() {
                         members: Vec::new(),
                     },
                     ApiItem {
+                        declaration_location: None,
                         name: "Secret<T>".to_string(),
                         kind: ApiItemKind::TraitImpl,
                         source_id: Some("secret-debug".to_string()),
@@ -1145,15 +1150,18 @@ fn model_reexport_collects_nested_impls_by_owner_identity() {
 fn model_reexport_resolves_duplicated_leading_module_segments() {
     let expanded = expand_model_item_reexport(
         &ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
             items: Vec::new(),
             modules: vec![ApiModule {
+                declaration_location: None,
                 path: "demo::credentials".to_string(),
                 doc_comments: Vec::new(),
                 attributes: Vec::new(),
                 items: vec![ApiItem {
+                    declaration_location: None,
                     name: "Secret".to_string(),
                     kind: ApiItemKind::Struct,
                     source_id: Some("secret".to_string()),
@@ -2575,4 +2583,146 @@ impl ItemTestExt for Item {
             .collect();
         self
     }
+}
+
+#[test]
+fn normalizes_repo_relative_source_paths() {
+    assert_eq!(
+        repo_relative_source_path(std::path::Path::new("sdk/core/typespec/src/lib.rs")).as_deref(),
+        Some("sdk/core/typespec/src/lib.rs")
+    );
+    assert_eq!(
+        repo_relative_source_path(
+            &std::env::current_dir()
+                .unwrap()
+                .join("sdk/core/typespec/src/lib.rs")
+        )
+        .as_deref(),
+        Some("sdk/core/typespec/src/lib.rs")
+    );
+    assert_eq!(
+        repo_relative_source_path(std::path::Path::new("../outside.rs")),
+        None
+    );
+}
+
+#[test]
+fn finds_out_of_line_module_declarations() {
+    let source = r#"
+#[path = "other.rs"]
+pub(crate) mod other;
+/// `mod ignored;` is documentation, not a declaration.
+pub mod cloud;
+"#;
+
+    assert_eq!(
+        find_module_declaration(source, "other", 0, 5, Some("other.rs".as_ref()), false),
+        Some((2, 0))
+    );
+    assert_eq!(
+        find_module_declaration(source, "cloud", 0, 5, Some("cloud.rs".as_ref()), true),
+        Some((4, 0))
+    );
+    assert_eq!(
+        find_module_declaration(source, "ignored", 0, 5, None, true),
+        None
+    );
+}
+
+#[test]
+fn limits_module_declaration_search_to_the_parent_span() {
+    let source =
+        "pub mod first {\n    pub mod shared;\n}\npub mod second {\n    pub mod shared;\n}";
+
+    assert_eq!(
+        find_module_declaration(source, "shared", 0, 3, Some("shared.rs".as_ref()), true),
+        Some((1, 4))
+    );
+    assert_eq!(
+        find_module_declaration(source, "shared", 3, 6, Some("shared.rs".as_ref()), true),
+        Some((4, 4))
+    );
+}
+
+#[test]
+fn uses_path_attributes_to_disambiguate_module_declarations() {
+    let source =
+        "#[path = \"unix/shared.rs\"]\nmod shared;\n#[path = \"windows/shared.rs\"]\nmod shared;";
+
+    assert_eq!(
+        find_module_declaration(
+            source,
+            "shared",
+            0,
+            4,
+            Some("src/windows/shared.rs".as_ref()),
+            false
+        ),
+        Some((3, 0))
+    );
+}
+
+#[test]
+fn uses_visibility_to_disambiguate_cfg_module_declarations() {
+    let source = "#[cfg(feature = \"testing\")]\npub mod query;\n#[cfg(not(feature = \"testing\"))]\npub(crate) mod query;";
+
+    assert_eq!(
+        find_module_declaration(source, "query", 0, 4, Some("query.rs".as_ref()), true),
+        Some((1, 0))
+    );
+}
+
+#[test]
+fn locates_macro_arms_relative_to_the_item_span() {
+    let source = "macro_rules! demo {\n    ($value:expr) => { $value };\n}";
+    let parsed = parse_macro_definition(source).unwrap();
+    let offset = parsed.members[0].0;
+    assert!(source[offset..].starts_with("($value:expr)"));
+
+    let mut macro_item = item(Id(1), Some("demo"), ItemEnum::Macro(source.to_string()));
+    macro_item.span = Some(rustdoc_types::Span {
+        filename: "sdk/example/src/lib.rs".into(),
+        begin: (10, 5),
+        end: (12, 2),
+    });
+
+    assert_eq!(
+        source_location_at_offset(&macro_item, source, offset),
+        Some(crate::model::SourceLocation {
+            path: "sdk/example/src/lib.rs".to_string(),
+            line: 10,
+            column: 4,
+        })
+    );
+}
+
+#[test]
+fn uses_actual_source_layout_for_macro_arm_locations() {
+    let actual = "macro_rules! demo {\n    (first) => {\n        one();\n        two();\n    };\n    (second) => { three() };\n} // outside the span";
+    let path = std::path::PathBuf::from(format!(
+        "generate_api_macro_source_test_{}.rs",
+        std::process::id()
+    ));
+    std::fs::write(&path, actual).unwrap();
+    let mut macro_item = item(
+        Id(1),
+        Some("demo"),
+        ItemEnum::Macro(
+            "macro_rules! demo {\n    (first) => { ... };\n    (second) => { ... };\n}".to_string(),
+        ),
+    );
+    macro_item.span = Some(rustdoc_types::Span {
+        filename: path.clone(),
+        begin: (1, 1),
+        end: (7, 2),
+    });
+
+    let members = extract_macro_members(
+        &macro_item,
+        "macro_rules! demo {\n    (first) => { ... };\n    (second) => { ... };\n}",
+    );
+
+    std::fs::remove_file(path).unwrap();
+    assert_eq!(members[0].declaration_location.as_ref().unwrap().line, 1);
+    assert_eq!(members[1].declaration_location.as_ref().unwrap().line, 5);
 }

--- a/eng/tools/generate_api/src/main.rs
+++ b/eng/tools/generate_api/src/main.rs
@@ -10,6 +10,7 @@ mod output;
 mod render;
 mod rustdoc_compat;
 mod source_cache;
+mod source_map;
 
 use std::path::Path;
 
@@ -42,6 +43,14 @@ fn run() -> Result<(), String> {
             let lines = render::markdown::render_lines(&model);
             let rendered = render::markdown::render_from_lines(&lines);
             save_or_check(&request, &output_path, &rendered)?;
+
+            if !request.no_map {
+                let map_path = output::output_file_path(&request, cli::SOURCE_MAP_FILE_NAME);
+                let mappings = render::markdown::source_mappings_from_lines(&lines);
+                let map =
+                    source_map::render(cli::OutputFormat::Markdown.default_file_name(), &mappings)?;
+                save_or_check(&request, &map_path, &map)?;
+            }
 
             if !request.no_docs {
                 let patch_path = output::output_file_path(&request, cli::COMMENTS_PATCH_FILE_NAME);

--- a/eng/tools/generate_api/src/main.rs
+++ b/eng/tools/generate_api/src/main.rs
@@ -47,8 +47,14 @@ fn run() -> Result<(), String> {
             if !request.no_map {
                 let map_path = output::output_file_path(&request, cli::SOURCE_MAP_FILE_NAME);
                 let mappings = render::markdown::source_mappings_from_lines(&lines);
-                let map =
-                    source_map::render(cli::OutputFormat::Markdown.default_file_name(), &mappings)?;
+                let repository_root = std::env::current_dir()
+                    .map_err(|error| format!("Failed to resolve repository root: {error}"))?;
+                let map = source_map::render(
+                    cli::OutputFormat::Markdown.default_file_name(),
+                    &mappings,
+                    &request.output_dir,
+                    &repository_root,
+                )?;
                 save_or_check(&request, &map_path, &map)?;
             }
 

--- a/eng/tools/generate_api/src/model.rs
+++ b/eng/tools/generate_api/src/model.rs
@@ -3,6 +3,13 @@
 
 use std::collections::BTreeMap;
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct SourceLocation {
+    pub(crate) path: String,
+    pub(crate) line: usize,
+    pub(crate) column: usize,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct ApiModel {
     pub(crate) package_name: String,
@@ -20,6 +27,7 @@ impl ApiModel {
     ) -> Self {
         let root_module = ApiModule {
             path: package_name.clone(),
+            declaration_location: None,
             doc_comments: Vec::new(),
             attributes: Vec::new(),
             items: Vec::new(),
@@ -99,6 +107,7 @@ impl PackageMetadata {
 #[derive(Debug, Clone)]
 pub(crate) struct ApiModule {
     pub(crate) path: String,
+    pub(crate) declaration_location: Option<SourceLocation>,
     pub(crate) doc_comments: Vec<String>,
     pub(crate) attributes: Vec<ApiAttribute>,
     pub(crate) items: Vec<ApiItem>,
@@ -117,6 +126,7 @@ impl ApiModule {
 pub(crate) struct ApiItem {
     pub(crate) name: String,
     pub(crate) kind: ApiItemKind,
+    pub(crate) declaration_location: Option<SourceLocation>,
     pub(crate) source_id: Option<String>,
     pub(crate) navigation_paths: Vec<ApiNavigationPath>,
     pub(crate) owner_name: Option<String>,
@@ -145,6 +155,7 @@ pub(crate) struct ApiAttribute {
 pub(crate) struct ApiMember {
     pub(crate) name: String,
     pub(crate) kind: ApiMemberKind,
+    pub(crate) declaration_location: Option<SourceLocation>,
     pub(crate) doc_comments: Vec<String>,
     pub(crate) attributes: Vec<ApiAttribute>,
     pub(crate) declaration: String,

--- a/eng/tools/generate_api/src/model/tests.rs
+++ b/eng/tools/generate_api/src/model/tests.rs
@@ -5,6 +5,7 @@ use super::*;
 
 fn item(name: &str, kind: ApiItemKind, declaration: &str) -> ApiItem {
     ApiItem {
+        declaration_location: None,
         name: name.to_string(),
         kind,
         source_id: None,
@@ -106,6 +107,7 @@ fn sorts_inherent_impls_by_type_parameter_then_infer_then_explicit_type() {
     });
 
     let module = ApiModule {
+        declaration_location: None,
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),

--- a/eng/tools/generate_api/src/render/apiview/tests.rs
+++ b/eng/tools/generate_api/src/render/apiview/tests.rs
@@ -10,6 +10,7 @@ use std::collections::BTreeMap;
 
 fn item(name: &str, kind: ApiItemKind, declaration: &str) -> ApiItem {
     ApiItem {
+        declaration_location: None,
         name: name.to_string(),
         kind,
         source_id: None,
@@ -28,6 +29,7 @@ fn item(name: &str, kind: ApiItemKind, declaration: &str) -> ApiItem {
 
 fn member(name: &str, kind: ApiMemberKind, declaration: &str) -> ApiMember {
     ApiMember {
+        declaration_location: None,
         name: name.to_string(),
         kind,
         doc_comments: Vec::new(),
@@ -124,6 +126,7 @@ fn renders_package_metadata_and_features_as_leading_text_tokens() {
             ]),
         },
         root_module: ApiModule {
+            declaration_location: None,
             path: "azure_security_keyvault_secrets".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -166,6 +169,7 @@ fn omits_missing_package_metadata() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -204,6 +208,7 @@ fn renders_trait_impl_tokens_with_typed_members() {
     ));
 
     let module = ApiModule {
+        declaration_location: None,
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
@@ -270,6 +275,7 @@ fn renders_root_inner_attrs_and_child_module_outer_attrs() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: vec![ApiAttribute {
@@ -277,6 +283,7 @@ fn renders_root_inner_attrs_and_child_module_outer_attrs() {
             }],
             items: Vec::new(),
             modules: vec![ApiModule {
+                declaration_location: None,
                 path: "demo::inner".to_string(),
                 doc_comments: Vec::new(),
                 attributes: vec![ApiAttribute {
@@ -312,6 +319,7 @@ fn renders_inherent_members_inside_impl_blocks() {
     ));
 
     let module = ApiModule {
+        declaration_location: None,
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
@@ -417,6 +425,7 @@ fn keeps_duplicate_member_names_in_separate_inherent_impl_blocks() {
     ));
 
     let module = ApiModule {
+        declaration_location: None,
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
@@ -455,6 +464,7 @@ fn omits_doc_comment_lines_when_docs_are_disabled() {
         .push("/// member docs".to_string());
 
     let module = ApiModule {
+        declaration_location: None,
         path: "demo".to_string(),
         doc_comments: vec!["/// module docs".to_string()],
         attributes: Vec::new(),
@@ -504,6 +514,7 @@ fn links_trait_impl_owner_to_local_definition() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -561,6 +572,7 @@ fn links_trait_impl_owner_to_public_reexport() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -619,11 +631,13 @@ fn links_trait_impl_owner_to_declaration_over_visible_reexport() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
             items: vec![root_error, trait_impl],
             modules: vec![ApiModule {
+                declaration_location: None,
                 path: "demo::hidden".to_string(),
                 doc_comments: Vec::new(),
                 attributes: Vec::new(),
@@ -669,6 +683,7 @@ fn keeps_trait_impl_owner_unlinked_without_visible_target() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -707,6 +722,7 @@ fn links_associated_error_type_to_visible_error_target() {
     try_from_impl.owner_kind = Some(ApiItemKind::Struct);
     try_from_impl.owner_source_id = Some("error-response".to_string());
     try_from_impl.members.push(ApiMember {
+        declaration_location: None,
         name: "Error".to_string(),
         kind: ApiMemberKind::Associated,
         doc_comments: Vec::new(),
@@ -725,6 +741,7 @@ fn links_associated_error_type_to_visible_error_target() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -796,6 +813,7 @@ fn links_bare_result_to_public_reexport_when_resolved_path_matches() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -839,6 +857,7 @@ fn links_crate_result_with_resolved_path_metadata() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -889,6 +908,7 @@ fn links_where_clause_references_after_signature_types() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -962,6 +982,7 @@ fn keeps_std_result_references_unlinked_without_current_crate_reexport() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -1009,12 +1030,14 @@ fn prefers_original_definition_over_public_reexport_for_bare_result_links() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
             items: vec![root_reexport],
             modules: vec![
                 ApiModule {
+                    declaration_location: None,
                     path: "demo::client".to_string(),
                     doc_comments: Vec::new(),
                     attributes: Vec::new(),
@@ -1022,6 +1045,7 @@ fn prefers_original_definition_over_public_reexport_for_bare_result_links() {
                     modules: Vec::new(),
                 },
                 ApiModule {
+                    declaration_location: None,
                     path: "demo::errors".to_string(),
                     doc_comments: Vec::new(),
                     attributes: Vec::new(),
@@ -1064,6 +1088,7 @@ fn keeps_field_type_links_out_of_navigation_tree() {
     ));
 
     let module = ApiModule {
+        declaration_location: None,
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
@@ -1118,6 +1143,7 @@ fn keeps_member_type_references_out_of_navigation_tree() {
     ));
 
     let module = ApiModule {
+        declaration_location: None,
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
@@ -1170,6 +1196,7 @@ fn orders_modules_after_non_module_navigation_items() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -1185,6 +1212,7 @@ fn orders_modules_after_non_module_navigation_items() {
             ],
             modules: vec![
                 ApiModule {
+                    declaration_location: None,
                     path: "demo::zeta".to_string(),
                     doc_comments: Vec::new(),
                     attributes: Vec::new(),
@@ -1192,6 +1220,7 @@ fn orders_modules_after_non_module_navigation_items() {
                     modules: Vec::new(),
                 },
                 ApiModule {
+                    declaration_location: None,
                     path: "demo::alpha".to_string(),
                     doc_comments: Vec::new(),
                     attributes: Vec::new(),
@@ -1221,6 +1250,7 @@ fn orders_modules_after_non_module_navigation_items() {
 #[test]
 fn shares_module_last_tree_order_with_navigation_walk() {
     let module = ApiModule {
+        declaration_location: None,
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
@@ -1230,6 +1260,7 @@ fn shares_module_last_tree_order_with_navigation_walk() {
         ],
         modules: vec![
             ApiModule {
+                declaration_location: None,
                 path: "demo::zeta".to_string(),
                 doc_comments: Vec::new(),
                 attributes: Vec::new(),
@@ -1237,6 +1268,7 @@ fn shares_module_last_tree_order_with_navigation_walk() {
                 modules: Vec::new(),
             },
             ApiModule {
+                declaration_location: None,
                 path: "demo::alpha".to_string(),
                 doc_comments: Vec::new(),
                 attributes: Vec::new(),
@@ -1272,6 +1304,7 @@ fn includes_same_crate_reexported_functions_in_tree() {
     module_sleep.source_id = Some("sleep-fn".to_string());
 
     let module = ApiModule {
+        declaration_location: None,
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
@@ -1280,6 +1313,7 @@ fn includes_same_crate_reexported_functions_in_tree() {
             top_level_sleep,
         ],
         modules: vec![ApiModule {
+            declaration_location: None,
             path: "demo::sleep".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -1338,11 +1372,13 @@ fn groups_same_crate_reexports_with_other_reexports() {
     module_item.source_id = Some("client-options".to_string());
 
     let module = ApiModule {
+        declaration_location: None,
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
         items: vec![top_level_reexport],
         modules: vec![ApiModule {
+            declaration_location: None,
             path: "demo::options".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -1389,11 +1425,13 @@ fn same_crate_reexport_links_to_nested_declaration() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
             items: vec![root_client],
             modules: vec![ApiModule {
+                declaration_location: None,
                 path: "demo::clients".to_string(),
                 doc_comments: Vec::new(),
                 attributes: Vec::new(),
@@ -1421,6 +1459,7 @@ fn same_crate_reexport_links_to_nested_declaration() {
 #[test]
 fn keeps_item_line_ids_stable_when_unrelated_siblings_are_inserted() {
     let base_module = ApiModule {
+        declaration_location: None,
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
@@ -1428,6 +1467,7 @@ fn keeps_item_line_ids_stable_when_unrelated_siblings_are_inserted() {
         modules: Vec::new(),
     };
     let expanded_module = ApiModule {
+        declaration_location: None,
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
@@ -1481,6 +1521,7 @@ fn keeps_member_line_ids_stable_when_unrelated_siblings_are_inserted() {
         access_token
     };
     let base_module = ApiModule {
+        declaration_location: None,
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
@@ -1491,6 +1532,7 @@ fn keeps_member_line_ids_stable_when_unrelated_siblings_are_inserted() {
         modules: Vec::new(),
     };
     let expanded_module = ApiModule {
+        declaration_location: None,
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),
@@ -1563,6 +1605,7 @@ fn distinguishes_repeated_trait_impl_methods_by_impl_identity() {
     ));
 
     let module = ApiModule {
+        declaration_location: None,
         path: "demo".to_string(),
         doc_comments: Vec::new(),
         attributes: Vec::new(),

--- a/eng/tools/generate_api/src/render/markdown.rs
+++ b/eng/tools/generate_api/src/render/markdown.rs
@@ -1,13 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use crate::model::{ApiItem, ApiMember, ApiMemberKind, ApiModel, ApiModule};
+use crate::{
+    model::{ApiItem, ApiMember, ApiMemberKind, ApiModel, ApiModule, SourceLocation},
+    source_map::GeneratedMapping,
+};
 
 /// A single rendered Markdown line and whether it is a documentation comment.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) struct RenderedLine {
     pub(crate) text: String,
     pub(crate) is_doc_comment: bool,
+    pub(crate) declaration_location: Option<SourceLocation>,
 }
 
 /// Renders the API surface without documentation comments.
@@ -18,6 +22,23 @@ pub(crate) fn render_from_lines(lines: &[RenderedLine]) -> String {
         output.push('\n');
     }
     output
+}
+
+pub(crate) fn source_mappings_from_lines(lines: &[RenderedLine]) -> Vec<GeneratedMapping> {
+    lines
+        .iter()
+        .filter(|line| !line.is_doc_comment)
+        .enumerate()
+        .filter_map(|(generated_line, line)| {
+            line.declaration_location
+                .clone()
+                .map(|original| GeneratedMapping {
+                    generated_line,
+                    generated_column: line.text.len() - line.text.trim_start_matches(' ').len(),
+                    original,
+                })
+        })
+        .collect()
 }
 
 /// Renders every Markdown line including documentation comments.
@@ -91,10 +112,11 @@ fn render_module(output: &mut Vec<RenderedLine>, module: &ApiModule, is_root: bo
         push_code(output, indent, &attribute.text);
     }
     if !is_root {
-        push_code(
+        push_declaration(
             output,
             indent,
             &format!("pub mod {} {{", module.local_name()),
+            module.declaration_location.as_ref(),
         );
     }
 
@@ -117,7 +139,12 @@ fn render_item(output: &mut Vec<RenderedLine>, item: &ApiItem, indent: usize) {
         push_code(output, indent, &attribute.text);
     }
 
-    push_multiline(output, indent, &item.declaration);
+    push_declaration_multiline(
+        output,
+        indent,
+        &item.declaration,
+        item.declaration_location.as_ref(),
+    );
 
     let members = sorted_members(&item.members);
 
@@ -140,7 +167,12 @@ fn render_member(output: &mut Vec<RenderedLine>, function: &ApiMember, indent: u
     for attribute in &function.attributes {
         push_code(output, indent, &attribute.text);
     }
-    push_multiline(output, indent, &function.declaration);
+    push_declaration_multiline(
+        output,
+        indent,
+        &function.declaration,
+        function.declaration_location.as_ref(),
+    );
 }
 
 fn sorted_members(members: &[ApiMember]) -> Vec<&ApiMember> {
@@ -157,15 +189,26 @@ fn sorted_members(members: &[ApiMember]) -> Vec<&ApiMember> {
     indexed.into_iter().map(|(_, member)| member).collect()
 }
 
-fn push_multiline(output: &mut Vec<RenderedLine>, indent: usize, text: &str) {
-    for line in text.lines() {
-        push_code(output, indent, line);
+fn push_declaration_multiline(
+    output: &mut Vec<RenderedLine>,
+    indent: usize,
+    text: &str,
+    location: Option<&SourceLocation>,
+) {
+    for (index, line) in text.lines().enumerate() {
+        push_line(
+            output,
+            indent,
+            line,
+            false,
+            (index == 0).then_some(location).flatten(),
+        );
     }
 }
 
 fn push_doc_comments(output: &mut Vec<RenderedLine>, indent: usize, doc_comments: &[String]) {
     for comment in doc_comments {
-        push_line(output, indent, comment, true);
+        push_line(output, indent, comment, true, None);
     }
 }
 
@@ -184,20 +227,36 @@ fn push_module_doc_comments(
         } else {
             comment.clone()
         };
-        push_line(output, indent, &comment, true);
+        push_line(output, indent, &comment, true, None);
     }
 }
 
 fn push_code(output: &mut Vec<RenderedLine>, indent: usize, text: &str) {
-    push_line(output, indent, text, false);
+    push_line(output, indent, text, false, None);
 }
 
-fn push_line(output: &mut Vec<RenderedLine>, indent: usize, text: &str, is_doc_comment: bool) {
+fn push_declaration(
+    output: &mut Vec<RenderedLine>,
+    indent: usize,
+    text: &str,
+    location: Option<&SourceLocation>,
+) {
+    push_line(output, indent, text, false, location);
+}
+
+fn push_line(
+    output: &mut Vec<RenderedLine>,
+    indent: usize,
+    text: &str,
+    is_doc_comment: bool,
+    declaration_location: Option<&SourceLocation>,
+) {
     let mut line = "    ".repeat(indent);
     line.push_str(text);
     output.push(RenderedLine {
         text: line,
         is_doc_comment,
+        declaration_location: declaration_location.cloned(),
     });
 }
 

--- a/eng/tools/generate_api/src/render/markdown/tests.rs
+++ b/eng/tools/generate_api/src/render/markdown/tests.rs
@@ -4,7 +4,7 @@
 use super::*;
 use crate::model::{
     ApiAttribute, ApiItem, ApiItemKind, ApiMember, ApiMemberKind, ApiModel, ApiModule,
-    PackageMetadata,
+    PackageMetadata, SourceLocation,
 };
 use std::collections::BTreeMap;
 
@@ -14,6 +14,7 @@ fn render(model: &ApiModel) -> String {
 
 fn item(name: &str, kind: ApiItemKind, declaration: &str) -> ApiItem {
     ApiItem {
+        declaration_location: None,
         name: name.to_string(),
         kind,
         source_id: None,
@@ -32,12 +33,21 @@ fn item(name: &str, kind: ApiItemKind, declaration: &str) -> ApiItem {
 
 fn member(name: &str, kind: ApiMemberKind, declaration: &str) -> ApiMember {
     ApiMember {
+        declaration_location: None,
         name: name.to_string(),
         kind,
         doc_comments: Vec::new(),
         attributes: Vec::new(),
         declaration: declaration.to_string(),
         declaration_path_references: Vec::new(),
+    }
+}
+
+fn location(path: &str, line: usize, column: usize) -> SourceLocation {
+    SourceLocation {
+        path: path.to_string(),
+        line,
+        column,
     }
 }
 
@@ -63,6 +73,7 @@ fn renders_explicit_trait_impl_blocks() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -96,6 +107,7 @@ fn renders_inherent_members_inside_impl_blocks() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -115,6 +127,49 @@ fn renders_inherent_members_inside_impl_blocks() {
 }
 
 #[test]
+fn maps_only_declaration_lines_after_removing_docs() {
+    let mut foo = item("Foo", ApiItemKind::Struct, "pub struct Foo {");
+    foo.declaration_location = Some(location("src/lib.rs", 10, 0));
+    let mut field = member("value", ApiMemberKind::Field, "pub value: u32,");
+    field.doc_comments = vec!["/// The value.".to_string()];
+    field.declaration_location = Some(location("src/lib.rs", 12, 4));
+    foo.members.push(field);
+
+    let model = ApiModel {
+        package_name: "demo".to_string(),
+        package_version: "1.0.0".to_string(),
+        parser_version: "0.0.0".to_string(),
+        package_metadata: Default::default(),
+        root_module: ApiModule {
+            declaration_location: None,
+            path: "demo".to_string(),
+            doc_comments: Vec::new(),
+            attributes: Vec::new(),
+            items: vec![foo],
+            modules: Vec::new(),
+        },
+    };
+
+    let mappings = source_mappings_from_lines(&render_lines(&model));
+
+    assert_eq!(
+        mappings,
+        vec![
+            GeneratedMapping {
+                generated_line: 7,
+                generated_column: 0,
+                original: location("src/lib.rs", 10, 0),
+            },
+            GeneratedMapping {
+                generated_line: 8,
+                generated_column: 4,
+                original: location("src/lib.rs", 12, 4),
+            },
+        ]
+    );
+}
+
+#[test]
 fn renders_root_inner_attrs_and_child_module_outer_attrs() {
     let model = ApiModel {
         package_name: "demo".to_string(),
@@ -122,6 +177,7 @@ fn renders_root_inner_attrs_and_child_module_outer_attrs() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: vec![ApiAttribute {
@@ -129,6 +185,7 @@ fn renders_root_inner_attrs_and_child_module_outer_attrs() {
             }],
             items: Vec::new(),
             modules: vec![ApiModule {
+                declaration_location: None,
                 path: "demo::inner".to_string(),
                 doc_comments: Vec::new(),
                 attributes: vec![ApiAttribute {
@@ -158,6 +215,7 @@ fn marks_doc_comments_and_omits_them_from_markdown() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: vec![
                 "/// Demo crate.".to_string(),
@@ -211,6 +269,7 @@ fn renders_package_metadata_and_features_before_api() {
             ]),
         },
         root_module: ApiModule {
+            declaration_location: None,
             path: "azure_security_keyvault_secrets".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -294,6 +353,7 @@ fn omits_missing_package_metadata() {
         parser_version: "0.0.0".to_string(),
         package_metadata: Default::default(),
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: Vec::new(),
             attributes: Vec::new(),
@@ -323,6 +383,7 @@ fn comments_patch_accounts_for_package_metadata_lines() {
             features: BTreeMap::from([("default".to_string(), vec!["dep:foo".to_string()])]),
         },
         root_module: ApiModule {
+            declaration_location: None,
             path: "demo".to_string(),
             doc_comments: vec!["//! Demo docs.".to_string()],
             attributes: Vec::new(),

--- a/eng/tools/generate_api/src/render/markdown/tests.rs
+++ b/eng/tools/generate_api/src/render/markdown/tests.rs
@@ -316,6 +316,7 @@ fn preserves_multiline_description_paragraphs() {
         },
         root_module: ApiModule {
             path: "demo".to_string(),
+            declaration_location: None,
             doc_comments: Vec::new(),
             attributes: Vec::new(),
             items: Vec::new(),

--- a/eng/tools/generate_api/src/render/patch/tests.rs
+++ b/eng/tools/generate_api/src/render/patch/tests.rs
@@ -5,6 +5,7 @@ use super::*;
 
 fn code(text: &str) -> RenderedLine {
     RenderedLine {
+        declaration_location: None,
         text: text.to_string(),
         is_doc_comment: false,
     }
@@ -12,6 +13,7 @@ fn code(text: &str) -> RenderedLine {
 
 fn doc(text: &str) -> RenderedLine {
     RenderedLine {
+        declaration_location: None,
         text: text.to_string(),
         is_doc_comment: true,
     }

--- a/eng/tools/generate_api/src/source_map.rs
+++ b/eng/tools/generate_api/src/source_map.rs
@@ -3,7 +3,10 @@
 
 use crate::model::SourceLocation;
 use serde::Serialize;
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    path::{Component, Path, PathBuf},
+};
 
 const BASE64_DIGITS: &[u8; 64] =
     b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -19,6 +22,9 @@ pub(crate) struct GeneratedMapping {
 struct SourceMap {
     version: u8,
     file: String,
+    #[serde(rename = "sourceRoot")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_root: Option<String>,
     sources: Vec<String>,
     mappings: String,
 }
@@ -26,10 +32,13 @@ struct SourceMap {
 pub(crate) fn render(
     file: impl Into<String>,
     mappings: &[GeneratedMapping],
+    source_map_dir: &Path,
+    repository_root: &Path,
 ) -> Result<String, String> {
     let mut mappings = mappings.to_vec();
     mappings.sort_by_key(|mapping| (mapping.generated_line, mapping.generated_column));
 
+    let source_root = relative_source_root(source_map_dir, repository_root)?;
     let mut source_indices = BTreeMap::new();
     let mut sources = Vec::new();
     for mapping in &mappings {
@@ -44,6 +53,7 @@ pub(crate) fn render(
     let map = SourceMap {
         version: 3,
         file: file.into(),
+        source_root,
         sources,
         mappings,
     };
@@ -51,6 +61,56 @@ pub(crate) fn render(
         .map_err(|error| format!("Failed to serialize source map: {error}"))?;
     json.push('\n');
     Ok(json)
+}
+
+fn relative_source_root(
+    source_map_dir: &Path,
+    repository_root: &Path,
+) -> Result<Option<String>, String> {
+    let source_map_dir = std::path::absolute(source_map_dir).map_err(|error| {
+        format!(
+            "Failed to resolve source map directory '{}': {error}",
+            source_map_dir.display()
+        )
+    })?;
+    let repository_root = std::path::absolute(repository_root).map_err(|error| {
+        format!(
+            "Failed to resolve repository root '{}': {error}",
+            repository_root.display()
+        )
+    })?;
+    if !source_map_dir.starts_with(&repository_root) {
+        return Ok(None);
+    }
+    Ok(relative_path(&source_map_dir, &repository_root)
+        .map(|path| path.to_string_lossy().replace('\\', "/")))
+}
+
+fn relative_path(from: &Path, to: &Path) -> Option<PathBuf> {
+    let from = from.components().collect::<Vec<_>>();
+    let to = to.components().collect::<Vec<_>>();
+    let common = from
+        .iter()
+        .zip(&to)
+        .take_while(|(from, to)| from == to)
+        .count();
+
+    if common == 0
+        || from[common..]
+            .iter()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return None;
+    }
+
+    let mut relative = PathBuf::new();
+    for _ in common..from.len() {
+        relative.push("..");
+    }
+    for component in &to[common..] {
+        relative.push(component.as_os_str());
+    }
+    Some(relative)
 }
 
 fn encode_mappings(

--- a/eng/tools/generate_api/src/source_map.rs
+++ b/eng/tools/generate_api/src/source_map.rs
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use crate::model::SourceLocation;
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+const BASE64_DIGITS: &[u8; 64] =
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct GeneratedMapping {
+    pub(crate) generated_line: usize,
+    pub(crate) generated_column: usize,
+    pub(crate) original: SourceLocation,
+}
+
+#[derive(Serialize)]
+struct SourceMap {
+    version: u8,
+    file: String,
+    sources: Vec<String>,
+    mappings: String,
+}
+
+pub(crate) fn render(
+    file: impl Into<String>,
+    mappings: &[GeneratedMapping],
+) -> Result<String, String> {
+    let mut mappings = mappings.to_vec();
+    mappings.sort_by_key(|mapping| (mapping.generated_line, mapping.generated_column));
+
+    let mut source_indices = BTreeMap::new();
+    let mut sources = Vec::new();
+    for mapping in &mappings {
+        if !source_indices.contains_key(&mapping.original.path) {
+            let index = sources.len();
+            source_indices.insert(mapping.original.path.clone(), index);
+            sources.push(mapping.original.path.clone());
+        }
+    }
+
+    let mappings = encode_mappings(&mappings, &source_indices)?;
+    let map = SourceMap {
+        version: 3,
+        file: file.into(),
+        sources,
+        mappings,
+    };
+    let mut json = serde_json::to_string(&map)
+        .map_err(|error| format!("Failed to serialize source map: {error}"))?;
+    json.push('\n');
+    Ok(json)
+}
+
+fn encode_mappings(
+    mappings: &[GeneratedMapping],
+    source_indices: &BTreeMap<String, usize>,
+) -> Result<String, String> {
+    let mut output = String::new();
+    let mut generated_line = 0usize;
+    let mut previous_source = 0i64;
+    let mut previous_original_line = 0i64;
+    let mut previous_original_column = 0i64;
+    let mut previous_generated_column = 0i64;
+    let mut first_segment_on_line = true;
+
+    for mapping in mappings {
+        if mapping.generated_line < generated_line {
+            return Err("Source map mappings are not ordered by generated line".to_string());
+        }
+        while generated_line < mapping.generated_line {
+            output.push(';');
+            generated_line += 1;
+            first_segment_on_line = true;
+            previous_generated_column = 0;
+        }
+        if !first_segment_on_line {
+            output.push(',');
+        }
+
+        let source = *source_indices
+            .get(&mapping.original.path)
+            .ok_or_else(|| format!("Source '{}' was not indexed", mapping.original.path))?
+            as i64;
+        encode_vlq(
+            mapping.generated_column as i64 - previous_generated_column,
+            &mut output,
+        );
+        encode_vlq(source - previous_source, &mut output);
+        encode_vlq(
+            mapping.original.line as i64 - previous_original_line,
+            &mut output,
+        );
+        encode_vlq(
+            mapping.original.column as i64 - previous_original_column,
+            &mut output,
+        );
+
+        previous_source = source;
+        previous_original_line = mapping.original.line as i64;
+        previous_original_column = mapping.original.column as i64;
+        previous_generated_column = mapping.generated_column as i64;
+        first_segment_on_line = false;
+    }
+
+    Ok(output)
+}
+
+fn encode_vlq(value: i64, output: &mut String) {
+    let mut value = if value < 0 {
+        ((-value) as u64) << 1 | 1
+    } else {
+        (value as u64) << 1
+    };
+
+    loop {
+        let mut digit = (value & 0b1_1111) as usize;
+        value >>= 5;
+        if value != 0 {
+            digit |= 0b10_0000;
+        }
+        output.push(BASE64_DIGITS[digit] as char);
+        if value == 0 {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/eng/tools/generate_api/src/source_map/tests.rs
+++ b/eng/tools/generate_api/src/source_map/tests.rs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use super::*;
+use serde_json::Value;
+
+fn mapping(
+    generated_line: usize,
+    generated_column: usize,
+    path: &str,
+    line: usize,
+    column: usize,
+) -> GeneratedMapping {
+    GeneratedMapping {
+        generated_line,
+        generated_column,
+        original: SourceLocation {
+            path: path.to_string(),
+            line,
+            column,
+        },
+    }
+}
+
+#[test]
+fn encodes_base64_vlq_values() {
+    let mut encoded = String::new();
+    encode_vlq(17, &mut encoded);
+    encode_vlq(-10, &mut encoded);
+    assert_eq!(encoded, "iBV");
+}
+
+#[test]
+fn renders_v3_source_map() {
+    let rendered = render(
+        "API.md",
+        &[
+            mapping(7, 0, "src/lib.rs", 4, 0),
+            mapping(9, 4, "src/client.rs", 11, 8),
+        ],
+    )
+    .unwrap();
+    let json: Value = serde_json::from_str(&rendered).unwrap();
+
+    assert_eq!(json["version"], 3);
+    assert_eq!(json["file"], "API.md");
+    assert_eq!(
+        json["sources"],
+        serde_json::json!(["src/lib.rs", "src/client.rs"])
+    );
+    assert_eq!(json["mappings"], ";;;;;;;AAIA;;ICOQ");
+    assert!(json.get("sourceRoot").is_none());
+    assert!(json.get("names").is_none());
+}
+
+#[test]
+fn sources_follow_first_mapping_occurrence() {
+    let rendered = render(
+        "API.md",
+        &[
+            mapping(2, 0, "src/z.rs", 0, 0),
+            mapping(1, 0, "src/a.rs", 0, 0),
+        ],
+    )
+    .unwrap();
+    let json: Value = serde_json::from_str(&rendered).unwrap();
+
+    assert_eq!(json["sources"], serde_json::json!(["src/a.rs", "src/z.rs"]));
+    assert_eq!(json["mappings"], ";AAAA;ACAA");
+}

--- a/eng/tools/generate_api/src/source_map/tests.rs
+++ b/eng/tools/generate_api/src/source_map/tests.rs
@@ -38,6 +38,8 @@ fn renders_v3_source_map() {
             mapping(7, 0, "src/lib.rs", 4, 0),
             mapping(9, 4, "src/client.rs", 11, 8),
         ],
+        Path::new("/repo"),
+        Path::new("/repo"),
     )
     .unwrap();
     let json: Value = serde_json::from_str(&rendered).unwrap();
@@ -49,7 +51,7 @@ fn renders_v3_source_map() {
         serde_json::json!(["src/lib.rs", "src/client.rs"])
     );
     assert_eq!(json["mappings"], ";;;;;;;AAIA;;ICOQ");
-    assert!(json.get("sourceRoot").is_none());
+    assert_eq!(json["sourceRoot"], "");
     assert!(json.get("names").is_none());
 }
 
@@ -61,10 +63,93 @@ fn sources_follow_first_mapping_occurrence() {
             mapping(2, 0, "src/z.rs", 0, 0),
             mapping(1, 0, "src/a.rs", 0, 0),
         ],
+        Path::new("/repo"),
+        Path::new("/repo"),
     )
     .unwrap();
     let json: Value = serde_json::from_str(&rendered).unwrap();
 
     assert_eq!(json["sources"], serde_json::json!(["src/a.rs", "src/z.rs"]));
     assert_eq!(json["mappings"], ";AAAA;ACAA");
+}
+
+fn source_map_from_rendered(rendered: &str) -> Value {
+    serde_json::from_str(rendered).unwrap()
+}
+
+fn resolved_source_from_rendered(rendered: &str) -> PathBuf {
+    let json: Value = serde_json::from_str(rendered).unwrap();
+    Path::new(json["sourceRoot"].as_str().unwrap()).join(json["sources"][0].as_str().unwrap())
+}
+
+#[test]
+fn source_root_points_to_repository_from_nested_output() {
+    let rendered = render(
+        "API.md",
+        &[mapping(0, 0, "sdk/core/azure_core/src/lib.rs", 0, 0)],
+        Path::new("/repo/target/generate_api/azure_core"),
+        Path::new("/repo"),
+    )
+    .unwrap();
+    let json = source_map_from_rendered(&rendered);
+
+    assert_eq!(json["sourceRoot"], "../../..");
+    assert_eq!(json["sources"][0], "sdk/core/azure_core/src/lib.rs");
+}
+
+#[test]
+fn source_root_accounts_for_deeper_output_directories() {
+    let rendered = render(
+        "API.md",
+        &[mapping(0, 0, "sdk/core/azure_core/src/lib.rs", 0, 0)],
+        Path::new("/repo/sdk/core/azure_core/api"),
+        Path::new("/repo"),
+    )
+    .unwrap();
+    let json = source_map_from_rendered(&rendered);
+
+    assert_eq!(json["sourceRoot"], "../../../..");
+    assert_eq!(json["sources"][0], "sdk/core/azure_core/src/lib.rs");
+}
+
+#[test]
+fn source_root_is_omitted_for_output_outside_the_repository() {
+    let rendered = render(
+        "API.md",
+        &[mapping(0, 0, "sdk/core/azure_core/src/lib.rs", 0, 0)],
+        Path::new("/artifacts/azure_core"),
+        Path::new("/repo"),
+    )
+    .unwrap();
+    let json = source_map_from_rendered(&rendered);
+
+    assert!(json.get("sourceRoot").is_none());
+    assert_eq!(json["sources"][0], "sdk/core/azure_core/src/lib.rs");
+}
+
+#[test]
+fn rendered_source_resolves_from_the_output_directory() {
+    let root = std::env::temp_dir().join(format!(
+        "generate_api_source_map_test_{}",
+        std::process::id()
+    ));
+    let repository_root = root.join("repo");
+    let source = repository_root.join("sdk/core/azure_core/src/lib.rs");
+    let output = repository_root.join("sdk/core/azure_core/api");
+    std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(&output).unwrap();
+    std::fs::write(&source, "").unwrap();
+
+    let rendered = render(
+        "API.md",
+        &[mapping(0, 0, "sdk/core/azure_core/src/lib.rs", 0, 0)],
+        &output,
+        &repository_root,
+    )
+    .unwrap();
+    let resolved = output.join(resolved_source_from_rendered(&rendered));
+    let resolved = resolved.canonicalize().unwrap();
+
+    assert_eq!(resolved, source.canonicalize().unwrap());
+    std::fs::remove_dir_all(root).unwrap();
 }


### PR DESCRIPTION
Add ECMA-426 v3 source map generation for Markdown API output, preserving repository-relative declaration locations for modules, items, members, and macros.

Add the --no-map switch, source map encoding and extraction tests, and documentation for the new API.md.map artifact.

Generate the azure_core API.md, documentation patch, and source map for review.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: eddfe116-95c6-49d3-87e8-84a50f4423b5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>