### PR TITLE
Migrate Cosmos tests to federated AAD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,7 @@ dependencies = [
  "azure_core 1.1.0",
  "azure_core_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure_data_cosmos_driver",
+ "azure_data_cosmos_test_support",
  "azure_identity 1.0.0",
  "base64",
  "clap",
@@ -630,7 +631,9 @@ dependencies = [
  "async-lock",
  "async-trait",
  "azure_core 1.1.0",
+ "azure_core_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure_data_cosmos_macros 0.2.0",
+ "azure_data_cosmos_test_support",
  "azure_identity 1.0.0",
  "backtrace",
  "base64",
@@ -753,6 +756,16 @@ dependencies = [
  "tokio-metrics",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "azure_data_cosmos_test_support"
+version = "0.0.0"
+dependencies = [
+ "azure_core 1.1.0",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "sdk/cosmos/azure_data_cosmos_macros",
   "sdk/cosmos/azure_data_cosmos_observability_harness",
   "sdk/cosmos/azure_data_cosmos_perf",
+  "sdk/cosmos/azure_data_cosmos_test_support",
   "sdk/identity/azure_identity",
   "sdk/eventhubs/azure_messaging_eventhubs",
   "sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob",

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -37,6 +37,7 @@ uuid = { workspace = true, optional = true, features = ["v4", "fast-rng"] }
 # compile-time cost.
 [dev-dependencies]
 azure_core_test = { workspace = true, features = ["tracing"] }
+azure_data_cosmos_test_support = { path = "../azure_data_cosmos_test_support" }
 # Re-declare the driver here with the internal test-only diagnostics-construction feature.
 # Putting it in dev-dependencies (instead of [dependencies]) means downstream consumers
 # of `azure_data_cosmos` do NOT compile with this feature enabled — the driver's

--- a/sdk/cosmos/azure_data_cosmos/tests/binary_roundtrip_fuzzer.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/binary_roundtrip_fuzzer.rs
@@ -19,8 +19,11 @@
 //! RUSTFLAGS='--cfg test_category="binary_encoding"' \
 //!   cargo test -p azure_data_cosmos --test binary_roundtrip_fuzzer --features key_auth,fault_injection,control_plane -- --nocapture
 //!
-//! # Multi-day soak (millions of docs), release build:
-//! AZURE_COSMOS_CONNECTION_STRING='...' AZURE_COSMOS_FUZZ_ITERATIONS=5000000 \
+//! # Multi-day soak against a live account using federated Entra ID:
+//! AZURE_COSMOS_AUTH_MODE=aad ACCOUNT_HOST='https://<account>.documents.azure.com:443/' \
+//! COSMOS_SUBSCRIPTION_ID='<subscription>' COSMOS_RESOURCE_GROUP='<resource-group>' \
+//! COSMOS_ACCOUNT_NAME='<account>' \
+//! AZURE_COSMOS_FUZZ_ITERATIONS=5000000 \
 //! RUSTFLAGS='--cfg test_category="binary_encoding"' \
 //!   cargo test -p azure_data_cosmos --test binary_roundtrip_fuzzer --features key_auth,fault_injection,control_plane --release -- --nocapture
 //!
@@ -55,7 +58,13 @@ use serde_json::{Map, Number, Value};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
+#[path = "framework/mod.rs"]
+mod framework;
+
+use framework::CosmosArmClient;
+
 const CONNECTION_STRING_ENV_VAR: &str = "AZURE_COSMOS_CONNECTION_STRING";
+const AUTH_MODE_ENV_VAR: &str = "AZURE_COSMOS_AUTH_MODE";
 const ALLOW_INVALID_CERT_ENV_VAR: &str = "AZURE_COSMOS_ALLOW_INVALID_CERT";
 const DATABASE_NAME_ENV_VAR: &str = "AZURE_COSMOS_BINARY_TEST_DATABASE";
 const CONTAINER_NAME_ENV_VAR: &str = "AZURE_COSMOS_BINARY_TEST_CONTAINER";
@@ -1818,6 +1827,16 @@ fn run_configs() -> Vec<RunConfig> {
 async fn build_client(
     binary: &Option<BinaryEncodingOptions>,
 ) -> Result<CosmosClient, Box<dyn Error>> {
+    if uses_aad_auth() {
+        return Ok(framework::build_aad_client_from_env(
+            Region::EAST_US,
+            Vec::new(),
+            binary.clone(),
+        )
+        .await?
+        .0);
+    }
+
     let connection_string = std::env::var(CONNECTION_STRING_ENV_VAR).map_err(|_| {
         format!("{CONNECTION_STRING_ENV_VAR} must be set to a Cosmos DB connection string")
     })?;
@@ -1853,6 +1872,46 @@ async fn build_client(
         .build(account, RoutingStrategy::ProximityTo(Region::EAST_US))
         .await?;
     Ok(client)
+}
+
+fn uses_aad_auth() -> bool {
+    std::env::var(AUTH_MODE_ENV_VAR).is_ok_and(|value| value.eq_ignore_ascii_case("aad"))
+}
+
+async fn create_test_resources(
+    client: &CosmosClient,
+    arm_client: Option<&CosmosArmClient>,
+    database_name: &str,
+    container_name: &str,
+) -> Result<(), Box<dyn Error>> {
+    let properties = ContainerProperties::new(container_name.to_owned(), PARTITION_KEY_PATH.into());
+    if let Some(arm_client) = arm_client {
+        arm_client.create_database(database_name).await?;
+        arm_client
+            .create_or_update_container(database_name, container_name, &properties, None)
+            .await?;
+        let container = client
+            .database_client(database_name)
+            .container_client(container_name, None)
+            .await?;
+        framework::probe_data_plane_ready("binary fuzzer setup client", &container, 1).await?;
+    } else {
+        ignore_conflict(client.create_database(database_name, None).await)?;
+        let database = client.database_client(database_name);
+        ignore_conflict(database.create_container(properties, None).await)?;
+    }
+    Ok(())
+}
+
+async fn delete_test_resources(
+    _client: &CosmosClient,
+    arm_client: Option<&CosmosArmClient>,
+    database_name: &str,
+) -> Result<(), Box<dyn Error>> {
+    if let Some(arm_client) = arm_client {
+        arm_client.delete_database(database_name).await?;
+    }
+    Ok(())
 }
 
 fn ignore_conflict<T>(result: azure_data_cosmos::Result<T>) -> Result<(), Box<dyn Error>> {
@@ -2148,7 +2207,7 @@ fn assert_query_hit(
 #[tokio::test]
 #[cfg_attr(
     not(test_category = "binary_encoding"),
-    ignore = "requires test_category 'binary_encoding' and a live account connection string"
+    ignore = "requires test_category 'binary_encoding' and a live account"
 )]
 async fn binary_encoding_roundtrip_fuzz() -> Result<(), Box<dyn Error>> {
     let cfg = FuzzConfig::from_env();
@@ -2179,17 +2238,31 @@ async fn binary_encoding_roundtrip_fuzz() -> Result<(), Box<dyn Error>> {
         .unwrap_or_else(|_| DEFAULT_CONTAINER_NAME.to_string());
 
     let setup_client = &clients[0].1;
-    ignore_conflict(setup_client.create_database(&database_name, None).await)?;
-    let setup_db = setup_client.database_client(&database_name);
-    ignore_conflict(
-        setup_db
-            .create_container(
-                ContainerProperties::new(container_name.clone(), PARTITION_KEY_PATH.into()),
-                None,
-            )
-            .await,
-    )?;
+    let arm_client = if uses_aad_auth() {
+        Some(CosmosArmClient::from_env(
+            azure_core_test::credentials::from_env(None)?,
+        )?)
+    } else {
+        None
+    };
+    create_test_resources(
+        setup_client,
+        arm_client.as_ref(),
+        &database_name,
+        &container_name,
+    )
+    .await?;
+    if uses_aad_auth() {
+        for (label, client) in clients.iter().skip(1) {
+            let container = client
+                .database_client(&database_name)
+                .container_client(&container_name, None)
+                .await?;
+            framework::probe_data_plane_ready(label, &container, 1).await?;
+        }
+    }
 
+    let test_result = async {
     let mut rng = SplitMix64::new(cfg.seed);
     let mut checked: u64 = 0;
 
@@ -2460,6 +2533,14 @@ async fn binary_encoding_roundtrip_fuzz() -> Result<(), Box<dyn Error>> {
         configs.len(),
         cfg.seed
     );
+    Ok::<(), Box<dyn Error>>(())
+    }
+    .await;
+
+    let cleanup_result =
+        delete_test_resources(setup_client, arm_client.as_ref(), &database_name).await;
+    test_result?;
+    cleanup_result?;
     Ok(())
 }
 
@@ -2572,17 +2653,24 @@ async fn run_calibration() -> Result<(), Box<dyn Error>> {
     let container_name = std::env::var(CONTAINER_NAME_ENV_VAR)
         .unwrap_or_else(|_| DEFAULT_CONTAINER_NAME.to_string());
 
-    ignore_conflict(client.create_database(&database_name, None).await)?;
+    let arm_client = if uses_aad_auth() {
+        Some(CosmosArmClient::from_env(
+            azure_core_test::credentials::from_env(None)?,
+        )?)
+    } else {
+        None
+    };
+    create_test_resources(
+        &client,
+        arm_client.as_ref(),
+        &database_name,
+        &container_name,
+    )
+    .await?;
     let db = client.database_client(&database_name);
-    ignore_conflict(
-        db.create_container(
-            ContainerProperties::new(container_name.clone(), PARTITION_KEY_PATH.into()),
-            None,
-        )
-        .await,
-    )?;
     let container = db.container_client(&container_name, None).await?;
 
+    let calibration_result = async {
     println!(
         "{:<26} {:<24} {:<24} {:<24} {}",
         "probe", "sent-literal", "our-canonical", "backend-returned", "status"
@@ -2644,6 +2732,13 @@ async fn run_calibration() -> Result<(), Box<dyn Error>> {
             "CALIBRATION: {diffs} probe(s) DIFF — update `normalize_number` to match the backend-returned column above."
         );
     }
+    Ok::<(), Box<dyn Error>>(())
+    }
+    .await;
+
+    let cleanup_result = delete_test_resources(&client, arm_client.as_ref(), &database_name).await;
+    calibration_result?;
+    cleanup_result?;
     Ok(())
 }
 

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_aad.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_aad.rs
@@ -43,10 +43,9 @@ struct AadTestItem {
 
 /// Drives a full item CRUD round-trip through an AAD-authenticated client.
 ///
-/// Setup (database + container) and teardown run through the framework's
-/// key-auth client; only the item operations use the AAD client. On the
-/// emulator we additionally assert the bespoke fake-JWT credential was actually
-/// invoked for the Cosmos scope, guarding against silently exercising key auth.
+/// Live setup and teardown use the framework's ARM client; item operations use
+/// the AAD data-plane client. On the emulator we additionally assert the fake
+/// JWT credential was invoked for the Cosmos scope.
 #[tokio::test]
 #[cfg_attr(
     any(not(cosmos_aad_supported), test_category = "emulator_inmemory"),
@@ -55,7 +54,6 @@ struct AadTestItem {
 pub async fn aad_item_crud_roundtrip() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
         async |run_context: &TestRunContext, db_client| {
-            // Key client creates the container (management-plane operation).
             let container_id = format!("aad-container-{}", Uuid::new_v4());
             run_context
                 .create_container(
@@ -73,14 +71,12 @@ pub async fn aad_item_crud_roundtrip() -> Result<(), Box<dyn Error>> {
                 .await?;
 
             // Metadata (5301) and name-based data (5302) authorize through
-            // separate RBAC paths. `run_context.create_container` above only
-            // warms the framework's key-auth client; this test's own
-            // freshly-built AAD client has never issued a data-plane
-            // request against this container, so its first item operation
-            // can still race and return
+            // separate RBAC paths. This freshly-built AAD client has not issued
+            // a data-plane request against the container, so its first item
+            // operation can still race and return
             // `403/5302 RbacUnauthorizedNameBasedDataRequest`. Probe this
             // client's data path before exercising real assertions.
-            probe_data_plane_ready("aad client", &aad_container).await?;
+            probe_data_plane_ready("aad client", &aad_container, 1).await?;
 
             let unique = Uuid::new_v4().to_string();
             let pk = format!("pk-{unique}");

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_backup_endpoints.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_backup_endpoints.rs
@@ -16,8 +16,8 @@
 use super::framework;
 
 use azure_data_cosmos::{AccountEndpoint, AccountReference, CosmosClient, RoutingStrategy};
-use framework::{resolve_connection_string, HUB_REGION};
-use std::error::Error;
+use framework::{resolve_connection_string, ACCOUNT_HOST_ENV_VAR, AUTH_MODE_ENV_VAR, HUB_REGION};
+use std::{error::Error, io};
 
 /// Tests that the SDK client can initialize when the primary global endpoint
 /// is unreachable but a valid backup endpoint is provided.
@@ -29,22 +29,50 @@ use std::error::Error;
     ignore = "requires test_category 'emulator'"
 )]
 async fn client_boots_via_backup_when_primary_unreachable() -> Result<(), Box<dyn Error>> {
-    let connection_string =
-        resolve_connection_string().expect("Cosmos DB connection string must be configured");
-
-    let real_endpoint: AccountEndpoint = connection_string.account_endpoint().parse()?;
+    let aad_mode = std::env::var(AUTH_MODE_ENV_VAR)
+        .map(|value| value.eq_ignore_ascii_case("aad"))
+        .unwrap_or(false);
+    let missing_connection_string = || {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Cosmos DB connection string must be configured for key authentication",
+        )
+    };
+    let connection_string = if aad_mode {
+        None
+    } else {
+        Some(resolve_connection_string().ok_or_else(missing_connection_string)?)
+    };
+    let real_endpoint: AccountEndpoint = if aad_mode {
+        std::env::var(ACCOUNT_HOST_ENV_VAR)?.parse()?
+    } else {
+        connection_string
+            .as_ref()
+            .ok_or_else(missing_connection_string)?
+            .account_endpoint()
+            .parse()?
+    };
     let fake_endpoint: AccountEndpoint = "https://localhost:9/".parse()?;
 
     let builder = CosmosClient::builder().with_backup_endpoints(vec![real_endpoint]);
+    let account = if aad_mode {
+        AccountReference::with_credential(
+            fake_endpoint,
+            azure_core_test::credentials::from_env(None)?,
+        )
+    } else {
+        AccountReference::with_authentication_key(
+            fake_endpoint,
+            connection_string
+                .as_ref()
+                .ok_or_else(missing_connection_string)?
+                .account_key()
+                .clone(),
+        )
+    };
 
     let client = builder
-        .build(
-            AccountReference::with_authentication_key(
-                fake_endpoint,
-                connection_string.account_key().clone(),
-            ),
-            RoutingStrategy::ProximityTo(HUB_REGION),
-        )
+        .build(account, RoutingStrategy::ProximityTo(HUB_REGION))
         .await;
 
     assert!(

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_change_feed.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_change_feed.rs
@@ -43,8 +43,7 @@ use azure_data_cosmos::models::{
     ThroughputProperties,
 };
 use azure_data_cosmos::options::{
-    ChangeFeedMode, ChangeFeedOptions, ChangeFeedStartFrom, CreateContainerOptions,
-    MaxItemCountHint,
+    ChangeFeedMode, ChangeFeedOptions, ChangeFeedStartFrom, MaxItemCountHint,
 };
 use framework::{test_data, MockItem, TestClient, TestOptions, TestRunContext};
 use futures::StreamExt;
@@ -148,7 +147,7 @@ fn currents(envelopes: Vec<ChangeFeedItem<MockItem>>) -> Vec<MockItem> {
 )]
 pub async fn change_feed_from_beginning_single_partition() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let items = test_data::generate_mock_items(10, 10);
             let mut expected: Vec<MockItem> = items
                 .iter()
@@ -157,7 +156,8 @@ pub async fn change_feed_from_beginning_single_partition() -> Result<(), Box<dyn
                 .collect();
             sort_by_id(&mut expected);
 
-            let container = test_data::create_container_with_items(db_client, items, None).await?;
+            let container =
+                test_data::create_container_with_items(run_context, db_client, items, None).await?;
 
             let mut iterator = container
                 .query_change_feed::<MockItem>(
@@ -197,7 +197,7 @@ pub async fn change_feed_from_beginning_single_partition() -> Result<(), Box<dyn
 )]
 pub async fn change_feed_from_beginning_full_container() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let items = test_data::generate_mock_items(10, 10);
             let mut expected = items.clone();
             sort_by_id(&mut expected);
@@ -205,6 +205,7 @@ pub async fn change_feed_from_beginning_full_container() -> Result<(), Box<dyn E
             // 11000 RU/s forces the service to create at least 2 physical
             // partitions, so the full-container read must fan out.
             let container = test_data::create_container_with_items(
+                run_context,
                 db_client,
                 items,
                 Some(ThroughputProperties::manual(11000)),
@@ -247,11 +248,12 @@ pub async fn change_feed_from_beginning_full_container() -> Result<(), Box<dyn E
 )]
 pub async fn change_feed_start_from_now_returns_only_new_changes() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             // Baseline items exist before the iterator is created.
             let baseline = test_data::generate_mock_items(10, 5);
             let container =
-                test_data::create_container_with_items(db_client, baseline, None).await?;
+                test_data::create_container_with_items(run_context, db_client, baseline, None)
+                    .await?;
 
             let mut iterator = container
                 .query_change_feed::<MockItem>(
@@ -314,10 +316,11 @@ pub async fn change_feed_start_from_now_returns_only_new_changes() -> Result<(),
 )]
 pub async fn change_feed_no_changes_returns_empty_page() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             // Empty container — there are no changes to report.
             let container =
-                test_data::create_container_with_items(db_client, Vec::new(), None).await?;
+                test_data::create_container_with_items(run_context, db_client, Vec::new(), None)
+                    .await?;
 
             let mut iterator = container
                 .query_change_feed::<MockItem>(
@@ -366,7 +369,7 @@ pub async fn change_feed_no_changes_returns_empty_page() -> Result<(), Box<dyn E
 )]
 pub async fn change_feed_continuation_token_resume() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let baseline = test_data::generate_mock_items(10, 5);
             let mut expected_baseline: Vec<MockItem> = baseline
                 .iter()
@@ -376,7 +379,8 @@ pub async fn change_feed_continuation_token_resume() -> Result<(), Box<dyn Error
             sort_by_id(&mut expected_baseline);
 
             let container =
-                test_data::create_container_with_items(db_client, baseline, None).await?;
+                test_data::create_container_with_items(run_context, db_client, baseline, None)
+                    .await?;
 
             // Drain the baseline, then capture a resume token.
             let mut iterator = container
@@ -457,13 +461,14 @@ pub async fn change_feed_continuation_token_resume() -> Result<(), Box<dyn Error
 )]
 pub async fn change_feed_now_resume_does_not_replay_history() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let baseline = test_data::generate_mock_items(10, 10);
 
             // 11000 RU/s forces at least 2 physical partitions so a single poll
             // leaves at least one partition unpolled (and thus without a saved
             // token) at checkpoint time.
             let container = test_data::create_container_with_items(
+                run_context,
                 db_client,
                 baseline,
                 Some(ThroughputProperties::manual(11000)),
@@ -546,11 +551,12 @@ pub async fn change_feed_now_resume_does_not_replay_history() -> Result<(), Box<
 )]
 pub async fn change_feed_point_in_time_excludes_earlier_changes() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             // Baseline items written before the point-in-time marker.
             let baseline = test_data::generate_mock_items(10, 5);
             let container =
-                test_data::create_container_with_items(db_client, baseline, None).await?;
+                test_data::create_container_with_items(run_context, db_client, baseline, None)
+                    .await?;
 
             // Guard band on each side of the captured marker so second-level
             // granularity cannot blur the baseline and the new writes together.
@@ -617,7 +623,7 @@ pub async fn change_feed_max_item_count_pages_backlog() -> Result<(), Box<dyn Er
     const PAGE_LIMIT: u32 = 10;
 
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             // 25 items in a single logical partition; at a page limit of 10 the
             // backlog must span multiple pages.
             let items: Vec<MockItem> = (0..25)
@@ -631,7 +637,7 @@ pub async fn change_feed_max_item_count_pages_backlog() -> Result<(), Box<dyn Er
             sort_by_id(&mut expected);
 
             let container =
-                test_data::create_container_with_items(db_client, items, None).await?;
+                test_data::create_container_with_items(run_context, db_client, items, None).await?;
 
             let mut iterator = container
                 .query_change_feed::<MockItem>(
@@ -739,17 +745,17 @@ async fn create_avad_container(
     name: &str,
     retention: Duration,
     throughput: Option<ThroughputProperties>,
-) -> azure_data_cosmos::Result<ContainerClient> {
+) -> Result<ContainerClient, Box<dyn Error>> {
     let mut properties = ContainerProperties::new(name.to_string(), "/partitionKey".into());
     if framework::targets_emulator() {
         properties = properties.with_change_feed_policy(
             ChangeFeedPolicy::default().with_retention_duration(retention),
         );
     }
-    let options = throughput.map(|t| CreateContainerOptions::default().with_throughput(t));
     run_context
-        .create_container(db_client, properties, options)
+        .create_container(db_client, properties, throughput)
         .await
+        .map_err(Into::into)
 }
 
 /// Polls an AVAD change feed, accumulating every envelope seen, until

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_containers.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_containers.rs
@@ -6,7 +6,6 @@ use super::framework;
 
 use std::error::Error;
 
-use azure_data_cosmos::options::CreateContainerOptions;
 use azure_data_cosmos::{
     models::PartitionKeyKind,
     models::{
@@ -52,11 +51,7 @@ pub async fn container_crud_simple() -> Result<(), Box<dyn Error>> {
             let throughput = ThroughputProperties::manual(400);
 
             let container_client = run_context
-                .create_container(
-                    db_client,
-                    properties.clone(),
-                    Some(CreateContainerOptions::default().with_throughput(throughput)),
-                )
+                .create_container(db_client, properties.clone(), Some(throughput))
                 .await?;
 
             // Read the container to get its properties
@@ -99,17 +94,16 @@ pub async fn container_crud_simple() -> Result<(), Box<dyn Error>> {
             }
             assert_eq!(vec![properties.id.clone()], ids);
 
-            let container_client = db_client
-                .container_client(properties.id.as_ref(), None)
-                .await?;
             let mut updated_indexing_policy = IndexingPolicy::default();
             updated_indexing_policy.automatic = false;
             updated_indexing_policy.indexing_mode = Some(IndexingMode::None);
             let updated_properties =
                 ContainerProperties::new(properties.id.clone(), properties.partition_key.clone())
                     .with_indexing_policy(updated_indexing_policy);
-            let update_response = container_client
-                .replace(updated_properties, None)
+            let update_response = run_context
+                .replace_container(db_client, updated_properties)
+                .await?
+                .read(None)
                 .await?
                 .into_model()?;
             let updated_indexing_policy = update_response.indexing_policy.unwrap();
@@ -122,9 +116,7 @@ pub async fn container_crud_simple() -> Result<(), Box<dyn Error>> {
             );
 
             let current_throughput = run_context
-                .management_container_client(db_client, "TheContainer")
-                .await?
-                .read_throughput(None)
+                .read_container_throughput(db_client, "TheContainer")
                 .await?
                 .expect("throughput should be present");
 
@@ -132,15 +124,13 @@ pub async fn container_crud_simple() -> Result<(), Box<dyn Error>> {
 
             let new_throughput = ThroughputProperties::manual(500);
             let throughput_response = run_context
-                .management_container_client(db_client, "TheContainer")
-                .await?
-                .begin_replace_throughput(new_throughput, None)
-                .await?
-                .await?
-                .into_model()?;
+                .replace_container_throughput(db_client, "TheContainer", new_throughput)
+                .await?;
             assert_eq!(Some(500), throughput_response.throughput());
 
-            container_client.delete(None).await?;
+            run_context
+                .delete_container(db_client, "TheContainer")
+                .await?;
 
             query_pager = db_client
                 .query_containers(
@@ -325,8 +315,10 @@ pub async fn container_vector_and_full_text_policies_round_trip() -> Result<(), 
 
             // Read-modify-replace: send the properties we just read straight back.
             // Anything the model dropped on read would be permanently lost here.
-            let replaced = container_client
-                .replace(created.clone(), None)
+            let replaced = run_context
+                .replace_container(db_client, created.clone())
+                .await?
+                .read(None)
                 .await?
                 .into_model()?;
 
@@ -337,7 +329,9 @@ pub async fn container_vector_and_full_text_policies_round_trip() -> Result<(), 
             let reread = container_client.read(None).await?.into_model()?;
             assert_vector_and_full_text_policies(&reread, "after re-read");
 
-            container_client.delete(None).await?;
+            run_context
+                .delete_container(db_client, properties.id.as_ref())
+                .await?;
 
             Ok(())
         },

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_databases.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_databases.rs
@@ -22,24 +22,16 @@ use futures::TryStreamExt;
 pub async fn database_crud() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_options(
         async |run_context| {
-            // This test exercises database management (create/read/query/
-            // throughput/delete), which is control-plane and not expressible as
-            // a Cosmos data-plane RBAC action. Use the management client so the
-            // test also works on the AAD live leg (where the primary client is
-            // AAD-authenticated). In key mode this is the same client.
-            let cosmos_client = run_context.management_client();
+            let cosmos_client = run_context.client();
 
             let test_db_id = run_context.db_name();
 
-            // Create a database
-            let properties = cosmos_client
-                .create_database(&test_db_id, None)
-                .await?
-                .into_model()?;
+            run_context.create_database(&test_db_id).await?;
+            let db_client = cosmos_client.database_client(&test_db_id);
+            let properties = db_client.read(None).await?.into_model()?;
 
             assert_eq!(Some(test_db_id.as_str()), properties.id.as_deref());
 
-            let db_client = cosmos_client.database_client(&test_db_id);
             let read_properties = db_client.read(None).await?.into_model()?;
 
             assert_eq!(Some(test_db_id.as_str()), read_properties.id.as_deref());
@@ -53,11 +45,11 @@ pub async fn database_crud() -> Result<(), Box<dyn Error>> {
             }
             assert_eq!(vec![Some(test_db_id.clone())], ids);
 
-            let current_throughput = db_client.read_throughput(None).await?;
+            let current_throughput = run_context.read_database_throughput(&db_client).await?;
             assert!(current_throughput.is_none());
 
             // We're testing delete, so we want to manually delete the DB rather than letting the clean-up process do it.
-            db_client.delete(None).await?;
+            run_context.delete_database(&test_db_id).await?;
 
             let mut pager = cosmos_client.query_databases(query, None).await?;
             let mut ids = Vec::new();

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_feed_ranges.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_feed_ranges.rs
@@ -13,7 +13,6 @@ use azure_data_cosmos::models::{
     ContainerProperties, CosmosStatus, EffectivePartitionKey, PartitionKeyDefinition,
     PartitionKeyValue, ThroughputProperties,
 };
-use azure_data_cosmos::options::CreateContainerOptions;
 use azure_data_cosmos::{PartitionKey, Query};
 use base64::Engine;
 use futures::StreamExt;
@@ -41,10 +40,9 @@ pub async fn read_feed_ranges_returns_physical_partitions() -> Result<(), Box<dy
 
             // Use 11000 RU/s to ensure at least 2 physical partitions (10000 RU/s per partition).
             let throughput = ThroughputProperties::manual(11000);
-            let options = CreateContainerOptions::default().with_throughput(throughput);
 
             let container_client = run_context
-                .create_container(db_client, properties, Some(options))
+                .create_container(db_client, properties, Some(throughput))
                 .await?;
 
             let ranges = container_client.read_feed_ranges(None).await?;
@@ -112,10 +110,9 @@ pub async fn feed_range_from_partition_key_maps_correctly() -> Result<(), Box<dy
 
             // Use 11000 RU/s to ensure at least 2 physical partitions.
             let throughput = ThroughputProperties::manual(11000);
-            let options = CreateContainerOptions::default().with_throughput(throughput);
 
             let container_client = run_context
-                .create_container(db_client, properties, Some(options))
+                .create_container(db_client, properties, Some(throughput))
                 .await?;
 
             // Get the physical partition ranges.

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_items.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_items.rs
@@ -156,51 +156,84 @@ async fn create_v1_container(
 ) -> Result<ContainerClient, Box<dyn Error>> {
     let db_client = run_context.create_db().await?;
     let container_id = format!("Container-V1-{}", Uuid::new_v4());
-    let connection_string = framework::resolve_connection_string()
-        .ok_or("Cosmos connection string is not configured")?;
-    let account = DriverAccountReference::with_master_key(
-        connection_string.account_endpoint().parse::<url::Url>()?,
-        connection_string.account_key().clone(),
-    );
-    let runtime = CosmosDriverRuntime::builder()
-        .with_connection_pool(
-            ConnectionPoolOptions::builder()
-                .with_server_certificate_validation(
-                    ServerCertificateValidation::RequiredUnlessEmulator,
-                )
-                .build()?,
-        )
-        .build()
-        .await?;
-    let driver = runtime
-        .create_driver(DriverOptions::builder(account.clone()).build())
-        .await?;
-    let database = DatabaseReference::from_name(
-        account,
-        db_client
+    if let Some(arm_client) = run_context.arm_client() {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct V1Container<'a> {
+            id: &'a str,
+            partition_key: V1PartitionKey<'a>,
+        }
+
+        #[derive(Serialize)]
+        struct V1PartitionKey<'a> {
+            paths: [&'a str; 1],
+            kind: &'a str,
+        }
+
+        let database_name = db_client
             .name()
-            .expect("emulator database is name-addressed")
-            .to_string(),
-    );
-    let body = format!(
-        r#"{{"id":"{container_id}","partitionKey":{{"paths":["/partition_key"],"kind":"Hash"}}}}"#
-    );
-    let response = driver
-        .execute_singleton_operation(
-            CosmosOperation::create_container(database).with_body(body.into_bytes()),
-            DriverOperationOptions::default(),
-        )
-        .await?;
-    if !response.status().is_success() {
-        return Err(format!(
-            "failed to create version-less V1 container: {}",
-            response.status()
-        )
-        .into());
+            .ok_or("ARM-backed resource management requires a name-addressed database")?;
+        let resource = V1Container {
+            id: &container_id,
+            partition_key: V1PartitionKey {
+                paths: ["/partition_key"],
+                kind: "Hash",
+            },
+        };
+        arm_client
+            .create_or_update_container(database_name, &container_id, &resource, None)
+            .await?;
+    } else {
+        let connection_string = framework::resolve_connection_string()
+            .ok_or("Cosmos connection string is not configured")?;
+        let account = DriverAccountReference::with_master_key(
+            connection_string.account_endpoint().parse::<url::Url>()?,
+            connection_string.account_key().clone(),
+        );
+        let runtime = CosmosDriverRuntime::builder()
+            .with_connection_pool(
+                ConnectionPoolOptions::builder()
+                    .with_server_certificate_validation(
+                        ServerCertificateValidation::RequiredUnlessEmulator,
+                    )
+                    .build()?,
+            )
+            .build()
+            .await?;
+        let driver = runtime
+            .create_driver(DriverOptions::builder(account.clone()).build())
+            .await?;
+        let database = DatabaseReference::from_name(
+            account,
+            db_client
+                .name()
+                .expect("emulator database is name-addressed")
+                .to_string(),
+        );
+        let body = format!(
+            r#"{{"id":"{container_id}","partitionKey":{{"paths":["/partition_key"],"kind":"Hash"}}}}"#
+        );
+        let response = driver
+            .execute_singleton_operation(
+                CosmosOperation::create_container(database).with_body(body.into_bytes()),
+                DriverOperationOptions::default(),
+            )
+            .await?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "failed to create version-less V1 container: {}",
+                response.status()
+            )
+            .into());
+        }
     }
     let container_client = db_client.container_client(&container_id, None).await?;
 
     let body = container_client.read(None).await?.into_body().single()?;
+    if run_context.arm_client().is_some() {
+        framework::probe_data_plane_ready("version-less V1 container", &container_client, 1)
+            .await?;
+    }
     let raw: serde_json::Value = serde_json::from_slice(&body)?;
     assert!(
         raw["partitionKey"].get("version").is_none(),

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_offers.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_offers.rs
@@ -7,7 +7,6 @@ use super::framework;
 use std::error::Error;
 
 use azure_data_cosmos::models::{ContainerProperties, ThroughputProperties};
-use azure_data_cosmos::options::CreateContainerOptions;
 use framework::{TestClient, TestOptions};
 
 #[tokio::test]
@@ -31,24 +30,11 @@ pub async fn container_throughput_crud_manual() -> Result<(), Box<dyn Error>> {
             let throughput = ThroughputProperties::manual(400);
 
             let _container_client = run_context
-                .create_container(
-                    db_client,
-                    properties.clone(),
-                    Some(CreateContainerOptions::default().with_throughput(throughput)),
-                )
+                .create_container(db_client, properties.clone(), Some(throughput))
                 .await?;
 
-            // Throughput/offer operations are control-plane and are not covered
-            // by the data-plane RBAC role used on the AAD live leg, so route them
-            // through the management (key) client. In key mode this is the same
-            // credential as `container_client`.
-            let offer_client = run_context
-                .management_container_client(db_client, "TheContainer")
-                .await?;
-
-            // Read throughput
-            let current_throughput = offer_client
-                .read_throughput(None)
+            let current_throughput = run_context
+                .read_container_throughput(db_client, "TheContainer")
                 .await?
                 .expect("throughput should be present");
 
@@ -56,11 +42,9 @@ pub async fn container_throughput_crud_manual() -> Result<(), Box<dyn Error>> {
 
             // Replace throughput
             let new_throughput = ThroughputProperties::manual(500);
-            let throughput_response = offer_client
-                .begin_replace_throughput(new_throughput, None)
-                .await?
-                .await?
-                .into_model()?;
+            let throughput_response = run_context
+                .replace_container_throughput(db_client, "TheContainer", new_throughput)
+                .await?;
             assert_eq!(Some(500), throughput_response.throughput());
 
             Ok(())
@@ -95,23 +79,11 @@ pub async fn container_throughput_crud_autoscale() -> Result<(), Box<dyn Error>>
             let throughput = ThroughputProperties::autoscale(5000, Some(42));
 
             let _container_client = run_context
-                .create_container(
-                    db_client,
-                    properties.clone(),
-                    Some(CreateContainerOptions::default().with_throughput(throughput)),
-                )
+                .create_container(db_client, properties.clone(), Some(throughput))
                 .await?;
 
-            // Throughput/offer operations are control-plane and are not covered
-            // by the data-plane RBAC role used on the AAD live leg, so route them
-            // through the management (key) client.
-            let offer_client = run_context
-                .management_container_client(db_client, "TheContainer")
-                .await?;
-
-            // Read throughput
-            let current_throughput = offer_client
-                .read_throughput(None)
+            let current_throughput = run_context
+                .read_container_throughput(db_client, "TheContainer")
                 .await?
                 .expect("throughput should be present");
             assert_eq!(Some(500), current_throughput.throughput());

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_query.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_query.rs
@@ -14,7 +14,7 @@ use azure_data_cosmos::{
     options::{MaxItemCountHint, QueryOptions},
     Query,
 };
-use framework::{test_data, MockItem, TestClient, TestOptions};
+use framework::{test_data, MockItem, TestClient, TestOptions, TestRunContext};
 use futures::StreamExt;
 use serde::de::DeserializeOwned;
 
@@ -80,6 +80,7 @@ fn unordered_query_results_preserve_multiplicity() {
 }
 
 async fn execute_query_test<T>(
+    run_context: &TestRunContext,
     db_client: &DatabaseClient,
     items: Vec<MockItem>,
     query: impl Into<Query>,
@@ -90,7 +91,8 @@ async fn execute_query_test<T>(
 where
     T: DeserializeOwned + Send + Eq + std::fmt::Debug + 'static,
 {
-    let container_client = test_data::create_container_with_items(db_client, items, None).await?;
+    let container_client =
+        test_data::create_container_with_items(run_context, db_client, items, None).await?;
     let query: Query = query.into();
 
     let build_options = || -> QueryOptions {
@@ -194,12 +196,13 @@ async fn collect_ids_for_scope(
 )]
 pub async fn single_partition_query_simple() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let items = test_data::generate_mock_items(10, 10);
             let expected_items =
                 collect_matching_items(&items, |p| p.partition_key == "partition0");
 
             execute_query_test(
+                run_context,
                 db_client,
                 items,
                 "select * from docs c",
@@ -227,7 +230,7 @@ pub async fn single_partition_query_simple() -> Result<(), Box<dyn Error>> {
 )]
 pub async fn single_partition_query_with_parameters() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let items = test_data::generate_mock_items(10, 10);
 
             // Find a merge order value in partition1's items
@@ -243,6 +246,7 @@ pub async fn single_partition_query_with_parameters() -> Result<(), Box<dyn Erro
             let expected_items = collect_matching_items(&items, |p| p.merge_order == merge_order);
 
             execute_query_test(
+                run_context,
                 db_client,
                 items,
                 query,
@@ -270,7 +274,7 @@ pub async fn single_partition_query_with_parameters() -> Result<(), Box<dyn Erro
 )]
 pub async fn single_partition_query_with_projection() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let items = test_data::generate_mock_items(10, 10);
             let expected_items = items
                 .iter()
@@ -282,6 +286,7 @@ pub async fn single_partition_query_with_projection() -> Result<(), Box<dyn Erro
                 .collect::<Vec<_>>();
 
             execute_query_test(
+                run_context,
                 db_client,
                 items,
                 "select c.id, c.mergeOrder from c",
@@ -309,7 +314,7 @@ pub async fn single_partition_query_with_projection() -> Result<(), Box<dyn Erro
 )]
 pub async fn cross_partition_query_with_projection_and_filter() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let items = test_data::generate_mock_items(10, 2);
             let expected_items = items
                 .iter()
@@ -318,6 +323,7 @@ pub async fn cross_partition_query_with_projection_and_filter() -> Result<(), Bo
                 .collect::<Vec<_>>();
 
             execute_query_test(
+                run_context,
                 db_client,
                 items,
                 "select value c.id from c where c.mergeOrder between 40 and 60",
@@ -349,13 +355,14 @@ pub async fn cross_partition_query_with_projection_and_filter() -> Result<(), Bo
 )]
 pub async fn cross_partition_query_with_order_by() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let items = test_data::generate_mock_items(10, 10);
             let mut expected = items.clone();
             expected.sort_by_key(|item| item.merge_order);
             let expected_ids = expected.into_iter().map(|item| item.id).collect();
 
             execute_query_test(
+                run_context,
                 db_client,
                 items,
                 "select value c.id from c order by c.mergeOrder",
@@ -397,10 +404,10 @@ pub async fn cross_partition_query_with_order_by() -> Result<(), Box<dyn Error>>
 )]
 pub async fn cross_partition_query_with_unordered_distinct() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let items = test_data::generate_mock_items(10, 10);
             let container_client =
-                test_data::create_container_with_items(db_client, items, None).await?;
+                test_data::create_container_with_items(run_context, db_client, items, None).await?;
 
             let mut pages = container_client
                 .query_items::<String>(
@@ -463,12 +470,13 @@ pub async fn cross_partition_query_with_unordered_distinct() -> Result<(), Box<d
 )]
 pub async fn cross_partition_query_with_ordered_distinct_resumes() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let items = test_data::generate_mock_items(10, 10);
             let mut expected: Vec<String> = (0..10).map(|i| format!("partition{i}")).collect();
             expected.sort();
 
             execute_query_test(
+                run_context,
                 db_client,
                 items,
                 "select distinct value c.partitionKey from c order by c.partitionKey",
@@ -508,10 +516,10 @@ pub async fn cross_partition_query_with_ordered_distinct_resumes() -> Result<(),
 )]
 pub async fn unordered_distinct_refuses_a_continuation_token() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let items = test_data::generate_mock_items(10, 10);
             let container_client =
-                test_data::create_container_with_items(db_client, items, None).await?;
+                test_data::create_container_with_items(run_context, db_client, items, None).await?;
 
             let mut pages = container_client
                 .query_items::<String>(
@@ -563,10 +571,16 @@ pub async fn unordered_distinct_refuses_a_continuation_token() -> Result<(), Box
 )]
 pub async fn query_returns_index_and_query_metrics() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let items = test_data::generate_mock_items(5, 1);
             let container_client =
-                test_data::create_container_with_items(db_client, items.clone(), None).await?;
+                test_data::create_container_with_items(
+                    run_context,
+                    db_client,
+                    items.clone(),
+                    None,
+                )
+                .await?;
 
             // Enable both index metrics and query metrics via typed options.
             let options = QueryOptions::default()
@@ -658,7 +672,7 @@ pub async fn query_returns_index_and_query_metrics() -> Result<(), Box<dyn Error
 )]
 pub async fn single_partition_query_pagination() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let items = test_data::generate_mock_items(1, 5);
             let expected_items =
                 collect_matching_items(&items, |p| p.partition_key == "partition0");
@@ -668,6 +682,7 @@ pub async fn single_partition_query_pagination() -> Result<(), Box<dyn Error>> {
             );
 
             execute_query_test(
+                run_context,
                 db_client,
                 items,
                 "select * from c",
@@ -699,9 +714,10 @@ pub async fn single_partition_query_pagination() -> Result<(), Box<dyn Error>> {
 )]
 pub async fn cross_partition_query_pagination() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let items = test_data::generate_mock_items(3, 3);
             execute_query_test(
+                run_context,
                 db_client,
                 items.clone(),
                 "select * from c",
@@ -733,15 +749,19 @@ pub async fn cross_partition_query_pagination() -> Result<(), Box<dyn Error>> {
 )]
 pub async fn feed_range_scoped_query_honors_range() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             // 10 logical partitions × 2 items. Provision 11000 RU/s so the
             // container splits into 2 physical partitions — a scoped query then
             // has a neighbouring range it must NOT touch.
             let items = test_data::generate_mock_items(10, 2);
             let throughput = ThroughputProperties::manual(11000);
-            let container_client =
-                test_data::create_container_with_items(db_client, items.clone(), Some(throughput))
-                    .await?;
+            let container_client = test_data::create_container_with_items(
+                run_context,
+                db_client,
+                items.clone(),
+                Some(throughput),
+            )
+            .await?;
 
             let ranges = container_client.read_feed_ranges(None).await?;
             assert_eq!(
@@ -807,13 +827,14 @@ pub async fn feed_range_scoped_query_honors_range() -> Result<(), Box<dyn Error>
 )]
 pub async fn cross_partition_query_suspend_resume() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             // Four logical partitions × three items per partition. With a
             // page size of one, this exercises both intra-partition and
             // cross-partition resume points.
             let items = test_data::generate_mock_items(4, 3);
 
             execute_query_test(
+                run_context,
                 db_client,
                 items.clone(),
                 "select * from c",
@@ -841,10 +862,10 @@ pub async fn cross_partition_query_suspend_resume() -> Result<(), Box<dyn Error>
 )]
 pub async fn query_rejects_newer_sdk_continuation_token() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let items = test_data::generate_mock_items(1, 1);
             let container_client =
-                test_data::create_container_with_items(db_client, items, None).await?;
+                test_data::create_container_with_items(run_context, db_client, items, None).await?;
 
             // A `c2.` prefix indicates the token was issued by a future
             // SDK version this client does not understand.
@@ -881,10 +902,10 @@ pub async fn query_rejects_newer_sdk_continuation_token() -> Result<(), Box<dyn 
 )]
 pub async fn query_rejects_server_token_for_cross_partition() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let items = test_data::generate_mock_items(2, 1);
             let container_client =
-                test_data::create_container_with_items(db_client, items, None).await?;
+                test_data::create_container_with_items(run_context, db_client, items, None).await?;
 
             // An un-prefixed token is treated as an opaque server
             // continuation, which is only valid for trivial (single-
@@ -925,7 +946,7 @@ pub async fn single_partition_query_resumes_with_raw_server_token() -> Result<()
     use base64::Engine as _;
 
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             // One logical partition × five items so we get multiple pages
             // with `max_item_count(1)`.
             let items = test_data::generate_mock_items(1, 5);
@@ -937,7 +958,7 @@ pub async fn single_partition_query_resumes_with_raw_server_token() -> Result<()
             );
 
             let container_client =
