### PR TITLE
Emit API metadata for markdown

### DIFF
--- a/eng/tools/generate_api/AGENTS.md
+++ b/eng/tools/generate_api/AGENTS.md
@@ -5,9 +5,10 @@
 `eng/tools/generate_api` is a Rust CLI that generates the following public API artifacts for a target crate:
 
 1. `API.md` — one fenced `rust` block
-2. `API.md.map` — an ECMA-426 source map for declaration lines in `API.md`
-3. `API.comments.patch` — a unified diff that adds doc comments back to `API.md`
-4. `apiview.json` — an APIView tree-style `CodeFile`
+2. `API.metadata.yml` — YAML metadata for `API.md`
+3. `API.md.map` — an ECMA-426 source map for declaration lines in `API.md`
+4. `API.comments.patch` — a unified diff that adds doc comments back to `API.md`
+5. `apiview.json` — an APIView tree-style `CodeFile`
 
 ## Scope
 
@@ -31,6 +32,7 @@ The tool exposes:
 Behavior:
 
 - default `markdown` writes `API.md`, `API.md.map`, and `API.comments.patch`
+- default `markdown` also writes `API.metadata.yml`
 - `--format apiview` writes `apiview.json`
 - `--no-docs` suppresses APIView doc comment tokens and the Markdown comments patch
 - check comparisons ignore line-ending differences and mismatches exit `1`
@@ -182,6 +184,7 @@ Documentation handling:
 Package metadata rendering:
 
 - Markdown renders the crate name first; APIView uses only the top-level `PackageName`
+- Markdown also writes `API.metadata.yml` with `apiMdSha256`, `packageVersion`, `parserVersion`, and `rustVersion`
 - missing description, edition, or rust-version values are omitted
 - multiline descriptions render with the `Description` label on its own line
 - features use `default` plus `package.metadata.docs.rs.features` when present

--- a/eng/tools/generate_api/Cargo.toml
+++ b/eng/tools/generate_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generate_api"
-version = "2.2.0"
+version = "2.2.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/eng/tools/generate_api/README.md
+++ b/eng/tools/generate_api/README.md
@@ -23,7 +23,8 @@ cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- \
 
 ### Outputs
 
-- default `markdown` output writes `API.md`, `API.md.map`, and `API.comments.patch`
+- default `markdown` output writes `API.md`, `API.metadata.yml`, `API.md.map`, and
+ `API.comments.patch`
 - `--no-docs` skips `API.comments.patch`
 - `--no-map` skips `API.md.map`
 - `--format apiview` writes `apiview.json`
@@ -37,6 +38,8 @@ starts with the crate name. Multiline descriptions render with the `Description`
 line before the description text. Children of the `default` feature are also listed. `API.md` never
 contains
 documentation comments.
+`API.metadata.yml` is written next to `API.md` and records the normalized SHA-256 of `API.md`, the
+crate version, the `generate_api` version, and the rustc version used for generation.
 `API.comments.patch` is a unified diff that adds them back, so it can be applied to toggle
 documentation comments on:
 

