### PR TITLE
[Storage] Prep for `azure_storage_blob` and `azure_storage_queue` `v1.1.0` release, `v1.0.0` of `azure_storage_sas` and `azure_storage_common`

### DIFF
--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.1.0 (Unreleased)
+
+### Features Added
+
+- Stable release of features from 1.1.0-beta.1 and 1.1.0-beta.2
+
 ## 1.1.0-beta.2 (2026-08-11)
 
 ### Features Added
@@ -9,10 +15,6 @@
 ### Breaking Changes
 
 - Removed `BlobContainerClient::list_blobs_hierarchical()`.
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 1.1.0-beta.1 (2026-07-14)
 

--- a/sdk/storage/azure_storage_blob/tests/blob_sas.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_sas.rs
@@ -18,7 +18,8 @@ use azure_core::{
 use azure_core_test::{recorded, TestContext};
 use azure_storage_blob::models::{BlobClientGetPropertiesResultHeaders, KeyInfo};
 use azure_storage_blob::{BlobClient, BlobServiceClient};
-use azure_storage_sas::{SasBuilder, UserDelegationKey};
+use azure_storage_common::models::UserDelegationKey;
+use azure_storage_sas::SasBuilder;
 use common::{
     create_test_blob, get_blob_name, get_blob_service_client, get_container_client, StorageAccount,
 };

--- a/sdk/storage/azure_storage_common/CHANGELOG.md
+++ b/sdk/storage/azure_storage_common/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 0.2.0 (Unreleased)
+## 1.0.0 (Unreleased)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Stable release of features from 0.1.0
 
 ## 0.1.0 (2026-07-14)
 

--- a/sdk/storage/azure_storage_queue/CHANGELOG.md
+++ b/sdk/storage/azure_storage_queue/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.1.0-beta.2 (Unreleased)
+## 1.1.0 (Unreleased)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Stable release of features from 1.1.0-beta.1
 
 ## 1.1.0-beta.1 (2026-07-14)
 

--- a/sdk/storage/azure_storage_sas/CHANGELOG.md
+++ b/sdk/storage/azure_storage_sas/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+- Removed the `UserDelegationKey` re-export; import it from `azure_storage_common::models` directly.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/storage/azure_storage_sas/CHANGELOG.md
+++ b/sdk/storage/azure_storage_sas/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 0.2.0 (Unreleased)
+## 1.0.0 (Unreleased)
 
 ### Features Added
+
+- Stable release of features from 0.1.0
 
 ### Breaking Changes
 
@@ -10,7 +12,7 @@
 
 ### Bugs Fixed
 
-### Other Changes
+- Fixed SAS generation for blob and directory paths containing backslashes by normalizing them to forward slashes in the signed resource.
 
 ## 0.1.0 (2026-07-14)
 

--- a/sdk/storage/azure_storage_sas/src/blob/blob_resource.rs
+++ b/sdk/storage/azure_storage_sas/src/blob/blob_resource.rs
@@ -36,7 +36,12 @@ impl BlobResource {
     }
 
     pub(crate) fn canonicalized_resource(&self, account: &str) -> String {
-        format!("/blob/{}/{}/{}", account, self.container, self.blob)
+        format!(
+            "/blob/{}/{}/{}",
+            account,
+            self.container,
+            self.blob.replace('\\', "/")
+        )
     }
 
     pub(crate) fn snapshot_time(&self) -> Option<&str> {
@@ -116,5 +121,20 @@ impl BlobPermissions {
             s.push('i');
         }
         s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalized_resource_normalizes_backslashes() {
+        let resource = BlobResource::new("container", r"dir\blob.txt");
+
+        assert_eq!(
+            resource.canonicalized_resource("account"),
+            "/blob/account/container/dir/blob.txt"
+        );
     }
 }

--- a/sdk/storage/azure_storage_sas/src/blob/directory_resource.rs
+++ b/sdk/storage/azure_storage_sas/src/blob/directory_resource.rs
@@ -11,8 +11,8 @@ pub(crate) struct DirectoryResource {
 impl DirectoryResource {
     /// Creates a new directory resource.
     ///
-    /// The directory depth (`sdd`) is computed automatically from the path
-    /// by counting `/`-separated segments (e.g., `"dir1/dir2"` → depth 2).
+    /// The directory depth (`sdd`) is computed automatically after normalizing
+    /// `\` to `/` and counting the resulting path segments.
     pub(crate) fn new(container: impl Into<String>, directory: impl Into<String>) -> Self {
         Self {
             container: container.into(),
@@ -21,7 +21,8 @@ impl DirectoryResource {
     }
 
     pub(crate) fn depth(&self) -> u32 {
-        let trimmed = self.directory.trim_matches('/');
+        let canonicalized_directory = self.canonicalized_directory();
+        let trimmed = canonicalized_directory.trim_matches('/');
         if trimmed.is_empty() {
             0
         } else {
@@ -30,6 +31,38 @@ impl DirectoryResource {
     }
 
     pub(crate) fn canonicalized_resource(&self, account: &str) -> String {
-        format!("/blob/{}/{}/{}", account, self.container, self.directory)
+        format!(
+            "/blob/{}/{}/{}",
+            account,
+            self.container,
+            self.canonicalized_directory()
+        )
+    }
+
+    fn canonicalized_directory(&self) -> String {
+        self.directory.replace('\\', "/")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalized_resource_and_depth_normalize_backslashes() {
+        let resource = DirectoryResource::new("container", r"dir1\dir2/dir3");
+
+        assert_eq!(
+            resource.canonicalized_resource("account"),
+            "/blob/account/container/dir1/dir2/dir3"
+        );
+        assert_eq!(resource.depth(), 3);
+    }
+
+    #[test]
+    fn backslash_root_has_zero_depth() {
+        let resource = DirectoryResource::new("container", r"\");
+
+        assert_eq!(resource.depth(), 0);
     }
 }

--- a/sdk/storage/azure_storage_sas/src/blob/mod.rs
+++ b/sdk/storage/azure_storage_sas/src/blob/mod.rs
@@ -8,7 +8,8 @@
 //! ## Blob user delegation SAS
 //!
 //! ```rust no_run
-//! use azure_storage_sas::{SasBuilder, UserDelegationKey};
+//! use azure_storage_common::models::UserDelegationKey;
+//! use azure_storage_sas::SasBuilder;
 //! use time::OffsetDateTime;
 //!
 //! # fn example(udk: UserDelegationKey) -> azure_core::Result<()> {
@@ -25,7 +26,8 @@
 //! ## Container SAS
 //!
 //! ```rust no_run
-//! use azure_storage_sas::{SasBuilder, UserDelegationKey};
+//! use azure_storage_common::models::UserDelegationKey;
+//! use azure_storage_sas::SasBuilder;
 //! use time::OffsetDateTime;
 //!
 //! # fn example(udk: UserDelegationKey) -> azure_core::Result<()> {

--- a/sdk/storage/azure_storage_sas/src/lib.rs
+++ b/sdk/storage/azure_storage_sas/src/lib.rs
@@ -21,7 +21,6 @@ mod protocol;
 pub mod blob;
 pub mod queue;
 
-pub use azure_storage_common::models::UserDelegationKey;
 pub use builder::SasBuilder;
 pub use ip_range::SasIpRange;
 pub use protocol::SasProtocol;

--- a/sdk/storage/azure_storage_sas/src/queue.rs
+++ b/sdk/storage/azure_storage_sas/src/queue.rs
@@ -6,7 +6,8 @@
 //! # Example
 //!
 //! ```rust no_run
-//! use azure_storage_sas::{SasBuilder, SasProtocol, UserDelegationKey};
+//! use azure_storage_common::models::UserDelegationKey;
+//! use azure_storage_sas::{SasBuilder, SasProtocol};
 //! use time::OffsetDateTime;
 //!
 //! # fn example(udk: UserDelegationKey) -> azure_core::Result<()> {


### PR DESCRIPTION
As title states. Cherry-picks the changes that are ready for release including:

- SAS fix for `/` and `\`
- Removing the `UserDelegationKey` re-export in `azure_storage_sas` from `azure_storage_common`


And also prepares for the stable release of `azure_storage_sas` and `azure_storage_common`