-                test_data::create_container_with_items(db_client, items, None).await?;
+                test_data::create_container_with_items(run_context, db_client, items, None).await?;
             let scope = FeedScope::partition("partition0");
 
             // --- Round 1: fetch the first page through the SDK and pull
@@ -1104,11 +1125,12 @@ pub async fn single_partition_query_resumes_with_raw_server_token() -> Result<()
 )]
 pub async fn distinct_projection_shapes() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             // 4 partitions x 3 items: `partitionKey` repeats within a
             // partition, `id` is unique across the container.
             let items = test_data::generate_mock_items(4, 3);
-            let container = test_data::create_container_with_items(db_client, items, None).await?;
+            let container =
+                test_data::create_container_with_items(run_context, db_client, items, None).await?;
 
             async fn count(
                 container: &ContainerClient,
@@ -1213,9 +1235,10 @@ pub async fn distinct_projection_shapes() -> Result<(), Box<dyn Error>> {
 )]
 pub async fn distinct_combined_with_unsupported_stages_is_rejected() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
+        async |run_context, db_client| {
             let items = test_data::generate_mock_items(4, 3);
-            let container = test_data::create_container_with_items(db_client, items, None).await?;
+            let container =
+                test_data::create_container_with_items(run_context, db_client, items, None).await?;
 
             // Each of these needs a composition stage the driver does not have
             // yet: GROUP BY and aggregates. `TOP` and `OFFSET`/`LIMIT` are no

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_query_features.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_query_features.rs
@@ -17,14 +17,13 @@ use super::framework;
 use std::collections::HashMap;
 use std::error::Error;
 
-use azure_core::http::StatusCode;
 use azure_data_cosmos::{
     clients::{ContainerClient, DatabaseClient},
     feed::FeedScope,
     models::ContainerProperties,
     Query,
 };
-use framework::{TestClient, TestOptions};
+use framework::{TestClient, TestOptions, TestRunContext};
 use futures::StreamExt;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -75,22 +74,13 @@ fn sales_records() -> Vec<SalesRecord> {
 }
 
 /// Creates a single-partition container and seeds it with [`sales_records`].
-async fn seed_container(db: &DatabaseClient) -> azure_data_cosmos::Result<ContainerClient> {
+async fn seed_container(
+    run_context: &TestRunContext,
+    db: &DatabaseClient,
+) -> azure_data_cosmos::Result<ContainerClient> {
     let properties = ContainerProperties::new("QueryFeaturesContainer", "/partitionKey".into());
 
-    // Retry on 429 (throttling) and tolerate a pre-existing container.
-    loop {
-        match db.create_container(properties.clone(), None).await {
-            Ok(_) => break,
-            Err(e) if e.status().status_code() == StatusCode::TooManyRequests => {
-                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-            }
-            Err(e) if e.status().status_code() == StatusCode::Conflict => break,
-            Err(e) => return Err(e),
-        }
-    }
-
-    let container = db.container_client("QueryFeaturesContainer", None).await?;
+    let container = run_context.create_container(db, properties, None).await?;
     for record in sales_records() {
         container
             .create_item(record.partition_key.clone(), &record.id, &record, None)
@@ -143,8 +133,8 @@ where
 )]
 pub async fn single_partition_count_aggregate() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
-            let container = seed_container(db_client).await?;
+        async |run_context, db_client| {
+            let container = seed_container(run_context, db_client).await?;
             let count: i64 = run_scalar(&container, "SELECT VALUE COUNT(1) FROM c").await?;
             assert_eq!(count, 6, "expected COUNT(1) to match seeded record count");
             Ok(())
@@ -161,8 +151,8 @@ pub async fn single_partition_count_aggregate() -> Result<(), Box<dyn Error>> {
 )]
 pub async fn single_partition_sum_min_max_aggregates() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
-            let container = seed_container(db_client).await?;
+        async |run_context, db_client| {
+            let container = seed_container(run_context, db_client).await?;
 
             let sum: i64 = run_scalar(&container, "SELECT VALUE SUM(c.amount) FROM c").await?;
             assert_eq!(sum, 180, "unexpected SUM(c.amount)");
@@ -187,8 +177,8 @@ pub async fn single_partition_sum_min_max_aggregates() -> Result<(), Box<dyn Err
 )]
 pub async fn single_partition_avg_aggregate() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
-            let container = seed_container(db_client).await?;
+        async |run_context, db_client| {
+            let container = seed_container(run_context, db_client).await?;
             let avg: f64 = run_scalar(&container, "SELECT VALUE AVG(c.amount) FROM c").await?;
             assert!(
                 (avg - 30.0).abs() < f64::EPSILON,
@@ -208,8 +198,8 @@ pub async fn single_partition_avg_aggregate() -> Result<(), Box<dyn Error>> {
 )]
 pub async fn single_partition_distinct() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
-            let container = seed_container(db_client).await?;
+        async |run_context, db_client| {
+            let container = seed_container(run_context, db_client).await?;
             let mut categories: Vec<String> =
                 run_query(&container, "SELECT DISTINCT VALUE c.category FROM c").await?;
             categories.sort();
@@ -232,8 +222,8 @@ pub async fn single_partition_distinct() -> Result<(), Box<dyn Error>> {
 )]
 pub async fn single_partition_top_with_order_by() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
-            let container = seed_container(db_client).await?;
+        async |run_context, db_client| {
+            let container = seed_container(run_context, db_client).await?;
             let amounts: Vec<i64> = run_query(
                 &container,
                 "SELECT VALUE c.amount FROM c ORDER BY c.amount DESC OFFSET 0 LIMIT 2",
@@ -267,8 +257,8 @@ pub async fn single_partition_top_with_order_by() -> Result<(), Box<dyn Error>> 
 )]
 pub async fn single_partition_offset_limit() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
-            let container = seed_container(db_client).await?;
+        async |run_context, db_client| {
+            let container = seed_container(run_context, db_client).await?;
             // Sorted amounts: [5, 10, 15, 20, 30, 100]; skip 1, take 2 => [10, 15].
             let amounts: Vec<i64> = run_query(
                 &container,
@@ -298,8 +288,8 @@ struct CategoryRollup {
 )]
 pub async fn single_partition_group_by() -> Result<(), Box<dyn Error>> {
     TestClient::run_with_unique_db(
-        async |_, db_client| {
-            let container = seed_container(db_client).await?;
+        async |run_context, db_client| {
+            let container = seed_container(run_context, db_client).await?;
             let groups: Vec<CategoryRollup> = run_query(
                 &container,
                 "SELECT c.category AS category, COUNT(1) AS count, SUM(c.amount) AS total \

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_rid_addressing.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_rid_addressing.rs
@@ -11,7 +11,6 @@ use azure_data_cosmos::{
     clients::ContainerClient,
     feed::FeedScope,
     models::{ContainerProperties, ThroughputProperties},
-    options::CreateContainerOptions,
     CosmosStatus, Query, ResourceId,
 };
 use futures::TryStreamExt;
@@ -67,10 +66,7 @@ pub async fn database_and_container_addressed_by_rid() -> Result<(), Box<dyn Err
                 .create_container(
                     db_client,
                     ContainerProperties::new(container_name.clone(), "/pk".into()),
-                    Some(
-                        CreateContainerOptions::default()
-                            .with_throughput(ThroughputProperties::manual(400)),
-                    ),
+                    Some(ThroughputProperties::manual(400)),
                 )
                 .await?;
 
@@ -114,20 +110,14 @@ pub async fn database_and_container_addressed_by_rid() -> Result<(), Box<dyn Err
             let read_back = rid_container.read(None).await?.into_model()?;
             assert_eq!(container_name, read_back.id);
 
-            // Throughput is reachable by RID. Reading an offer is a
-            // control-plane operation that the data-plane RBAC role used in
-            // AAD mode cannot perform, so route it through the management (key)
-            // client — still addressed purely by RID. In key mode the
-            // management client is the same as the primary client.
-            let mgmt_rid_container = run_context
-                .management_client()
-                .database_client(ResourceId::from(db_rid.clone()))
-                .container_client(ResourceId::from(container_rid.clone()), None)
-                .await?;
-            let throughput = mgmt_rid_container
-                .read_throughput(None)
-                .await?
-                .expect("throughput should be present");
+            let throughput = if run_context.arm_client().is_some() {
+                run_context
+                    .read_container_throughput(db_client, &container_name)
+                    .await?
+            } else {
+                rid_container.read_throughput(None).await?
+            }
+            .expect("throughput should be present");
             assert_eq!(Some(400), throughput.throughput());
 
             // Create an item through the RID-addressed container. Create POSTs
@@ -279,18 +269,9 @@ pub async fn container_rid_from_another_database_is_rejected() -> Result<(), Box
                 .resource_id
                 .expect("db1 read should return a _rid");
 
-            // db2 + a container in db2, created out of band. Database
-            // create/delete is management-plane and is not granted by the
-            // data-plane RBAC role used in AAD mode, so both go through the
-            // management (key) client.
             let db2_name = format!("rid-otherdb-{}", Uuid::new_v4());
-            let _ = run_context
-                .management_client()
-                .create_database(&db2_name, None)
-                .await?;
-            let db2_client = run_context
-                .management_client()
-                .database_client(db2_name.as_str());
+            run_context.create_database(&db2_name).await?;
+            let db2_client = run_context.client().database_client(db2_name.as_str());
             let container2_name = format!("rid-otherc-{}", Uuid::new_v4());
             let container2 = run_context
                 .create_container(
@@ -316,7 +297,7 @@ pub async fn container_rid_from_another_database_is_rejected() -> Result<(), Box
                 .await;
 
             // Clean up db2 regardless of the assertion outcome below.
-            db2_client.delete(None).await?;
+            run_context.delete_database(&db2_name).await?;
 
             let Err(err) = result else {
                 panic!("expected a container RID from another database to be rejected");

--- a/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_vector_query.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/emulator_tests/cosmos_vector_query.rs
@@ -20,7 +20,7 @@ use azure_data_cosmos::{
         VectorDataType, VectorDistanceFunction, VectorEmbedding, VectorEmbeddingPolicy,
         VectorIndex, VectorIndexType,
     },
-    options::{CreateContainerOptions, MaxItemCountHint, QueryOptions},
+    options::{MaxItemCountHint, QueryOptions},
     Query,
 };
 use framework::{TestClient, TestOptions};
@@ -274,9 +274,7 @@ async fn seed_vector_container(
         ))
         .with_indexing_policy(indexing_policy);
 
-    let options = throughput.map(|throughput| {
-        CreateContainerOptions::default().with_throughput(ThroughputProperties::manual(throughput))
-    });
+    let options = throughput.map(ThroughputProperties::manual);
     let container = run_context
         .create_container(db_client, properties, options)
         .await?;
@@ -320,10 +318,9 @@ async fn seed_precomputed_vector_container(
         ContainerProperties::new("PrecomputedVectorQueryContainer", "/partitionKey".into())
             .with_vector_embedding_policy(embedding_policy)
             .with_indexing_policy(indexing_policy);
-    let options = CreateContainerOptions::default()
-        .with_throughput(ThroughputProperties::manual(CROSS_PARTITION_THROUGHPUT));
+    let throughput = ThroughputProperties::manual(CROSS_PARTITION_THROUGHPUT);
     let container = run_context
-        .create_container(db_client, properties, Some(options))
+        .create_container(db_client, properties, Some(throughput))
         .await?;
 
     for (index, document) in fixture.documents.iter().enumerate() {

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
@@ -14,18 +14,21 @@
 //!
 //! The framework allows tests to easily run against real Cosmos DB instances, the local emulator, or a mock server using test-proxy.
 
+pub use azure_data_cosmos_test_support::arm_client;
 pub mod emulator_credential;
 pub mod mock_account;
 pub mod test_client;
 pub mod test_data;
 
+pub use arm_client::{ArmThroughput, CosmosArmClient};
 pub use emulator_credential::{CosmosEmulatorCredential, CredentialRecorder};
 pub use test_client::{
     assert_local_retry_attempted_on_region, assert_region_contacted_with_retry,
-    assert_region_not_contacted, get_effective_hub_endpoint, get_global_endpoint,
-    probe_data_plane_ready, resolve_connection_string, targets_emulator, TestClient, TestOptions,
-    TestRunContext, AUTH_MODE_ENV_VAR, CONNECTION_STRING_ENV_VAR, DEFAULT_TEST_TIMEOUT,
-    EMULATOR_CONNECTION_STRING, HUB_REGION, SATELLITE_REGION,
+    assert_region_not_contacted, build_aad_client_from_env, get_effective_hub_endpoint,
+    get_global_endpoint, probe_data_plane_ready, resolve_connection_string, targets_emulator,
+    TestClient, TestOptions, TestRunContext, ACCOUNT_HOST_ENV_VAR, AUTH_MODE_ENV_VAR,
+    CONNECTION_STRING_ENV_VAR, DEFAULT_TEST_TIMEOUT, EMULATOR_CONNECTION_STRING, HUB_REGION,
+    SATELLITE_REGION,
 };
 
 use serde::{Deserialize, Serialize};

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/test_client.rs
@@ -3,12 +3,13 @@
 
 // cspell:ignore: TEAMPROJECTID
 
+use super::{ArmThroughput, CosmosArmClient};
 use azure_core::{http::StatusCode, Uuid};
 use azure_data_cosmos::{
     clients::{ContainerClient, DatabaseClient},
     fault_injection::FaultInjectionRule,
     feed::FeedScope,
-    models::{ItemResponse, ThroughputProperties},
+    models::{ItemResponse, PartitionKeyValue, ThroughputProperties},
     options::{
         BinaryEncodingOptions, ConnectionPoolOptions, CreateContainerOptions, ItemReadOptions,
         ItemWriteOptions, Region, ServerCertificateValidation,
@@ -18,6 +19,7 @@ use azure_data_cosmos::{
 };
 use azure_data_cosmos_driver::models::ConnectionString;
 use futures::TryStreamExt;
+use std::error::Error;
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
@@ -55,6 +57,9 @@ pub const HUB_REGION: Region = Region::EAST_US_2;
 pub const SATELLITE_REGION: Region = Region::WEST_US_3;
 pub const DATABASE_NAME_ENV_VAR: &str = "DATABASE_NAME";
 pub const EMULATOR_HOST: &str = "127.0.0.1";
+type BoxError = Box<dyn Error>;
+type ContainerFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<ContainerClient, BoxError>> + Send + 'a>>;
 /// Asserts that the operation contacted `expected_region` at least once and
 /// that more than one request was tracked (i.e. some form of retry or
 /// failover happened). Does **not** require the *final* request to land on
@@ -271,25 +276,24 @@ fn container_readiness_timeout_error(region: &str, attempts: usize) -> CosmosErr
 /// (the delete answers a bare 404), reuses the same `items/*` grant tests need,
 /// and returns as soon as the data path answers with a normal not-found. It
 /// tolerates `5302` and `collection_create_in_progress` as retryable while the
-/// name registers on this client. Read-path races that leak past this probe
-/// are absorbed by `TestClient::read_item`'s 5302 retry loop; probing reads
-/// here as well would spuriously trip fault-injection assertions that count
-/// retries on the fault client.
+/// name registers on this client.
 pub async fn probe_data_plane_ready(
     label: &str,
     container: &ContainerClient,
+    partition_key_component_count: usize,
 ) -> azure_data_cosmos::Result<()> {
     const MAX_ATTEMPTS: usize = 20;
     const RETRY_DELAY: Duration = Duration::from_millis(500);
 
     let probe_id = format!("data-plane-readiness-probe-{}", Uuid::new_v4());
+    let partition_key = PartitionKey::from(
+        (0..partition_key_component_count)
+            .map(|_| PartitionKeyValue::from(probe_id.clone()))
+            .collect::<Vec<_>>(),
+    );
     for attempt in 1..=MAX_ATTEMPTS {
         let outcome = container
-            .delete_item(
-                PartitionKey::from(probe_id.clone()),
-                probe_id.as_str(),
-                None,
-            )
+            .delete_item(partition_key.clone(), probe_id.as_str(), None)
             .await;
 
         let error = match outcome {
@@ -309,8 +313,9 @@ pub async fn probe_data_plane_ready(
             return Ok(());
         }
 
-        let retryable =
-            rbac_name_based_data_not_ready(&error) || collection_create_in_progress(&error);
+        let retryable = rbac_name_based_data_not_ready(&error)
+            || collection_create_in_progress(&error)
+            || owner_resource_not_found(&error);
         if !retryable || attempt == MAX_ATTEMPTS {
             return Err(error);
         }
@@ -467,9 +472,8 @@ pub enum AuthMode {
     /// Authenticate every operation with the account key (default).
     #[default]
     Key,
-    /// Authenticate data-plane operations with an Entra ID (AAD) token. Database
-    /// management (create/delete) still uses the account key, because it is not
-    /// expressible as a Cosmos data-plane RBAC action.
+    /// Authenticate data-plane operations with an Entra ID (AAD) token and use
+    /// Azure Resource Manager for database, container, and throughput lifecycle.
     Aad,
 }
 
@@ -500,6 +504,9 @@ const DEFAULT_EMULATOR_DATABASE_NAME: &str = "emulator-test-db";
 /// Resolves the connection string from the environment, handling the `"emulator"` shorthand.
 pub fn resolve_connection_string() -> Option<ConnectionString> {
     let env_var = std::env::var(CONNECTION_STRING_ENV_VAR).ok()?;
+    if env_var.trim().is_empty() {
+        return None;
+    }
     let raw = if env_var == "emulator" {
         EMULATOR_CONNECTION_STRING
     } else {
@@ -784,13 +791,6 @@ impl TestClient {
             .with_env_filter(test_env_filter())
             .try_init();
 
-        let test_client = Self::from_env(
-            options.client_application_region.clone(),
-            options.allow_invalid_certificates,
-            options.binary_encoding.clone(),
-        )
-        .await?;
-
         // Decide whether a fault-injection client is needed, and with which rules.
         // Rules should be passed in for emulator tests to ensure the FaultClient
         // wraps the HTTP client with invalid cert acceptance,
@@ -807,29 +807,32 @@ impl TestClient {
             (None, false) => None,
         };
 
-        // CosmosClient is designed to be cloned cheaply, so we can clone it here.
-        if let Some(key_client) = test_client.cosmos_client.clone() {
-            // In AAD mode the primary (data-plane) client authenticates with an
-            // Entra ID token, while the key client is retained for database
-            // management (create/delete), which is not a data-plane RBAC action.
-            let auth_mode = AuthMode::from_env();
-            let (primary_client, management_client) = match auth_mode {
-                AuthMode::Aad => {
-                    let region = options
-                        .client_application_region
-                        .clone()
-                        .unwrap_or(HUB_REGION);
-                    let (aad_client, _recorder) = build_aad_client_from_env(
-                        region,
-                        Vec::new(),
-                        options.binary_encoding.clone(),
-                    )
-                    .await?;
-                    (aad_client, Some(key_client))
-                }
-                AuthMode::Key => (key_client, None),
-            };
+        let auth_mode = AuthMode::from_env();
+        let primary_client = match auth_mode {
+            AuthMode::Aad => {
+                let region = options
+                    .client_application_region
+                    .clone()
+                    .unwrap_or(HUB_REGION);
+                Some(
+                    build_aad_client_from_env(region, Vec::new(), options.binary_encoding.clone())
+                        .await?
+                        .0,
+                )
+            }
+            AuthMode::Key => {
+                Self::from_env(
+                    options.client_application_region.clone(),
+                    options.allow_invalid_certificates,
+                    options.binary_encoding.clone(),
+                )
+                .await?
+                .cosmos_client
+            }
+        };
 
+        if let Some(primary_client) = primary_client {
+            let fault_injection_rules = fault_rules.clone().unwrap_or_default();
             // The fault client must authenticate the same way as the primary client.
             // Building it from the connection string unconditionally left the
             // `aad_auth` legs running every fault-injection test under key auth, and
@@ -865,7 +868,19 @@ impl TestClient {
                 },
             };
 
-            let run = TestRunContext::new(primary_client, fault_cosmos_client, management_client);
+            let arm_client = if auth_mode == AuthMode::Aad && !targets_emulator() {
+                Some(CosmosArmClient::from_env(
+                    azure_core_test::credentials::from_env(None)?,
+                )?)
+            } else {
+                None
+            };
+            let run = TestRunContext::new(
+                primary_client,
+                fault_cosmos_client,
+                arm_client,
+                fault_injection_rules,
+            );
 
             // Apply timeout around entire test including retries on 429s
             let timeout = options.timeout.unwrap_or(DEFAULT_TEST_TIMEOUT);
@@ -918,10 +933,15 @@ impl TestClient {
                 Err(_) => Err(format!("Test timed out after {} seconds", timeout.as_secs()).into()),
             }
         } else if test_mode == CosmosTestMode::Required {
-            panic!("Cosmos Test Mode is 'required' but no connection string was provided in the AZURE_COSMOS_CONNECTION_STRING environment variable.");
+            panic!(
+                "Cosmos Test Mode is 'required' but no account endpoint was provided in {} or {}.",
+                CONNECTION_STRING_ENV_VAR, ACCOUNT_HOST_ENV_VAR
+            );
         } else {
-            // Test mode is 'allowed' but no connection string was provided, so we skip the test.
-            eprintln!("Skipping emulator/live tests because no connection string was provided in the AZURE_COSMOS_CONNECTION_STRING environment variable.");
+            eprintln!(
+                "Skipping emulator/live tests because no account endpoint was provided in {} or {}.",
+                CONNECTION_STRING_ENV_VAR, ACCOUNT_HOST_ENV_VAR
+            );
             Ok(())
         }
     }
@@ -952,18 +972,8 @@ impl TestClient {
     {
         Self::run_with_options(
             async |run_context| {
-                // Ensure the shared database exists (create if needed, ignore conflict).
                 let db_id = get_shared_database_id();
-                // Emulator is always strong consistency, so we can skip the read check in that case
-                match run_context
-                    .management_client()
-                    .create_database(db_id, None)
-                    .await
-                {
-                    Ok(_) => {}
-                    Err(e) if e.status().status_code() == StatusCode::Conflict => {}
-                    Err(e) => return Err(e.into()),
-                }
+                run_context.create_database(db_id).await?;
                 let db_client = run_context.shared_db_client();
                 db_client.read(None).await?;
                 Box::pin(test(run_context, &db_client)).await
@@ -986,23 +996,51 @@ pub struct TestRunContext {
     client: CosmosClient,
     /// The fault injection Cosmos client (if configured).
     fault_client: Option<CosmosClient>,
-    /// The key-authenticated client used for database management in AAD mode.
-    /// `None` in key mode (management uses `client`).
-    management_client: Option<CosmosClient>,
+    /// The ARM client used for resource lifecycle in live AAD mode.
+    arm_client: Option<CosmosArmClient>,
+    fault_injection_rules: Vec<std::sync::Arc<FaultInjectionRule>>,
+}
+
+struct DisabledFaultInjectionRules(Vec<(std::sync::Arc<FaultInjectionRule>, bool)>);
+
+impl DisabledFaultInjectionRules {
+    fn new(rules: &[std::sync::Arc<FaultInjectionRule>]) -> Self {
+        let states = rules
+            .iter()
+            .map(|rule| {
+                let enabled = rule.is_enabled();
+                rule.disable();
+                (rule.clone(), enabled)
+            })
+            .collect();
+        Self(states)
+    }
+}
+
+impl Drop for DisabledFaultInjectionRules {
+    fn drop(&mut self) {
+        for (rule, was_enabled) in &self.0 {
+            if *was_enabled {
+                rule.enable();
+            }
+        }
+    }
 }
 
 impl TestRunContext {
     pub fn new(
         client: CosmosClient,
         fault_client: Option<CosmosClient>,
-        management_client: Option<CosmosClient>,
+        arm_client: Option<CosmosArmClient>,
+        fault_injection_rules: Vec<std::sync::Arc<FaultInjectionRule>>,
     ) -> Self {
         let run_id = azure_core::Uuid::new_v4().simple().to_string();
         Self {
             run_id,
             client,
             fault_client,
-            management_client,
+            arm_client,
+            fault_injection_rules,
         }
     }
 
@@ -1018,33 +1056,68 @@ impl TestRunContext {
         &self.client
     }
 
-    /// Gets the client used for database management (create/delete databases).
-    ///
-    /// In AAD mode this is a key-authenticated client, because database
-    /// management is not expressible as a Cosmos data-plane RBAC action. In key
-    /// mode it is the same client returned by [`TestRunContext::client`].
-    pub fn management_client(&self) -> &CosmosClient {
-        self.management_client.as_ref().unwrap_or(&self.client)
+    /// Gets the ARM client used for live AAD resource management.
+    pub fn arm_client(&self) -> Option<&CosmosArmClient> {
+        self.arm_client.as_ref()
     }
 
-    /// Gets a container client derived from the management (key) client, for
-    /// operations that are not permitted by the data-plane RBAC role used in
-    /// AAD mode.
-    ///
-    /// Throughput/offer operations (`read_throughput`, `begin_replace_throughput`)
-    /// are control-plane and are rejected by the data-plane role granted in
-    /// `test-resources.bicep`, so they must go through the key client. In key
-    /// mode this is equivalent to deriving a container client from
-    /// [`TestRunContext::client`].
-    pub async fn management_container_client(
+    pub async fn read_container_throughput(
         &self,
         db_client: &DatabaseClient,
         container_id: &str,
-    ) -> azure_data_cosmos::Result<ContainerClient> {
-        self.management_client()
-            .database_client(db_client.id())
+    ) -> Result<Option<ThroughputProperties>, Box<dyn std::error::Error>> {
+        if let Some(arm_client) = self.arm_client() {
+            return Ok(Some(from_arm_throughput(
+                arm_client
+                    .read_container_throughput(database_name(db_client)?, container_id)
+                    .await?,
+            )?));
+        }
+        Ok(db_client
             .container_client(container_id, None)
-            .await
+            .await?
+            .read_throughput(None)
+            .await?)
+    }
+
+    pub async fn read_database_throughput(
+        &self,
+        db_client: &DatabaseClient,
+    ) -> Result<Option<ThroughputProperties>, Box<dyn std::error::Error>> {
+        if let Some(arm_client) = self.arm_client() {
+            return Ok(arm_client
+                .read_database_throughput(database_name(db_client)?)
+                .await?
+                .map(from_arm_throughput)
+                .transpose()?);
+        }
+        Ok(db_client.read_throughput(None).await?)
+    }
+
+    pub async fn replace_container_throughput(
+        &self,
+        db_client: &DatabaseClient,
+        container_id: &str,
+        throughput: ThroughputProperties,
+    ) -> Result<ThroughputProperties, Box<dyn std::error::Error>> {
+        if let Some(arm_client) = self.arm_client() {
+            return Ok(from_arm_throughput(
+                arm_client
+                    .replace_container_throughput(
+                        database_name(db_client)?,
+                        container_id,
+                        to_arm_throughput(&throughput)?,
+                    )
+                    .await?,
+            )?);
+        }
+        Ok(db_client
+            .container_client(container_id, None)
+            .await?
+            .begin_replace_throughput(throughput, None)
+            .await?
+            .await?
+            .into_model()?)
     }
 
     /// Gets the fault injection [`CosmosClient`], if configured.
@@ -1073,44 +1146,40 @@ impl TestRunContext {
 
     /// Creates a new, empty, database for this test run with default throughput options.
     pub async fn create_db(&self) -> azure_data_cosmos::Result<DatabaseClient> {
-        // Database creation/deletion is management-plane and is not expressible
-        // as a Cosmos data-plane RBAC action, so it always goes through the
-        // management (key) client. The returned handle is derived from the
-        // primary client so downstream container/item operations exercise the
-        // primary credential (AAD in AAD mode).
         let db_name = self.db_name();
-        let response = match self
-            .management_client()
-            .create_database(&db_name, None)
-            .await
-        {
-            // The database creation was successful.
-            Ok(props) => props,
-            Err(e) if e.status().status_code() == StatusCode::Conflict => {
-                // The database already exists, from a previous test run.
-                // Delete it and re-create it.
-                let db_client = self.management_client().database_client(&db_name);
-                db_client.delete(None).await?;
+        self.create_database(&db_name).await?;
+        Ok(self.client().database_client(db_name))
+    }
 
-                // Re-create the database.
-                self.management_client()
-                    .create_database(&db_name, None)
-                    .await?
+    pub async fn create_database(&self, database_name: &str) -> azure_data_cosmos::Result<()> {
+        if let Some(arm_client) = self.arm_client() {
+            arm_client
+                .create_database(database_name)
+                .await
+                .map_err(arm_error)?;
+        } else {
+            match self.client().create_database(database_name, None).await {
+                Ok(_) => {}
+                Err(error) if error.status().status_code() == StatusCode::Conflict => {}
+                Err(error) => return Err(error),
             }
-            Err(e) => {
-                // Some other error occurred.
-                return Err(e);
-            }
-        };
+        }
+        Ok(())
+    }
 
-        let props = response.into_model()?;
-
-        let id = props
-            .id
-            .as_deref()
-            .expect("Cosmos DB should always return a database id on create");
-        let db_client = self.client().database_client(id);
-        Ok(db_client)
+    pub async fn delete_database(&self, database_name: &str) -> azure_data_cosmos::Result<()> {
+        if let Some(arm_client) = self.arm_client() {
+            arm_client
+                .delete_database(database_name)
+                .await
+                .map_err(arm_error)?;
+        } else {
+            self.client()
+                .database_client(database_name)
+                .delete(None)
+                .await?;
+        }
+        Ok(())
     }
 
     /// Reads an item from the specified container with exponential backoff retries on 404 errors.
@@ -1229,8 +1298,38 @@ impl TestRunContext {
         &self,
         db_client: &DatabaseClient,
         properties: azure_data_cosmos::models::ContainerProperties,
-        options: Option<azure_data_cosmos::options::CreateContainerOptions>,
+        throughput: Option<ThroughputProperties>,
     ) -> azure_data_cosmos::Result<ContainerClient> {
+        if let Some(arm_client) = self.arm_client() {
+            let partition_key_component_count = properties.partition_key.paths().len();
+            let database_name = database_name(db_client)?;
+            arm_client
+                .delete_container(database_name, properties.id.as_ref())
+                .await
+                .map_err(arm_error)?;
+            let resource = to_arm_container_resource(&properties)?;
+            arm_client
+                .create_or_update_container(
+                    database_name,
+                    properties.id.as_ref(),
+                    &resource,
+                    throughput.as_ref().map(to_arm_throughput).transpose()?,
+                )
+                .await
+                .map_err(arm_error)?;
+            let container =
+                Self::wait_for_container_ready(db_client, properties.id.as_ref()).await?;
+            probe_data_plane_ready(
+                "TestRunContext::create_container",
+                &container,
+                partition_key_component_count,
+            )
+            .await?;
+            return Ok(container);
+        }
+
+        let options = throughput
+            .map(|throughput| CreateContainerOptions::default().with_throughput(throughput));
         let mut backoff = Duration::from_millis(100);
         const MAX_BACKOFF: Duration = Duration::from_secs(10);
 
@@ -1270,6 +1369,52 @@ impl TestRunContext {
         }
     }
 
+    pub async fn replace_container(
+        &self,
+        db_client: &DatabaseClient,
+        properties: azure_data_cosmos::models::ContainerProperties,
+    ) -> azure_data_cosmos::Result<ContainerClient> {
+        if let Some(arm_client) = self.arm_client() {
+            let resource = to_arm_container_resource(&properties)?;
+            arm_client
+                .create_or_update_container(
+                    database_name(db_client)?,
+                    properties.id.as_ref(),
+                    &resource,
+                    None,
+                )
+                .await
+                .map_err(arm_error)?;
+        } else {
+            db_client
+                .container_client(properties.id.as_ref(), None)
+                .await?
+                .replace(properties.clone(), None)
+                .await?;
+        }
+        Self::wait_for_container_ready(db_client, properties.id.as_ref()).await
+    }
+
+    pub async fn delete_container(
+        &self,
+        db_client: &DatabaseClient,
+        container_id: &str,
+    ) -> azure_data_cosmos::Result<()> {
+        if let Some(arm_client) = self.arm_client() {
+            arm_client
+                .delete_container(database_name(db_client)?, container_id)
+                .await
+                .map_err(arm_error)?;
+        } else {
+            db_client
+                .container_client(container_id, None)
+                .await?
+                .delete(None)
+                .await?;
+        }
+        Ok(())
+    }
+
     /// Waits until a newly created container is usable through the current
     /// test client's metadata and data-plane paths.
     ///
@@ -1292,10 +1437,9 @@ impl TestRunContext {
                 Err(error) => error,
             };
 
-            let is_create_in_progress = error.status().status_code() == StatusCode::NotFound
-                && error.status().sub_status()
-                    == Some(SubStatusCode::COLLECTION_CREATE_IN_PROGRESS);
-            if !is_create_in_progress || attempt + 1 == MAX_ATTEMPTS {
+            let is_propagating =
+                collection_create_in_progress(&error) || owner_resource_not_found(&error);
+            if !is_propagating || attempt + 1 == MAX_ATTEMPTS {
                 return Err(error);
             }
 
@@ -1317,23 +1461,17 @@ impl TestRunContext {
         db_client: &'a DatabaseClient,
         properties: azure_data_cosmos::models::ContainerProperties,
         throughput: ThroughputProperties,
-    ) -> Pin<Box<dyn Future<Output = azure_data_cosmos::Result<ContainerClient>> + Send + 'a>> {
+    ) -> ContainerFuture<'a> {
         let fault_client = self
             .fault_client
             .clone()
             .expect("fault-injection client must be configured");
 
         Box::pin(async move {
-            let created = db_client
-                .create_container(
-                    properties,
-                    Some(CreateContainerOptions::default().with_throughput(throughput)),
-                )
-                .await?
-                .into_model()?;
-            let container_id = created.id;
-            let probe_container_id = container_id.clone();
-            let probe_db_id = db_client.id().clone();
+            let container_id = properties.id.clone();
+            let partition_key_component_count = properties.partition_key.paths().len();
+            self.create_container(db_client, properties, Some(throughput))
+                .await?;
 
             let original_db_client = db_client;
             let original_container_id = container_id.clone();
@@ -1379,31 +1517,17 @@ impl TestRunContext {
                 },
             );
 
-            let (container, _) = tokio::try_join!(original_readiness, fault_readiness)?;
+            let (container, fault_container) =
+                tokio::try_join!(original_readiness, fault_readiness)?;
 
-            // Metadata (5301) and name-based data (5302) authorize through
-            // separate RBAC paths, so a `container.read(...)` succeeding on
-            // the primary client does not guarantee the next item request is
-            // authorized on that connection. Under AAD this races and shows
-            // up as `403/5302 RbacUnauthorizedNameBasedDataRequest` on the
-            // first data-plane call. Probe the primary client's data path
-            // once to warm it up.
-            //
-            // Deliberately do NOT probe the fault-injection client: the
-            // probe issues a DELETE, which would trip fault-injection rules
-            // targeting DeleteItem (or consume fault-injection budget) and
-            // cause false-positive failures in fault-injection retry tests.
-            // The residual 5302 race on the fault client is absorbed by
-            // `TestClient::read_item`'s 5302 retry loop for tests that go
-            // through the framework helper.
-            let auth_mode = AuthMode::from_env();
-            if auth_mode == AuthMode::Aad {
-                let primary_client_for_probe = self.client().clone();
-                let primary_container = primary_client_for_probe
-                    .database_client(probe_db_id.clone())
-                    .container_client(&*probe_container_id, None)
-                    .await?;
-                probe_data_plane_ready("original client", &primary_container).await?;
+            if AuthMode::from_env() == AuthMode::Aad {
+                let _disabled_rules = DisabledFaultInjectionRules::new(&self.fault_injection_rules);
+                probe_data_plane_ready(
+                    "fault-injection client",
+                    &fault_container,
+                    partition_key_component_count,
+                )
+                .await?;
             }
 
             Ok(container)
@@ -1427,22 +1551,18 @@ impl TestRunContext {
         db_client: &'a DatabaseClient,
         properties: azure_data_cosmos::models::ContainerProperties,
         throughput: ThroughputProperties,
-    ) -> Pin<Box<dyn Future<Output = azure_data_cosmos::Result<ContainerClient>> + Send + 'a>> {
+    ) -> ContainerFuture<'a> {
         Box::pin(async move {
-            let created_properties = db_client
-                .create_container(
-                    properties,
-                    Some(CreateContainerOptions::default().with_throughput(throughput)),
-                )
-                .await?
-                .into_model()?;
+            let container_id = properties.id.clone();
+            self.create_container(db_client, properties, Some(throughput))
+                .await?;
 
             // Create two clients with different preferred regions to ensure container is available in both
             let hub_client = Self::create_client_with_preferred_region(HUB_REGION).await?;
             let satellite_client =
                 Self::create_client_with_preferred_region(SATELLITE_REGION).await?;
 
-            let container_id = created_properties.id.to_string();
+            let container_id = container_id.to_string();
 
             let db_id = db_client.id().to_owned();
 
@@ -1522,26 +1642,6 @@ impl TestRunContext {
             #[cfg(test_category = "multi_write")]
             self.wait_for_satellite_data_plane_readiness(&db_id, &container_id)
                 .await?;
-
-            // Under AAD, RBAC authorizes metadata (5301) and name-based data
-            // (5302) on separate paths, so `container.read(...)` succeeding
-            // does not guarantee the next data-plane call is authorized. Probe
-            // the data path once here so tests that immediately create/read
-            // items after container creation don't race with `403/5302
-            // RbacUnauthorizedNameBasedDataRequest` and burn their per-test
-            // budget on driver retries.
-            //
-            // Deliberately do NOT probe the fault-injection client here: the
-            // probe issues a DELETE, which would trip
-            // fault-injection rules targeting DeleteItem (or otherwise
-            // consume fault-injection budget) and cause false-positive
-            // failures in emulator/multi-write fault-injection tests. The
-            // residual read-path 5302 race on the fault client is absorbed by
-            // `TestClient::read_item`'s 5302 retry loop for tests that go
-            // through the framework helper.
-            if !targets_emulator() && AuthMode::from_env() == AuthMode::Aad {
-                probe_data_plane_ready("original client", &container).await?;
-            }
 
             Ok(container)
         })
@@ -1720,9 +1820,11 @@ impl TestRunContext {
     }
 
     /// Creates a CosmosClient with a specific preferred region.
-    async fn create_client_with_preferred_region(
-        region: Region,
-    ) -> Result<CosmosClient, azure_data_cosmos::CosmosError> {
+    async fn create_client_with_preferred_region(region: Region) -> Result<CosmosClient, BoxError> {
+        if AuthMode::from_env() == AuthMode::Aad {
+            return Ok(build_aad_client_from_env(region, Vec::new(), None).await?.0);
+        }
+
         let env_var = std::env::var(CONNECTION_STRING_ENV_VAR)
             .unwrap_or_else(|_| EMULATOR_CONNECTION_STRING.to_string());
 
@@ -1748,7 +1850,7 @@ impl TestRunContext {
                 .await?,
         );
 
-        builder
+        Ok(builder
             .build(
                 azure_data_cosmos::AccountReference::with_authentication_key(
                     endpoint,
@@ -1756,17 +1858,15 @@ impl TestRunContext {
                 ),
                 RoutingStrategy::ProximityTo(region),
             )
-            .await
+            .await?)
     }
 
     /// Builds a [`CosmosClient`] authenticated with an Entra ID (AAD) token
-    /// credential, targeting the same account the key client uses.
+    /// credential, targeting the configured account endpoint.
     ///
     /// This is the entry point for AAD integration tests. The returned client
-    /// performs data-plane operations under AAD; database/container management
-    /// must still go through the key client (`client()`), because the
-    /// data-plane RBAC role granted in `test-resources.bicep` does not permit
-    /// management-plane operations.
+    /// performs data-plane operations under AAD; live resource lifecycle uses
+    /// the ARM client exposed by [`TestRunContext::arm_client`].
     ///
     /// See [`build_aad_client_from_env`] for credential-selection details.
     pub async fn aad_client(
@@ -1780,14 +1880,16 @@ impl TestRunContext {
     /// This should be called at the end of a test run to delete any databases created during the test.
     /// If using [`TestClient::run`], this will be called automatically.
     pub async fn cleanup(&self) -> Result<(), Box<dyn std::error::Error>> {
+        if self.arm_client().is_some() {
+            self.delete_database(&self.db_name()).await?;
+            return Ok(());
+        }
+
         let query = Query::from(format!(
             "SELECT * FROM root r WHERE r.id LIKE 'auto-test-{}'",
             self.run_id
         ));
-        let mut pager = self
-            .management_client()
-            .query_databases(query, None)
-            .await?;
+        let mut pager = self.client().query_databases(query, None).await?;
         let mut ids = Vec::new();
         while let Some(db) = pager.try_next().await? {
             if let Some(id) = db.id {
@@ -1799,13 +1901,123 @@ impl TestRunContext {
         // We COULD choose not to delete them and instead validate that they were deleted, but this is what I've gone with for now.
         for id in ids {
             println!("Deleting left-over database: {}", id);
-            self.management_client()
-                .database_client(&id)
-                .delete(None)
-                .await?;
+            self.delete_database(&id).await?;
         }
         Ok(())
     }
+}
+
+fn database_name(db_client: &DatabaseClient) -> azure_data_cosmos::Result<&str> {
+    db_client.name().ok_or_else(|| {
+        azure_data_cosmos_driver::error::CosmosError::builder()
+            .with_status(CosmosStatus::CLIENT_INVALID_RESOURCE_ID)
+            .with_message("ARM-backed test resource management requires a name-addressed database")
+            .build()
+            .into()
+    })
+}
+
+fn to_arm_container_resource(
+    properties: &azure_data_cosmos::models::ContainerProperties,
+) -> azure_data_cosmos::Result<serde_json::Value> {
+    const READ_ONLY_FIELDS: &[&str] = &[
+        "_rid",
+        "_self",
+        "_etag",
+        "_ts",
+        "_docs",
+        "_sprocs",
+        "_triggers",
+        "_udfs",
+        "_conflicts",
+    ];
+
+    let mut resource = serde_json::to_value(properties).map_err(|error| {
+        azure_data_cosmos_driver::error::CosmosError::builder()
+            .with_status(CosmosStatus::SERIALIZATION_RESPONSE_BODY_INVALID)
+            .with_message("failed to serialize Cosmos container properties for ARM")
+            .with_source(error)
+            .build()
+    })?;
+    let resource = resource.as_object_mut().ok_or_else(|| {
+        azure_data_cosmos_driver::error::CosmosError::builder()
+            .with_status(CosmosStatus::SERIALIZATION_RESPONSE_BODY_INVALID)
+            .with_message("serialized Cosmos container properties were not an object")
+            .build()
+    })?;
+    for field in READ_ONLY_FIELDS {
+        resource.remove(*field);
+    }
+    Ok(serde_json::Value::Object(resource.clone()))
+}
+
+fn to_arm_throughput(
+    throughput: &ThroughputProperties,
+) -> azure_data_cosmos::Result<ArmThroughput> {
+    match throughput.autoscale_maximum() {
+        Some(maximum) => Ok(ArmThroughput::Autoscale {
+            maximum,
+            current: throughput.throughput(),
+            increment_percent: throughput.autoscale_increment(),
+        }),
+        None => throughput
+            .throughput()
+            .map(ArmThroughput::Manual)
+            .ok_or_else(|| {
+                azure_data_cosmos_driver::error::CosmosError::builder()
+                    .with_status(CosmosStatus::CLIENT_INVALID_RESOURCE_ID)
+                    .with_message("throughput must specify either manual or autoscale RU/s")
+                    .build()
+                    .into()
+            }),
+    }
+}
+
+fn from_arm_throughput(
+    throughput: ArmThroughput,
+) -> azure_data_cosmos::Result<ThroughputProperties> {
+    match throughput {
+        ArmThroughput::Manual(value) => Ok(ThroughputProperties::manual(value)),
+        ArmThroughput::Autoscale {
+            maximum,
+            current,
+            increment_percent,
+        } => serde_json::from_value(serde_json::json!({
+            "resource": "",
+            "content": {
+                "offerThroughput": current,
+                "offerAutopilotSettings": {
+                    "maxThroughput": maximum,
+                    "autoUpgradePolicy": increment_percent.map(|increment_percent| serde_json::json!({
+                        "throughputPolicy": {
+                            "incrementPercent": increment_percent
+                        }
+                    }))
+                }
+            },
+            "id": "",
+            "offerResourceId": "",
+            "offerType": "",
+            "offerVersion": "V2"
+        }))
+        .map_err(|error| {
+            azure_data_cosmos_driver::error::CosmosError::builder()
+                .with_status(CosmosStatus::SERIALIZATION_RESPONSE_BODY_INVALID)
+                .with_message("failed to convert ARM throughput response")
+                .with_source(error)
+                .build()
+                .into()
+        }),
+    }
+}
+
+fn arm_error(error: azure_core::Error) -> CosmosError {
+    azure_data_cosmos_driver::error::CosmosError::builder()
+        .with_status(CosmosStatus::TRANSPORT_GENERATED_503)
+        .with_message("Azure Resource Manager operation failed")
+        .with_source(error)
+        .build()
+        .into()
 }
 
 /// Returns `true` if `endpoint`'s host is a loopback/local host, indicating the
@@ -1833,21 +2045,27 @@ fn host_is_local(endpoint: &str) -> bool {
 /// Defaults to `true` when no connection string is configured, matching the
 /// rest of the harness (which falls back to the emulator).
 pub fn targets_emulator() -> bool {
-    let Ok(env_var) = std::env::var(CONNECTION_STRING_ENV_VAR) else {
-        return true;
-    };
-    if env_var == "emulator" {
-        return true;
+    if let Some(env_var) = std::env::var(CONNECTION_STRING_ENV_VAR)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        if env_var == "emulator" {
+            return true;
+        }
+        return match env_var.parse::<ConnectionString>() {
+            Ok(parsed) => host_is_local(parsed.account_endpoint()),
+            Err(_) => false,
+        };
     }
-    match env_var.parse::<ConnectionString>() {
-        Ok(parsed) => host_is_local(parsed.account_endpoint()),
-        Err(_) => false,
+    match std::env::var(ACCOUNT_HOST_ENV_VAR) {
+        Ok(endpoint) => host_is_local(&endpoint),
+        Err(_) => true,
     }
 }
 
 /// Builds a [`CosmosClient`] authenticated with an Entra ID (AAD) token
-/// credential, reading the target account from the same environment the
-/// key-auth client uses (`AZURE_COSMOS_CONNECTION_STRING`).
+/// credential, reading the target account from `ACCOUNT_HOST` for live tests
+/// and `AZURE_COSMOS_CONNECTION_STRING` for the emulator.
 ///
 /// Credential selection is based on the target host:
 /// - **Emulator** (`AZURE_COSMOS_CONNECTION_STRING=emulator`, or an endpoint
@@ -1869,16 +2087,27 @@ pub async fn build_aad_client_from_env(
 ) -> Result<(CosmosClient, Option<super::CredentialRecorder>), Box<dyn std::error::Error>> {
     use super::CosmosEmulatorCredential;
 
-    let env_var = std::env::var(CONNECTION_STRING_ENV_VAR)?;
-    let is_emulator_shorthand = env_var == "emulator";
-    let connection_string_str = if is_emulator_shorthand {
-        EMULATOR_CONNECTION_STRING
-    } else {
-        env_var.as_str()
+    let connection_string = std::env::var(CONNECTION_STRING_ENV_VAR)
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    let is_emulator_shorthand = connection_string.as_deref() == Some("emulator");
+    let parsed = match connection_string.as_deref() {
+        Some("emulator") => Some(EMULATOR_CONNECTION_STRING.parse::<ConnectionString>()?),
+        Some(value) => Some(value.parse::<ConnectionString>()?),
+        None => None,
     };
-
-    let parsed: ConnectionString = connection_string_str.parse()?;
-    let endpoint_str = parsed.account_endpoint().to_string();
+    let endpoint_str = match std::env::var(ACCOUNT_HOST_ENV_VAR) {
+        Ok(endpoint) if !endpoint.trim().is_empty() => endpoint,
+        _ => parsed
+            .as_ref()
+            .map(|connection| connection.account_endpoint().to_string())
+            .ok_or_else(|| {
+                format!(
+                    "{} or {} must be set for AAD Cosmos tests",
+                    ACCOUNT_HOST_ENV_VAR, CONNECTION_STRING_ENV_VAR
+                )
+            })?,
+    };
     let endpoint: azure_data_cosmos::AccountEndpoint = endpoint_str.parse()?;
 
     let is_emulator = is_emulator_shorthand || host_is_local(&endpoint_str);
@@ -1909,7 +2138,12 @@ pub async fn build_aad_client_from_env(
         builder = builder.with_runtime(runtime);
 
         // Sign the fake JWT with the same master key the emulator validates against.
-        let master_key = parsed.account_key().secret().to_string();
+        let master_key = parsed
+            .as_ref()
+            .ok_or("emulator AAD authentication requires a connection string")?
+            .account_key()
+            .secret()
+            .to_string();
         let credential = std::sync::Arc::new(CosmosEmulatorCredential::with_master_key(master_key));
         let recorder = credential.recorder();
         (credential, Some(recorder))
@@ -1930,12 +2164,15 @@ pub async fn build_aad_client_from_env(
 #[cfg(test)]
 mod tests {
     use super::{
-        aad_token_invalid_issuer, effective_binary_encoding, item_not_found,
+        aad_token_invalid_issuer, effective_binary_encoding, from_arm_throughput, item_not_found,
         rbac_name_based_data_not_ready, retry_container_readiness, satellite_probe_should_retry,
-        transient_satellite_readiness_error, AuthMode, BinaryEncodingOptions,
+        to_arm_container_resource, transient_satellite_readiness_error, ArmThroughput, AuthMode,
+        BinaryEncodingOptions,
     };
     use azure_core::http::StatusCode;
-    use azure_data_cosmos::{CosmosError, CosmosStatus, SubStatusCode};
+    use azure_data_cosmos::{
+        models::ContainerProperties, CosmosError, CosmosStatus, SubStatusCode,
+    };
     use std::{
         future::pending,
         sync::{
@@ -1944,6 +2181,42 @@ mod tests {
         },
         time::Duration,
     };
+
+    #[test]
+    fn arm_autoscale_throughput_preserves_service_values() {
+        let throughput = from_arm_throughput(ArmThroughput::Autoscale {
+            maximum: 5000,
+            current: Some(500),
+            increment_percent: Some(42),
+        })
+        .unwrap();
+
+        assert_eq!(throughput.throughput(), Some(500));
+        assert_eq!(throughput.autoscale_maximum(), Some(5000));
+        assert_eq!(throughput.autoscale_increment(), Some(42));
+    }
+
+    #[test]
+    fn arm_container_resource_omits_service_metadata() {
+        let properties: ContainerProperties = serde_json::from_value(serde_json::json!({
+            "id": "container",
+            "partitionKey": {"paths": ["/pk"], "kind": "Hash", "version": 2},
+            "_rid": "rid",
+            "_docs": "docs/",
+            "geospatialConfig": {"type": "Geography"},
+            "clientEncryptionPolicy": {"policyFormatVersion": 2}
+        }))
+        .unwrap();
+
+        let resource = to_arm_container_resource(&properties).unwrap();
+
+        assert_eq!(resource["id"], "container");
+        assert_eq!(resource["partitionKey"]["paths"][0], "/pk");
+        assert!(resource.get("_rid").is_none());
+        assert!(resource.get("_docs").is_none());
+        assert_eq!(resource["geospatialConfig"]["type"], "Geography");
+        assert_eq!(resource["clientEncryptionPolicy"]["policyFormatVersion"], 2);
+    }
 
     #[test]
     #[cfg(test_category = "emulator_vnext")]

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/test_data.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/test_data.rs
@@ -1,12 +1,9 @@
-use azure_core::http::StatusCode;
-use azure_data_cosmos::options::CreateContainerOptions;
 use azure_data_cosmos::{
     clients::{ContainerClient, DatabaseClient},
     models::{ContainerProperties, ThroughputProperties},
 };
-use std::time::Duration;
 
-use super::test_client::{probe_data_plane_ready, AuthMode};
+use super::test_client::TestRunContext;
 use super::MockItem;
 
 const ITEMS_PER_PARTITION: usize = 10;
@@ -33,46 +30,15 @@ pub fn generate_mock_items(partition_count: usize, items_per_partition: usize) -
 
 /// Creates a batch of simple mock items
 pub async fn create_container_with_items(
+    run_context: &TestRunContext,
     db: &DatabaseClient,
     items: Vec<MockItem>,
     throughput: Option<ThroughputProperties>,
 ) -> azure_data_cosmos::Result<ContainerClient> {
     let properties = ContainerProperties::new("TestContainer", "/partitionKey".into());
-
-    // Retry on 429 errors
-    loop {
-        match db
-            .create_container(
-                properties.clone(),
-                throughput.clone().map(|throughput| {
-                    CreateContainerOptions::default().with_throughput(throughput)
-                }),
-            )
-            .await
-        {
-            Ok(_) => break,
-            Err(e) if e.status().status_code() == StatusCode::TooManyRequests => {
-                println!("Create container got 429 (Too Many Requests). Retrying...");
-                tokio::time::sleep(Duration::from_secs(1)).await;
-            }
-            Err(e) if e.status().status_code() == StatusCode::Conflict => {
-                // Container already exists, continue
-                break;
-            }
-            Err(e) => return Err(e),
-        }
-    }
-
-    let container_client = db.container_client("TestContainer", None).await?;
-
-    // Under AAD, the first data-plane request against a freshly created
-    // container can race with 403/5302 RbacUnauthorizedNameBasedDataRequest
-    // before the name→RID mapping is cached on this client's connection.
-    // Probe once so the item-seeding loop below doesn't burn its budget
-    // being retried by the driver.
-    if AuthMode::from_env() == AuthMode::Aad {
-        probe_data_plane_ready("test_data::create_container_with_items", &container_client).await?;
-    }
+    let container_client = run_context
+        .create_container(db, properties, throughput)
+        .await?;
 
     for item in items {
         let item_id = item.id.clone();

--- a/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/driver_end_to_end.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/driver_end_to_end.rs
@@ -1347,7 +1347,14 @@ async fn try_real_failover_comparison(
     };
     use std::sync::Arc;
 
-    let conn_str_raw = std::env::var("AZURE_COSMOS_CONNECTION_STRING").ok()?;
+    if std::env::var("AZURE_COSMOS_AUTH_MODE").is_ok_and(|value| value.eq_ignore_ascii_case("aad"))
+    {
+        return None;
+    }
+
+    let conn_str_raw = std::env::var("AZURE_COSMOS_CONNECTION_STRING")
+        .ok()
+        .filter(|value| !value.trim().is_empty())?;
     let mode = std::env::var("AZURE_COSMOS_TEST_MODE")
         .unwrap_or_default()
         .to_lowercase();

--- a/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/dual_backend.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/dual_backend.rs
@@ -43,6 +43,7 @@ use super::validation::{
 
 /// Environment variable for the real-account connection string.
 const CONNECTION_STRING_ENV_VAR: &str = "AZURE_COSMOS_CONNECTION_STRING";
+const AUTH_MODE_ENV_VAR: &str = "AZURE_COSMOS_AUTH_MODE";
 
 /// Environment variable controlling test mode.
 const TEST_MODE_ENV_VAR: &str = "AZURE_COSMOS_TEST_MODE";
@@ -500,6 +501,10 @@ impl DualBackend {
 /// Returns `Ok(None)` when the env var is unset and mode is not `required`.
 async fn resolve_real_account(
 ) -> Result<Option<(Arc<CosmosDriver>, AccountReference)>, Box<dyn Error>> {
+    if std::env::var(AUTH_MODE_ENV_VAR).is_ok_and(|value| value.eq_ignore_ascii_case("aad")) {
+        return Ok(None);
+    }
+
     let mode = std::env::var(TEST_MODE_ENV_VAR)
         .unwrap_or_default()
         .to_lowercase();

--- a/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/end_to_end.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/end_to_end.rs
@@ -262,6 +262,7 @@ async fn read_item_with_503_retry(
 
 const EMULATOR_GATEWAY_URL: &str = "https://eastus.emulator.local";
 const CONNECTION_STRING_ENV_VAR: &str = "AZURE_COSMOS_CONNECTION_STRING";
+const AUTH_MODE_ENV_VAR: &str = "AZURE_COSMOS_AUTH_MODE";
 const TEST_MODE_ENV_VAR: &str = "AZURE_COSMOS_TEST_MODE";
 
 struct SdkDualBackend {
@@ -1860,6 +1861,10 @@ async fn resolve_real_client_with_fault_injection(
     use azure_data_cosmos_driver::fault_injection::FaultInjectionRuleBuilder;
     use std::sync::Arc;
 
+    if std::env::var(AUTH_MODE_ENV_VAR).is_ok_and(|value| value.eq_ignore_ascii_case("aad")) {
+        return Ok(None);
+    }
+
     let mode = std::env::var(TEST_MODE_ENV_VAR)
         .unwrap_or_default()
         .to_lowercase();
@@ -1908,6 +1913,10 @@ async fn resolve_real_client_with_fault_injection(
 // ─── Helper ──────────────────────────────────────────────────────────────────
 
 async fn resolve_real_client() -> Result<Option<CosmosClient>, Box<dyn Error>> {
+    if std::env::var(AUTH_MODE_ENV_VAR).is_ok_and(|value| value.eq_ignore_ascii_case("aad")) {
+        return Ok(None);
+    }
+
     let mode = std::env::var(TEST_MODE_ENV_VAR)
         .unwrap_or_default()
         .to_lowercase();

--- a/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/query_comparison.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/in_memory_emulator_tests/query_comparison.rs
@@ -49,6 +49,7 @@ use super::validation::{compare_headers, HeaderValidationSpec};
 const EMULATOR_GATEWAY_URL: &str = "https://eastus.emulator.local";
 const CONNECTION_STRING_ENV_VAR: &str = "AZURE_COSMOS_CONNECTION_STRING";
 const TEST_MODE_ENV_VAR: &str = "AZURE_COSMOS_TEST_MODE";
+const AUTH_MODE_ENV_VAR: &str = "AZURE_COSMOS_AUTH_MODE";
 const EMULATOR_CONNECTION_STRING: &str = "AccountEndpoint=https://127.0.0.1:8081;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;";
 const HUB_REGION: Region = Region::EAST_US_2;
 
@@ -133,6 +134,10 @@ impl QueryComparisonHarness {
 }
 
 async fn resolve_external_backend() -> Result<Option<Backend>, Box<dyn Error>> {
+    if std::env::var(AUTH_MODE_ENV_VAR).is_ok_and(|value| value.eq_ignore_ascii_case("aad")) {
+        return Ok(None);
+    }
+
     let mode = std::env::var(TEST_MODE_ENV_VAR)
         .unwrap_or_default()
         .to_lowercase();

--- a/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_change_feed_split.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_change_feed_split.rs
@@ -28,9 +28,7 @@ use azure_data_cosmos::models::{
     ChangeFeedItem, ChangeFeedOperationType, ChangeFeedPolicy, ContainerProperties,
     ThroughputProperties,
 };
-use azure_data_cosmos::options::{
-    ChangeFeedMode, ChangeFeedOptions, ChangeFeedStartFrom, CreateContainerOptions,
-};
+use azure_data_cosmos::options::{ChangeFeedMode, ChangeFeedOptions, ChangeFeedStartFrom};
 use framework::{MockItem, TestClient, TestOptions};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -109,7 +107,7 @@ pub async fn change_feed_resume_across_split() -> Result<(), Box<dyn Error>> {
                     .create_container(
                         db_client,
                         properties,
-                        Some(CreateContainerOptions::default().with_throughput(throughput)),
+                        Some(throughput),
                     )
                     .await?,
             );
@@ -159,7 +157,14 @@ pub async fn change_feed_resume_across_split() -> Result<(), Box<dyn Error>> {
             // Force a real split AFTER the token is captured so the resume must
             // map the pre-split parent token onto the post-split children.
             let partitions_after =
-                force_split_and_wait(&container_client, partitions_before).await?;
+                force_split_and_wait(
+                    run_context,
+                    db_client,
+                    &container_client,
+                    "ChangeFeedResumeAcrossSplit",
+                    partitions_before,
+                )
+                .await?;
             assert!(
                 partitions_after > partitions_before,
                 "split must increase partition count: before={partitions_before}, after={partitions_after}"
@@ -326,7 +331,7 @@ pub async fn change_feed_all_versions_and_deletes_resume_across_split() -> Resul
                     .create_container(
                         db_client,
                         properties,
-                        Some(CreateContainerOptions::default().with_throughput(throughput)),
+                        Some(throughput),
                     )
                     .await?,
             );
@@ -395,7 +400,14 @@ pub async fn change_feed_all_versions_and_deletes_resume_across_split() -> Resul
             // Force a real split AFTER the token is captured so the resume must
             // map the pre-split parent token onto the post-split children.
             let partitions_after =
-                force_split_and_wait(&container_client, partitions_before).await?;
+                force_split_and_wait(
+                    run_context,
+                    db_client,
+                    &container_client,
+                    "ChangeFeedAvadResumeAcrossSplit",
+                    partitions_before,
+                )
+                .await?;
             assert!(
                 partitions_after > partitions_before,
                 "split must increase partition count: before={partitions_before}, after={partitions_after}"

--- a/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_partition_merge.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_partition_merge.rs
@@ -11,165 +11,12 @@ use super::{
 use azure_data_cosmos::{
     feed::FeedScope,
     models::{ContainerProperties, ThroughputProperties},
-    options::{
-        ChangeFeedStartFrom, CreateContainerOptions, MaxItemCountHint, QueryOptions,
-        ReadFeedRangesOptions,
-    },
+    options::{ChangeFeedStartFrom, MaxItemCountHint, QueryOptions, ReadFeedRangesOptions},
 };
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use std::{collections::BTreeSet, error::Error, num::NonZeroU32, time::Duration};
 
 const CONTAINER_NAME: &str = "PartitionMergeLive";
-const MANAGEMENT_SCOPE: &str = "https://management.azure.com/.default";
-const MERGE_API_VERSION: &str = "2026-04-01-preview";
-const MERGE_TIMEOUT: Duration = Duration::from_secs(60 * 60);
-const MERGE_POLL_INTERVAL: Duration = Duration::from_secs(30);
-
-async fn invoke_partition_merge(
-    database_name: &str,
-    container_name: &str,
-) -> Result<(), Box<dyn Error>> {
-    let subscription_id = std::env::var("COSMOS_SUBSCRIPTION_ID")?;
-    let resource_group = std::env::var("COSMOS_RESOURCE_GROUP")?;
-    let account_name = std::env::var("COSMOS_ACCOUNT_NAME")?;
-    let credential = azure_core_test::credentials::from_env(None)?;
-    let token = credential.get_token(&[MANAGEMENT_SCOPE], None).await?;
-    let client = reqwest::Client::new();
-    let merge_started = time::OffsetDateTime::now_utc();
-    let resource_id = format!(
-        "/subscriptions/{subscription_id}/resourceGroups/{resource_group}/providers/Microsoft.DocumentDB/databaseAccounts/{account_name}/sqlDatabases/{database_name}/containers/{container_name}"
-    );
-    let merge_url = format!(
-        "https://management.azure.com{resource_id}/partitionMerge?api-version={MERGE_API_VERSION}"
-    );
-
-    let response = client
-        .post(merge_url)
-        .bearer_auth(token.token.secret())
-        .header("content-type", "application/json")
-        .body(r#"{"isDryRun":false}"#)
-        .send()
-        .await?;
-    let status = response.status();
-    if !status.is_success() {
-        return Err(format!(
-            "partition merge request failed with {status}: {}",
-            response.text().await?
-        )
-        .into());
-    }
-
-    let deadline = tokio::time::Instant::now() + MERGE_TIMEOUT;
-    let mut poll_count = 0usize;
-    if status == reqwest::StatusCode::ACCEPTED {
-        let operation_url = response
-            .headers()
-            .get("azure-asyncoperation")
-            .or_else(|| response.headers().get("location"))
-            .ok_or("partition merge response did not include an operation URL")?
-            .to_str()?
-            .to_owned();
-        loop {
-            if tokio::time::Instant::now() >= deadline {
-                return Err(
-                    "partition merge ARM operation did not complete within 60 minutes".into(),
-                );
-            }
-
-            let token = credential.get_token(&[MANAGEMENT_SCOPE], None).await?;
-            let response = client
-                .get(&operation_url)
-                .bearer_auth(token.token.secret())
-                .send()
-                .await?
-                .error_for_status()?;
-            let body: serde_json::Value = serde_json::from_slice(&response.bytes().await?)?;
-            if body.get("physicalPartitionStorageInfoCollection").is_some() {
-                break;
-            }
-            let status = body
-                .get("status")
-                .and_then(serde_json::Value::as_str)
-                .or_else(|| {
-                    body.pointer("/status/code")
-                        .and_then(serde_json::Value::as_str)
-                })
-                .or_else(|| {
-                    body.pointer("/properties/status")
-                        .and_then(serde_json::Value::as_str)
-                })
-                .or_else(|| {
-                    body.pointer("/properties/provisioningState")
-                        .and_then(serde_json::Value::as_str)
-                })
-                .map(str::to_ascii_lowercase)
-                .unwrap_or_default();
-            match status.as_str() {
-                "succeeded" | "completed" => break,
-                "failed" | "canceled" | "cancelled" => {
-                    return Err(format!("partition merge operation failed: {body}").into());
-                }
-                _ => {
-                    if poll_count.is_multiple_of(10) {
-                        println!("Partition merge ARM operation is still running: {body}");
-                    }
-                    poll_count += 1;
-                    tokio::time::sleep(MERGE_POLL_INTERVAL).await;
-                }
-            }
-        }
-    }
-
-    let merge_started = merge_started.format(&time::format_description::well_known::Rfc3339)?;
-    let activity_url = reqwest::Url::parse(&format!(
-        "https://management.azure.com/subscriptions/{subscription_id}/providers/microsoft.insights/eventtypes/management/values"
-    ))?;
-
-    poll_count = 0;
-    loop {
-        if tokio::time::Instant::now() >= deadline {
-            return Err("partition merge backend did not complete within 60 minutes".into());
-        }
-        let merge_ended = time::OffsetDateTime::now_utc()
-            .format(&time::format_description::well_known::Rfc3339)?;
-        let activity_filter = format!(
-            "eventTimestamp ge '{merge_started}' and eventTimestamp le '{merge_ended}' and resourceGroupName eq '{resource_group}'"
-        );
-        let mut request_url = activity_url.clone();
-        request_url
-            .query_pairs_mut()
-            .append_pair("api-version", "2015-04-01")
-            .append_pair("$filter", &activity_filter);
-        let token = credential.get_token(&[MANAGEMENT_SCOPE], None).await?;
-        let response = client
-            .get(request_url)
-            .bearer_auth(token.token.secret())
-            .send()
-            .await?
-            .error_for_status()?;
-        let body: serde_json::Value = serde_json::from_slice(&response.bytes().await?)?;
-        let completed = body["value"].as_array().is_some_and(|events| {
-            events.iter().any(|event| {
-                event["resourceId"]
-                    .as_str()
-                    .is_some_and(|id| id.eq_ignore_ascii_case(&resource_id))
-                    && ["value", "localizedValue"].iter().any(|field| {
-                        event["operationName"][field]
-                            == "PartitionCoalescer Merge operation for Container"
-                    })
-                    && event["status"]["value"] == "Succeeded"
-            })
-        });
-        if completed {
-            return Ok(());
-        }
-        if poll_count.is_multiple_of(4) {
-            println!("Waiting for the partition merge backend to complete...");
-        }
-        poll_count += 1;
-        tokio::time::sleep(MERGE_POLL_INTERVAL).await;
-    }
-}
 
 #[tokio::test]
 #[cfg_attr(
@@ -188,10 +35,7 @@ async fn routing_query_and_point_in_time_feed_survive_merge() -> Result<(), Box<
                 .create_container(
                     db_client,
                     properties,
-                    Some(
-                        CreateContainerOptions::default()
-                            .with_throughput(ThroughputProperties::manual(1000)),
-                    ),
+                    Some(ThroughputProperties::manual(1000)),
                 )
                 .await?;
 
@@ -212,8 +56,14 @@ async fn routing_query_and_point_in_time_feed_survive_merge() -> Result<(), Box<
             }
 
             let partitions_before = container.read_feed_ranges(None).await?.len();
-            let partitions_after_split =
-                force_split_and_wait(&container, partitions_before).await?;
+            let partitions_after_split = force_split_and_wait(
+                run_context,
+                db_client,
+                &container,
+                CONTAINER_NAME,
+                partitions_before,
+            )
+            .await?;
             assert!(partitions_after_split > partitions_before);
 
             let mut pages = container
@@ -237,23 +87,27 @@ async fn routing_query_and_point_in_time_feed_survive_merge() -> Result<(), Box<
             let query_token = pages.to_continuation_token()?;
             drop(pages);
 
-            let mut throughput = container
-                .begin_replace_throughput(ThroughputProperties::manual(4000), None)
+            run_context
+                .replace_container_throughput(
+                    db_client,
+                    CONTAINER_NAME,
+                    ThroughputProperties::manual(4000),
+                )
                 .await?;
-            while let Some(status) = throughput.try_next().await? {
-                assert!(status.status().is_success());
-            }
 
             let point_in_time = time::OffsetDateTime::now_utc();
-            invoke_partition_merge(
-                db_client
-                    .name()
-                    .ok_or("partition merge test requires a name-addressed database")?,
-                CONTAINER_NAME,
-            )
-            .await?;
+            run_context
+                .arm_client()
+                .ok_or("partition merge requires AAD-backed ARM resource management")?
+                .merge_partitions(
+                    db_client
+                        .name()
+                        .ok_or("partition merge test requires a name-addressed database")?,
+                    CONTAINER_NAME,
+                )
+                .await?;
 
-            let merge_deadline = tokio::time::Instant::now() + Duration::from_secs(10 * 60);
+            let merge_deadline = tokio::time::Instant::now() + Duration::from_secs(60 * 60);
             loop {
                 let count = container
                     .read_feed_ranges(Some(
@@ -304,7 +158,7 @@ async fn routing_query_and_point_in_time_feed_survive_merge() -> Result<(), Box<
                     MockItem {
                         id: probe_id.to_owned(),
                         partition_key: probe_pk.to_owned(),
-                        merge_order: usize::MAX,
+                        merge_order: 100_000,
                     },
                     None,
                 )
@@ -323,7 +177,7 @@ async fn routing_query_and_point_in_time_feed_survive_merge() -> Result<(), Box<
                     MockItem {
                         id: post_merge_id.to_owned(),
                         partition_key: probe_pk.to_owned(),
-                        merge_order: usize::MAX - 1,
+                        merge_order: 100_001,
                     },
                     None,
                 )
@@ -343,7 +197,7 @@ async fn routing_query_and_point_in_time_feed_survive_merge() -> Result<(), Box<
 
             Ok(())
         },
-        Some(TestOptions::new().with_timeout(Duration::from_secs(85 * 60))),
+        Some(TestOptions::new().with_timeout(Duration::from_secs(150 * 60))),
     )
     .await
 }

--- a/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_query_distinct_split.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_query_distinct_split.rs
@@ -36,7 +36,6 @@ use std::num::NonZeroU32;
 use std::time::Duration;
 
 use azure_data_cosmos::feed::{ContinuationToken, QueryPageIterator};
-use azure_data_cosmos::options::CreateContainerOptions;
 use azure_data_cosmos::{
     clients::ContainerClient,
     feed::FeedScope,
@@ -208,11 +207,7 @@ pub async fn text_and_binary_distinct_queries_reuse_one_split() -> Result<(), Bo
                 ContainerProperties::new("DistinctAcrossSplit", "/partitionKey".into());
             let throughput = ThroughputProperties::manual(1000);
             let container_client = run_context
-                .create_container(
-                    db_client,
-                    properties,
-                    Some(CreateContainerOptions::default().with_throughput(throughput)),
-                )
+                .create_container(db_client, properties, Some(throughput))
                 .await?;
 
             println!(
@@ -258,8 +253,14 @@ pub async fn text_and_binary_distinct_queries_reuse_one_split() -> Result<(), Bo
             let (mut unordered_binary_pages, unordered_binary) =
                 start_query(&container_client, UNORDERED_QUERY, true, PAGE_SIZE).await?;
 
-            let partitions_after =
-                force_split_and_wait(&container_client, partitions_before).await?;
+            let partitions_after = force_split_and_wait(
+                run_context,
+                db_client,
+                &container_client,
+                "DistinctAcrossSplit",
+                partitions_before,
+            )
+            .await?;
             assert!(
                 partitions_after > partitions_before,
                 "split must increase partition count: before={partitions_before}, \

--- a/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_query_order_by_split.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_query_order_by_split.rs
@@ -32,7 +32,6 @@ use std::time::Duration;
 
 use azure_core::http::StatusCode;
 use azure_data_cosmos::feed::ContinuationToken;
-use azure_data_cosmos::options::CreateContainerOptions;
 use azure_data_cosmos::{
     clients::ContainerClient,
     feed::FeedScope,
@@ -243,11 +242,7 @@ pub async fn order_by_query_resume_across_split_preserves_global_order(
             let throughput = ThroughputProperties::manual(1000);
             let container_client = std::sync::Arc::new(
                 run_context
-                    .create_container(
-                        db_client,
-                        properties,
-                        Some(CreateContainerOptions::default().with_throughput(throughput)),
-                    )
+                    .create_container(db_client, properties, Some(throughput))
                     .await?,
             );
 
@@ -326,8 +321,14 @@ pub async fn order_by_query_resume_across_split_preserves_global_order(
                 str_asc_first.len(),
                 str_desc_first.len(),
             );
-            let partitions_after =
-                force_split_and_wait(&container_client, partitions_before).await?;
+            let partitions_after = force_split_and_wait(
+                run_context,
+                db_client,
+                &container_client,
+                "OrderByResumeAcrossSplit",
+                partitions_before,
+            )
+            .await?;
             assert!(
                 partitions_after > partitions_before,
                 "split must increase partition count: before={partitions_before}, \
@@ -563,10 +564,7 @@ pub async fn order_by_live_mixed_types_and_join_resume_matrix() -> Result<(), Bo
                 .create_container(
                     db_client,
                     properties,
-                    Some(
-                        CreateContainerOptions::default()
-                            .with_throughput(ThroughputProperties::manual(1000)),
-                    ),
+                    Some(ThroughputProperties::manual(1000)),
                 )
                 .await?;
 

--- a/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_query_skip_take_split.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_query_skip_take_split.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 use azure_data_cosmos::clients::ContainerClient;
 use azure_data_cosmos::feed::{ContinuationToken, FeedScope};
 use azure_data_cosmos::models::{ContainerProperties, ThroughputProperties};
-use azure_data_cosmos::options::{CreateContainerOptions, MaxItemCountHint, QueryOptions};
+use azure_data_cosmos::options::{MaxItemCountHint, QueryOptions};
 use framework::{MockItem, TestClient, TestOptions};
 use futures::StreamExt;
 
@@ -140,10 +140,7 @@ pub async fn skip_take_queries_preserve_global_windows_across_split() -> Result<
                     .create_container(
                         db_client,
                         properties,
-                        Some(
-                            CreateContainerOptions::default()
-                                .with_throughput(ThroughputProperties::manual(1000)),
-                        ),
+                        Some(ThroughputProperties::manual(1000)),
                     )
                     .await?,
             );
@@ -177,8 +174,14 @@ pub async fn skip_take_queries_preserve_global_windows_across_split() -> Result<
             let (tail_first, tail_token) =
                 capture_first_page(&container_client, TAIL_OFFSET_LIMIT_QUERY).await?;
 
-            let partitions_after =
-                force_split_and_wait(&container_client, partitions_before).await?;
+            let partitions_after = force_split_and_wait(
+                run_context,
+                db_client,
+                &container_client,
+                "SkipTakeAcrossSplit",
+                partitions_before,
+            )
+            .await?;
             assert!(
                 partitions_after > partitions_before,
                 "split must increase partition count: before={partitions_before}, \

--- a/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_query_split.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/split_tests/cosmos_query_split.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use azure_data_cosmos::feed::ContinuationToken;
-use azure_data_cosmos::options::{CreateContainerOptions, ReadFeedRangesOptions};
+use azure_data_cosmos::options::ReadFeedRangesOptions;
 use azure_data_cosmos::{
     clients::ContainerClient,
     feed::FeedScope,
@@ -19,7 +19,7 @@ use azure_data_cosmos::{
     options::{MaxItemCountHint, QueryOptions},
 };
 use framework::{MockItem, TestClient, TestOptions};
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 
 // Backend splits can occasionally exceed 10 minutes under repeated test load.
 // Report a 15-minute miss as inconclusive rather than failing later assumptions.
@@ -39,35 +39,17 @@ const SPLIT_POLL_INTERVAL: Duration = Duration::from_secs(15);
 /// Returns [`InconclusiveError::SplitNotCompleted`] if a strictly larger
 /// topology has not appeared within [`SPLIT_POLL_TIMEOUT`].
 pub(crate) async fn force_split_and_wait(
+    run_context: &framework::TestRunContext,
+    db_client: &azure_data_cosmos::clients::DatabaseClient,
     container_client: &ContainerClient,
+    container_name: &str,
     starting_partitions: usize,
 ) -> Result<usize, Box<dyn Error>> {
     let split_start = Instant::now();
     let new_throughput = ThroughputProperties::manual(13000);
-    let mut poller = container_client
-        .begin_replace_throughput(new_throughput, None)
+    let final_throughput = run_context
+        .replace_container_throughput(db_client, container_name, new_throughput)
         .await?;
-    println!("Throughput update initiated, polling for completion...");
-    let mut last_throughput = None;
-    let mut poll_count = 0;
-    while let Some(status) = poller.try_next().await? {
-        if split_start.elapsed() >= SPLIT_POLL_TIMEOUT {
-            return Err(InconclusiveError::SplitNotCompleted.into());
-        }
-
-        assert!(status.status().is_success());
-        last_throughput = Some(status.into_model()?);
-        if poll_count % 15 == 0 {
-            println!(
-                "Throughput update in progress... polled {} times, last observed throughput: {} RU/s",
-                poll_count,
-                last_throughput.as_ref().and_then(|t| t.throughput()).unwrap_or(0)
-            );
-        }
-        poll_count += 1;
-    }
-    let final_throughput =
-        last_throughput.expect("throughput poller should have yielded at least one response");
     assert_eq!(Some(13000), final_throughput.throughput());
     println!(
         "Throughput update completed, new throughput: {} RU/s",
@@ -149,7 +131,7 @@ pub async fn query_resume_across_split_covers_both_snapshot_shapes() -> Result<(
                     .create_container(
                         db_client,
                         properties,
-                        Some(CreateContainerOptions::default().with_throughput(throughput)),
+                        Some(throughput),
                     )
                     .await?,
             );
@@ -235,7 +217,14 @@ pub async fn query_resume_across_split_covers_both_snapshot_shapes() -> Result<(
                 token_b_collected.len()
             );
             let partitions_after =
-                force_split_and_wait(&container_client, partitions_before).await?;
+                force_split_and_wait(
+                    run_context,
+                    db_client,
+                    &container_client,
+                    "QueryResumeAcrossSplit",
+                    partitions_before,
+                )
+                .await?;
             assert!(
                 partitions_after > partitions_before,
                 "split must increase partition count: before={partitions_before}, after={partitions_after}"

--- a/sdk/cosmos/azure_data_cosmos_driver/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_driver/Cargo.toml
@@ -58,6 +58,8 @@ uuid = { workspace = true, features = ["v4", "fast-rng"] }
 rustc_version.workspace = true
 
 [dev-dependencies]
+azure_core_test = { workspace = true, features = ["tracing"] }
+azure_data_cosmos_test_support = { path = "../azure_data_cosmos_test_support" }
 azure_identity.workspace = true
 quick-xml.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/sdk/cosmos/azure_data_cosmos_driver/build.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/build.rs
@@ -16,6 +16,6 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(fuzzing)");
     // Allow `#[cfg_attr(not(test_category = "..."), ignore)]` in `tests/*.rs`.
     println!(
-        "cargo:rustc-check-cfg=cfg(test_category, values(\"emulator\", \"emulator_vnext\", \"emulator_inmemory\", \"emulator_inmemory_gateway_v2\", \"multi_write\", \"multi_region\", \"gateway_v2\", \"gateway_v2_multi_region\", \"native_query_plan\"))"
+        "cargo:rustc-check-cfg=cfg(test_category, values(\"emulator\", \"emulator_vnext\", \"emulator_inmemory\", \"emulator_inmemory_gateway_v2\", \"multi_write\", \"multi_region\", \"split\", \"merge\", \"binary_encoding\", \"gateway_v2\", \"gateway_v2_multi_region\", \"native_query_plan\"))"
     );
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/emulator_tests/driver_account_metadata_failover.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/emulator_tests/driver_account_metadata_failover.rs
@@ -44,10 +44,13 @@ pub async fn account_metadata_503_surfaces_as_status_error() -> Result<(), Box<d
 
         // First op on the driver triggers the lazy account-properties fetch via
         // create_driver. Under a persistent 503 it must surface upstream HTTP status.
-        let err = context.create_database(&db_name).await.expect_err(
-            "create_database must fail when GET / is faulted with a persistent 503; \
+        let err = context
+            .create_database_data_plane(&db_name)
+            .await
+            .expect_err(
+                "create_database must fail when GET / is faulted with a persistent 503; \
                  the account-metadata fetch is the first network call and cannot succeed",
-        );
+            );
 
         // Harness wraps the typed error in Box<dyn Error>; inspect Display/Debug for the bug
         // signature (the scripted-transport unit test asserts on the typed error directly).

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/emulator_tests/driver_backup_endpoints.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/emulator_tests/driver_backup_endpoints.rs
@@ -83,32 +83,45 @@ async fn driver_operations_work_after_backup_boot() -> Result<(), Box<dyn Error>
         .create_driver(DriverOptions::builder(account.clone()).build())
         .await?;
 
-    // Create a database to verify the driver is operational.
     let db_name = format!(
         "backup-test-{}",
         uuid::Uuid::new_v4().to_string()[..8].to_owned()
     );
-    let body = format!(r#"{{"id": "{}"}}"#, db_name);
-    let operation = CosmosOperation::create_database(account.clone()).with_body(body.into_bytes());
+    if let Some(arm_client) = &env.arm_client {
+        arm_client.create_database(&db_name).await?;
+    } else {
+        let body = format!(r#"{{"id": "{}"}}"#, db_name);
+        let operation =
+            CosmosOperation::create_database(account.clone()).with_body(body.into_bytes());
+        driver
+            .execute_singleton_operation(operation, OperationOptions::default())
+            .await?;
+    }
 
+    let db_ref = DatabaseReference::from_name(account, db_name.clone());
     let result = driver
-        .execute_singleton_operation(operation, OperationOptions::default())
+        .execute_singleton_operation(
+            CosmosOperation::read_database(db_ref.clone()),
+            OperationOptions::default(),
+        )
         .await;
 
     assert!(
         result.is_ok(),
-        "should be able to create database after backup boot: {:?}",
+        "should be able to read a database after backup boot: {:?}",
         result.err()
     );
 
-    // Cleanup
-    let db_ref = DatabaseReference::from_name(account, db_name);
-    let _ = driver
-        .execute_singleton_operation(
-            CosmosOperation::delete_database(db_ref),
-            OperationOptions::default(),
-        )
-        .await;
+    if let Some(arm_client) = &env.arm_client {
+        arm_client.delete_database(&db_name).await?;
+    } else {
+        driver
+            .execute_singleton_operation(
+                CosmosOperation::delete_database(db_ref),
+                OperationOptions::default(),
+            )
+            .await?;
+    }
 
     Ok(())
 }

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/framework/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/framework/mod.rs
@@ -6,5 +6,11 @@
 mod env;
 mod test_client;
 
+pub use azure_data_cosmos_test_support::arm_client;
+
+pub use arm_client::CosmosArmClient;
 pub use env::{get_test_mode, is_azure_pipelines, CosmosTestMode};
-pub use test_client::{resolve_test_env, DriverTestClient};
+pub use test_client::{
+    probe_driver_data_plane_ready, resolve_driver_container_ready, resolve_test_env,
+    DriverTestClient,
+};

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/framework/test_client.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/framework/test_client.rs
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//! Driver test client for emulator-based E2E tests.
+//! Driver test client for emulator and live E2E tests.
 
 use azure_core::http::StatusCode;
 #[cfg(feature = "fault_injection")]
 use azure_data_cosmos_driver::fault_injection::FaultInjectionRule;
-#[cfg(feature = "__internal_testing")]
 use azure_data_cosmos_driver::CosmosDriver;
 use azure_data_cosmos_driver::{
     diagnostics::{DiagnosticsContext, PipelineKind, TransportSecurity},
@@ -14,7 +13,7 @@ use azure_data_cosmos_driver::{
     error::CosmosError,
     models::{
         AccountReference, ConnectionString, ContainerReference, CosmosOperation, CosmosResponse,
-        DatabaseReference, ItemReference, PartitionKey,
+        DatabaseReference, ItemReference, PartitionKey, PartitionKeyValue,
     },
     options::{
         ConnectionPoolOptions, DriverOptions, OperationOptions, OperationOptionsBuilder,
@@ -22,10 +21,12 @@ use azure_data_cosmos_driver::{
     },
     SubStatusCode,
 };
+use serde::Serialize;
 use std::{error::Error, future::Future, sync::Arc, time::Duration};
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 
+use super::arm_client::CosmosArmClient;
 use super::env::{
     get_test_mode, is_azure_pipelines, CosmosTestMode, CONNECTION_STRING_ENV_VAR,
     EMULATOR_CONNECTION_STRING, GATEWAY_V2_ENDPOINT_ENV_VAR, GATEWAY_V2_KEY_ENV_VAR,
@@ -47,6 +48,7 @@ fn test_env_filter() -> EnvFilter {
 pub struct DriverTestClient {
     runtime: Arc<CosmosDriverRuntime>,
     account: AccountReference,
+    arm_client: Option<CosmosArmClient>,
     /// Driver-level preferred regions applied to every driver created by the
     /// per-operation helpers (`create_database`, `read_item`, …). Empty by
     /// default; populated by [`run_with_unique_db_and_hedging`] for the
@@ -73,6 +75,155 @@ pub struct DriverTestClient {
 pub struct TestEnv {
     pub account: AccountReference,
     pub connection_pool: ConnectionPoolOptions,
+    pub arm_client: Option<CosmosArmClient>,
+}
+
+const ACCOUNT_HOST_ENV_VAR: &str = "ACCOUNT_HOST";
+const AUTH_MODE_ENV_VAR: &str = "AZURE_COSMOS_AUTH_MODE";
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ArmContainerResource<'a> {
+    id: &'a str,
+    partition_key: ArmPartitionKey<'a>,
+}
+
+#[derive(Serialize)]
+struct ArmPartitionKey<'a> {
+    paths: &'a [&'a str],
+    kind: &'a str,
+    version: u8,
+}
+
+#[cfg(feature = "fault_injection")]
+struct DisabledFaultInjectionRules(Vec<(Arc<FaultInjectionRule>, bool)>);
+
+#[cfg(feature = "fault_injection")]
+impl DisabledFaultInjectionRules {
+    fn new(rules: &[Arc<FaultInjectionRule>]) -> Self {
+        let states = rules
+            .iter()
+            .map(|rule| {
+                let enabled = rule.is_enabled();
+                rule.disable();
+                (rule.clone(), enabled)
+            })
+            .collect();
+        Self(states)
+    }
+}
+
+#[cfg(feature = "fault_injection")]
+impl Drop for DisabledFaultInjectionRules {
+    fn drop(&mut self) {
+        for (rule, was_enabled) in &self.0 {
+            if *was_enabled {
+                rule.enable();
+            }
+        }
+    }
+}
+
+pub async fn probe_driver_data_plane_ready(
+    driver: &CosmosDriver,
+    container: &ContainerReference,
+    partition_key_component_count: usize,
+) -> Result<(), CosmosError> {
+    const MAX_ATTEMPTS: usize = 20;
+    const RETRY_DELAY: Duration = Duration::from_millis(500);
+
+    let probe_id = format!("data-plane-readiness-probe-{}", Uuid::new_v4());
+    let partition_key = PartitionKey::from(
+        (0..partition_key_component_count)
+            .map(|_| PartitionKeyValue::from(probe_id.clone()))
+            .collect::<Vec<_>>(),
+    );
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        let item = ItemReference::from_name(container, partition_key.clone(), probe_id.clone());
+        let outcome = driver
+            .execute_singleton_operation(
+                CosmosOperation::delete_item(item),
+                OperationOptions::default(),
+            )
+            .await;
+        match outcome {
+            Ok(response) => {
+                return Err(CosmosError::builder()
+                    .with_status(response.status())
+                    .with_message(format!(
+                        "driver data-plane readiness probe unexpectedly deleted {probe_id}"
+                    ))
+                    .build());
+            }
+            Err(error)
+                if error.status().status_code() == StatusCode::NotFound
+                    && error
+                        .status()
+                        .sub_status()
+                        .is_none_or(|sub_status| sub_status.value() == 0) =>
+            {
+                return Ok(());
+            }
+            Err(error) => {
+                let status = error.status();
+                let retryable = (status.status_code() == StatusCode::Forbidden
+                    && status.sub_status() == Some(SubStatusCode::new(5302)))
+                    || (status.status_code() == StatusCode::NotFound
+                        && status.sub_status()
+                            == Some(SubStatusCode::COLLECTION_CREATE_IN_PROGRESS))
+                    || (status.status_code() == StatusCode::NotFound
+                        && status.sub_status() == Some(SubStatusCode::OWNER_RESOURCE_NOT_FOUND))
+                    || matches!(
+                        status.status_code(),
+                        StatusCode::TooManyRequests
+                            | StatusCode::ServiceUnavailable
+                            | StatusCode::Gone
+                    );
+                if !retryable || attempt == MAX_ATTEMPTS {
+                    return Err(error);
+                }
+            }
+        }
+
+        tokio::time::sleep(RETRY_DELAY).await;
+    }
+
+    unreachable!("the final probe attempt returns above")
+}
+
+pub async fn resolve_driver_container_ready(
+    driver: &CosmosDriver,
+    database_name: &str,
+    container_name: &str,
+) -> Result<ContainerReference, CosmosError> {
+    const MAX_ATTEMPTS: usize = 60;
+    const RETRY_DELAY: Duration = Duration::from_millis(500);
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        match driver
+            .resolve_container_by_name(database_name, container_name, OperationOptions::default())
+            .await
+        {
+            Ok(container) => return Ok(container),
+            Err(error)
+                if error.status().status_code() == StatusCode::NotFound
+                    && matches!(
+                        error.status().sub_status(),
+                        Some(
+                            SubStatusCode::COLLECTION_CREATE_IN_PROGRESS
+                                | SubStatusCode::OWNER_RESOURCE_NOT_FOUND
+                        )
+                    )
+                    && attempt < MAX_ATTEMPTS =>
+            {
+                tokio::time::sleep(RETRY_DELAY).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    unreachable!("the final container resolution attempt returns above")
 }
 
 /// Resolves the test environment from environment variables.
@@ -106,6 +257,25 @@ pub fn resolve_test_env() -> Result<Option<TestEnv>, Box<dyn Error>> {
         return resolve_gateway_v2_env(test_mode);
     }
 
+    if std::env::var(AUTH_MODE_ENV_VAR).is_ok_and(|value| value.eq_ignore_ascii_case("aad")) {
+        let endpoint = std::env::var(ACCOUNT_HOST_ENV_VAR)
+            .ok()
+            .filter(|value| !value.trim().is_empty());
+        let Some(endpoint) = endpoint else {
+            if test_mode == CosmosTestMode::Required || is_azure_pipelines() {
+                panic!("{ACCOUNT_HOST_ENV_VAR} is not set but AAD test mode is required");
+            }
+            return Ok(None);
+        };
+        let credential = azure_core_test::credentials::from_env(None)?;
+        let account = AccountReference::with_credential(endpoint.parse()?, credential.clone());
+        return Ok(Some(TestEnv {
+            account,
+            connection_pool: ConnectionPoolOptions::builder().build()?,
+            arm_client: Some(CosmosArmClient::from_env(credential)?),
+        }));
+    }
+
     #[allow(unreachable_code)]
     let connection_string = match std::env::var(CONNECTION_STRING_ENV_VAR) {
         Ok(val) if val.to_lowercase() == "emulator" => EMULATOR_CONNECTION_STRING.to_string(),
@@ -137,6 +307,7 @@ pub fn resolve_test_env() -> Result<Option<TestEnv>, Box<dyn Error>> {
     Ok(Some(TestEnv {
         account,
         connection_pool,
+        arm_client: None,
     }))
 }
 
@@ -199,6 +370,7 @@ fn resolve_gateway_v2_env(test_mode: CosmosTestMode) -> Result<Option<TestEnv>, 
             Ok(Some(TestEnv {
                 account,
                 connection_pool,
+                arm_client: None,
             }))
         }
         (None, None) => {
@@ -248,9 +420,9 @@ fn normalize_gateway_v2_endpoint(raw: &str) -> String {
 impl DriverTestClient {
     /// Creates a new test client from environment variables.
     ///
-    /// If the `AZURE_COSMOS_CONNECTION_STRING` environment variable is set to
-    /// "emulator", uses the well-known emulator connection string. Otherwise,
-    /// parses the provided connection string.
+    /// Uses `ACCOUNT_HOST` plus the standard test token credential when
+    /// `AZURE_COSMOS_AUTH_MODE=aad`; otherwise resolves the emulator or live
+    /// account from `AZURE_COSMOS_CONNECTION_STRING`.
     ///
     /// Returns `None` if:
     /// - The environment variable is not set and test mode is not "required"
@@ -268,6 +440,7 @@ impl DriverTestClient {
         Ok(Some(Self {
             runtime,
             account: env.account,
+            arm_client: env.arm_client,
             preferred_regions: Vec::new(),
             #[cfg(feature = "fault_injection")]
             fault_injection_rules: Vec::new(),
@@ -295,6 +468,7 @@ impl DriverTestClient {
         Ok(Some(Self {
             runtime,
             account: env.account,
+            arm_client: env.arm_client,
             preferred_regions: Vec::new(),
             fault_injection_rules: rules,
             partition_failover_options: None,
@@ -390,6 +564,7 @@ impl DriverTestClient {
         let client = Self {
             runtime,
             account: env.account,
+            arm_client: env.arm_client,
             preferred_regions: Vec::new(),
             fault_injection_rules: rules,
             partition_failover_options: None,
@@ -439,6 +614,7 @@ impl DriverTestClient {
         let client = Self {
             runtime,
             account: env.account,
+            arm_client: env.arm_client,
             preferred_regions: Vec::new(),
             fault_injection_rules: rules,
             partition_failover_options: Some(partition_failover_options),
@@ -491,6 +667,7 @@ impl DriverTestClient {
         let client = Self {
             runtime,
             account: env.account,
+            arm_client: env.arm_client,
             preferred_regions,
             fault_injection_rules: rules,
             partition_failover_options: None,
@@ -552,6 +729,7 @@ impl DriverTestClient {
         let client = Self {
             runtime,
             account: env.account,
+            arm_client: env.arm_client,
             preferred_regions: Vec::new(),
             #[cfg(feature = "fault_injection")]
             fault_injection_rules: Vec::new(),
@@ -717,6 +895,25 @@ impl DriverTestRunContext {
         &self,
         db_name: &str,
     ) -> Result<DatabaseReference, Box<dyn Error>> {
+        if let Some(arm_client) = &self.client.arm_client {
+            arm_client.create_database(db_name).await?;
+            return Ok(DatabaseReference::from_name(
+                self.client.account.clone(),
+                db_name.to_string(),
+            ));
+        }
+
+        self.create_database_data_plane(db_name).await
+    }
+
+    /// Executes the driver database-create operation directly.
+    ///
+    /// Resource setup uses ARM in AAD mode; tests that explicitly validate the
+    /// driver's database-create path use this method instead.
+    pub async fn create_database_data_plane(
+        &self,
+        db_name: &str,
+    ) -> Result<DatabaseReference, Box<dyn Error>> {
         let driver = self
             .client
             .runtime
@@ -758,6 +955,14 @@ impl DriverTestRunContext {
         &self,
         database: &DatabaseReference,
     ) -> Result<(), Box<dyn Error>> {
+        if let Some(arm_client) = &self.client.arm_client {
+            let database_name = database
+                .name()
+                .ok_or("ARM-backed resource management requires a name-addressed database")?;
+            arm_client.delete_database(database_name).await?;
+            return Ok(());
+        }
+
         let driver = self
             .client
             .runtime
@@ -826,52 +1031,73 @@ impl DriverTestRunContext {
         } else {
             "MultiHash"
         };
-        let body = format!(
-            r#"{{"id": "{}", "partitionKey": {{"paths": [{}], "kind": "{}", "version": 2}}}}"#,
-            container_name, paths_json, kind
-        );
-        let operation =
-            CosmosOperation::create_container(database.clone()).with_body(body.into_bytes());
+        let arm_managed = self.client.arm_client.is_some();
+        let mut ambiguous_create_error = None;
+        if let Some(arm_client) = &self.client.arm_client {
+            let database_name = database
+                .name()
+                .ok_or("ARM-backed resource management requires a name-addressed database")?;
+            let resource = ArmContainerResource {
+                id: container_name,
+                partition_key: ArmPartitionKey {
+                    paths: partition_key_paths,
+                    kind,
+                    version: 2,
+                },
+            };
+            arm_client
+                .create_or_update_container(database_name, container_name, &resource, None)
+                .await?;
+        } else {
+            let body = format!(
+                r#"{{"id": "{}", "partitionKey": {{"paths": [{}], "kind": "{}", "version": 2}}}}"#,
+                container_name, paths_json, kind
+            );
+            let operation =
+                CosmosOperation::create_container(database.clone()).with_body(body.into_bytes());
 
-        let create_result = self
-            .retry_transient_transport("create container", || {
-                let operation = operation.clone();
-                let driver = driver.clone();
-                async move {
-                    driver
-                        .execute_singleton_operation(operation, OperationOptions::default())
-                        .await
-                        .map_err(Into::into)
+            let create_result = self
+                .retry_transient_transport("create container", || {
+                    let operation = operation.clone();
+                    let driver = driver.clone();
+                    async move {
+                        driver
+                            .execute_singleton_operation(operation, OperationOptions::default())
+                            .await
+                            .map_err(Into::into)
+                    }
+                })
+                .await;
+            // Tolerate a 409 Conflict from the create itself: a client-side
+            // timeout (surfaced as a synthetic `TransportGenerated503`) doesn't
+            // mean the server never processed the request — the driver's own
+            // region-failover retry can legitimately observe the container
+            // already exists. Fall through to the resolve-retry loop below
+            // exactly as a successful create would, since that's what actually
+            // produces the `ContainerReference` this method returns.
+            ambiguous_create_error = match create_result {
+                Err(error)
+                    if error.downcast_ref::<CosmosError>().is_some_and(|error| {
+                        error.status().status_code() == StatusCode::Conflict
+                    }) =>
+                {
+                    None
                 }
-            })
-            .await;
-        // Tolerate a 409 Conflict from the create itself: a client-side
-        // timeout (surfaced as a synthetic `TransportGenerated503`) doesn't
-        // mean the server never processed the request — the driver's own
-        // region-failover retry can legitimately observe the container
-        // already exists. Fall through to the resolve-retry loop below
-        // exactly as a successful create would, since that's what actually
-        // produces the `ContainerReference` this method returns.
-        let mut ambiguous_create_error = match create_result {
-            Err(error)
-                if error
-                    .downcast_ref::<CosmosError>()
-                    .is_some_and(|error| error.status().status_code() == StatusCode::Conflict) =>
-            {
-                None
-            }
-            Err(error) if Self::is_transport_generated_503(error.as_ref()) => Some(error),
-            other => {
-                let result = other?;
-                // Check for success status (201 Created)
-                let diagnostics = result.diagnostics();
-                let status = diagnostics.status();
-                if !status.map(|s| s.is_success()).unwrap_or(false) {
-                    return Err(format!("Failed to create container, status: {:?}", status).into());
+                Err(error) if Self::is_transport_generated_503(error.as_ref()) => Some(error),
+                other => {
+                    let result = other?;
+                    // Check for success status (201 Created)
+                    let diagnostics = result.diagnostics();
+                    let status = diagnostics.status();
+                    if !status.map(|s| s.is_success()).unwrap_or(false) {
+                        return Err(
+                            format!("Failed to create container, status: {:?}", status).into()
+                        );
+                    }
+                    None
                 }
-                None
-            }
-        };
+            };
+        }
         let db_name = database
             .name()
             .ok_or_else(|| "database reference must be name-based".to_string())?;
@@ -890,7 +1116,20 @@ impl DriverTestRunContext {
                 .resolve_container_by_name(db_name, container_name, OperationOptions::default())
                 .await
             {
-                Ok(c) => return Ok(c),
+                Ok(container) => {
+                    if arm_managed {
+                        #[cfg(feature = "fault_injection")]
+                        let _disabled_rules =
+                            DisabledFaultInjectionRules::new(&self.client.fault_injection_rules);
+                        probe_driver_data_plane_ready(
+                            &driver,
+                            &container,
+                            partition_key_paths.len(),
+                        )
+                        .await?;
+                    }
+                    return Ok(container);
+                }
                 Err(e) => {
                     // Match on the typed status/sub-status (404/1013) rather
                     // than substring-scanning the error message.

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/gateway_query_plan_comparison.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/gateway_query_plan_comparison.rs
@@ -23,7 +23,7 @@
 
 mod framework;
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use azure_core::http::headers::{HeaderName, HeaderValue};
 use tokio::sync::OnceCell;
@@ -36,7 +36,10 @@ use azure_data_cosmos_driver::options::DriverOptions;
 use azure_data_cosmos_driver::options::{OperationOptions, PlanOptions};
 use azure_data_cosmos_driver::CosmosDriver;
 
-use framework::resolve_test_env;
+use framework::{
+    probe_driver_data_plane_ready, resolve_driver_container_ready, resolve_test_env,
+    CosmosArmClient,
+};
 
 // ─── Test infrastructure ─────────────────────────────────────────────────────
 
@@ -63,7 +66,34 @@ async fn get_driver() -> Option<&'static Arc<CosmosDriver>> {
 
 const DB_NAME: &str = "query_plan_test_db";
 
+fn arm_client() -> Option<&'static CosmosArmClient> {
+    static ARM_CLIENT: OnceLock<Option<CosmosArmClient>> = OnceLock::new();
+    ARM_CLIENT
+        .get_or_init(|| {
+            if !std::env::var("AZURE_COSMOS_AUTH_MODE")
+                .is_ok_and(|value| value.eq_ignore_ascii_case("aad"))
+            {
+                return None;
+            }
+            let credential = azure_core_test::credentials::from_env(None)
+                .expect("failed to resolve federated test credential");
+            Some(
+                CosmosArmClient::from_env(credential)
+                    .expect("failed to resolve Cosmos ARM test environment"),
+            )
+        })
+        .as_ref()
+}
+
 async fn ensure_database(driver: &CosmosDriver) {
+    if let Some(arm_client) = arm_client() {
+        arm_client
+            .create_database(DB_NAME)
+            .await
+            .expect("failed to ensure query-plan test database through ARM");
+        return;
+    }
+
     let account = driver.account().clone();
     let op = CosmosOperation::create_database(account)
         .with_body(serde_json::to_vec(&serde_json::json!({"id": DB_NAME})).unwrap());
@@ -85,6 +115,29 @@ async fn ensure_container(
     pk_def: PartitionKeyDefinition,
 ) -> ContainerReference {
     ensure_database(driver).await;
+    let partition_key_component_count = pk_def.paths().len();
+
+    if let Some(arm_client) = arm_client() {
+        arm_client
+            .create_or_update_container(
+                DB_NAME,
+                container_name,
+                &serde_json::json!({
+                    "id": container_name,
+                    "partitionKey": pk_def,
+                }),
+                None,
+            )
+            .await
+            .expect("failed to ensure query-plan test container through ARM");
+        let container = resolve_driver_container_ready(driver, DB_NAME, container_name)
+            .await
+            .expect("failed to resolve container");
+        probe_driver_data_plane_ready(driver, &container, partition_key_component_count)
+            .await
+            .expect("query-plan container data path did not become ready");
+        return container;
+    }
 
     let body = serde_json::to_vec(&serde_json::json!({
         "id": container_name,

--- a/sdk/cosmos/azure_data_cosmos_driver/tests/multi_region_failover.rs
+++ b/sdk/cosmos/azure_data_cosmos_driver/tests/multi_region_failover.rs
@@ -26,6 +26,7 @@ use azure_data_cosmos_driver::options::DriverOptions;
 use azure_data_cosmos_driver::options::OperationOptions;
 use azure_data_cosmos_driver::options::{ExcludedRegions, OperationOptionsBuilder, Region};
 use azure_data_cosmos_driver::{CosmosStatus, SubStatusCode};
+use serde::Serialize;
 use std::error::Error;
 use std::sync::Arc;
 use std::time::Duration;
@@ -37,7 +38,24 @@ use uuid::Uuid;
 #[allow(dead_code, unused_imports)]
 mod framework;
 
-use framework::resolve_test_env;
+use framework::{
+    probe_driver_data_plane_ready, resolve_driver_container_ready, resolve_test_env,
+    CosmosArmClient,
+};
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ArmContainerResource<'a> {
+    id: &'a str,
+    partition_key: ArmPartitionKey<'a>,
+}
+
+#[derive(Serialize)]
+struct ArmPartitionKey<'a> {
+    paths: [&'a str; 1],
+    kind: &'a str,
+    version: u8,
+}
 
 /// Persistent fault on every `MetadataReadDatabaseAccount` (GET /) request.
 /// Fires unconditionally on `create_driver`, regardless of the data-plane op that follows.
@@ -247,12 +265,12 @@ fn assert_final_request_left_faulted_region(response: &CosmosResponse, faulted_r
     );
 }
 
-/// Creates a fresh DB + container via raw `CosmosOperation`s + JSON bodies (mirrors
-/// `framework::DriverTestClient::{create_database, create_container_with_pk_paths}`).
+/// Creates a fresh DB + container, using ARM for federated live accounts.
 /// Caller is responsible for cleanup via [`delete_database`].
 async fn create_unique_db_and_container(
     runtime: &Arc<CosmosDriverRuntime>,
     account: &AccountReference,
+    arm_client: Option<&CosmosArmClient>,
 ) -> Result<(DatabaseReference, ContainerReference), Box<dyn Error>> {
     let driver = runtime
         .create_driver(DriverOptions::builder(account.clone()).build())
@@ -260,36 +278,61 @@ async fn create_unique_db_and_container(
     let db_name = format!("failover-test-db-{}", Uuid::new_v4());
     let container_name = "c".to_string();
 
-    // Create database.
-    let db_body = format!(r#"{{"id":"{db_name}"}}"#);
-    let db_op = CosmosOperation::create_database(account.clone()).with_body(db_body.into_bytes());
-    let db_result = driver
-        .execute_singleton_operation(db_op, OperationOptions::default())
-        .await?;
-    let db_diag = db_result.diagnostics();
-    let db_status = db_diag.status();
-    if !db_status.map(|s| s.is_success()).unwrap_or(false) {
-        return Err(format!("create database failed, status: {db_status:?}").into());
-    }
     let db_ref = DatabaseReference::from_name(account.clone(), db_name.clone());
+    if let Some(arm_client) = arm_client {
+        arm_client.create_database(&db_name).await?;
+        arm_client
+            .create_or_update_container(
+                &db_name,
+                &container_name,
+                &ArmContainerResource {
+                    id: &container_name,
+                    partition_key: ArmPartitionKey {
+                        paths: ["/pk"],
+                        kind: "Hash",
+                        version: 2,
+                    },
+                },
+                None,
+            )
+            .await?;
+    } else {
+        let db_body = format!(r#"{{"id":"{db_name}"}}"#);
+        let db_op =
+            CosmosOperation::create_database(account.clone()).with_body(db_body.into_bytes());
+        let db_result = driver
+            .execute_singleton_operation(db_op, OperationOptions::default())
+            .await?;
+        let db_diagnostics = db_result.diagnostics();
+        let db_status = db_diagnostics.status();
+        if !db_status.map(|s| s.is_success()).unwrap_or(false) {
+            return Err(format!("create database failed, status: {db_status:?}").into());
+        }
 
-    // Create container.
-    let container_body = format!(
-        r#"{{"id":"{container_name}","partitionKey":{{"paths":["/pk"],"kind":"Hash","version":2}}}}"#
-    );
-    let container_op =
-        CosmosOperation::create_container(db_ref.clone()).with_body(container_body.into_bytes());
-    let container_result = driver
-        .execute_singleton_operation(container_op, OperationOptions::default())
-        .await?;
-    let container_diag = container_result.diagnostics();
-    let container_status = container_diag.status();
-    if !container_status.map(|s| s.is_success()).unwrap_or(false) {
-        return Err(format!("create container failed, status: {container_status:?}").into());
+        let container_body = format!(
+            r#"{{"id":"{container_name}","partitionKey":{{"paths":["/pk"],"kind":"Hash","version":2}}}}"#
+        );
+        let container_op = CosmosOperation::create_container(db_ref.clone())
+            .with_body(container_body.into_bytes());
+        let container_result = driver
+            .execute_singleton_operation(container_op, OperationOptions::default())
+            .await?;
+        let container_diagnostics = container_result.diagnostics();
+        let container_status = container_diagnostics.status();
+        if !container_status.map(|s| s.is_success()).unwrap_or(false) {
+            return Err(format!("create container failed, status: {container_status:?}").into());
+        }
     }
-    let container_ref = driver
-        .resolve_container_by_name(&db_name, &container_name, OperationOptions::default())
-        .await?;
+
+    let container_ref = if arm_client.is_some() {
+        let container = resolve_driver_container_ready(&driver, &db_name, &container_name).await?;
+        probe_driver_data_plane_ready(&driver, &container, 1).await?;
+        container
+    } else {
+        driver
+            .resolve_container_by_name(&db_name, &container_name, OperationOptions::default())
+            .await?
+    };
     Ok((db_ref, container_ref))
 }
 
@@ -298,7 +341,13 @@ async fn delete_database(
     runtime: &Arc<CosmosDriverRuntime>,
     account: &AccountReference,
     db: &DatabaseReference,
+    arm_client: Option<&CosmosArmClient>,
 ) {
+    if let (Some(arm_client), Some(database_name)) = (arm_client, db.name()) {
+        let _ = arm_client.delete_database(database_name).await;
+        return;
+    }
+
     if let Ok(driver) = runtime
         .create_driver(DriverOptions::builder(account.clone()).build())
         .await
@@ -501,9 +550,11 @@ async fn excluded_regions_honored_end_to_end() -> Result<(), Box<dyn Error>> {
         return Ok(());
     };
     let account = env.account;
+    let arm_client = env.arm_client;
 
     let runtime = CosmosDriverRuntime::builder().build().await?;
-    let (db_ref, container_ref) = create_unique_db_and_container(&runtime, &account).await?;
+    let (db_ref, container_ref) =
+        create_unique_db_and_container(&runtime, &account, arm_client.as_ref()).await?;
 
     let all_regions = [HUB_REGION, SATELLITE_REGION];
     let mut setup_err = None;
@@ -516,7 +567,7 @@ async fn excluded_regions_honored_end_to_end() -> Result<(), Box<dyn Error>> {
         }
     }
     if let Some(msg) = setup_err {
-        delete_database(&runtime, &account, &db_ref).await;
+        delete_database(&runtime, &account, &db_ref, arm_client.as_ref()).await;
         return Err(msg.into());
     }
 
@@ -553,7 +604,7 @@ async fn excluded_regions_honored_end_to_end() -> Result<(), Box<dyn Error>> {
         }
     }
 
-    delete_database(&runtime, &account, &db_ref).await;
+    delete_database(&runtime, &account, &db_ref, arm_client.as_ref()).await;
     result
 }
 
@@ -580,11 +631,13 @@ where
         return Ok(());
     };
     let account = env.account;
+    let arm_client = env.arm_client;
 
     // Setup runtime: NO fault rule. Used for DB/container creation + warmup so
     // those operations are unaffected by the rule we will exercise.
     let setup_runtime = CosmosDriverRuntime::builder().build().await?;
-    let (db_ref, container_ref) = create_unique_db_and_container(&setup_runtime, &account).await?;
+    let (db_ref, container_ref) =
+        create_unique_db_and_container(&setup_runtime, &account, arm_client.as_ref()).await?;
 
     let all_regions = [HUB_REGION, SATELLITE_REGION];
     let mut warmup_err = None;
@@ -603,7 +656,7 @@ where
         }
     }
     if let Some(msg) = warmup_err {
-        delete_database(&setup_runtime, &account, &db_ref).await;
+        delete_database(&setup_runtime, &account, &db_ref, arm_client.as_ref()).await;
         return Err(msg.into());
     }
 
@@ -628,6 +681,6 @@ where
          before the driver failed over; hit_count was 0. Test result: {result:?}"
     );
 
-    delete_database(&setup_runtime, &account, &db_ref).await;
+    delete_database(&setup_runtime, &account, &db_ref, arm_client.as_ref()).await;
     result
 }

--- a/sdk/cosmos/azure_data_cosmos_perf/build.rs
+++ b/sdk/cosmos/azure_data_cosmos_perf/build.rs
@@ -7,5 +7,7 @@
 // unknown cfg names are warned/denied unless explicitly declared via check-cfg.
 fn main() {
     // Allow `#[cfg_attr(not(test_category = "..."), ignore)]` in `tests/*.rs`.
-    println!("cargo:rustc-check-cfg=cfg(test_category, values(\"binary_encoding\"))");
+    println!(
+        "cargo:rustc-check-cfg=cfg(test_category, values(\"split\", \"merge\", \"binary_encoding\"))"
+    );
 }

--- a/sdk/cosmos/azure_data_cosmos_test_support/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos_test_support/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "azure_data_cosmos_test_support"
+version = "0.0.0"
+publish = false
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+azure_core.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["time"] }

--- a/sdk/cosmos/azure_data_cosmos_test_support/src/arm_client.rs
+++ b/sdk/cosmos/azure_data_cosmos_test_support/src/arm_client.rs
@@ -1,0 +1,647 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Typed Azure Resource Manager client helpers for Cosmos live tests.
+//!
+//! This test-only client fills the gap until a generated Cosmos ARM crate is available.
+
+use azure_core::{
+    credentials::TokenCredential,
+    http::{
+        headers::HeaderName,
+        policies::{auth::BearerTokenAuthorizationPolicy, Policy},
+        ClientOptions, Method, Pipeline, PipelineSendOptions, RawResponse, Request, StatusCode,
+        Url,
+    },
+    Result,
+};
+use serde::{Deserialize, Serialize};
+use std::{sync::Arc, time::Duration};
+
+const DEFAULT_RESOURCE_MANAGER_ENDPOINT: &str = "https://management.azure.com/";
+const RESOURCE_API_VERSION: &str = "2026-03-15";
+const PARTITION_MERGE_API_VERSION: &str = "2026-04-01-preview";
+const LRO_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const LRO_TIMEOUT: Duration = Duration::from_secs(60 * 60);
+
+const SUBSCRIPTION_ID_ENV_VAR: &str = "COSMOS_SUBSCRIPTION_ID";
+const RESOURCE_GROUP_ENV_VAR: &str = "COSMOS_RESOURCE_GROUP";
+const ACCOUNT_NAME_ENV_VAR: &str = "COSMOS_ACCOUNT_NAME";
+const LOCATION_ENV_VAR: &str = "COSMOS_LOCATION";
+const RESOURCE_MANAGER_URL_ENV_VAR: &str = "COSMOS_RESOURCE_MANAGER_URL";
+
+#[derive(Clone)]
+pub struct CosmosArmClient {
+    endpoint: Url,
+    subscription_id: String,
+    resource_group: String,
+    account_name: String,
+    location: Option<String>,
+    pipeline: Pipeline,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ArmThroughput {
+    Manual(usize),
+    Autoscale {
+        maximum: usize,
+        current: Option<usize>,
+        increment_percent: Option<usize>,
+    },
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SqlResourceCreateUpdateParameters<T> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    location: Option<String>,
+    properties: SqlResourceProperties<T>,
+}
+
+#[derive(Serialize)]
+struct SqlResourceProperties<T> {
+    resource: T,
+    options: CreateUpdateOptions,
+}
+
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateUpdateOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    throughput: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    autoscale_settings: Option<CreateAutoscaleSettings>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateAutoscaleSettings {
+    max_throughput: usize,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AutoscaleAutoUpgradePolicy {
+    throughput_policy: AutoscaleThroughputPolicy,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AutoscaleThroughputPolicy {
+    increment_percent: usize,
+}
+
+#[derive(Serialize)]
+struct SqlDatabaseResource<'a> {
+    id: &'a str,
+}
+
+#[derive(Serialize)]
+struct ThroughputSettingsUpdateParameters {
+    properties: ThroughputSettingsProperties,
+}
+
+#[derive(Serialize)]
+struct ThroughputSettingsProperties {
+    resource: ThroughputSettingsResource,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ThroughputSettingsResource {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    throughput: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    autoscale_settings: Option<ThroughputAutoscaleSettings>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ThroughputAutoscaleSettings {
+    max_throughput: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auto_upgrade_policy: Option<AutoscaleAutoUpgradePolicy>,
+}
+
+#[derive(Deserialize)]
+struct ThroughputSettingsGetResults {
+    properties: ThroughputSettingsGetProperties,
+}
+
+#[derive(Deserialize)]
+struct ThroughputSettingsGetProperties {
+    resource: ThroughputSettingsGetResource,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ThroughputSettingsGetResource {
+    throughput: Option<usize>,
+    autoscale_settings: Option<AutoscaleSettingsResult>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AutoscaleSettingsResult {
+    max_throughput: usize,
+    auto_upgrade_policy: Option<AutoscaleAutoUpgradePolicyResult>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AutoscaleAutoUpgradePolicyResult {
+    throughput_policy: Option<AutoscaleThroughputPolicyResult>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AutoscaleThroughputPolicyResult {
+    increment_percent: usize,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PartitionMergeParameters {
+    is_dry_run: bool,
+}
+
+impl CosmosArmClient {
+    pub fn from_env(credential: Arc<dyn TokenCredential>) -> Result<Self> {
+        let endpoint = std::env::var(RESOURCE_MANAGER_URL_ENV_VAR)
+            .unwrap_or_else(|_| DEFAULT_RESOURCE_MANAGER_ENDPOINT.to_string());
+        let endpoint = normalize_endpoint(&endpoint)?;
+        let scope = format!("{}.default", endpoint.as_str());
+        let auth_policy: Arc<dyn Policy> =
+            Arc::new(BearerTokenAuthorizationPolicy::new(credential, [scope]));
+
+        Ok(Self {
+            endpoint,
+            subscription_id: required_env(SUBSCRIPTION_ID_ENV_VAR)?,
+            resource_group: required_env(RESOURCE_GROUP_ENV_VAR)?,
+            account_name: required_env(ACCOUNT_NAME_ENV_VAR)?,
+            location: std::env::var(LOCATION_ENV_VAR)
+                .ok()
+                .filter(|value| !value.trim().is_empty()),
+            pipeline: Pipeline::new(
+                option_env!("CARGO_PKG_NAME"),
+                option_env!("CARGO_PKG_VERSION"),
+                ClientOptions::default(),
+                Vec::new(),
+                vec![auth_policy],
+                None,
+            ),
+        })
+    }
+
+    pub async fn create_database(&self, database_name: &str) -> Result<()> {
+        let body = SqlResourceCreateUpdateParameters {
+            location: self.location.clone(),
+            properties: SqlResourceProperties {
+                resource: SqlDatabaseResource { id: database_name },
+                options: CreateUpdateOptions::default(),
+            },
+        };
+        let path = format!("{}/sqlDatabases/{database_name}", self.account_path());
+        self.send_resource_operation(Method::Put, &path, Some(&body))
+            .await
+    }
+
+    pub async fn delete_database(&self, database_name: &str) -> Result<()> {
+        let path = format!("{}/sqlDatabases/{database_name}", self.account_path());
+        self.send_resource_operation::<()>(Method::Delete, &path, None)
+            .await
+    }
+
+    pub async fn create_or_update_container<T>(
+        &self,
+        database_name: &str,
+        container_name: &str,
+        resource: &T,
+        throughput: Option<ArmThroughput>,
+    ) -> Result<()>
+    where
+        T: Serialize + ?Sized,
+    {
+        let body = SqlResourceCreateUpdateParameters {
+            location: self.location.clone(),
+            properties: SqlResourceProperties {
+                resource,
+                options: throughput.map(create_update_options).unwrap_or_default(),
+            },
+        };
+        let path = self.container_path(database_name, container_name);
+        self.send_resource_operation(Method::Put, &path, Some(&body))
+            .await?;
+        if let Some(
+            throughput @ ArmThroughput::Autoscale {
+                increment_percent: Some(_),
+                ..
+            },
+        ) = throughput
+        {
+            self.replace_container_throughput(database_name, container_name, throughput)
+                .await?;
+        }
+        Ok(())
+    }
+
+    pub async fn delete_container(&self, database_name: &str, container_name: &str) -> Result<()> {
+        let path = self.container_path(database_name, container_name);
+        self.send_resource_operation::<()>(Method::Delete, &path, None)
+            .await
+    }
+
+    pub async fn read_container_throughput(
+        &self,
+        database_name: &str,
+        container_name: &str,
+    ) -> Result<ArmThroughput> {
+        let path = format!(
+            "{}/throughputSettings/default",
+            self.container_path(database_name, container_name)
+        );
+        self.read_throughput(&path).await?.ok_or_else(|| {
+            azure_core::Error::with_message(
+                azure_core::error::ErrorKind::DataConversion,
+                "Cosmos container does not have dedicated throughput",
+            )
+        })
+    }
+
+    pub async fn read_database_throughput(
+        &self,
+        database_name: &str,
+    ) -> Result<Option<ArmThroughput>> {
+        let path = format!(
+            "{}/sqlDatabases/{database_name}/throughputSettings/default",
+            self.account_path()
+        );
+        self.read_throughput(&path).await
+    }
+
+    async fn read_throughput(&self, path: &str) -> Result<Option<ArmThroughput>> {
+        let response = self
+            .send(Method::Get, path, RESOURCE_API_VERSION, None::<&()>)
+            .await?;
+        if response.status() == StatusCode::NotFound {
+            return Ok(None);
+        }
+        ensure_success(&response, "read Cosmos container throughput")?;
+        let result: ThroughputSettingsGetResults = response.body().json()?;
+        let resource = result.properties.resource;
+        Ok(Some(
+            match (resource.throughput, resource.autoscale_settings) {
+                (current, Some(settings)) => ArmThroughput::Autoscale {
+                    maximum: settings.max_throughput,
+                    current,
+                    increment_percent: settings
+                        .auto_upgrade_policy
+                        .and_then(|policy| policy.throughput_policy)
+                        .map(|policy| policy.increment_percent),
+                },
+                (Some(throughput), None) => ArmThroughput::Manual(throughput),
+                (None, None) => {
+                    return Err(azure_core::Error::with_message(
+                        azure_core::error::ErrorKind::DataConversion,
+                        "ARM throughput response contained neither manual nor autoscale settings",
+                    ));
+                }
+            },
+        ))
+    }
+
+    pub async fn replace_container_throughput(
+        &self,
+        database_name: &str,
+        container_name: &str,
+        throughput: ArmThroughput,
+    ) -> Result<ArmThroughput> {
+        let body = ThroughputSettingsUpdateParameters {
+            properties: ThroughputSettingsProperties {
+                resource: throughput_settings_resource(throughput),
+            },
+        };
+        let path = format!(
+            "{}/throughputSettings/default",
+            self.container_path(database_name, container_name)
+        );
+        self.send_resource_operation(Method::Put, &path, Some(&body))
+            .await?;
+        self.read_container_throughput(database_name, container_name)
+            .await
+    }
+
+    pub async fn merge_partitions(&self, database_name: &str, container_name: &str) -> Result<()> {
+        let path = format!(
+            "{}/partitionMerge",
+            self.container_path(database_name, container_name)
+        );
+        self.send_operation(
+            Method::Post,
+            &path,
+            PARTITION_MERGE_API_VERSION,
+            Some(&PartitionMergeParameters { is_dry_run: false }),
+        )
+        .await
+    }
+
+    fn account_path(&self) -> String {
+        format!(
+            "subscriptions/{}/resourceGroups/{}/providers/Microsoft.DocumentDB/databaseAccounts/{}",
+            self.subscription_id, self.resource_group, self.account_name
+        )
+    }
+
+    fn container_path(&self, database_name: &str, container_name: &str) -> String {
+        format!(
+            "{}/sqlDatabases/{database_name}/containers/{container_name}",
+            self.account_path()
+        )
+    }
+
+    async fn send_resource_operation<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<&T>,
+    ) -> Result<()>
+    where
+        T: Serialize + ?Sized,
+    {
+        self.send_operation(method, path, RESOURCE_API_VERSION, body)
+            .await
+    }
+
+    async fn send_operation<T>(
+        &self,
+        method: Method,
+        path: &str,
+        api_version: &str,
+        body: Option<&T>,
+    ) -> Result<()>
+    where
+        T: Serialize + ?Sized,
+    {
+        let response = self.send(method, path, api_version, body).await?;
+        if method == Method::Delete && response.status() == StatusCode::NotFound {
+            return Ok(());
+        }
+        ensure_success(&response, "manage Cosmos ARM resource")?;
+        if response.status() == StatusCode::Accepted {
+            let operation_url = operation_url(&response)?;
+            self.wait_for_operation(operation_url).await?;
+        }
+        Ok(())
+    }
+
+    async fn send<T>(
+        &self,
+        method: Method,
+        path: &str,
+        api_version: &str,
+        body: Option<&T>,
+    ) -> Result<RawResponse>
+    where
+        T: Serialize + ?Sized,
+    {
+        let mut url = self.endpoint.join(path)?;
+        url.query_pairs_mut()
+            .append_pair("api-version", api_version);
+        let mut request = Request::new(url, method);
+        request.insert_header("accept", "application/json");
+        if let Some(body) = body {
+            request.insert_header("content-type", "application/json");
+            request.set_json(body)?;
+        }
+        self.pipeline
+            .send(
+                &azure_core::http::Context::new(),
+                &mut request,
+                Some(PipelineSendOptions {
+                    skip_checks: true,
+                    ..Default::default()
+                }),
+            )
+            .await
+    }
+
+    async fn wait_for_operation(&self, operation_url: Url) -> Result<()> {
+        let deadline = tokio::time::Instant::now() + LRO_TIMEOUT;
+        loop {
+            if tokio::time::Instant::now() >= deadline {
+                return Err(azure_core::Error::with_message(
+                    azure_core::error::ErrorKind::Other,
+                    format!("ARM operation did not complete within {LRO_TIMEOUT:?}"),
+                ));
+            }
+
+            let mut request = Request::new(operation_url.clone(), Method::Get);
+            request.insert_header("accept", "application/json");
+            let response = self
+                .pipeline
+                .send(
+                    &azure_core::http::Context::new(),
+                    &mut request,
+                    Some(PipelineSendOptions {
+                        skip_checks: true,
+                        ..Default::default()
+                    }),
+                )
+                .await?;
+            ensure_success(&response, "poll Cosmos ARM operation")?;
+            if response.status() == StatusCode::Accepted {
+                tokio::time::sleep(retry_after(&response).unwrap_or(LRO_POLL_INTERVAL)).await;
+                continue;
+            }
+            if response.body().is_empty() {
+                return Ok(());
+            }
+
+            let body: serde_json::Value = response.body().json()?;
+            let status = operation_status(&body);
+            match status.as_deref() {
+                Some("succeeded" | "completed") => return Ok(()),
+                Some("failed" | "canceled" | "cancelled") => {
+                    return Err(azure_core::Error::with_message(
+                        azure_core::error::ErrorKind::Other,
+                        format!("ARM operation failed: {body}"),
+                    ));
+                }
+                Some(_) => {
+                    tokio::time::sleep(retry_after(&response).unwrap_or(LRO_POLL_INTERVAL)).await;
+                }
+                None => return Ok(()),
+            }
+        }
+    }
+}
+
+fn required_env(name: &str) -> Result<String> {
+    std::env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            azure_core::Error::with_message(
+                azure_core::error::ErrorKind::Other,
+                format!("{name} must be set for ARM-backed Cosmos tests"),
+            )
+        })
+}
+
+fn normalize_endpoint(endpoint: &str) -> Result<Url> {
+    let mut endpoint = Url::parse(endpoint)?;
+    endpoint.set_query(None);
+    endpoint.set_fragment(None);
+    if !endpoint.path().ends_with('/') {
+        endpoint.set_path(&format!("{}/", endpoint.path()));
+    }
+    Ok(endpoint)
+}
+
+fn create_update_options(throughput: ArmThroughput) -> CreateUpdateOptions {
+    match throughput {
+        ArmThroughput::Autoscale { maximum, .. } => CreateUpdateOptions {
+            throughput: None,
+            autoscale_settings: Some(CreateAutoscaleSettings {
+                max_throughput: maximum,
+            }),
+        },
+        ArmThroughput::Manual(throughput) => CreateUpdateOptions {
+            throughput: Some(throughput),
+            autoscale_settings: None,
+        },
+    }
+}
+
+fn throughput_settings_resource(throughput: ArmThroughput) -> ThroughputSettingsResource {
+    match throughput {
+        ArmThroughput::Autoscale {
+            maximum,
+            increment_percent,
+            ..
+        } => ThroughputSettingsResource {
+            throughput: None,
+            autoscale_settings: Some(ThroughputAutoscaleSettings {
+                max_throughput: maximum,
+                auto_upgrade_policy: increment_percent.map(|increment_percent| {
+                    AutoscaleAutoUpgradePolicy {
+                        throughput_policy: AutoscaleThroughputPolicy { increment_percent },
+                    }
+                }),
+            }),
+        },
+        ArmThroughput::Manual(throughput) => ThroughputSettingsResource {
+            throughput: Some(throughput),
+            autoscale_settings: None,
+        },
+    }
+}
+
+fn retry_after(response: &RawResponse) -> Option<Duration> {
+    response
+        .headers()
+        .get_optional_str(&HeaderName::from_static("retry-after"))
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_secs)
+}
+
+fn operation_url(response: &RawResponse) -> Result<Url> {
+    for name in ["azure-asyncoperation", "location"] {
+        if let Ok(value) = response.headers().get_str(&HeaderName::from_static(name)) {
+            return Ok(Url::parse(value)?);
+        }
+    }
+    Err(azure_core::Error::with_message(
+        azure_core::error::ErrorKind::DataConversion,
+        "ARM 202 response did not include azure-asyncoperation or location",
+    ))
+}
+
+fn ensure_success(response: &RawResponse, operation: &str) -> Result<()> {
+    if response.status().is_success() {
+        return Ok(());
+    }
+    Err(azure_core::Error::with_message(
+        azure_core::error::ErrorKind::HttpResponse {
+            status: response.status(),
+            error_code: None,
+            raw_response: None,
+        },
+        format!(
+            "{operation} failed with HTTP {}: {}",
+            response.status(),
+            String::from_utf8_lossy(response.body().as_ref())
+        ),
+    ))
+}
+
+fn operation_status(body: &serde_json::Value) -> Option<String> {
+    body.get("status")
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| {
+            body.pointer("/status/code")
+                .and_then(serde_json::Value::as_str)
+        })
+        .or_else(|| {
+            body.pointer("/properties/status")
+                .and_then(serde_json::Value::as_str)
+        })
+        .or_else(|| {
+            body.pointer("/properties/provisioningState")
+                .and_then(serde_json::Value::as_str)
+        })
+        .map(str::to_ascii_lowercase)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        create_update_options, operation_status, throughput_settings_resource, ArmThroughput,
+    };
+
+    #[test]
+    fn maps_manual_throughput() {
+        let options = create_update_options(ArmThroughput::Manual(400));
+        assert_eq!(options.throughput, Some(400));
+        assert!(options.autoscale_settings.is_none());
+    }
+
+    #[test]
+    fn maps_autoscale_throughput() {
+        let options = create_update_options(ArmThroughput::Autoscale {
+            maximum: 4000,
+            current: Some(400),
+            increment_percent: Some(25),
+        });
+        assert!(options.throughput.is_none());
+        assert_eq!(
+            options
+                .autoscale_settings
+                .as_ref()
+                .map(|settings| settings.max_throughput),
+            Some(4000)
+        );
+        let create_options = serde_json::to_value(&options).unwrap();
+        assert!(create_options
+            .pointer("/autoscaleSettings/autoUpgradePolicy")
+            .is_none());
+        let resource = throughput_settings_resource(ArmThroughput::Autoscale {
+            maximum: 4000,
+            current: Some(400),
+            increment_percent: Some(25),
+        });
+        assert_eq!(
+            resource
+                .autoscale_settings
+                .and_then(|settings| settings.auto_upgrade_policy)
+                .map(|policy| policy.throughput_policy.increment_percent),
+            Some(25)
+        );
+    }
+
+    #[test]
+    fn reads_nested_operation_status() {
+        let body = serde_json::json!({"properties": {"provisioningState": "Succeeded"}});
+        assert_eq!(operation_status(&body).as_deref(), Some("succeeded"));
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos_test_support/src/lib.rs
+++ b/sdk/cosmos/azure_data_cosmos_test_support/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! Shared support for Azure Cosmos DB integration tests.
+
+pub mod arm_client;

--- a/sdk/cosmos/ci.yml
+++ b/sdk/cosmos/ci.yml
@@ -32,9 +32,9 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: cosmos
-    # macOS/Windows live-test legs need ~63-65 min; raise from the 60-min default
-    # so they finish instead of being cancelled at the agent cap.
-    TestTimeoutInMinutes: 90
+    # Existing live legs need ~63-65 min, while partition merge may spend up to
+    # 150 min waiting for split, ARM merge, and topology convergence after setup.
+    TestTimeoutInMinutes: 180
     RunLiveTests: ${{ or(parameters.RunLiveTests, eq(variables['Build.Reason'], 'Schedule'), endsWith(variables['Build.DefinitionName'], '- weekly')) }}
     Artifacts:
     - name: azure_data_cosmos_macros
@@ -51,7 +51,7 @@ extends:
       RUST_BACKTRACE: '1'
       # Live budget for the binary-encoding round-trip fuzzer
       # (azure_data_cosmos/tests/binary_roundtrip_fuzzer.rs). Only consumed on
-      # the `binary_encoding` live leg (live-legacy-arm-matrix.json); a no-op
+      # the `binary_encoding` live leg (live-federated-aad-matrix.json); a no-op
       # elsewhere. Each iteration exercises 3 encoding configs; every config runs
       # 4 point ops + 1 single-partition query + 1 cross-partition ORDER BY
       # query, and the pure-`binary` config adds a typed wide-integer probe of
@@ -144,25 +144,37 @@ extends:
         parameters:
           AccountSelector: $(AccountSelector)
     LiveTestMatrixConfigs:
-      # Legs that still use ARM-deployed per-run Cosmos accounts (not migrated
-      # to fixed self-owned accounts):
+      # Gateway V2 legs keep their existing ARM-deployed primary account and
+      # secret-backed thin-client endpoint/key configuration.
       #   * Thin-client (GatewayV2) legs use $(thinclient-test-endpoint)/
       #     $(thinclient-test-key) for the thin-client itself, but their primary
       #     client still needs an ARM-provisioned account.
-      #   * Binary-encoding round-trip fuzz leg exercises encoding boundaries
-      #     against a fresh account and is short-lived.
-      # Left on the legacy per-run path intentionally.
       - Name: Cosmos_live_arm
         Path: sdk/cosmos/live-legacy-arm-matrix.json
+        Selection: all
+        GenerateVMJobs: true
+      # Binary encoding and partition merge require fresh, dedicated accounts
+      # but authenticate exclusively with the federated pipeline identity. The
+      # resource template disables local auth, grants Cosmos data-plane RBAC,
+      # and the tests use their typed ARM helper for resource lifecycle.
+      #
+      # Partition merge intentionally stays on this per-run ARM path rather
+      # than FixedAccountMatrixConfigs: the fixed-account generator forces
+      # UseFederatedAuth=false, while merge needs both the preview account
+      # property and an ARM token to invoke partitionMerge.
+      - Name: Cosmos_live_federated_aad
+        Path: sdk/cosmos/live-federated-aad-matrix.json
         Selection: all
         GenerateVMJobs: true
       # Dedicated live leg that runs the full integration suite with the primary
       # (data-plane) client authenticated via Entra ID (AAD) instead of the
       # account key. `AZURE_COSMOS_AUTH_MODE=aad` surfaces as a job env var and
       # is read by the test framework (tests/framework/test_client.rs), which
-      # then uses AAD for data-plane operations and the account key only for
-      # database create/delete. Pinned to a single consistency config on Linux
-      # to bound live-account cost.
+      # then uses AAD for data-plane operations and the typed ARM test helper for
+      # database, container, and throughput lifecycle. Local authentication is
+      # disabled on every account in this matrix, proving no account-key fallback
+      # is possible. Pinned to a single consistency config on Linux to bound
+      # live-account cost.
       - Name: Cosmos_live_test_aad
         Path: sdk/cosmos/live-aad-platform-matrix.json
         Selection: all

--- a/sdk/cosmos/docs/specs/0016-binary-encoding-roundtrip-fuzzer.md
+++ b/sdk/cosmos/docs/specs/0016-binary-encoding-roundtrip-fuzzer.md
@@ -10,7 +10,7 @@ golden vectors (`binary_json_vectors.json`)
 prove specific byte layouts and the in-tree fuzz suite hammers the *decoder* with
 malformed input, this harness exercises the **end-to-end path**:
 
-```
+```text
 generate JSON → Rust encode → wire → backend store+rewrite → wire → Rust decode → compare
 ```
 
@@ -62,7 +62,7 @@ intentionally excluded.
 sent keys: any *extra* field the round-trip introduced (e.g. a codec bug that
 invents a property) survives into the comparison and fails the assertion.
 
-> **Reserved fields are also stripped on the _send_ side.** Cosmos *owns* the
+> **Reserved fields are also stripped on the *send* side.** Cosmos *owns* the
 > `_rid`/`_self`/`_etag`/`_ts`/`_attachments` properties and overwrites any value
 > a client authors. Because the corpus shapes are modeled on real exported
 > service documents (which carry `_self`), and the free-form value generator
@@ -211,12 +211,12 @@ flowchart LR
 
 Two JSON texts are "the same value" if they canonicalize identically. Rules:
 
-| Aspect      | Rule |
-| ----------- | ---- |
-| Whitespace  | removed entirely |
+| Aspect | Rule |
+| --- | --- |
+| Whitespace | removed entirely |
 | Object keys | sorted lexicographically (by UTF-16 code unit, per RFC 8785) |
-| Strings     | minimally JSON-escaped (via `serde_json`) |
-| Arrays      | order preserved |
+| Strings | minimally JSON-escaped (via `serde_json`) |
+| Arrays | order preserved |
 | **Numbers** | **Cosmos-compatible normalization — see §3.1** |
 
 ### 3.1 Number normalization (the tuning surface)
@@ -342,17 +342,19 @@ build time):
 
 > **Not yet implemented:** running each document through a *second* account (to
 > cover dictionary encoding on/off) is a planned extension. The harness reads a
-> single `AZURE_COSMOS_CONNECTION_STRING`; there is no second-account lookup.
+> single `ACCOUNT_HOST`; there is no second-account lookup.
 
 ## 6. Running the harness
 
 In CI, the harness runs automatically on the **`binary_encoding` live leg**
-(`live-platform-matrix.json` → `Session SingleWrite BinaryEncodingRoundtripFuzz`, which sets
-`testCategory = 'binary_encoding'`). That leg's bicep emits
-`--cfg=test_category="binary_encoding"` into `RUSTFLAGS` and provides the live
-`AZURE_COSMOS_CONNECTION_STRING`, so `binary_encoding_roundtrip_fuzz` (and the
-sibling `binary_encoding` item tests) stop being ignored. The per-run iteration
-budget is set by `AZURE_COSMOS_FUZZ_ITERATIONS` in `sdk/cosmos/ci.yml`
+(`live-federated-aad-matrix.json` →
+`Session SingleWrite BinaryEncodingRoundtripFuzz`, which sets
+`testCategory = 'binary_encoding'`). That federated leg's bicep emits
+`--cfg=test_category="binary_encoding"` into `RUSTFLAGS`, disables local
+authentication on the account, and provides `ACCOUNT_HOST`. The fuzzer uses
+Entra ID for all data-plane operations and the shared typed ARM test client for
+database and container lifecycle. The per-run iteration budget is set by
+`AZURE_COSMOS_FUZZ_ITERATIONS` in `sdk/cosmos/ci.yml`
 (default 180 there). Live tests only run on the weekly schedule or when a build
 is queued with **Run live tests** enabled.
 
@@ -363,8 +365,12 @@ AZURE_COSMOS_ALLOW_INVALID_CERT=true \
 RUSTFLAGS='--cfg test_category="binary_encoding"' \
   cargo test -p azure_data_cosmos --test binary_roundtrip_fuzzer --features key_auth,fault_injection,control_plane -- --nocapture
 
-# Multi-day soak (millions of docs):
-AZURE_COSMOS_CONNECTION_STRING='...' \
+# Multi-day soak (millions of docs) with federated Entra ID:
+AZURE_COSMOS_AUTH_MODE=aad \
+ACCOUNT_HOST='https://<account>.documents.azure.com:443/' \
+COSMOS_SUBSCRIPTION_ID='<subscription>' \
+COSMOS_RESOURCE_GROUP='<resource-group>' \
+COSMOS_ACCOUNT_NAME='<account>' \
 AZURE_COSMOS_FUZZ_ITERATIONS=5000000 \
 AZURE_COSMOS_FUZZ_MAX_DEPTH=6 \
 RUSTFLAGS='--cfg test_category="binary_encoding"' \
@@ -374,7 +380,10 @@ RUSTFLAGS='--cfg test_category="binary_encoding"' \
 AZURE_COSMOS_FUZZ_SEED=12345678901234567890 ... cargo test ...
 
 # Calibrate number canonicalization against the account (prints a table, no assert):
-AZURE_COSMOS_CONNECTION_STRING='...' AZURE_COSMOS_FUZZ_CALIBRATE=true \
+AZURE_COSMOS_AUTH_MODE=aad ACCOUNT_HOST='https://<account>.documents.azure.com:443/' \
+COSMOS_SUBSCRIPTION_ID='<subscription>' COSMOS_RESOURCE_GROUP='<resource-group>' \
+COSMOS_ACCOUNT_NAME='<account>' \
+AZURE_COSMOS_FUZZ_CALIBRATE=true \
 RUSTFLAGS='--cfg test_category="binary_encoding"' \
   cargo test -p azure_data_cosmos --test binary_roundtrip_fuzzer --features key_auth,fault_injection,control_plane -- --nocapture
 ```
@@ -383,7 +392,10 @@ RUSTFLAGS='--cfg test_category="binary_encoding"' \
 
 | Variable | Default | Meaning |
 | -------- | ------- | ------- |
-| `AZURE_COSMOS_CONNECTION_STRING` | — (required) | live account (endpoint + key) |
+| `AZURE_COSMOS_AUTH_MODE` | key | set to `aad` for federated live runs |
+| `ACCOUNT_HOST` | — (required for AAD) | live account endpoint |
+| `COSMOS_SUBSCRIPTION_ID` / `COSMOS_RESOURCE_GROUP` / `COSMOS_ACCOUNT_NAME` | — (required for AAD) | ARM resource identity used for test lifecycle |
+| `AZURE_COSMOS_CONNECTION_STRING` | — (emulator/key mode only) | endpoint and key for local emulator runs |
 | `AZURE_COSMOS_ALLOW_INVALID_CERT` | false | accept emulator cert |
 | `AZURE_COSMOS_FUZZ_ITERATIONS` | 180 | number of generated docs |
 | `AZURE_COSMOS_FUZZ_SEED` | random | PRNG seed (for reproduction) |
@@ -438,7 +450,7 @@ The two most easily-confused layers are the **two fuzzers**. They sit at
 *opposite ends of the same pipeline* and answer different questions — neither
 replaces the other.
 
-```
+```text
                     round-trip fuzzer starts here (random JSON value)
                               │
    JSON value ──encode──► binary bytes ──wire──► service ──► bytes ──decode──► JSON value
@@ -485,8 +497,6 @@ point that a value generator alone does not fuzz the *protocol*.
   the in-tree `binary_json/fuzz_tests.rs` (`cargo test -p azure_data_cosmos_driver
   --lib fuzz`).
 
-
-
 ## 9. Enhancement plan (library-backed generator & canonicalizer)
 
 This section captures an agreed enhancement plan for the harness. The current harness uses a hand-rolled seeded generator (§4) and a hand-rolled canonicalizer (§3). Three well-maintained crates can replace the parts of that machinery that are pure boilerplate, while we **keep** the one part that is genuinely Cosmos-specific.
@@ -514,7 +524,7 @@ If we canonicalized numbers with raw JCS, a *faithful* round-trip would report *
 
 ### 9.3 Target pipeline
 
-```
+```text
 generate:      bytes ──ArbitraryValue──▶ Value
 normalize:     Value  ──our normalize_numbers (calibrated §3.1)──▶ Value′
 canonicalize:  Value′ ──json_canon (RFC 8785 structural)──▶ canonical String

--- a/sdk/cosmos/eng/pipelines/README.md
+++ b/sdk/cosmos/eng/pipelines/README.md
@@ -21,10 +21,11 @@ account endpoints and keys - stored once in an ADO secret - keep working
 indefinitely, with no per-run Azure authentication and no service-connection
 dependency at all for this leg.
 
-`Cosmos_live_test_aad` (the dedicated AAD/Entra ID leg) is **unaffected** by
-this change: it continues to deploy fresh accounts per run via
-`test-resources.bicep` against the existing service connection, exactly as
-before. Thin-client/GatewayV2 legs are also unaffected/out of scope.
+`Cosmos_live_test_aad` and `Cosmos_live_federated_aad` are intentionally not
+fixed-account jobs. They deploy fresh accounts through `test-resources.bicep`,
+set `disableLocalAuth`, and use the federated pipeline identity for both Cosmos
+data-plane RBAC and ARM resource management. Thin-client/GatewayV2 legs retain
+their existing configuration.
 
 ## How it fits together
 
@@ -74,12 +75,11 @@ before. Thin-client/GatewayV2 legs are also unaffected/out of scope.
    `eng/pipelines/templates/stages/archetype-sdk-client.yml` gained a
    `FixedAccountMatrixConfigs` parameter (a second, independent
    `LiveTestMatrixConfigs`-like list) so this only applies to the matrix
-   configs that opt in - `Cosmos_live_test_aad` keeps deploying real ARM
-   resources, unaffected.
+   configs that opt in. Federated AAD jobs keep deploying real ARM resources.
 9. `sdk/cosmos/ci.yml` wires `Cosmos_live_test` through
    `FixedAccountMatrixConfigs` with `PreTestRunSteps` pointing at
-   `resolve-test-account-steps.yml`, while `Cosmos_live_test_aad` remains on
-   `LiveTestMatrixConfigs` exactly as before.
+   `resolve-test-account-steps.yml`, while the AAD matrices remain on
+   `LiveTestMatrixConfigs`.
 
 ## Local testing
 
@@ -90,8 +90,8 @@ pwsh sdk/cosmos/eng/pipelines/resolve-cosmos-test-account.tests.ps1
 ```
 
 You can also invoke the resolver directly against the sample JSON. Dot-source
-it (note the leading `. `) so the resolved variables land directly in your
-current shell instead of just being printed:
+it (a leading `.` followed by a space) so the resolved variables land directly
+in your current shell instead of just being printed:
 
 ```powershell
 $env:COSMOS_ACCOUNTS_LOCAL = 'true'
@@ -106,9 +106,10 @@ See `account-provisioning/README.md`.
 
 ## What this does *not* solve
 
-This mechanism only covers **key-based** tests. AAD-specific behavior
-requires a real Entra ID identity/tenant to authenticate against; fixed
-accounts don't remove that requirement, they only remove it for the tests
-that don't need AAD in the first place. `Cosmos_live_test_aad` still depends
-on the ephemeral tenant and the `azure-sdk-tests-cosmos` service connection,
-exactly as it did before this change.
+This mechanism only covers **key-based** tests. The fixed-account job generator
+explicitly sets `UseFederatedAuth: false`, so it cannot run the AAD integration,
+binary round-trip, or partition-merge legs. Those jobs require a real Entra ID
+identity and remain on the per-run ARM path through the
+`azure-sdk-tests-cosmos` service connection. Partition merge additionally
+requires a preview-enabled account and an ARM token for the merge operation,
+which is why it is not assigned to a fixed account.

--- a/sdk/cosmos/eng/scripts/Invoke-CosmosTestSetup.ps1
+++ b/sdk/cosmos/eng/scripts/Invoke-CosmosTestSetup.ps1
@@ -248,9 +248,19 @@ if ($env:AZURE_COSMOS_EMULATOR_FLAVOR -eq 'vnext') {
     return
 }
 
-# Skip emulator setup if AZURE_COSMOS_CONNECTION_STRING is already set
+# Skip emulator setup when a live account is already configured. Federated live
+# legs intentionally have no connection string because local auth is disabled.
 if ($env:AZURE_COSMOS_CONNECTION_STRING) {
     Write-Host "AZURE_COSMOS_CONNECTION_STRING is already set. Skipping Cosmos DB Emulator setup."
+    return
+}
+if ($env:AZURE_COSMOS_AUTH_MODE -eq "aad") {
+    if (-not $env:ACCOUNT_HOST) {
+        LogError "ACCOUNT_HOST must be set for federated Cosmos live tests."
+        exit 1
+    }
+    $env:AZURE_COSMOS_TEST_MODE = "required"
+    Write-Host "Federated Cosmos live account is configured. Skipping Cosmos DB Emulator setup."
     return
 }
 

--- a/sdk/cosmos/live-aad-platform-matrix.json
+++ b/sdk/cosmos/live-aad-platform-matrix.json
@@ -13,13 +13,13 @@
     "AZURE_COSMOS_AUTH_MODE": ["aad"],
     "Account Settings": {
       "Eventual SingleWrite": {
-        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Eventual'; enableAutomaticFailover = $false; enableContinuousBackup = $true }"
+        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Eventual'; enableAutomaticFailover = $false; enableContinuousBackup = $true; disableLocalAuth = $true }"
       },
       "Session SingleWrite": {
-        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableAutomaticFailover = $false; enableContinuousBackup = $true }"
+        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableAutomaticFailover = $false; enableContinuousBackup = $true; disableLocalAuth = $true }"
       },
       "Session MultiWrite": {
-        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableMultipleWriteLocations = $true; enableAutomaticFailover = $false; testCategory = 'multi_write'; enableMultipleRegions = $true }"
+        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableMultipleWriteLocations = $true; enableAutomaticFailover = $false; testCategory = 'multi_write'; enableMultipleRegions = $true; disableLocalAuth = $true }"
       }
     }
   }

--- a/sdk/cosmos/live-federated-aad-matrix.json
+++ b/sdk/cosmos/live-federated-aad-matrix.json
@@ -1,0 +1,23 @@
+{
+  "displayNames": {
+    "aad": "aad_auth"
+  },
+  "matrix": {
+    "Agent": {
+      "ubuntu": {
+        "OSVmImage": "env:LINUXVMIMAGE",
+        "Pool": "env:LINUXPOOL"
+      }
+    },
+    "RustToolchainName": ["stable"],
+    "AZURE_COSMOS_AUTH_MODE": ["aad"],
+    "Account Settings": {
+      "Session SingleWrite BinaryEncodingRoundtripFuzz": {
+        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableAutomaticFailover = $false; disableLocalAuth = $true; testCategory = 'binary_encoding' }"
+      },
+      "Session Partition Merge Preview": {
+        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableAutomaticFailover = $false; enablePartitionMerge = $true; disableLocalAuth = $true; testCategory = 'merge' }"
+      }
+    }
+  }
+}

--- a/sdk/cosmos/live-legacy-arm-matrix.json
+++ b/sdk/cosmos/live-legacy-arm-matrix.json
@@ -14,12 +14,6 @@
       },
       "Session MultiRegion GatewayV2": {
         "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableMultipleRegions = $true; testCategory = 'gateway_v2_multi_region' }"
-      },
-      "Session SingleWrite BinaryEncodingRoundtripFuzz": {
-        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableAutomaticFailover = $false; testCategory = 'binary_encoding' }"
-      },
-      "Session Partition Merge Preview": {
-        "ArmTemplateParameters": "@{ defaultConsistencyLevel = 'Session'; enableAutomaticFailover = $false; enablePartitionMerge = $true; testCategory = 'merge' }"
       }
     }
   }

--- a/sdk/cosmos/test-resources.bicep
+++ b/sdk/cosmos/test-resources.bicep
@@ -18,6 +18,9 @@ param defaultConsistencyLevel string = 'Session'
 @description('Enable multiple regions, default value is false')
 param enableMultipleRegions bool = false
 
+@description('Disable account-key authentication so tests must use Microsoft Entra ID')
+param disableLocalAuth bool = false
+
 @description('Enable the partition merge preview on the Cosmos DB account')
 param enablePartitionMerge bool = false
 
@@ -83,6 +86,7 @@ resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2026-03-15' = {
     enableMultipleWriteLocations: enableMultipleWriteLocations
     isVirtualNetworkFilterEnabled: false
     disableKeyBasedMetadataWriteAccess: false
+    disableLocalAuth: disableLocalAuth
     enableFreeTier: false
     enableAnalyticalStorage: false
     enablePartitionMerge: enablePartitionMerge
@@ -143,7 +147,7 @@ resource accountName_roleAssignmentId 'Microsoft.DocumentDB/databaseAccounts/sql
 
 output COSMOS_RUSTFLAGS string = '--cfg=test_category="${testCategory}" --cfg=cosmos_aad_supported'
 output DATABASE_NAME string = databaseName
-output AZURE_COSMOS_CONNECTION_STRING string = 'AccountEndpoint=${reference(resourceId, apiVersion).documentEndpoint};AccountKey=${listKeys(resourceId, apiVersion).primaryMasterKey};'
+output AZURE_COSMOS_CONNECTION_STRING string = disableLocalAuth ? '' : 'AccountEndpoint=${reference(resourceId, apiVersion).documentEndpoint};AccountKey=${listKeys(resourceId, apiVersion).primaryMasterKey};'
 output ACCOUNT_HOST string = reference(resourceId, apiVersion).documentEndpoint
 output COSMOS_ACCOUNT_NAME string = cosmosAccount.name
 output AZURE_COSMOS_DEFAULT_CONSISTENCY string = defaultConsistencyLevel


### PR DESCRIPTION
Migrate the existing Cosmos AAD live suite, BinaryEncodingRoundtripFuzz leg, and Partition Merge Preview leg to fully federated Entra ID authentication.

- Use AAD Cosmos data-plane RBAC for item, query, and change-feed operations with `disableLocalAuth` enabled, proving there is no account-key fallback.
- Add a private typed ARM test-support crate built on Azure Core HTTP/auth conventions for database, container, throughput, and partition-merge lifecycle.
- Add propagation-aware metadata and data-path readiness handling for ARM-created resources, including hierarchical partition keys and fault-injection clients.
- Provision partition merge on a dedicated preview-enabled ARM account because the fixed-account pipeline forces `UseFederatedAuth=false`.
- Move binary fuzz and partition merge to a dedicated federated matrix while preserving the existing key-backed Gateway V2 legs.
- Update Bicep role assignment/output behavior, pipeline setup, and directly related test documentation.

Validation includes formatting, all-target/all-feature checks and clippy for the affected Cosmos crates, targeted SDK/driver/helper tests, AAD-mode in-memory coverage, matrix JSON validation, PowerShell parsing, Bicep compilation, markdown linting, spelling checks, and independent staged-diff review.

Bicep compilation retains the expected warnings for the registered `2026-03-15` API version lacking local type metadata and the conditional `listKeys` output still required by preserved Gateway/key legs.