--- a/eng/tools/generate_api/src/cli.rs
+++ b/eng/tools/generate_api/src/cli.rs
@@ -54,6 +54,7 @@ pub(crate) enum OutputFormat {
 
 /// File name of the patch that adds documentation comments back to `API.md`.
 pub(crate) const COMMENTS_PATCH_FILE_NAME: &str = "API.comments.patch";
+pub(crate) const MARKDOWN_METADATA_FILE_NAME: &str = "API.metadata.yml";
 pub(crate) const SOURCE_MAP_FILE_NAME: &str = "API.md.map";
 
 impl OutputFormat {

--- a/eng/tools/generate_api/src/driver.rs
+++ b/eng/tools/generate_api/src/driver.rs
@@ -23,6 +23,25 @@ pub(crate) fn load_model(request: &Request) -> Result<ApiModel, String> {
     Ok((*loader.load_model_for_workspace(&metadata.current_package)?).clone())
 }
 
+pub(crate) fn rust_version() -> Result<String, String> {
+    let channel = env!("TOOLCHAIN_CHANNEL");
+    let mut command = Command::new("rustc");
+    command.arg(format!("+{channel}")).arg("-Vv");
+
+    let output = run_command(command, "Failed to query rustc version")?;
+    let version = String::from_utf8(output.stdout)
+        .map_err(|error| format!("Failed to decode rustc version: {error}"))?;
+    parse_rust_version(&version)
+}
+
+fn parse_rust_version(version_output: &str) -> Result<String, String> {
+    version_output
+        .lines()
+        .find_map(|line| line.strip_prefix("release: "))
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| "rustc -Vv output did not contain a release field".to_string())
+}
+
 fn run_command(mut command: Command, error_prefix: &str) -> Result<std::process::Output, String> {
     diagnostics::info(format!(
         "Running command: {} {}",
@@ -368,7 +387,9 @@ impl PackageMetadata {
 
 #[cfg(test)]
 mod tests {
-    use super::{crate_target_name, select_features, CargoPackage, CargoTarget};
+    use super::{
+        crate_target_name, parse_rust_version, select_features, CargoPackage, CargoTarget,
+    };
     use std::{collections::BTreeMap, path::PathBuf};
 
     #[test]
@@ -547,5 +568,28 @@ mod tests {
             select_features(BTreeMap::new(), Some(&["test".to_string()])),
             BTreeMap::from([("default".to_string(), Vec::new())])
         );
+    }
+
+    #[test]
+    fn parses_rust_release_field_from_verbose_version_output() {
+        let version = parse_rust_version(
+            "rustc 1.99.0-nightly (abcdef012 2026-09-01)\n\
+             binary: rustc\n\
+             commit-hash: abcdef0123456789\n\
+             commit-date: 2026-09-01\n\
+             host: x86_64-unknown-linux-gnu\n\
+             release: 1.99.0-nightly\n\
+             LLVM version: 21.0.0\n",
+        )
+        .unwrap();
+
+        assert_eq!(version, "1.99.0-nightly");
+    }
+
+    #[test]
+    fn rejects_verbose_version_output_without_release_field() {
+        let error = parse_rust_version("rustc 1.99.0-nightly\n").unwrap_err();
+
+        assert_eq!(error, "rustc -Vv output did not contain a release field");
     }
 }

--- a/eng/tools/generate_api/src/main.rs
+++ b/eng/tools/generate_api/src/main.rs
@@ -44,6 +44,17 @@ fn run() -> Result<(), String> {
             let rendered = render::markdown::render_from_lines(&lines);
             save_or_check(&request, &output_path, &rendered)?;
 
+            let metadata_path =
+                output::output_file_path(&request, cli::MARKDOWN_METADATA_FILE_NAME);
+            let rust_version = driver::rust_version()?;
+            let metadata = output::render_markdown_metadata(
+                &rendered,
+                &model.package_version,
+                &model.parser_version,
+                &rust_version,
+            )?;
+            save_or_check(&request, &metadata_path, &metadata)?;
+
             if !request.no_map {
                 let map_path = output::output_file_path(&request, cli::SOURCE_MAP_FILE_NAME);
                 let mappings = render::markdown::source_mappings_from_lines(&lines);

--- a/eng/tools/generate_api/src/output.rs
+++ b/eng/tools/generate_api/src/output.rs
@@ -17,6 +17,23 @@ pub(crate) fn output_file_path(request: &Request, file_name: &str) -> PathBuf {
     request.output_dir.join(file_name)
 }
 
+pub(crate) fn render_markdown_metadata(
+    api_md_contents: &str,
+    package_version: &str,
+    parser_version: &str,
+    rust_version: &str,
+) -> Result<String, String> {
+    let api_md_sha256 = sha256_hex(api_md_contents.as_bytes())
+        .map_err(|error| format!("Failed to hash API.md content: {error}"))?;
+
+    Ok(format!(
+        "apiMdSha256: {api_md_sha256}\npackageVersion: {}\nparserVersion: {}\nrustVersion: {}\n",
+        yaml_scalar(package_version),
+        yaml_scalar(parser_version),
+        yaml_scalar(rust_version),
+    ))
+}
+
 pub(crate) fn write_file(path: &Path, contents: &str) -> Result<(), String> {
     let parent = path
         .parent()
@@ -58,6 +75,11 @@ pub(crate) fn check_file(path: &Path, contents: &str) -> Result<bool, String> {
     }
 }
 
+fn sha256_hex(reader: impl Read) -> io::Result<String> {
+    let hash = sha256(reader)?;
+    Ok(hash.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
 fn sha256(mut reader: impl Read) -> io::Result<[u8; 32]> {
     let mut contents = Vec::new();
     reader.read_to_end(&mut contents)?;
@@ -75,6 +97,59 @@ fn sha256(mut reader: impl Read) -> io::Result<[u8; 32]> {
     }
 
     Ok(Sha256::digest(normalized).into())
+}
+
+fn yaml_scalar(value: &str) -> String {
+    if requires_yaml_quotes(value) {
+        format!("'{}'", value.replace('\'', "''"))
+    } else {
+        value.to_string()
+    }
+}
+
+fn requires_yaml_quotes(value: &str) -> bool {
+    if value.is_empty()
+        || value.chars().next().is_some_and(char::is_whitespace)
+        || value.chars().last().is_some_and(char::is_whitespace)
+    {
+        return true;
+    }
+
+    if value.contains('\n')
+        || value.contains('\r')
+        || value.contains('\t')
+        || value.contains(": ")
+        || value.contains(" #")
+    {
+        return true;
+    }
+
+    matches!(
+        value.chars().next(),
+        Some(
+            '-' | '?'
+                | ':'
+                | '!'
+                | '&'
+                | '*'
+                | '{'
+                | '}'
+                | '['
+                | ']'
+                | ','
+                | '#'
+                | '|'
+                | '>'
+                | '\''
+                | '"'
+                | '%'
+                | '@'
+                | '`'
+        )
+    ) || matches!(
+        value.to_ascii_lowercase().as_str(),
+        "null" | "~" | "true" | "false" | "yes" | "no" | "on" | "off"
+    )
 }
 
 #[cfg(test)]

--- a/eng/tools/generate_api/src/output/tests.rs
+++ b/eng/tools/generate_api/src/output/tests.rs
@@ -33,6 +33,29 @@ fn sha256_ignores_legacy_mac_line_endings() {
 }
 
 #[test]
+fn renders_markdown_metadata_with_line_ending_normalized_hash() {
+    let metadata =
+        render_markdown_metadata("one\r\ntwo\r\n", "1.2.3", "2.2.0", "rustc 1.99.0").unwrap();
+
+    assert_eq!(
+        metadata,
+        "apiMdSha256: c3f9c8c283a2b1f2f1896f27a01cbe3cddc0c9d93f752e4639035a0f5b36f6e8\n\
+         packageVersion: 1.2.3\n\
+         parserVersion: 2.2.0\n\
+         rustVersion: rustc 1.99.0\n"
+    );
+}
+
+#[test]
+fn quotes_yaml_values_only_when_needed() {
+    let metadata = render_markdown_metadata("api\n", "1.2.3", "value: detail", "true").unwrap();
+
+    assert!(metadata.contains("packageVersion: 1.2.3\n"));
+    assert!(metadata.contains("parserVersion: 'value: detail'\n"));
+    assert!(metadata.contains("rustVersion: 'true'\n"));
+}
+
+#[test]
 fn missing_file_is_positive() {
     let path = test_path("missing", line!());
     let _ = fs::remove_file(&path);


### PR DESCRIPTION
Generate API.metadata.yml next to API.md with a line-ending-normalized SHA-256 hash, the crate version, the parser version, and the rustc release reported by rustc -Vv.

Document the new artifact in generate_api guidance and bump the tool version to 2.2.1.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 450e6753-68ea-4648-a703-4076ba6382ad
