### PR TITLE
[Storage] Remove `UserDelegationKey` re-export from `azure_storage_sas`

### DIFF
--- a/sdk/storage/azure_storage_blob/tests/blob_sas.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_sas.rs
@@ -18,7 +18,8 @@ use azure_core::{
 use azure_core_test::{recorded, TestContext};
 use azure_storage_blob::models::{BlobClientGetPropertiesResultHeaders, KeyInfo};
 use azure_storage_blob::{BlobClient, BlobServiceClient};
-use azure_storage_sas::{SasBuilder, UserDelegationKey};
+use azure_storage_common::models::UserDelegationKey;
+use azure_storage_sas::SasBuilder;
 use common::{
     create_test_blob, get_blob_name, get_blob_service_client, get_container_client, StorageAccount,
 };

--- a/sdk/storage/azure_storage_sas/CHANGELOG.md
+++ b/sdk/storage/azure_storage_sas/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+- Removed the `UserDelegationKey` re-export; import it from `azure_storage_common::models` directly.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/storage/azure_storage_sas/src/blob/mod.rs
+++ b/sdk/storage/azure_storage_sas/src/blob/mod.rs
@@ -8,7 +8,8 @@
 //! ## Blob user delegation SAS
 //!
 //! ```rust no_run
-//! use azure_storage_sas::{SasBuilder, UserDelegationKey};
+//! use azure_storage_common::models::UserDelegationKey;
+//! use azure_storage_sas::SasBuilder;
 //! use time::OffsetDateTime;
 //!
 //! # fn example(udk: UserDelegationKey) -> azure_core::Result<()> {
@@ -25,7 +26,8 @@
 //! ## Container SAS
 //!
 //! ```rust no_run
-//! use azure_storage_sas::{SasBuilder, UserDelegationKey};
+//! use azure_storage_common::models::UserDelegationKey;
+//! use azure_storage_sas::SasBuilder;
 //! use time::OffsetDateTime;
 //!
 //! # fn example(udk: UserDelegationKey) -> azure_core::Result<()> {

--- a/sdk/storage/azure_storage_sas/src/lib.rs
+++ b/sdk/storage/azure_storage_sas/src/lib.rs
@@ -21,7 +21,6 @@ mod protocol;
 pub mod blob;
 pub mod queue;
 
-pub use azure_storage_common::models::UserDelegationKey;
 pub use builder::SasBuilder;
 pub use ip_range::SasIpRange;
 pub use protocol::SasProtocol;

--- a/sdk/storage/azure_storage_sas/src/queue.rs
+++ b/sdk/storage/azure_storage_sas/src/queue.rs
@@ -6,7 +6,8 @@
 //! # Example
 //!
 //! ```rust no_run
-//! use azure_storage_sas::{SasBuilder, SasProtocol, UserDelegationKey};
+//! use azure_storage_common::models::UserDelegationKey;
+//! use azure_storage_sas::{SasBuilder, SasProtocol};
 //! use time::OffsetDateTime;
 //!
 //! # fn example(udk: UserDelegationKey) -> azure_core::Result<()> {


### PR DESCRIPTION
As title states, cx should just import directly from `azure_storage_common` if they need typed access. The rest of the crate still functions as intended even without this re-export.