### PR TITLE
[Storage] Bump crate versions for `v1.1.0` and `v1.0.0` releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,15 +975,15 @@ dependencies = [
 
 [[package]]
 name = "azure_storage_blob"
-version = "1.1.0-beta.2"
+version = "1.1.0"
 dependencies = [
  "async-stream",
  "async-trait",
  "azure_core 1.1.0",
  "azure_core_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure_identity 1.0.0",
- "azure_storage_common 0.1.0",
- "azure_storage_sas 0.1.0",
+ "azure_storage_common",
+ "azure_storage_sas",
  "bytes",
  "clap",
  "flate2",
@@ -1001,18 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "azure_storage_common"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8d86465df4adce8ab1246205be0b99165683808701cd6f0f84e382ad7cd504"
-dependencies = [
- "azure_core 1.1.0",
- "serde",
- "time",
-]
-
-[[package]]
-name = "azure_storage_common"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "azure_core 1.2.0-beta.1",
  "serde",
@@ -1022,14 +1011,14 @@ dependencies = [
 
 [[package]]
 name = "azure_storage_queue"
-version = "1.1.0-beta.2"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "azure_core 1.2.0-beta.1",
  "azure_core_test 0.2.0",
  "azure_identity 1.1.0-beta.1",
- "azure_storage_common 0.2.0",
- "azure_storage_sas 0.2.0",
+ "azure_storage_common",
+ "azure_storage_sas",
  "futures",
  "rand 0.10.2",
  "serde",
@@ -1039,25 +1028,10 @@ dependencies = [
 
 [[package]]
 name = "azure_storage_sas"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab4d6a4713e35009e11b63ca8d19f39fe33552f7b129d469d15367757fa6e35"
-dependencies = [
- "azure_core 1.1.0",
- "azure_storage_common 0.1.0",
- "base64",
- "hmac",
- "percent-encoding",
- "sha2",
- "time",
-]
-
-[[package]]
-name = "azure_storage_sas"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "azure_core 1.2.0-beta.1",
- "azure_storage_common 0.2.0",
+ "azure_storage_common",
  "base64",
  "hmac",
  "include-file",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,7 +1003,7 @@ dependencies = [
 name = "azure_storage_common"
 version = "1.0.0"
 dependencies = [
- "azure_core 1.2.0-beta.1",
+ "azure_core 1.1.0",
  "serde",
  "serde_json",
  "time",
@@ -1014,9 +1014,9 @@ name = "azure_storage_queue"
 version = "1.1.0"
 dependencies = [
  "async-trait",
- "azure_core 1.2.0-beta.1",
- "azure_core_test 0.2.0",
- "azure_identity 1.1.0-beta.1",
+ "azure_core 1.1.0",
+ "azure_core_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "azure_identity 1.0.0",
  "azure_storage_common",
  "azure_storage_sas",
  "futures",
@@ -1030,7 +1030,7 @@ dependencies = [
 name = "azure_storage_sas"
 version = "1.0.0"
 dependencies = [
- "azure_core 1.2.0-beta.1",
+ "azure_core 1.1.0",
  "azure_storage_common",
  "base64",
  "hmac",

--- a/samples/storage_blob_logging/Cargo.toml
+++ b/samples/storage_blob_logging/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 azure_core = { path = "../../sdk/core/azure_core", version = "1.2.0-beta.1", default-features = false }
 azure_core_opentelemetry = { path = "../../sdk/core/azure_core_opentelemetry", version = "1.1.0-beta.1" }
 azure_identity = { path = "../../sdk/identity/azure_identity", version = "1.1.0-beta.1", default-features = false }
-azure_storage_blob = { path = "../../sdk/storage/azure_storage_blob", version = "1.1.0-beta.2" }
+azure_storage_blob = { path = "../../sdk/storage/azure_storage_blob", version = "1.1.0" }
 clap = { version = "4.6.0", features = ["derive", "env"] }
 opentelemetry-stdout = "0.32"
 opentelemetry_sdk = "0.32.1"

--- a/samples/storage_blob_logging/Cargo.toml
+++ b/samples/storage_blob_logging/Cargo.toml
@@ -8,12 +8,12 @@ repository = "https://github.com/azure/azure-sdk-for-rust"
 publish = false
 
 [dependencies]
-azure_core = { path = "../../sdk/core/azure_core", version = "1.2.0-beta.1", default-features = false }
-azure_core_opentelemetry = { path = "../../sdk/core/azure_core_opentelemetry", version = "1.1.0-beta.1" }
-azure_identity = { path = "../../sdk/identity/azure_identity", version = "1.1.0-beta.1", default-features = false }
+azure_core = { version = "1.1.0", default-features = false }
+azure_core_opentelemetry = "1.0.0"
+azure_identity = { version = "1.0.0", default-features = false }
 azure_storage_blob = { path = "../../sdk/storage/azure_storage_blob", version = "1.1.0" }
 clap = { version = "4.6.0", features = ["derive", "env"] }
-opentelemetry-stdout = "0.32"
-opentelemetry_sdk = "0.32.1"
+opentelemetry-stdout = "0.31.0"
+opentelemetry_sdk = "0.31.0"
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/sdk/storage/azure_storage_blob/Cargo.toml
+++ b/sdk/storage/azure_storage_blob/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_storage_blob"
-version = "1.1.0-beta.2"
+version = "1.1.0"
 description = "Microsoft Azure Blob Storage client library for Rust"
 readme = "README.md"
 authors.workspace = true
@@ -21,7 +21,7 @@ tokio = ["dep:tokio", "azure_core/tokio"]
 async-stream.workspace = true
 async-trait.workspace = true
 azure_core = { workspace = true, features = ["xml"] }
-azure_storage_common = "0.1.0"
+azure_storage_common = { path = "../azure_storage_common", version = "1.0.0" }
 bytes.workspace = true
 futures.workspace = true
 percent-encoding.workspace = true
@@ -41,7 +41,7 @@ workspace = true
 [dev-dependencies]
 azure_core_test = { workspace = true, features = ["tracing"] }
 azure_identity.workspace = true
-azure_storage_sas = "0.1.0"
+azure_storage_sas = { path = "../azure_storage_sas", version = "1.0.0" }
 clap = { workspace = true, features = ["env"] }
 flate2.workspace = true
 futures.workspace = true

--- a/sdk/storage/azure_storage_common/Cargo.toml
+++ b/sdk/storage/azure_storage_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_storage_common"
-version = "0.2.0"
+version = "1.0.0"
 description = "Common types shared across Azure Storage client libraries."
 readme = "README.md"
 authors.workspace = true

--- a/sdk/storage/azure_storage_common/Cargo.toml
+++ b/sdk/storage/azure_storage_common/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["sdk", "cloud"]
 categories = ["api-bindings"]
 
 [dependencies]
-azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1", features = ["xml"] }
+azure_core = { workspace = true, features = ["xml"] }
 serde = { workspace = true }
 time = { workspace = true }
 

--- a/sdk/storage/azure_storage_queue/Cargo.toml
+++ b/sdk/storage/azure_storage_queue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_storage_queue"
-version = "1.1.0-beta.2"
+version = "1.1.0"
 description = "Microsoft Azure Queue client library for Rust"
 readme = "README.md"
 authors.workspace = true
@@ -19,7 +19,7 @@ default = ["azure_core/default"]
 [dependencies]
 async-trait.workspace = true
 azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1", features = ["xml"] }
-azure_storage_common = { path = "../azure_storage_common", version = "0.2.0" }
+azure_storage_common = { path = "../azure_storage_common", version = "1.0.0" }
 serde = { workspace = true }
 time.workspace = true
 

--- a/sdk/storage/azure_storage_queue/Cargo.toml
+++ b/sdk/storage/azure_storage_queue/Cargo.toml
@@ -18,7 +18,7 @@ default = ["azure_core/default"]
 
 [dependencies]
 async-trait.workspace = true
-azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1", features = ["xml"] }
+azure_core = { workspace = true, features = ["xml"] }
 azure_storage_common = { path = "../azure_storage_common", version = "1.0.0" }
 serde = { workspace = true }
 time.workspace = true
@@ -27,8 +27,8 @@ time.workspace = true
 workspace = true
 
 [dev-dependencies]
-azure_core_test = { path = "../../core/azure_core_test", features = ["tracing"] }
-azure_identity = { path = "../../identity/azure_identity" }
+azure_core_test = { workspace = true, features = ["tracing"] }
+azure_identity.workspace = true
 azure_storage_sas.path = "../azure_storage_sas"
 futures.workspace = true
 rand.workspace = true

--- a/sdk/storage/azure_storage_sas/Cargo.toml
+++ b/sdk/storage/azure_storage_sas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_storage_sas"
-version = "0.2.0"
+version = "1.0.0"
 description = "User delegation Shared Access Signature (SAS) builder for Microsoft Azure Storage services"
 readme = "README.md"
 authors.workspace = true
@@ -15,7 +15,7 @@ categories = ["api-bindings"]
 
 [dependencies]
 azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1" }
-azure_storage_common = { path = "../azure_storage_common", version = "0.2.0" }
+azure_storage_common = { path = "../azure_storage_common", version = "1.0.0" }
 base64 = { workspace = true }
 hmac = { workspace = true }
 percent-encoding = { workspace = true }

--- a/sdk/storage/azure_storage_sas/Cargo.toml
+++ b/sdk/storage/azure_storage_sas/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["sdk", "cloud"]
 categories = ["api-bindings"]
 
 [dependencies]
-azure_core = { path = "../../core/azure_core", version = "1.2.0-beta.1" }
+azure_core.workspace = true
 azure_storage_common = { path = "../azure_storage_common", version = "1.0.0" }
 base64 = { workspace = true }
 hmac = { workspace = true }


### PR DESCRIPTION
v1.1.0

- `azure_storage_blob`
- `azure_storage_queue`

v1.0.0

- `azure_storage_sas`
- `azure_storage_common`