### PR TITLE
Narrow empty package-info fallback

### DIFF
--- a/eng/pipelines/templates/jobs/analyze.yml
+++ b/eng/pipelines/templates/jobs/analyze.yml
@@ -37,6 +37,8 @@ jobs:
           ConfigureRegistry: false
 
   - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
+    parameters:
+      ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
   # Always skip audit. Audit requires contact with restricted endpoints and is
   # excluded from use in internal builds. Instead, teams must check on the state

--- a/eng/scripts/Analyze-Code.ps1
+++ b/eng/scripts/Analyze-Code.ps1
@@ -57,38 +57,66 @@ if ($PackageInfoDirectory -and !(Test-Path -Path $PackageInfoDirectory -PathType
   $packageInfoPath = $null
 }
 
-$packagesToAnalyze = Get-CargoSelectedPackages `
+$workspacePackages = Get-CargoPackages
+$selectedManifestPaths = Get-CargoManifestPaths `
   -PackageName $PackageName `
   -ManifestDir $ManifestDir `
-  -PackageInfoDirectory $packageInfoPath
+  -PackageInfoDirectory $packageInfoPath `
+  -WorkspacePackages $workspacePackages
+$packagesToAnalyze = Get-CargoPackagesFromManifestPaths `
+  -ManifestPath $selectedManifestPaths `
+  -WorkspacePackages $workspacePackages
 $workspaceManifestPath = [System.IO.Path]::Combine($RepoRoot, 'Cargo.toml')
 $exportApiScript = [System.IO.Path]::Combine($RepoRoot, 'eng', 'tools', 'Export-API.ps1')
-$packageArgs = if ($PackageName -or $ManifestDir) {
-  '--package ' + ($packagesToAnalyze.name -join ' --package ')
+$hasPackageSelection = $PackageName -or $ManifestDir -or $packageInfoPath
+$azureCoreManifestPath = (
+  Get-CargoPackageByName `
+    -WorkspacePackages $workspacePackages `
+    -PackageName azure_core
+).manifest_path
+$checkManifestPaths = if ($hasPackageSelection) {
+  @($packagesToAnalyze.manifest_path) + $azureCoreManifestPath | Select-Object -Unique
+}
+else {
+  @($azureCoreManifestPath)
+}
+$clippyManifestPaths = if ($hasPackageSelection) {
+  $checkManifestPaths
+}
+else {
+  @($workspaceManifestPath)
 }
 
 if ($Audit) {
   Invoke-LoggedCommand "cargo audit" -GroupOutput
 }
 
-Invoke-LoggedCommand "cargo check --manifest-path sdk/core/azure_core/Cargo.toml $packageArgs --all-features --all-targets --keep-going" -GroupOutput
+foreach ($manifestPath in $checkManifestPaths) {
+  Invoke-LoggedCommand "cargo check --manifest-path '$manifestPath' --all-features --all-targets --keep-going" -GroupOutput
+}
 
-if ($packageArgs) {
-  Invoke-LoggedCommand "cargo fmt --manifest-path '$workspaceManifestPath' $packageArgs -- --check" -GroupOutput
+if (!$hasPackageSelection) {
+  Invoke-LoggedCommand "cargo fmt --manifest-path '$workspaceManifestPath' --all -- --check" -GroupOutput
 }
 else {
-  Invoke-LoggedCommand "cargo fmt --manifest-path '$workspaceManifestPath' --all -- --check" -GroupOutput
+  foreach ($manifestPath in $selectedManifestPaths) {
+    Invoke-LoggedCommand "cargo fmt --manifest-path '$manifestPath' -- --check" -GroupOutput
+  }
 }
 
 Invoke-LoggedCommand "taplo format --check"
 
-Invoke-LoggedCommand "cargo clippy --manifest-path '$workspaceManifestPath' $packageArgs --all-features --all-targets --keep-going --no-deps" -GroupOutput
+foreach ($manifestPath in $clippyManifestPaths) {
+  Invoke-LoggedCommand "cargo clippy --manifest-path '$manifestPath' --all-features --all-targets --keep-going --no-deps" -GroupOutput
+}
 
 if ($Deny) {
   Invoke-LoggedCommand "cargo deny --manifest-path '$workspaceManifestPath' --all-features check bans licenses sources" -GroupOutput
 }
 
-Invoke-LoggedCommand "cargo doc --manifest-path '$workspaceManifestPath' $packageArgs --no-deps --all-features" -GroupOutput
+foreach ($manifestPath in $selectedManifestPaths) {
+  Invoke-LoggedCommand "cargo doc --manifest-path '$manifestPath' --no-deps --all-features" -GroupOutput
+}
 
 # Verify package dependencies and keywords
 $verifyDependenciesScript = ([System.IO.Path]::Combine($RepoRoot, 'eng', 'scripts', 'verify-dependencies.rs'))
@@ -110,7 +138,12 @@ if (!$SkipPackageAnalysis) {
     $exportApiParams['PackageInfoDirectory'] = $packageInfoPath
   }
 
-  & $exportApiScript @exportApiParams
+  $exportApiArgs = @('-Check')
+  foreach ($entry in $exportApiParams.GetEnumerator() | Where-Object Key -NE 'Check') {
+    $values = @($entry.Value) | ForEach-Object { "'$_'" }
+    $exportApiArgs += "-$($entry.Key)", ($values -join ',')
+  }
+  Invoke-LoggedCommand "& '$exportApiScript' $($exportApiArgs -join ' ')" -GroupOutput
 
   if (!$PackageName -and !$ManifestDir -and !$packageInfoPath) {
     Write-Host "Analyzing workspace`n"

--- a/eng/scripts/Analyze-Code.ps1
+++ b/eng/scripts/Analyze-Code.ps1
@@ -58,17 +58,29 @@ if ($PackageInfoDirectory -and !(Test-Path -Path $PackageInfoDirectory -PathType
 }
 
 $workspacePackages = Get-CargoPackages
+$resolvedPackageName = $PackageName
+$resolvedPackageInfoPath = $packageInfoPath
+if (!$resolvedPackageName -and !$ManifestDir -and $resolvedPackageInfoPath) {
+  $packageInfoPackages = @(Get-PackagesFromPackageInfo $resolvedPackageInfoPath)
+
+  if (!$packageInfoPackages) {
+    $resolvedPackageName = Get-CanaryPackageNames
+    $resolvedPackageInfoPath = $null
+    Write-Host "No service crates were identified. Falling back to '$($resolvedPackageName -join "', '")'."
+  }
+}
+
 $selectedManifestPaths = Get-CargoManifestPaths `
-  -PackageName $PackageName `
+  -PackageName $resolvedPackageName `
   -ManifestDir $ManifestDir `
-  -PackageInfoDirectory $packageInfoPath `
+  -PackageInfoDirectory $resolvedPackageInfoPath `
   -WorkspacePackages $workspacePackages
 $packagesToAnalyze = Get-CargoPackagesFromManifestPaths `
   -ManifestPath $selectedManifestPaths `
   -WorkspacePackages $workspacePackages
 $workspaceManifestPath = [System.IO.Path]::Combine($RepoRoot, 'Cargo.toml')
 $exportApiScript = [System.IO.Path]::Combine($RepoRoot, 'eng', 'tools', 'Export-API.ps1')
-$hasPackageSelection = $PackageName -or $ManifestDir -or $packageInfoPath
+$hasPackageSelection = $resolvedPackageName -or $ManifestDir -or $resolvedPackageInfoPath
 $azureCoreManifestPath = (
   Get-CargoPackageByName `
     -WorkspacePackages $workspacePackages `
@@ -128,14 +140,14 @@ if (!$SkipPackageAnalysis) {
   $exportApiParams = @{
     Check = $true
   }
-  if ($PackageName) {
-    $exportApiParams['PackageName'] = $PackageName
+  if ($resolvedPackageName) {
+    $exportApiParams['PackageName'] = $resolvedPackageName
   }
   elseif ($ManifestDir) {
     $exportApiParams['ManifestDir'] = $ManifestDir
   }
-  elseif ($packageInfoPath) {
-    $exportApiParams['PackageInfoDirectory'] = $packageInfoPath
+  elseif ($resolvedPackageInfoPath) {
+    $exportApiParams['PackageInfoDirectory'] = $resolvedPackageInfoPath
   }
 
   $exportApiArgs = @('-Check')
@@ -145,7 +157,7 @@ if (!$SkipPackageAnalysis) {
   }
   Invoke-LoggedCommand "& '$exportApiScript' $($exportApiArgs -join ' ')" -GroupOutput
 
-  if (!$PackageName -and !$ManifestDir -and !$packageInfoPath) {
+  if (!$resolvedPackageName -and !$ManifestDir -and !$resolvedPackageInfoPath) {
     Write-Host "Analyzing workspace`n"
     Invoke-LoggedCommand "&$verifyDependenciesScript $workspaceManifestPath" -GroupOutput
     Invoke-LoggedCommand "&$verifyKeywordsScript $workspaceManifestPath" -GroupOutput

--- a/eng/scripts/Generate-CargoSbom.ps1
+++ b/eng/scripts/Generate-CargoSbom.ps1
@@ -39,18 +39,6 @@ $manifestPaths = Get-CargoManifestPaths `
   -ManifestDir $ManifestDir `
   -Workspace:$Workspace
 $workspaceManifestPath = [System.IO.Path]::Combine($RepoRoot, 'Cargo.toml')
-$packageArgs = @('--manifest-path', "'$workspaceManifestPath'")
-if ($Workspace) {
-  $packageArgs += '--workspace'
-}
-else {
-  $packages = Get-CargoSelectedPackages `
-    -PackageName $PackageName `
-    -ManifestDir $ManifestDir
-  foreach ($package in $packages) {
-    $packageArgs += '--package', $package.name
-  }
-}
 
 # Cargo owns SBOM generation, so nightly Cargo can drive the stable compiler without
 # weakening the stable-toolchain validation performed by the rest of the pipeline.
@@ -58,9 +46,12 @@ $env:CARGO_BUILD_SBOM = 'true'
 $env:RUSTC = $stableRustc
 $env:RUSTUP_TOOLCHAIN = $stableToolchain
 
-Invoke-LoggedCommand `
-  "& `"$nightlyCargo`" -Z sbom build --locked --all-features --keep-going $($packageArgs -join ' ')" `
-  -GroupOutput
+foreach ($manifestPath in $manifestPaths) {
+  $workspaceArg = if ($Workspace) { '--workspace' } else { '' }
+  Invoke-LoggedCommand `
+    "& `"$nightlyCargo`" -Z sbom build --manifest-path '$manifestPath' $workspaceArg --locked --all-features --keep-going" `
+    -GroupOutput
+}
 
 $metadata = Invoke-LoggedCommand `
   "& `"$nightlyCargo`" metadata --manifest-path '$workspaceManifestPath' --no-deps --format-version 1 --locked" |

--- a/eng/scripts/Pack-Crates.ps1
+++ b/eng/scripts/Pack-Crates.ps1
@@ -165,13 +165,21 @@ try {
   Set-Location $RepoRoot
 
   [array]$packages = Get-PackagesToBuild
-  $packageParams = @("--manifest-path", ([System.IO.Path]::Combine($RepoRoot, 'Cargo.toml')))
-  foreach ($package in $packages) {
-    $packageParams += "--package", $package.name
+  $packageParams = if ($packages.Count -gt 1) {
+    @('--manifest-path', ([System.IO.Path]::Combine($RepoRoot, 'Cargo.toml')))
+  }
+  else {
+    @('--manifest-path', "'$($packages[0].manifest_path)'")
+  }
+
+  if ($packages.Count -gt 1) {
+    foreach ($package in $packages) {
+      $packageParams += '--package', $package.name
+    }
   }
 
   if ($NoVerify) {
-    $packageParams += "--no-verify"
+    $packageParams += '--no-verify'
   }
 
   # Some packages are not publishable, in cases where the script is not in a
@@ -183,22 +191,25 @@ try {
     $subCommand = @("publish", "--dry-run")
   }
 
-  LogGroupStart "cargo $($subCommand -join ' ') --locked --allow-dirty $($packageParams -join ' ')"
-  Write-Host "cargo $($subCommand -join ' ') --locked --allow-dirty $($packageParams -join ' ')"
-  & cargo @subCommand --locked --allow-dirty @packageParams 2>&1 `
-  | Tee-Object -Variable packResult `
-  | ForEach-Object { Write-Host $_ -ForegroundColor Gray }
-  LogGroupEnd
+  $packResult = Invoke-LoggedCommand `
+    "cargo $($subCommand -join ' ') --locked --allow-dirty $($packageParams -join ' ') 2>&1" `
+    -GroupOutput `
+    -DoNotExitOnFailedExitCode `
+    -OutputProcessor {
+      param($line)
+      Write-Host $line -ForegroundColor Gray
+      $line
+    }
 
-  Write-Host "Finished packing crates"
   if ($LASTEXITCODE) {
     if ($packResult -match 'cannot update the lock file') {
       LogWarning "cargo package could not update the lock file. Rebase on the main branch and try again."
     }
 
-    Write-Host "cargo publish failed with exit code $LASTEXITCODE"
+    LogError "cargo $($subCommand -join ' ') failed with exit code $LASTEXITCODE"
     exit $LASTEXITCODE
   }
+  Write-Host "Finished packing crates"
 
   if ($APIReview) {
     foreach ($package in $packages) {

--- a/eng/scripts/Test-Packages.ps1
+++ b/eng/scripts/Test-Packages.ps1
@@ -19,6 +19,20 @@ $activeToolchain = Get-ResolvedRustToolchain
 $usesJsonTestOutput = Test-IsNightlyRustToolchain
 $cargoFeatureArgs = if ($FeatureSet -eq 'All') { @('--all-features') } else { @() }
 
+function Get-TestPackagesFromCargoPackages(
+  $CargoPackages
+) {
+  return @(
+    foreach ($package in $CargoPackages) {
+      $packageDirectory = Split-Path -Path $package.manifest_path -Parent
+      [PSCustomObject]@{
+        Name = $package.name
+        DirectoryPath = [System.IO.Path]::GetRelativePath($RepoRoot, $packageDirectory).Replace('\', '/')
+      }
+    }
+  )
+}
+
 # Helper function to run cargo test, capturing JSON output only when the active
 # toolchain supports `--format json -Z unstable-options`.
 function Invoke-CargoTest (
@@ -85,9 +99,13 @@ if ($PackageInfoDirectory) {
     exit 1
   }
 
-  $packagesToTest = Get-ChildItem $PackageInfoDirectory -Filter "*.json" -Recurse
-  | Get-Content -Raw
-  | ConvertFrom-Json
+  $packagesToTest = @(Get-PackagesFromPackageInfo $PackageInfoDirectory)
+  if (!$packagesToTest) {
+    $fallbackPackageNames = Get-CanaryPackageNames
+    Write-Host "No service crates were identified. Falling back to '$($fallbackPackageNames -join "', '")'."
+    $packagesToTest = Get-TestPackagesFromCargoPackages `
+      -CargoPackages (Get-CargoSelectedPackages -PackageName $fallbackPackageNames)
+  }
 }
 else {
   $packagesToTest = Get-AllPackageInfoFromRepo

--- a/eng/scripts/Test-Packages.ps1
+++ b/eng/scripts/Test-Packages.ps1
@@ -28,7 +28,7 @@ function Invoke-CargoTest (
   [string]$OutputFile
 ) {
   Write-Host "Running tests for $PackageName"
-  $commandParts = @('cargo', 'test', $TestParams, '--manifest-path', $ManifestPath) + $cargoFeatureArgs + @('--no-fail-fast')
+  $commandParts = @('cargo', 'test', $TestParams, '--manifest-path', "'$ManifestPath'") + $cargoFeatureArgs + @('--no-fail-fast')
   $command = $commandParts -join ' '
 
   if ($usesJsonTestOutput) {
@@ -113,11 +113,11 @@ foreach ($package in $packagesToTest) {
 
   Write-Host "`n`nTesting package: '$($package.Name)'`n"
 
-  $buildCommand = (@('cargo', 'build') + $cargoFeatureArgs + @('--keep-going')) -join ' '
+  $manifestPath = [System.IO.Path]::Combine($packageDirectory, 'Cargo.toml')
+  $buildCommand = (@('cargo', 'build', '--manifest-path', "'$manifestPath'") + $cargoFeatureArgs + @('--keep-going')) -join ' '
   Invoke-LoggedCommand $buildCommand -GroupOutput
   Write-Host "`n`n"
 
-  $manifestPath = [System.IO.Path]::Combine($packageDirectory, 'Cargo.toml')
   $timestamp = Get-Date -Format "yyyyMMdd-HHmmss-fff"
 
   $docTestOutput = ([System.IO.Path]::Combine($testResultsDir, "$($package.Name)-doctest-$timestamp.json"))
@@ -134,7 +134,7 @@ foreach ($package in $packagesToTest) {
     -ManifestPath $manifestPath `
     -OutputFile $allTargetsOutput
 
-  $benchCommand = (@('cargo', 'test', '--benches', '--manifest-path', $manifestPath) + $cargoFeatureArgs + @('--no-fail-fast')) -join ' '
+  $benchCommand = (@('cargo', 'test', '--benches', '--manifest-path', "'$manifestPath'") + $cargoFeatureArgs + @('--no-fail-fast')) -join ' '
   Invoke-LoggedCommand $benchCommand -GroupOutput
 
   $cleanupScript = ([System.IO.Path]::Combine($packageDirectory, 'Test-Cleanup.ps1'))

--- a/eng/scripts/shared/Cargo.ps1
+++ b/eng/scripts/shared/Cargo.ps1
@@ -83,6 +83,10 @@ function Get-PackageNamesFromPackageInfo($packageInfoDirectory) {
   $packages.name
 }
 
+function Get-CanaryPackageNames() {
+  return @('azure_canary', 'azure_canary_core')
+}
+
 function Get-CargoPackageByName(
   $WorkspacePackages,
   [string] $PackageName


### PR DESCRIPTION
Normalize cargo manifest targeting

Forward the analyze job's `ServiceDirectory` into package selection so PR validation can honor `auto` mode instead of always materializing repo-wide Rust package info.

In `eng/scripts/Analyze-Code.ps1` and `eng/scripts/Test-Packages.ps1`, treat an existing-but-empty `PackageInfo` directory as an eng-only validation case and fall back to `azure_canary` and `azure_canary_core` instead of analyzing or testing the full workspace. Keep the existing `azure_core` analysis coverage and preserve explicit failures for missing `PackageInfo` paths.

Normalize the shared Rust script helpers around that behavior by adding `Get-CanaryPackageNames()` in `eng/scripts/shared/Cargo.ps1`, and keep `Test-Packages.ps1` on narrow cargo-based selection instead of repo-wide package enumeration for the fallback path.

`eng/scripts/Analyze-Code.ps1`, `eng/scripts/Test-Packages.ps1`, and `eng/pipelines/templates/jobs/analyze.yml` now avoid broad PR checks when no service crates are selected, while the earlier manifest-targeting changes in the same PR continue to resolve selected crates through shared cargo helpers.
