### PR TITLE
Cosmos: optional session token management

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -7,8 +7,11 @@
 - Extended Cosmos binary JSON encoding to cross-partition `DISTINCT` query pages. ([#5070](https://github.com/Azure/azure-sdk-for-rust/pull/5070))
 - Added `QueryPlanMode::{LocalPreferred, GatewayOnly}` to `OperationOptions`, allowing applications to force Gateway query planning globally or for an individual query as a livesite mitigation. ([#5181](https://github.com/Azure/azure-sdk-for-rust/pull/5181))
 - Added finite cross-partition `ORDER BY VectorDistance(...)` queries with `TOP` or `OFFSET`/`LIMIT`. Results are fully buffered before the first page and cannot be resumed from continuation tokens. Hybrid/full-text vector ranking remains unsupported. ([#5130](https://github.com/Azure/azure-sdk-for-rust/pull/5130))
+- Added `CosmosClientBuilder::with_session_token_management_enabled` to disable automatic session-token storage and bookkeeping while retaining explicit token support. ([#5191](https://github.com/Azure/azure-sdk-for-rust/issues/5191))
 
 ### Breaking Changes
+
+- Renamed the driver operation option `session_capturing_disabled` to the positive `session_token_management_enabled`. ([#5191](https://github.com/Azure/azure-sdk-for-rust/issues/5191))
 
 ### Bugs Fixed
 

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client_builder.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client_builder.rs
@@ -100,6 +100,7 @@ pub struct CosmosClientBuilder {
     /// Options to use for per-partition failover (PPAF, PPCB)
     partition_failover_options: Option<PartitionFailoverOptions>,
     partition_key_range_cache_enabled: Option<bool>,
+    session_token_management_enabled: Option<bool>,
 }
 
 impl CosmosClientBuilder {
@@ -165,6 +166,18 @@ impl CosmosClientBuilder {
     /// session tokens are still sent unchanged.
     pub fn with_partition_key_range_cache_enabled(mut self, enabled: bool) -> Self {
         self.partition_key_range_cache_enabled = Some(enabled);
+        self
+    }
+
+    /// Enables or disables automatic session token management for this client.
+    ///
+    /// When disabled, the client does not allocate session-token storage, capture
+    /// tokens from responses, or resolve them for later requests. User-provided
+    /// session tokens are still sent unchanged. Partition key range topology
+    /// caching remains independently configurable. Session-consistent requests
+    /// without an explicit token can therefore observe a weaker effective guarantee.
+    pub fn with_session_token_management_enabled(mut self, enabled: bool) -> Self {
+        self.session_token_management_enabled = Some(enabled);
         self
     }
 
@@ -337,6 +350,7 @@ impl CosmosClientBuilder {
             partition_key_range_cache_enabled: self
                 .partition_key_range_cache_enabled
                 .unwrap_or(true),
+            session_token_management_enabled: self.session_token_management_enabled.unwrap_or(true),
             #[cfg(feature = "fault_injection")]
             fault_injection_rules: self.fault_injection_rules,
             throughput_control_groups: self.throughput_control_groups,
@@ -372,6 +386,7 @@ struct DriverOptionsInput {
     user_agent_suffix: Option<UserAgentSuffix>,
     partition_failover_options: Option<PartitionFailoverOptions>,
     partition_key_range_cache_enabled: bool,
+    session_token_management_enabled: bool,
     #[cfg(feature = "fault_injection")]
     fault_injection_rules: Vec<Arc<azure_data_cosmos_driver::fault_injection::FaultInjectionRule>>,
     throughput_control_groups: Vec<ThroughputControlGroupOptions>,
@@ -395,7 +410,8 @@ impl DriverOptionsInput {
         let mut builder = azure_data_cosmos_driver::options::DriverOptions::builder(self.account)
             .with_preferred_regions(preferred_regions)
             .with_operation_options(self.operation_options)
-            .with_partition_key_range_cache_enabled(self.partition_key_range_cache_enabled);
+            .with_partition_key_range_cache_enabled(self.partition_key_range_cache_enabled)
+            .with_session_token_management_enabled(self.session_token_management_enabled);
         if let Some(suffix) = self.user_agent_suffix {
             builder = builder.with_user_agent_suffix(suffix);
         }
@@ -512,6 +528,7 @@ mod tests {
             user_agent_suffix: None,
             partition_failover_options: None,
             partition_key_range_cache_enabled: true,
+            session_token_management_enabled: true,
             #[cfg(feature = "fault_injection")]
             fault_injection_rules: Vec::new(),
             throughput_control_groups: Vec::new(),
@@ -657,5 +674,18 @@ mod tests {
         .expect("driver options should build");
 
         assert!(!opts.partition_key_range_cache_enabled());
+    }
+
+    #[test]
+    fn session_token_management_option_flows_to_driver_options() {
+        let opts = DriverOptionsInput {
+            session_token_management_enabled: false,
+            ..test_driver_options_input(RoutingStrategy::PreferredRegions(Vec::new()))
+        }
+        .build()
+        .expect("driver options should build");
+
+        assert!(!opts.session_token_management_enabled());
+        assert!(opts.partition_key_range_cache_enabled());
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/session_token.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/session_token.rs
@@ -14,7 +14,7 @@
 //! 2. **Resolve** — subsequent **read** requests carry the cached token on the
 //!    wire when (and only when) Session consistency is effective.
 //!
-//! The negative controls (Eventual consistency, session-capturing disabled,
+//! The negative controls (Eventual consistency, session management disabled,
 //! empty cache) confirm the driver does *not* attach a token when it should
 //! not, and the precedence test confirms a user-supplied token wins over the
 //! cache verbatim (no merge).
@@ -138,6 +138,15 @@ impl RecordingObserver {
             "cache-disabled operations must not request /pkranges"
         );
     }
+
+    fn assert_partition_key_range_request(&self) {
+        assert!(
+            self.snapshots()
+                .iter()
+                .any(RequestSnapshot::is_partition_key_range_request),
+            "topology resolution must request /pkranges"
+        );
+    }
 }
 
 impl RequestObserver for RecordingObserver {
@@ -182,10 +191,21 @@ struct Harness {
 
 impl Harness {
     async fn setup() -> Self {
-        Self::setup_with_partition_key_range_cache(true).await
+        Self::setup_with_configuration(true, true).await
     }
 
     async fn setup_with_partition_key_range_cache(enabled: bool) -> Self {
+        Self::setup_with_configuration(enabled, true).await
+    }
+
+    async fn setup_with_session_token_management(enabled: bool) -> Self {
+        Self::setup_with_configuration(true, enabled).await
+    }
+
+    async fn setup_with_configuration(
+        partition_key_range_cache_enabled: bool,
+        session_token_management_enabled: bool,
+    ) -> Self {
         let observer = RecordingObserver::new();
 
         let config = VirtualAccountConfig::new(vec![VirtualRegion::new(
@@ -222,7 +242,8 @@ impl Harness {
         let driver = runtime
             .create_driver(
                 DriverOptions::builder(account)
-                    .with_partition_key_range_cache_enabled(enabled)
+                    .with_partition_key_range_cache_enabled(partition_key_range_cache_enabled)
+                    .with_session_token_management_enabled(session_token_management_enabled)
                     .build(),
             )
             .await
@@ -298,6 +319,57 @@ impl Harness {
 }
 
 #[tokio::test]
+async fn session_management_disabled_preserves_topology_and_explicit_tokens() {
+    let h = Harness::setup_with_session_token_management(false).await;
+
+    h.observer.clear();
+    let response_token = h
+        .create("pk1", "item-1", 1)
+        .await
+        .expect("create should return a session token");
+
+    h.driver
+        .execute_singleton_operation(
+            CosmosOperation::read_item(h.item_ref("pk1", "item-1")),
+            OperationOptionsBuilder::new()
+                .with_session_token_management_enabled(true)
+                .build(),
+        )
+        .await
+        .expect("read without an explicit token should succeed");
+    assert_eq!(
+        h.observer.single_item_read().session_token,
+        None,
+        "an operation-level value must not recreate driver-disabled session storage"
+    );
+
+    h.observer.clear();
+    let ranges = h
+        .driver
+        .resolve_all_partition_key_ranges(&h.container, true)
+        .await
+        .expect("topology resolution should remain available")
+        .expect("the container should have partition key ranges");
+    assert!(!ranges.is_empty());
+    h.observer.assert_partition_key_range_request();
+
+    h.observer.clear();
+    h.driver
+        .execute_singleton_operation(
+            CosmosOperation::read_item(h.item_ref("pk1", "item-1"))
+                .with_session_token(response_token.clone()),
+            OperationOptionsBuilder::new().build(),
+        )
+        .await
+        .expect("read with an explicit token should succeed");
+    assert_eq!(
+        h.observer.single_item_read().session_token.as_deref(),
+        Some(response_token.as_str()),
+        "the explicit token must be sent unchanged"
+    );
+}
+
+#[tokio::test]
 async fn cache_disabled_preserves_explicit_tokens_without_automatic_session_management() {
     let h = Harness::setup_with_partition_key_range_cache(false).await;
 
@@ -351,7 +423,7 @@ async fn explicit_false_cannot_reactivate_cache_disabled_session_management() {
         .execute_singleton_operation(
             CosmosOperation::read_item(h.item_ref("pk1", "item-1")),
             OperationOptionsBuilder::new()
-                .with_session_capturing_disabled(false)
+                .with_session_token_management_enabled(true)
                 .build(),
         )
         .await
@@ -468,7 +540,7 @@ async fn eventual_read_omits_session_token() {
 /// A read issued with session capturing disabled must **not** carry a session
 /// token: disabling session management gates both capture and resolve.
 #[tokio::test]
-async fn session_capturing_disabled_omits_session_token() {
+async fn session_token_management_disabled_omits_session_token() {
     let h = Harness::setup().await;
 
     h.create("pk1", "item-1", 1)
@@ -480,7 +552,7 @@ async fn session_capturing_disabled_omits_session_token() {
         .execute_singleton_operation(
             CosmosOperation::read_item(h.item_ref("pk1", "item-1")),
             OperationOptionsBuilder::new()
-                .with_session_capturing_disabled(true)
+                .with_session_token_management_enabled(false)
                 .build(),
         )
         .await

--- a/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/CHANGELOG.md
@@ -7,10 +7,12 @@
 - Extended Cosmos binary JSON query-page handling to cross-partition `DISTINCT`, including composition with streaming `ORDER BY` and `OFFSET`/`LIMIT`/`TOP`. ([#5070](https://github.com/Azure/azure-sdk-for-rust/pull/5070))
 - Added local Rust query planning for supported cross-partition queries, avoiding Gateway query-plan requests while retaining native and Gateway fallbacks for advanced query shapes. Added layered `OperationOptions::query_plan_mode`, `QueryPlanMode::{LocalPreferred, GatewayOnly}`, and the authoritative `AZURE_COSMOS_QUERY_PLAN_MODE_OVERRIDE=gateway` break-glass setting to force Gateway planning globally or per operation. ([#5181](https://github.com/Azure/azure-sdk-for-rust/pull/5181))
 - Added a fully buffered cross-partition merge for finite non-streaming `ORDER BY` plans, including `VectorDistance(...)`. Unbounded, resumed, DISTINCT, and hybrid non-streaming plans are rejected with typed statuses. ([#5130](https://github.com/Azure/azure-sdk-for-rust/pull/5130))
+- Added `DriverOptionsBuilder::with_session_token_management_enabled` to omit automatic session-token storage and bookkeeping without disabling partition-key-range topology. ([#5191](https://github.com/Azure/azure-sdk-for-rust/issues/5191))
 
 ### Breaking Changes
 
 - `error::cosmos_status` is no longer a public module; `CosmosStatus` and `SubStatusCode` remain available as re-exports from `error`. The internal-only `query` module (gated behind the `__internal_testing` feature) is now `#[doc(hidden)]` so it no longer appears as an empty public module in generated API surfaces. ([#5205](https://github.com/Azure/azure-sdk-for-rust/pull/5205))
+- Renamed the operation option `session_capturing_disabled` to the positive `session_token_management_enabled`. ([#5191](https://github.com/Azure/azure-sdk-for-rust/issues/5191))
 
 ### Bugs Fixed
 

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/cosmos_driver.rs
@@ -1812,6 +1812,8 @@ impl CosmosDriver {
         // Read the hedge ceiling once, here: it is fixed for the driver's
         // lifetime, and `options` is moved into `Self` below.
         let hedge_budget = HedgeBudget::new(options.hedging_options());
+        let session_token_management_enabled = options.partition_key_range_cache_enabled()
+            && options.session_token_management_enabled();
         let pk_range_cache = options
             .partition_key_range_cache_enabled()
             .then(PartitionKeyRangeCache::new);
@@ -1829,7 +1831,7 @@ impl CosmosDriver {
             pk_range_cache,
             pk_range_region_pins: Mutex::new(HashMap::new()),
             hedge_budget,
-            session_manager: SessionManager::new(),
+            session_manager: SessionManager::with_enabled(session_token_management_enabled),
             initialized: AtomicBool::new(false),
             user_agent,
             client_id,
@@ -3062,12 +3064,12 @@ impl CosmosDriver {
         }
 
         let operation_count = request.operations.len();
-        let is_session_consistency = {
+        let automatic_session_management_active = {
             let effective_options = self.operation_options_view(&options);
-            let session_capturing_disabled = effective_options
-                .session_capturing_disabled()
+            let session_token_management_enabled = effective_options
+                .session_token_management_enabled()
                 .copied()
-                .unwrap_or(false);
+                .unwrap_or(true);
             let read_consistency_strategy = effective_options
                 .read_consistency_strategy()
                 .copied()
@@ -3080,8 +3082,8 @@ impl CosmosDriver {
                     self.fetch_account_properties(self.options.account())
                 })
                 .await?;
-            self.pk_range_cache.is_some()
-                && !session_capturing_disabled
+            self.session_manager.is_enabled()
+                && session_token_management_enabled
                 && read_consistency_strategy.is_session_effective(
                     account_properties
                         .user_consistency_policy
@@ -3092,7 +3094,7 @@ impl CosmosDriver {
         // token with the resolved session token *before* serialization so the
         // coordinator honors read-your-own-writes (mirrors .NET
         // ResolvePartitionLocalToken).
-        if is_session_consistency {
+        if automatic_session_management_active {
             self.resolve_distributed_transaction_session_tokens(&mut request.operations)
                 .await;
         }
@@ -3171,14 +3173,14 @@ impl CosmosDriver {
                 outer_deadline,
             );
             let Some(retry_delay) = retry_delay else {
-                // Cache-disabled mode disables automatic session management.
-                // Explicit per-operation tokens remain in the request unchanged.
-                if is_session_consistency {
+                // Disabled automatic management leaves explicit per-operation
+                // tokens in the request unchanged.
+                if automatic_session_management_active {
                     self.session_manager
                         .merge_distributed_transaction_session_tokens(
                             &response,
                             &request.operations,
-                            is_session_consistency,
+                            true,
                         )?;
                 }
 
@@ -3547,11 +3549,11 @@ impl CosmosDriver {
         let write_region = account_properties.write_account_region();
         let endpoint = Self::endpoint_for_write_region(&account, write_region);
 
-        let automatic_session_management_active = self.pk_range_cache.is_some()
-            && !effective_options
-                .session_capturing_disabled()
+        let automatic_session_management_active = self.session_manager.is_enabled()
+            && effective_options
+                .session_token_management_enabled()
                 .copied()
-                .unwrap_or(false)
+                .unwrap_or(true)
             && effective_options
                 .read_consistency_strategy()
                 .copied()
@@ -3642,7 +3644,6 @@ impl CosmosDriver {
                 .default_consistency_level,
             effective_throughput_control,
             pre_resolved_pk_range_id,
-            self.pk_range_cache.is_some(),
             &self.hedge_budget,
         )
         .await;
@@ -3716,7 +3717,6 @@ impl CosmosDriver {
                 .default_consistency_level,
             retry_throughput_control,
             retry_pk_range_id,
-            self.pk_range_cache.is_some(),
             &self.hedge_budget,
         )
         .await;

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/operation_pipeline.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/pipeline/operation_pipeline.rs
@@ -405,7 +405,6 @@ pub(crate) async fn execute_operation_pipeline(
     account_default_consistency: DefaultConsistencyLevel,
     throughput_control: Option<ResolvedThroughputControl>,
     pre_resolved_pk_range_id: Option<PartitionKeyRangeId>,
-    partition_key_range_cache_enabled: bool,
     hedge_budget: &HedgeBudget,
 ) -> crate::error::Result<CosmosResponse> {
     let mut diagnostics = diagnostics;
@@ -440,19 +439,19 @@ pub(crate) async fn execute_operation_pipeline(
         .copied()
         .unwrap_or(default_wait);
 
-    // Determine if session consistency is active for this operation.
-    let session_capturing_disabled = options
-        .session_capturing_disabled()
+    // Determine whether automatic session management is active for this operation.
+    let session_token_management_enabled = options
+        .session_token_management_enabled()
         .copied()
-        .unwrap_or(false);
+        .unwrap_or(true);
     let read_consistency_strategy = options
         .read_consistency_strategy()
         .copied()
         .unwrap_or(ReadConsistencyStrategy::Default);
     let effective_consistency =
         resolve_effective_consistency(read_consistency_strategy, account_default_consistency);
-    let session_consistency_active = partition_key_range_cache_enabled
-        && !session_capturing_disabled
+    let automatic_session_management_active = session_manager.is_enabled()
+        && session_token_management_enabled
         && read_consistency_strategy.is_session_effective(account_default_consistency);
 
     // Rule 4 (RCS validation): GlobalStrong is
@@ -591,8 +590,8 @@ pub(crate) async fn execute_operation_pipeline(
             attempt_read_consistency_strategy,
             account_default_consistency,
         );
-        let attempt_session_consistency_active = partition_key_range_cache_enabled
-            && !session_capturing_disabled
+        let attempt_automatic_session_management_active = session_manager.is_enabled()
+            && session_token_management_enabled
             && attempt_read_consistency_strategy.is_session_effective(account_default_consistency);
 
         // Emit one structured debug record per attempt with the chosen
@@ -683,7 +682,7 @@ pub(crate) async fn execute_operation_pipeline(
                     effective_consistency,
                     read_consistency_strategy,
                     session_manager,
-                    session_consistency_active,
+                    automatic_session_management_active,
                     options,
                     throughput_control,
                     deadline,
@@ -794,7 +793,7 @@ pub(crate) async fn execute_operation_pipeline(
             } else {
                 ReadConsistencyStrategy::Default
             },
-            resolved_session_token: attempt_session_consistency_active
+            resolved_session_token: attempt_automatic_session_management_active
                 .then(|| {
                     // Scope the session token to the target partition-key-range
                     // only for thin-client (Gateway 2.0) requests: the RNTBD
@@ -897,7 +896,7 @@ pub(crate) async fn execute_operation_pipeline(
         // Abort, or a retry action. 409/412 map to Abort, and the Abort
         // variant does not carry headers — capturing after evaluation
         // would silently drop tokens from those responses.
-        if attempt_session_consistency_active {
+        if attempt_automatic_session_management_active {
             if let Some(cosmos_headers) = result.cosmos_headers() {
                 if should_capture_session_token_from_status(
                     cosmos_headers.substatus.as_ref(),
@@ -957,7 +956,7 @@ pub(crate) async fn execute_operation_pipeline(
                         Box::pin(driver.pre_resolve_partition_key_range_id(
                             operation,
                             &overrides,
-                            session_consistency_active,
+                            automatic_session_management_active,
                             operation_options,
                         ))
                         .await;
@@ -1292,7 +1291,7 @@ pub(crate) async fn execute_operation_pipeline(
                     effective_consistency,
                     read_consistency_strategy,
                     session_manager,
-                    session_consistency_active,
+                    automatic_session_management_active,
                     options,
                     throughput_control,
                     deadline,
@@ -2922,9 +2921,8 @@ struct AttemptContext<'a> {
     /// rationale as `effective_consistency`.
     read_consistency_strategy: ReadConsistencyStrategy,
     session_manager: &'a SessionManager,
-    /// Whether session consistency is in effect for this operation
-    /// (drives session-token resolve/capture inside the attempt).
-    session_consistency_active: bool,
+    /// Whether automatic session-token resolve/capture is active for this operation.
+    automatic_session_management_active: bool,
     options: &'a OperationOptionsView<'a>,
     throughput_control: Option<ResolvedThroughputControl>,
     /// End-to-end deadline (operation timeout) — passed through to each
@@ -3300,7 +3298,7 @@ async fn perform_single_attempt(
     // Scope to the target range only for thin-client (Gateway 2.0); classic
     // gateway keeps the composite token (see main-loop rationale).
     let resolved_session_token = ctx
-        .session_consistency_active
+        .automatic_session_management_active
         .then(|| {
             let scoped_pk_range_id = if matches!(routing.transport_mode, TransportMode::GatewayV2) {
                 ctx.partition_key_range_id.as_ref().map(|id| id.as_str())
@@ -3405,7 +3403,7 @@ async fn perform_single_attempt(
 /// whose response the caller never observes would leak stale state and
 /// violate read-your-writes against the winning region.
 fn capture_session_token_for_winner(ctx: &AttemptContext<'_>, result: &TransportResult) {
-    if !ctx.session_consistency_active {
+    if !ctx.automatic_session_management_active {
         return;
     }
     if let Some(cosmos_headers) = result.cosmos_headers() {

--- a/sdk/cosmos/azure_data_cosmos_driver/src/driver/routing/session_manager.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/driver/routing/session_manager.rs
@@ -47,15 +47,26 @@ fn is_reading_from_master(resource_type: ResourceType, operation_type: Operation
 /// checks, user-provided token precedence) on top of raw cache operations.
 #[derive(Debug)]
 pub(crate) struct SessionManager {
-    container: SessionContainer,
+    container: Option<Box<SessionContainer>>,
 }
 
 impl SessionManager {
-    /// Creates a new session manager with an empty cache.
+    /// Creates an enabled session manager with empty storage for unit tests.
+    #[cfg(test)]
     pub(crate) fn new() -> Self {
+        Self::with_enabled(true)
+    }
+
+    /// Creates a session manager, allocating storage only when enabled.
+    pub(crate) fn with_enabled(enabled: bool) -> Self {
         Self {
-            container: SessionContainer::new(),
+            container: enabled.then(|| Box::new(SessionContainer::new())),
         }
+    }
+
+    /// Returns whether automatic session token storage is available.
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.container.is_some()
     }
 
     /// Resolves the session token that should be sent on the next request.
@@ -83,6 +94,7 @@ impl SessionManager {
         if let Some(token) = user_token {
             return Some(token.clone());
         }
+        let session_container = self.container.as_deref()?;
 
         // TODO(partition-key-range-parents): When a PKRange cache is available,
         // use it to resolve parent range IDs during splits/merges. Currently
@@ -91,10 +103,10 @@ impl SessionManager {
 
         let container = operation.container()?;
         match pk_range_id {
-            Some(pk_range_id) => self
-                .container
-                .resolve_session_token_for_range(container, pk_range_id),
-            None => self.container.resolve_session_token(container),
+            Some(pk_range_id) => {
+                session_container.resolve_session_token_for_range(container, pk_range_id)
+            }
+            None => session_container.resolve_session_token(container),
         }
     }
 
@@ -109,6 +121,10 @@ impl SessionManager {
         operation: &CosmosOperation,
         headers: &CosmosResponseHeaders,
     ) {
+        let Some(session_container) = self.container.as_deref() else {
+            return;
+        };
+
         // Skip capture for master/metadata resource operations. Session tokens
         // from metadata partition replicas should not be used for data reads.
         // For DocumentCollection, only ReadFeed/Query/SqlQuery target master;
@@ -130,7 +146,7 @@ impl SessionManager {
             None => return,
         };
 
-        self.container.set_session_token(container, session_token);
+        session_container.set_session_token(container, session_token);
     }
 
     /// Clears the old RID's cached tokens and moves the logical container name
@@ -140,7 +156,9 @@ impl SessionManager {
         old: &ContainerReference,
         new: &ContainerReference,
     ) -> bool {
-        self.container.remap_container(old, new)
+        self.container
+            .as_deref()
+            .is_some_and(|container| container.remap_container(old, new))
     }
 
     /// Merges per-operation DTX session tokens into the shared session cache.
@@ -151,6 +169,10 @@ impl SessionManager {
         operations: &[crate::models::DistributedTransactionOperation],
         is_session_consistency: bool,
     ) -> crate::error::Result<()> {
+        let Some(session_container) = self.container.as_deref() else {
+            return Ok(());
+        };
+
         // Only a 2xx-success committed response under Session consistency turns a
         // malformed per-operation token into a hard error. A `304 NotModified`
         // or any non-success envelope must not fail on token bookkeeping.
@@ -178,9 +200,8 @@ impl SessionManager {
             // missing partition key range prefixes from side-channel fields.
             let token = token.trim();
 
-            if let Err(error) = self
-                .container
-                .set_session_token_checked(&operation.target.container, token)
+            if let Err(error) =
+                session_container.set_session_token_checked(&operation.target.container, token)
             {
                 if throw_on_malformed {
                     return Err(dtx_malformed_session_token_error(format!(
@@ -207,22 +228,19 @@ impl SessionManager {
         operation: &crate::models::DistributedTransactionOperation,
         partition_key_range: Option<&PartitionKeyRange>,
     ) -> Option<SessionToken> {
+        let session_container = self.container.as_deref()?;
         if let Some(range) = partition_key_range {
             let parents = range.parents.as_deref().unwrap_or(&[]);
-            if let Some(token) = self
-                .container
-                .resolve_session_token_for_partition_key_range(
-                    &operation.target.container,
-                    &range.id,
-                    parents,
-                )
-            {
+            if let Some(token) = session_container.resolve_session_token_for_partition_key_range(
+                &operation.target.container,
+                &range.id,
+                parents,
+            ) {
                 return Some(token);
             }
         }
 
-        self.container
-            .resolve_session_token(&operation.target.container)
+        session_container.resolve_session_token(&operation.target.container)
     }
 }
 
@@ -283,6 +301,35 @@ mod tests {
             "doc1",
         ));
         assert!(mgr.resolve_session_token(&op, None, None).is_none());
+    }
+
+    #[test]
+    fn disabled_manager_allocates_no_container_and_preserves_user_tokens() {
+        let mgr = SessionManager::with_enabled(false);
+        assert!(!mgr.is_enabled());
+        assert!(mgr.container.is_none());
+
+        let container = test_container();
+        let op = CosmosOperation::read_item(ItemReference::from_name(
+            &container,
+            PartitionKey::from("pk1"),
+            "doc1",
+        ));
+        let headers = make_response_headers(
+            Some("0:1#100#1=10"),
+            Some("coll_rid1"),
+            Some("dbs/db1/colls/coll1"),
+        );
+        mgr.capture_session_token(&op, &headers);
+
+        assert!(mgr.resolve_session_token(&op, None, None).is_none());
+        let user_token = SessionToken::new("user-provided");
+        assert_eq!(
+            mgr.resolve_session_token(&op, Some(&user_token), None)
+                .unwrap()
+                .as_str(),
+            "user-provided"
+        );
     }
 
     #[test]
@@ -533,13 +580,18 @@ mod tests {
             error_message: None,
         };
 
+        let operations = [operation];
         let error = mgr
-            .merge_distributed_transaction_session_tokens(&response, &[operation], true)
+            .merge_distributed_transaction_session_tokens(&response, &operations, true)
             .unwrap_err();
         assert_eq!(
             error.status().status_code(),
             azure_core::http::StatusCode::InternalServerError
         );
+
+        SessionManager::with_enabled(false)
+            .merge_distributed_transaction_session_tokens(&response, &operations, true)
+            .expect("disabled session management should skip DTX token validation");
     }
 
     #[cfg(feature = "preview_dtx")]

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/driver_options.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/driver_options.rs
@@ -102,6 +102,15 @@ pub struct DriverOptions {
     /// session token management is also disabled; user-provided session tokens are
     /// still sent unchanged.
     partition_key_range_cache_enabled: bool,
+    /// Whether the driver allocates and maintains automatic session-token state.
+    ///
+    /// When disabled, session tokens are not captured from responses or resolved
+    /// for later requests. User-provided session tokens are still sent unchanged.
+    /// Session-consistent requests without an explicit token can therefore observe
+    /// a weaker effective guarantee.
+    /// Per-operation options cannot re-enable management because no session-token
+    /// container exists for this driver.
+    session_token_management_enabled: bool,
     /// Driver-level limits on simultaneous cross-region attempts.
     ///
     /// Hedging adds a regional attempt to complete an operation when the first is
@@ -168,6 +177,11 @@ impl DriverOptions {
         self.partition_key_range_cache_enabled
     }
 
+    /// Returns whether automatic session token management is enabled.
+    pub fn session_token_management_enabled(&self) -> bool {
+        self.session_token_management_enabled
+    }
+
     /// Returns the driver-level cross-region hedging limits.
     pub fn hedging_options(&self) -> &HedgingOptions {
         &self.hedging_options
@@ -190,6 +204,7 @@ pub struct DriverOptionsBuilder {
     throughput_control_groups: ThroughputControlGroupRegistry,
     partition_failover_options: Option<PartitionFailoverOptions>,
     partition_key_range_cache_enabled: bool,
+    session_token_management_enabled: bool,
     hedging_options: Option<HedgingOptions>,
 }
 
@@ -206,6 +221,7 @@ impl DriverOptionsBuilder {
             throughput_control_groups: ThroughputControlGroupRegistry::new(),
             partition_failover_options: None,
             partition_key_range_cache_enabled: true,
+            session_token_management_enabled: true,
             hedging_options: None,
         }
     }
@@ -225,6 +241,19 @@ impl DriverOptionsBuilder {
     /// session tokens are still sent unchanged.
     pub fn with_partition_key_range_cache_enabled(mut self, enabled: bool) -> Self {
         self.partition_key_range_cache_enabled = enabled;
+        self
+    }
+
+    /// Enables or disables automatic session token management.
+    ///
+    /// Disabling this prevents the driver from allocating session-token storage,
+    /// capturing tokens from responses, or resolving tokens for later requests.
+    /// User-provided session tokens are still sent unchanged, and partition key
+    /// range topology caching remains independently configurable. Session-consistent
+    /// requests without an explicit token can therefore observe a weaker effective
+    /// guarantee.
+    pub fn with_session_token_management_enabled(mut self, enabled: bool) -> Self {
+        self.session_token_management_enabled = enabled;
         self
     }
 
@@ -390,6 +419,7 @@ impl DriverOptionsBuilder {
             throughput_control_groups: self.throughput_control_groups,
             partition_failover_options,
             partition_key_range_cache_enabled: self.partition_key_range_cache_enabled,
+            session_token_management_enabled: self.session_token_management_enabled,
             hedging_options: self.hedging_options.unwrap_or_default(),
         }
     }
@@ -428,6 +458,7 @@ mod tests {
             .max_session_retry_count
             .is_none());
         assert!(options.partition_key_range_cache_enabled());
+        assert!(options.session_token_management_enabled());
     }
 
     #[test]
@@ -437,6 +468,16 @@ mod tests {
             .build();
 
         assert!(!options.partition_key_range_cache_enabled());
+    }
+
+    #[test]
+    fn builder_disables_session_token_management() {
+        let options = DriverOptionsBuilder::new(test_account())
+            .with_session_token_management_enabled(false)
+            .build();
+
+        assert!(!options.session_token_management_enabled());
+        assert!(options.partition_key_range_cache_enabled());
     }
 
     #[test]

--- a/sdk/cosmos/azure_data_cosmos_driver/src/options/operation_options.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/src/options/operation_options.rs
@@ -95,14 +95,14 @@ pub struct OperationOptions {
     /// How long an endpoint is considered unavailable after a failure.
     pub endpoint_unavailability_ttl: Option<Duration>,
 
-    /// Disables automatic session token management.
+    /// Enables automatic session token management for this request.
     ///
-    /// When `None` or `Some(false)`, session tokens are captured from responses
-    /// and sent on subsequent requests for session consistency. Set to `Some(true)`
-    /// to disable both automatic capture and automatic resolution. User-provided
-    /// session tokens are unaffected. This setting cannot enable automatic session
-    /// token management when the driver's partition key range cache is disabled.
-    pub session_capturing_disabled: Option<bool>,
+    /// When `None` or `Some(true)`, session tokens are captured from responses
+    /// and sent on subsequent requests for session consistency. Set to `Some(false)`
+    /// to disable both automatic capture and automatic resolution for this request.
+    /// User-provided session tokens are unaffected. This setting cannot enable
+    /// automatic session token management when it is disabled on the driver.
+    pub session_token_management_enabled: Option<bool>,
 
     /// Maximum number of session-consistency retries on 404/1002 errors.
     #[option(env = "AZURE_COSMOS_MAX_SESSION_RETRY_COUNT")]

--- a/sdk/cosmos/azure_data_cosmos_driver_native/c_tests/account_and_driver_options.c
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/c_tests/account_and_driver_options.c
@@ -150,11 +150,15 @@ static int test_driver_options_build_happy_path(void) {
 
     const char *regions[] = {"East US", "West US 3"};
     cosmos_driver_options_config_t cfg = cosmos_driver_options_config_default();
+    ASSERT(cfg.session_token_management_enabled == 0,
+           "session management defaults to unset (=%d)",
+           cfg.session_token_management_enabled);
     cfg.preferred_regions = regions;
     cfg.preferred_regions_len = 2;
     cosmos_operation_options_t operation_options = cosmos_operation_options_default();
     operation_options.query_plan_mode = COSMOS_QUERY_PLAN_MODE_GATEWAY_ONLY;
     cfg.operation_options = &operation_options;
+    cfg.session_token_management_enabled = 1;
 
     cosmos_driver_options_t *opts = NULL;
     int32_t rc = cosmos_driver_options_build(account, &cfg, &opts);

--- a/sdk/cosmos/azure_data_cosmos_driver_native/c_tests/operation_construction.c
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/c_tests/operation_construction.c
@@ -43,8 +43,8 @@ static int test_options_default_is_all_unset(void)
               "patch strategy ServerSide ABI value (=%d)", COSMOS_PATCH_STRATEGY_SERVER_SIDE);
        ASSERT(opts.patch_strategy == COSMOS_PATCH_STRATEGY_UNSET,
               "patch_strategy unset (=%d)", opts.patch_strategy);
-       ASSERT(opts.session_capturing_disabled == 0,
-              "session_capturing unset (=%d)", opts.session_capturing_disabled);
+       ASSERT(opts.session_token_management_enabled == 0,
+              "session management unset (=%d)", opts.session_token_management_enabled);
        ASSERT(opts.max_failover_retry_count < 0,
               "max_failover unset (=%d)", opts.max_failover_retry_count);
        ASSERT(opts.max_session_retry_count < 0,

--- a/sdk/cosmos/azure_data_cosmos_driver_native/include/azurecosmosdriver.h
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/include/azurecosmosdriver.h
@@ -1345,9 +1345,9 @@ typedef struct cosmos_operation_options_t {
    */
   int32_t patch_strategy;
   /**
-   * Disable automatic session token management. Tri-state bool.
+   * Enable automatic session token management. Tri-state bool.
    */
-  int8_t session_capturing_disabled;
+  int8_t session_token_management_enabled;
   /**
    * Max region-failover retries. `< 0` = unset.
    */
@@ -1451,6 +1451,8 @@ typedef struct cosmos_operation_options_t {
  * - `operation_options`: pointer to a flat
  *   [`cosmos_operation_options_t`](crate::op_request::CosmosOperationOptions),
  *   or NULL to inherit the driver defaults.
+ * - `session_token_management_enabled`: `0` = unset, `1` = false, `2` = true.
+ *
  * The account reference stays a separate handle parameter on
  * [`cosmos_driver_options_build`] — it owns `Arc`-shared state and cannot be
  * flattened into bytes.
@@ -1473,6 +1475,11 @@ typedef struct cosmos_driver_options_config_t {
    * defaults.
    */
   const struct cosmos_operation_options_t *operation_options;
+  /**
+   * Whether automatic session token storage, capture, and resolution are
+   * enabled. Tri-state bool (`0` unset / `1` false / `2` true).
+   */
+  int8_t session_token_management_enabled;
 } cosmos_driver_options_config_t;
 
 /**

--- a/sdk/cosmos/azure_data_cosmos_driver_native/src/driver_options.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/src/driver_options.rs
@@ -4,12 +4,11 @@
 //! C ABI surface for `cosmos_driver_options_t` — wraps the driver's
 //! [`azure_data_cosmos_driver::options::DriverOptions`].
 //!
-//! Construction is a single flat call: the host fills a
-//! [`CosmosDriverOptionsConfig`] `#[repr(C)]` struct (preferred regions + a
-//! pointer to the flat `cosmos_operation_options_t`) and
-//! passes it, together with the account handle, to
-//! [`cosmos_driver_options_build`]. Drivers that don't configure operation
-//! options inherit the driver's own defaults.
+//! `DriverOptions` contains the bound account, per-driver `OperationOptions`,
+//! preferred regions, and driver-lifetime controls. Construction is a single
+//! flat call: the host fills a [`CosmosDriverOptionsConfig`] `#[repr(C)]`
+//! struct and passes it, together with the account handle, to
+//! [`cosmos_driver_options_build`].
 //!
 //! The settings frequently confused with "per-driver" defaults
 //! (excluded regions, consistency, content-response-on-write,
@@ -147,6 +146,8 @@ unsafe fn decode_preferred_regions(
 /// - `operation_options`: pointer to a flat
 ///   [`cosmos_operation_options_t`](crate::op_request::CosmosOperationOptions),
 ///   or NULL to inherit the driver defaults.
+/// - `session_token_management_enabled`: `0` = unset, `1` = false, `2` = true.
+///
 /// The account reference stays a separate handle parameter on
 /// [`cosmos_driver_options_build`] — it owns `Arc`-shared state and cannot be
 /// flattened into bytes.
@@ -164,6 +165,9 @@ pub struct CosmosDriverOptionsConfig {
     /// Per-driver default operation options, or NULL to inherit the driver
     /// defaults.
     pub operation_options: *const crate::op_request::CosmosOperationOptions,
+    /// Whether automatic session token storage, capture, and resolution are
+    /// enabled. Tri-state bool (`0` unset / `1` false / `2` true).
+    pub session_token_management_enabled: i8,
 }
 
 /// Returns an all-unset [`CosmosDriverOptionsConfig`] by value. The host
@@ -175,6 +179,7 @@ pub extern "C" fn cosmos_driver_options_config_default() -> CosmosDriverOptionsC
         preferred_regions: std::ptr::null(),
         preferred_regions_len: 0,
         operation_options: std::ptr::null(),
+        session_token_management_enabled: 0,
     }
 }
 
@@ -243,6 +248,14 @@ pub extern "C" fn cosmos_driver_options_build(
             };
             builder = builder.with_operation_options(driver_opts);
         }
+
+        match crate::op_request::decode_tristate_bool(cfg.session_token_management_enabled) {
+            Ok(Some(enabled)) => {
+                builder = builder.with_session_token_management_enabled(enabled);
+            }
+            Ok(None) => {}
+            Err(code) => return code.as_status_code(),
+        }
     }
 
     let handle = DriverOptionsHandle::into_raw(builder.build());
@@ -284,6 +297,7 @@ mod tests {
         assert!(c.preferred_regions.is_null());
         assert_eq!(c.preferred_regions_len, 0);
         assert!(c.operation_options.is_null());
+        assert_eq!(c.session_token_management_enabled, 0);
     }
 
     #[test]
@@ -317,6 +331,7 @@ mod tests {
         assert!(!opts.is_null());
         let inner = DriverOptionsHandle::inner_arc(opts).unwrap();
         assert!(inner.inner.preferred_regions().is_empty());
+        assert!(inner.inner.session_token_management_enabled());
         drop(inner);
         cosmos_driver_options_free(opts);
         crate::account_ref::cosmos_account_ref_free(account);
@@ -334,6 +349,7 @@ mod tests {
         cfg.preferred_regions = arr.as_ptr();
         cfg.preferred_regions_len = arr.len();
         cfg.operation_options = &op_opts;
+        cfg.session_token_management_enabled = 1;
 
         let mut opts: *mut DriverOptionsHandle = ptr::null_mut();
         assert_eq!(
@@ -350,9 +366,28 @@ mod tests {
         // Region::new normalizes (lowercased, spaces stripped) — same as the
         // incremental setter's roundtrip test.
         assert_eq!(names, vec!["eastus", "westus3"]);
+        assert!(!inner.inner.session_token_management_enabled());
         drop(inner);
         cosmos_driver_options_free(opts);
         crate::account_ref::cosmos_account_ref_free(account);
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn driver_options_config_abi_layout_is_stable() {
+        use std::mem::{offset_of, size_of};
+
+        assert_eq!(size_of::<CosmosDriverOptionsConfig>(), 32);
+        assert_eq!(offset_of!(CosmosDriverOptionsConfig, preferred_regions), 0);
+        assert_eq!(
+            offset_of!(CosmosDriverOptionsConfig, preferred_regions_len),
+            8
+        );
+        assert_eq!(offset_of!(CosmosDriverOptionsConfig, operation_options), 16);
+        assert_eq!(
+            offset_of!(CosmosDriverOptionsConfig, session_token_management_enabled),
+            24
+        );
     }
 
     #[test]
@@ -366,6 +401,21 @@ mod tests {
         assert_eq!(
             cosmos_driver_options_build(account, &cfg, &mut opts),
             CosmosErrorCode::CosmosErrorCodeInvalidArgument.as_status_code()
+        );
+        assert!(opts.is_null());
+        crate::account_ref::cosmos_account_ref_free(account);
+    }
+
+    #[test]
+    fn flat_build_rejects_invalid_session_management_value() {
+        let account = make_account();
+        let mut cfg = cosmos_driver_options_config_default();
+        cfg.session_token_management_enabled = 3;
+        let mut opts: *mut DriverOptionsHandle = ptr::null_mut();
+
+        assert_eq!(
+            cosmos_driver_options_build(account, &cfg, &mut opts),
+            CosmosErrorCode::CosmosErrorCodeInvalidOptionValue.as_status_code()
         );
         assert!(opts.is_null());
         crate::account_ref::cosmos_account_ref_free(account);

--- a/sdk/cosmos/azure_data_cosmos_driver_native/src/op_request.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/src/op_request.rs
@@ -70,7 +70,7 @@ use crate::partition_key::{CosmosPartitionKeyComponent, PartitionKeyHandle};
 ///
 /// - **enum fields** (`*_strategy`, `content_response_on_write`): `0` = unset
 ///   (inherit), any other value = the corresponding driver variant.
-/// - **tri-state bools** (`session_capturing_disabled`): `0` = unset,
+/// - **tri-state bools** (`session_token_management_enabled`): `0` = unset,
 ///   `1` = `false`, `2` = `true`.
 /// - **i32 numeric fields** (retry counters): `< 0` = unset,
 ///   `>= 0` = the value.
@@ -88,7 +88,7 @@ const TRISTATE_TRUE: i8 = 2;
 
 /// Decodes a tri-state bool. Returns `Err(INVALID_OPTION_VALUE)` for an
 /// out-of-range discriminant.
-fn decode_tristate_bool(v: i8) -> Result<Option<bool>, CosmosErrorCode> {
+pub(crate) fn decode_tristate_bool(v: i8) -> Result<Option<bool>, CosmosErrorCode> {
     match v {
         TRISTATE_UNSET => Ok(None),
         TRISTATE_FALSE => Ok(Some(false)),
@@ -409,8 +409,8 @@ pub struct CosmosOperationOptions {
     /// discriminant. `0` (`Unset`) inherits. Stored as a raw `i32` so invalid
     /// host values can be rejected before materializing the enum.
     pub patch_strategy: i32,
-    /// Disable automatic session token management. Tri-state bool.
-    pub session_capturing_disabled: i8,
+    /// Enable automatic session token management. Tri-state bool.
+    pub session_token_management_enabled: i8,
     /// Max region-failover retries. `< 0` = unset.
     pub max_failover_retry_count: i32,
     /// Max session-consistency retries on 404/1002. `< 0` = unset.
@@ -497,7 +497,8 @@ impl CosmosOperationOptions {
                 .to_driver()?;
         opts.patch_strategy = CosmosPatchStrategy::from_i32(self.patch_strategy)?.to_driver();
         opts.query_plan_mode = CosmosQueryPlanMode::from_i32(self.query_plan_mode)?.to_driver();
-        opts.session_capturing_disabled = decode_tristate_bool(self.session_capturing_disabled)?;
+        opts.session_token_management_enabled =
+            decode_tristate_bool(self.session_token_management_enabled)?;
 
         opts.max_failover_retry_count = decode_opt_u32(self.max_failover_retry_count);
         opts.max_session_retry_count = decode_opt_u32(self.max_session_retry_count);
@@ -595,7 +596,7 @@ pub extern "C" fn cosmos_operation_options_default() -> CosmosOperationOptions {
             CosmosContentResponseOnWriteOpt::CosmosContentResponseOnWriteOptUnset as i32,
         patch_strategy: CosmosPatchStrategy::CosmosPatchStrategyUnset as i32,
         query_plan_mode: CosmosQueryPlanMode::CosmosQueryPlanModeUnset as i32,
-        session_capturing_disabled: TRISTATE_UNSET,
+        session_token_management_enabled: TRISTATE_UNSET,
         max_failover_retry_count: -1,
         max_session_retry_count: -1,
         end_to_end_timeout_ms: -1,
@@ -1675,7 +1676,7 @@ mod tests {
             o.query_plan_mode,
             CosmosQueryPlanMode::CosmosQueryPlanModeUnset as i32
         );
-        assert_eq!(o.session_capturing_disabled, TRISTATE_UNSET);
+        assert_eq!(o.session_token_management_enabled, TRISTATE_UNSET);
         assert_eq!(o.max_failover_retry_count, -1);
         assert_eq!(o.max_session_retry_count, -1);
         assert_eq!(o.end_to_end_timeout_ms, -1);
@@ -1700,13 +1701,27 @@ mod tests {
         assert_eq!(driver.content_response_on_write, None);
         assert_eq!(driver.patch_strategy, None);
         assert_eq!(driver.query_plan_mode, None);
-        assert_eq!(driver.session_capturing_disabled, None);
+        assert_eq!(driver.session_token_management_enabled, None);
         assert_eq!(driver.max_failover_retry_count, None);
         assert_eq!(driver.max_session_retry_count, None);
         assert_eq!(driver.end_to_end_latency_policy, None);
         assert_eq!(driver.excluded_regions, None);
         assert!(driver.throughput_control.is_none());
         assert!(driver.binary_encoding.is_none());
+    }
+
+    #[test]
+    fn session_management_flag_converts_to_driver_option() {
+        let mut o = cosmos_operation_options_default();
+        o.session_token_management_enabled = TRISTATE_FALSE;
+        // SAFETY: all pointer fields are NULL / len 0.
+        let driver = unsafe { o.to_driver() }.expect("options convert");
+        assert_eq!(driver.session_token_management_enabled, Some(false));
+
+        o.session_token_management_enabled = TRISTATE_TRUE;
+        // SAFETY: all pointer fields are NULL / len 0.
+        let driver = unsafe { o.to_driver() }.expect("options convert");
+        assert_eq!(driver.session_token_management_enabled, Some(true));
     }
 
     #[cfg(target_pointer_width = "64")]
@@ -1725,7 +1740,7 @@ mod tests {
         );
         assert_eq!(offset_of!(CosmosOperationOptions, patch_strategy), 8);
         assert_eq!(
-            offset_of!(CosmosOperationOptions, session_capturing_disabled),
+            offset_of!(CosmosOperationOptions, session_token_management_enabled),
             12
         );
         assert_eq!(

--- a/sdk/cosmos/docs/specs/0006-error-codes-and-retries.md
+++ b/sdk/cosmos/docs/specs/0006-error-codes-and-retries.md
@@ -127,6 +127,10 @@ Outside these explicit exceptions, excluded regions remain a hard per-operation 
 
 The session token is preserved on all retry attempts — it is never cleared to allow stale reads, as that would violate the customer's chosen consistency guarantees. When all session retries are exhausted, the 404/1002 error is surfaced to the caller.
 
+Disabling automatic session-token management does not disable this retry
+classification. Requests carrying caller-supplied tokens can still receive
+404/1002 and retain the same retry behavior.
+
 ### 408 — Request Timeout
 
 | Operation                                            | Action                          | Budget              |

--- a/sdk/cosmos/docs/specs/0007-partition-key-range-cache.md
+++ b/sdk/cosmos/docs/specs/0007-partition-key-range-cache.md
@@ -933,6 +933,15 @@ compares the `change_feed_next_if_none_match` on the cached map against the valu
 the caller saw. If the cache has already been refreshed by another request (new ETag),
 the predicate returns `false`, avoiding redundant fetches.
 
+### 13.6 Independent Session-Token Management
+
+`DriverOptions::session_token_management_enabled` controls automatic
+session-token storage, lookup, and capture, not partition topology. Disabling
+session management while leaving `partition_key_range_cache_enabled` true keeps
+`/pkranges` discovery, split refresh, query routing, PPAF, and PPCB available.
+Disabling the PK-range cache also prevents automatic session storage because the
+driver cannot perform range-scoped token resolution.
+
 ---
 
 ## 14. SDK Deprecation & Migration

--- a/sdk/cosmos/docs/specs/0009-cross-region-hedging.md
+++ b/sdk/cosmos/docs/specs/0009-cross-region-hedging.md
@@ -1417,12 +1417,18 @@ have the session token captured from a prior request that went to Region A.
 
 **Resolution:** The `SessionManager` is shared across all hedges. Each pipeline
 invocation:
+
 1. Reads the latest session token before sending (STAGE 3).
 2. Captures the response session token after receiving (post-STAGE 4).
 
 Because hedges run in parallel, a hedge to Region B may use a session token from
 Region A. If that fails with 404/1002, the pipeline's session retry logic handles
 it internally — this is indistinguishable from normal session retry behavior.
+
+When `session_token_management_enabled` is false at the driver or operation
+layer, hedge legs skip automatic lookup and winner capture. A caller-supplied
+token is still sent, and a resulting 404/1002 still enters the normal session
+retry path.
 
 **Concurrent capture from competing hedges.** Even after `execute_hedged()`
 cancels losing hedges and returns the winner, a losing hedge's transport

--- a/sdk/cosmos/docs/specs/0009-cross-region-hedging.md
+++ b/sdk/cosmos/docs/specs/0009-cross-region-hedging.md
@@ -1417,7 +1417,6 @@ have the session token captured from a prior request that went to Region A.
 
 **Resolution:** The `SessionManager` is shared across all hedges. Each pipeline
 invocation:
-
 1. Reads the latest session token before sending (STAGE 3).
 2. Captures the response session token after receiving (post-STAGE 4).
 

--- a/sdk/cosmos/docs/specs/0019-native-wrapper.md
+++ b/sdk/cosmos/docs/specs/0019-native-wrapper.md
@@ -1039,35 +1039,33 @@ The shared `CosmosDriverRuntime` is built via the wrapper's mirrored `CosmosDriv
 
 > **Landing prerequisites.** The companion implementation prototype lives in PR [#4452](https://github.com/Azure/azure-sdk-for-rust/pull/4452) ("Implement `azure_data_cosmos_driver_native` crate"). #4452 is the implementation of this spec — its symbol set, `_t` suffix policy, and `export.rename` configuration **must** be reconciled with §2.2 before either PR merges (#4452 currently checks in headers using `cosmos_cosmos_*` symbols without `_t` suffix, which §2.2 mandates CI must reject). Any builder method below whose Rust counterpart only exists on a branch in #4452 is marked "*landed in #4452*" inline; once #4452 merges, those marks are removed.
 
-`DriverOptions` in the driver crate is a small, account-scoped settings bag (3 fields: the bound `AccountReference`, an `Arc<OperationOptions>` carrying the per-driver operation defaults, and a `Vec<Region>` of preferred regions — see `src/options/driver_options.rs:44-127`). The wrapper exposes a builder handle that mirrors `DriverOptionsBuilder` exactly — including the fact that the builder is constructed from an `AccountReference`:
+`DriverOptions` is an account-scoped settings bag. The native wrapper builds it
+from one flat configuration value and the separate account handle:
 
 ```c
-typedef struct cosmos_driver_options_builder cosmos_driver_options_builder_t;
 typedef struct cosmos_driver_options cosmos_driver_options_t;
 
-/* Mirrors DriverOptionsBuilder::new(account). The account ref is borrowed
- * during build; the produced cosmos_driver_options_t holds its own clone. */
-cosmos_driver_options_builder_t *cosmos_driver_options_builder_new(
-    const cosmos_account_ref_t *account);
-void cosmos_driver_options_builder_free(cosmos_driver_options_builder_t *b);
+typedef struct cosmos_driver_options_config {
+    const char *const *preferred_regions;
+    size_t preferred_regions_len;
+    const cosmos_operation_options_t *operation_options;
+    int8_t session_token_management_enabled; /* 0 unset, 1 false, 2 true */
+} cosmos_driver_options_config_t;
 
-/* Mirrors DriverOptionsBuilder::with_preferred_regions. */
-cosmos_status_code_t cosmos_driver_options_builder_with_preferred_regions(
-    cosmos_driver_options_builder_t *b,
-    const char *const *regions, size_t regions_len);
-
-/* Mirrors DriverOptionsBuilder::with_operation_options. Takes ownership of
- * the provided cosmos_operation_options_t handle (consumed). */
-cosmos_status_code_t cosmos_driver_options_builder_with_operation_options(
-    cosmos_driver_options_builder_t *b,
-    cosmos_operation_options_t *operation_options);
-
-cosmos_driver_options_t *cosmos_driver_options_builder_build(
-    cosmos_driver_options_builder_t *b);  /* consumes builder */
+cosmos_driver_options_config_t cosmos_driver_options_config_default(void);
+cosmos_status_code_t cosmos_driver_options_build(
+    const cosmos_account_ref_t *account,
+    const cosmos_driver_options_config_t *config,
+    cosmos_driver_options_t **out_options);
 void cosmos_driver_options_free(cosmos_driver_options_t *opts);
 ```
 
-That is the **entire** `DriverOptions` surface. The settings frequently associated with "per-driver" defaults in older Cosmos SDKs — `excluded_regions`, `read_consistency_strategy`, `content_response_on_write`, throughput-control group, priority, end-to-end timeout, per-partition circuit-breaker tuning (8 knobs), retry counts (`max_failover_retry_count`, `max_session_retry_count`), `session_capturing_disabled`, `endpoint_unavailability_ttl`, and custom headers — all live on `OperationOptions` in this driver (`src/options/operation_options.rs:41-188`, 17 public fields), not `DriverOptions`. They are exposed under `cosmos_operation_options_*` (per-call) and can be set as driver-wide defaults by stashing them in the `DriverOptions` via `cosmos_driver_options_builder_with_operation_options`. **`max_item_count` is the exception**: it lives directly on `CosmosOperation::with_max_item_count` (not on `OperationOptions`) and is exposed through the §4.6.2 mutators rather than `cosmos_operation_options_*`. See Phase 5 in §8 for the full enumeration of `OperationOptions` setters the wrapper ships.
+The session-management tri-state defaults to enabled. Setting it to false
+prevents the driver from allocating automatic session-token storage; an
+operation-level true value cannot re-enable absent storage. Explicit operation
+tokens are still sent, and partition-key-range topology remains independently
+available. Session-consistent requests without an explicit token can therefore
+observe a weaker effective guarantee.
 
 Likewise, transport-side knobs (connection pool sizing, user-agent suffix, workload id, correlation id, emulator-certificate trust) live on `CosmosDriverRuntimeBuilder` and are exposed under `cosmos_runtime_builder_*`, **not** `cosmos_driver_options_*`. There is no `cosmos_driver_options_builder_with_allow_emulator_invalid_certs` — that knob lives on the runtime.
 
@@ -1395,18 +1393,26 @@ distinguish "inherit from a lower layer" from an explicit value:
 - **enum fields** (`read_consistency_strategy`, `content_response_on_write`),
   stored as raw `int32` and validated on conversion: `0` = unset (inherit),
   other values map to the driver variant.
-- **tri-state bools** (`session_capturing_disabled`,
+- **tri-state bools** (`session_token_management_enabled`,
   `per_partition_circuit_breaker_enabled`): `0` unset / `1` false / `2` true.
 - **`int32` numeric fields** (retry / circuit-breaker counters): `< 0` = unset.
 - **`int64` duration fields** (`*_ms`): `< 0` = unset, else milliseconds.
 - **string / array fields** (`throughput_control_group`, `excluded_regions`,
   `custom_headers`): NULL / length `0` = unset.
 
+> **Migration note:** `session_token_management_enabled` replaces the negative
+> `session_capturing_disabled` field and reverses its polarity. This is not a
+> name-only migration: old value `2` (disabled) maps to new value `1` (false),
+> while old value `1` maps to new value `2` (true). Value `0` remains unset and
+> resolves to enabled behavior. Native bindings must also regenerate
+> `cosmos_driver_options_config_t` because it gained the trailing driver-level
+> tri-state field.
+
 ```c
 typedef struct cosmos_operation_options {
     int32_t read_consistency_strategy;  /* cosmos_read_consistency_strategy_t; 0 = unset */
     int32_t content_response_on_write;  /* cosmos_content_response_on_write_t; 0 = unset */
-    int8_t  session_capturing_disabled;                 /* tri-state */
+    int8_t  session_token_management_enabled;           /* tri-state */
     int8_t  per_partition_circuit_breaker_enabled;      /* tri-state */
     int32_t max_failover_retry_count;                   /* < 0 = unset */
     int32_t max_session_retry_count;                    /* < 0 = unset */
@@ -2106,8 +2112,8 @@ Each item below is independent; ship as feature-gated when ready.
         uint32_t max_failover_retry_count;               /* flag bit 15 */
         uint32_t max_session_retry_count;                /* flag bit 16 */
 
-        /* Session capture */
-        bool session_capturing_disabled;                 /* flag bit 17 */
+        /* Session token management */
+        bool session_token_management_enabled;           /* flag bit 17 */
 
         /* Region availability */
         uint64_t endpoint_unavailability_ttl_ms;         /* flag bit 18 */

--- a/sdk/cosmos/docs/specs/0022-distributed-transactions.md
+++ b/sdk/cosmos/docs/specs/0022-distributed-transactions.md
@@ -459,15 +459,21 @@ the normal recovery handlers still applies:
 
 ## 8. Session-Token Handling
 
-Before serialization, when Session consistency is effective, each operation that
-does not already carry a caller-supplied session token is stamped from the session
-container. The driver resolves the operation's partition key range through the
-PKRange cache, prefers an exact range token, walks parent range tokens for freshly
-split children, and falls back to the compound collection-level token when the
-range cannot be resolved. This mirrors .NET PR #5958's best-effort
-`ResolvePartitionLocalToken` behavior.
+Before serialization, when Session consistency and automatic session-token
+management are effective, each operation that does not already carry a
+caller-supplied session token is stamped from the session container. The driver
+resolves the operation's partition key range through the PKRange cache, prefers
+an exact range token, walks parent range tokens for freshly split children, and
+falls back to the compound collection-level token when the range cannot be
+resolved. This mirrors .NET PR #5958's best-effort `ResolvePartitionLocalToken`
+behavior.
 
-After a **terminal success** (the outer loop returning `Ok`), the driver calls
+When driver-level session-token management is disabled, the driver allocates no
+session container and skips automatic DTX token resolution, response validation,
+and merging. Caller-supplied per-operation DTX tokens remain unchanged.
+
+After a **terminal success** (the outer loop returning `Ok`) with automatic
+management enabled, the driver calls
 `merge_distributed_transaction_session_tokens`. Because a distributed transaction
 spans partitions, tokens are **per operation**, keyed by the operation's
 `partitionKeyRangeId`. The merge:

--- a/sdk/cosmos/docs/specs/0026-session-consistency.md
+++ b/sdk/cosmos/docs/specs/0026-session-consistency.md
@@ -162,7 +162,7 @@ azure_data_cosmos (SDK)                 azure_data_cosmos_driver
 ──────────────────────                  ────────────────────────
 options.session_token  ─────────────▶   CosmosOperation::with_session_token
 OperationOptions
-  .session_capturing_disabled ──────▶   pipeline consistency gate
+  .session_token_management_enabled ▶   pipeline consistency gate
   .read_consistency_strategy  ──────▶   ReadConsistencyStrategy::is_session_effective
   .max_session_retry_count    ──────▶   OperationRetryState session budget
 
@@ -175,9 +175,10 @@ ContainerClient::get_latest_session_token  (pure, uses SessionTokenSegment)
 ```
 
 - **The driver owns automatic session state.** `CosmosDriver` holds exactly one
-  `SessionManager`, which wraps the `SessionContainer` cache
+  `SessionManager`, which optionally owns a boxed `SessionContainer` cache
   (`driver/routing/session_manager.rs`, `driver/routing/session_container.rs`).
-  Nothing above the driver mutates it.
+  Disabled drivers allocate no session container. Nothing above the driver
+  mutates it.
 - **The SDK owns the public surface.** Per-operation `session_token` fields on
   `ItemReadOptions`, `ItemWriteOptions`, `PatchItemOptions`, `FeedOptions`,
   `QueryOptions`, `ChangeFeedOptions`, batch and DTX options; the
@@ -202,9 +203,13 @@ The pipeline computes, per attempt:
 
 ```text
 automatic_session_management_effective =
-    partition_key_range_cache_enabled
-    && !session_capturing_disabled
+    driver_session_manager_allocated
+    && session_token_management_enabled
     && read_consistency_strategy.is_session_effective(account_default)
+
+driver_session_manager_allocated =
+    partition_key_range_cache_enabled
+    && driver_session_token_management_enabled
 ```
 
 `is_session_effective` is true when the strategy is `Session`, or when the
@@ -213,10 +218,12 @@ strategy is `Default` and the account default consistency level is `Session`.
 lane, so the pipeline neither resolves cached tokens nor captures response
 tokens.
 
-`session_capturing_disabled` is a single switch that turns off *both* automatic
-halves — no cache-based attach and no capture. Explicit per-operation tokens
-remain operation headers and are written directly to the transport request;
-they do not depend on the guarded automatic resolver (see §4).
+`session_token_management_enabled` is a positive switch that controls *both*
+automatic halves — cache-based attach and capture. The driver-level false value
+is authoritative because no session container is allocated; an operation-level
+true value cannot re-enable it. Explicit per-operation tokens remain operation
+headers and are written directly to the transport request; they do not depend
+on the guarded automatic resolver (see §4).
 
 ---
 
@@ -459,9 +466,10 @@ formatting of driver state.
 - **Read-then-write races are benign.** Two concurrent operations may resolve the
   same token and capture different advances; the merge is commutative and
   monotone within a topology version, so the cache converges to the maximum.
-- **No persistence, no eviction.** State is process-local and lives for the life
-  of the client, except for the RID-mismatch purge on container recreation.
-  Memory is bounded by (containers touched × ranges per container).
+- **No persistence, no eviction.** When enabled, state is process-local and lives
+  for the life of the client, except for the RID-mismatch purge on container
+  recreation. Memory is bounded by (containers touched × ranges per container).
+  Disabled clients allocate no session container.
 - **Boundary with routing state.** Session state is separate from the location
   cache, endpoint-unavailability state, and PK-range cache. Session retries read
   routing state but never mutate endpoint health, and no routing decision mutates
@@ -485,8 +493,8 @@ formatting of driver state.
 4. **A caller-supplied token is never merged with the cache.** It replaces it for
    that request. Callers combining sessions must merge explicitly via
    `SessionToken::merge` or `ContainerClient::get_latest_session_token`.
-5. **`session_capturing_disabled` is coarse** — it disables capture *and*
-   resolution together; there is no capture-only mode.
+5. **`session_token_management_enabled` is coarse** — false disables capture
+   *and* resolution together; there is no capture-only mode.
 6. **No cross-client or cross-process sharing** is built in; applications that
    need it must ferry tokens themselves.
 7. **Consistency-level diagnostics attribute is not yet populated** on the


### PR DESCRIPTION
## Summary

- add a driver/client switch that avoids session-token storage when automatic management is disabled
- preserve explicit tokens, 404/1002 retries, and independent partition-key-range topology
- apply the setting across standard, hedged, distributed-transaction, and container-recreation paths
- use positive operation/native ABI semantics with matching coverage and documentation

Fixes #5191