### PR TITLE
[Storage] Fixed SAS generation for blob names with a backslash

### DIFF
--- a/sdk/storage/azure_storage_sas/src/blob/blob_resource.rs
+++ b/sdk/storage/azure_storage_sas/src/blob/blob_resource.rs
@@ -36,7 +36,12 @@ impl BlobResource {
     }
 
     pub(crate) fn canonicalized_resource(&self, account: &str) -> String {
-        format!("/blob/{}/{}/{}", account, self.container, self.blob)
+        format!(
+            "/blob/{}/{}/{}",
+            account,
+            self.container,
+            self.blob.replace('\\', "/")
+        )
     }
 
     pub(crate) fn snapshot_time(&self) -> Option<&str> {
@@ -116,5 +121,20 @@ impl BlobPermissions {
             s.push('i');
         }
         s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalized_resource_normalizes_backslashes() {
+        let resource = BlobResource::new("container", r"dir\blob.txt");
+
+        assert_eq!(
+            resource.canonicalized_resource("account"),
+            "/blob/account/container/dir/blob.txt"
+        );
     }
 }

--- a/sdk/storage/azure_storage_sas/src/blob/directory_resource.rs
+++ b/sdk/storage/azure_storage_sas/src/blob/directory_resource.rs
@@ -11,8 +11,8 @@ pub(crate) struct DirectoryResource {
 impl DirectoryResource {
     /// Creates a new directory resource.
     ///
-    /// The directory depth (`sdd`) is computed automatically from the path
-    /// by counting `/`-separated segments (e.g., `"dir1/dir2"` → depth 2).
+    /// The directory depth (`sdd`) is computed automatically after normalizing
+    /// `\` to `/` and counting the resulting path segments.
     pub(crate) fn new(container: impl Into<String>, directory: impl Into<String>) -> Self {
         Self {
             container: container.into(),
@@ -21,7 +21,8 @@ impl DirectoryResource {
     }
 
     pub(crate) fn depth(&self) -> u32 {
-        let trimmed = self.directory.trim_matches('/');
+        let canonicalized_directory = self.canonicalized_directory();
+        let trimmed = canonicalized_directory.trim_matches('/');
         if trimmed.is_empty() {
             0
         } else {
@@ -30,6 +31,38 @@ impl DirectoryResource {
     }
 
     pub(crate) fn canonicalized_resource(&self, account: &str) -> String {
-        format!("/blob/{}/{}/{}", account, self.container, self.directory)
+        format!(
+            "/blob/{}/{}/{}",
+            account,
+            self.container,
+            self.canonicalized_directory()
+        )
+    }
+
+    fn canonicalized_directory(&self) -> String {
+        self.directory.replace('\\', "/")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalized_resource_and_depth_normalize_backslashes() {
+        let resource = DirectoryResource::new("container", r"dir1\dir2/dir3");
+
+        assert_eq!(
+            resource.canonicalized_resource("account"),
+            "/blob/account/container/dir1/dir2/dir3"
+        );
+        assert_eq!(resource.depth(), 3);
+    }
+
+    #[test]
+    fn backslash_root_has_zero_depth() {
+        let resource = DirectoryResource::new("container", r"\");
+
+        assert_eq!(resource.depth(), 0);
     }
 }


### PR DESCRIPTION
Same fix as in Python: https://github.com/Azure/azure-sdk-for-python/pull/48883