### PR TITLE
Move recreation changelog entries

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- Name-based container clients now automatically recover when a container is deleted and recreated. ([#5219](https://github.com/Azure/azure-sdk-for-rust/pull/5219))
+
 ### Other Changes
 
 ## 0.38.0 (2026-09-02)
@@ -52,7 +54,6 @@
 
 ### Bugs Fixed
 
-- Name-based container clients now automatically recover when a container is deleted and recreated. ([#5219](https://github.com/Azure/azure-sdk-for-rust/pull/5219))
 - Fixed doubles losing up to 1 ULP when a text JSON response body is parsed, so a value such as `96.182417728091792` no longer comes back as `96.1824177280918`. `serde_json`'s default float parser is not correctly rounded; the `float_roundtrip` feature is now enabled. ([#5040](https://github.com/Azure/azure-sdk-for-rust/pull/5040))
 - Unsafe client-side PATCH operations now persist a bounded marker with the mutation, preventing duplicate increments, array edits, removes, and moves when a Replace commits but its response is lost. ([#5173](https://github.com/Azure/azure-sdk-for-rust/pull/5173))
 - `PatchOperation::Increment` now serializes with the `incr` wire tag the Cosmos DB service expects, instead of `increment`. This is observable where patch instructions reach the service directly — today the distributed-transaction patch operation, whose increments were rejected. `ContainerClient::patch_item` is unaffected, as its read-modify-write loop never puts the instructions on the wire. Deserialization stays backward compatible: `increment` is still accepted on input, so persisted patch documents keep parsing, and re-serializing upgrades them to `incr`. ([#5087](https://github.com/Azure/azure-sdk-for-rust/pull/5087))

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- Name-addressed container operations now refresh metadata and retry once after container recreation, clearing generation-specific session and partition-routing state before targeting the replacement. ([#5219](https://github.com/Azure/azure-sdk-for-rust/pull/5219))
+
 ### Other Changes
 
 ## 0.7.0 (2026-09-02)
@@ -50,7 +52,6 @@
 
 ### Bugs Fixed
 
-- Name-addressed container operations now refresh metadata and retry once after container recreation, clearing generation-specific session and partition-routing state before targeting the replacement. ([#5219](https://github.com/Azure/azure-sdk-for-rust/pull/5219))
 - Fixed doubles losing up to 1 ULP when a text JSON body is parsed, so a value such as `96.182417728091792` no longer comes back as `96.1824177280918`. `serde_json`'s default float parser is not correctly rounded; the `float_roundtrip` feature is now enabled. ([#5040](https://github.com/Azure/azure-sdk-for-rust/pull/5040))
 - Literal `%` characters in resource names are now percent-encoded on the HTTP request path so the gateway resolves the intended resource while authorization continues to use the original name. ([#5207](https://github.com/Azure/azure-sdk-for-rust/pull/5207))
 - Unsafe PATCH operations now atomically persist bounded tracking markers so ambiguous Replace retries and caller-token retries recognize their own prior commit instead of reapplying non-idempotent instructions. ([#5173](https://github.com/Azure/azure-sdk-for-rust/pull/5173))

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
@@ -2466,15 +2466,14 @@ impl CosmosDriver {
                 };
                 let is_cold = region_pin.is_none();
 
-                let (result, serving_endpoint) = self
-                    .fetch_pk_ranges_from_service(
-                        container.clone(),
-                        continuation,
-                        region_pin,
-                        options,
-                        absolute_deadline,
-                    )
-                    .await;
+                let (result, serving_endpoint) = Box::pin(self.fetch_pk_ranges_from_service(
+                    container.clone(),
+                    continuation,
+                    region_pin,
+                    options,
+                    absolute_deadline,
+                ))
+                .await;
                 // Record the serving region for every successful cold page, so
                 // the continuation pages that follow are pinned to it. Pages
                 // that already carry a pin leave it untouched: the chain must
@@ -4375,15 +4374,15 @@ impl CosmosDriver {
                 ..
             })) => {
                 tracing::debug!("native query plan library not available, falling back to gateway");
-                self.gateway_query_plan(container, operation, options).await
+                Box::pin(self.gateway_query_plan(container, operation, options)).await
             }
             Some(Err(e)) => {
                 tracing::warn!(error = %e, "native query plan generation failed, falling back to gateway");
-                self.gateway_query_plan(container, operation, options).await
+                Box::pin(self.gateway_query_plan(container, operation, options)).await
             }
             None => {
                 tracing::debug!("using gateway query plan");
-                self.gateway_query_plan(container, operation, options).await
+                Box::pin(self.gateway_query_plan(container, operation, options)).await
             }
         }
     }


### PR DESCRIPTION
Moves the PR #5219 container-recreation entries from the versions released on 2026-09-04 into each crate's newest unreleased section. The entries and links are otherwise unchanged.