### PR TITLE
Fix generate_api visibility output

### DIFF
--- a/eng/tools/generate_api/AGENTS.md
+++ b/eng/tools/generate_api/AGENTS.md
@@ -200,6 +200,7 @@ Signature normalization:
 - render receivers spelled as `self: Self`, `self: &Self`, `self: &mut Self` as `self`, `&self`, `&mut self`
 - keep `Self` unchanged in non-receiver positions
 - keep inherent impls in their original impl-header shape including generics and bounds
+- render functions in inherent impls as `pub`; keep trait and trait-impl functions without visibility
 
 ## Async-trait rendering
 

--- a/eng/tools/generate_api/Cargo.toml
+++ b/eng/tools/generate_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generate_api"
-version = "2.2.1"
+version = "2.2.2"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/eng/tools/generate_api/src/extract.rs
+++ b/eng/tools/generate_api/src/extract.rs
@@ -1935,7 +1935,7 @@ fn extract_trait_impl(
         declaration_path_references: collect_trait_impl_declaration_path_references(
             krate, impl_block,
         ),
-        members: extract_impl_items(krate, &impl_block.items),
+        members: extract_impl_items(krate, &impl_block.items, false),
     })
 }
 
@@ -1965,7 +1965,7 @@ fn extract_inherent_impl(
     impl_block: &Impl,
 ) -> Option<ApiItem> {
     let self_type = render_type(&impl_block.for_);
-    let members = extract_impl_items(krate, &impl_block.items);
+    let members = extract_impl_items(krate, &impl_block.items, true);
     if members.is_empty() {
         return None;
     }
@@ -2027,12 +2027,16 @@ fn inherent_impl_type_arg_classes(type_: &Type) -> Vec<u8> {
     }
 }
 
-fn extract_impl_items(krate: &Crate, item_ids: &[Id]) -> Vec<ApiMember> {
+fn extract_impl_items(
+    krate: &Crate,
+    item_ids: &[Id],
+    functions_are_public: bool,
+) -> Vec<ApiMember> {
     item_ids
         .iter()
         .filter_map(|item_id| krate.index.get(item_id))
         .filter(|item| is_visible(item))
-        .filter_map(|item| extract_associated_member(krate, item))
+        .filter_map(|item| extract_associated_member(krate, item, functions_are_public))
         .collect()
 }
 
@@ -2041,7 +2045,7 @@ fn extract_trait_members(krate: &Crate, trait_item: &Trait) -> Vec<ApiMember> {
         .items
         .iter()
         .filter_map(|item_id| krate.index.get(item_id))
-        .filter_map(|item| extract_associated_member(krate, item))
+        .filter_map(|item| extract_associated_member(krate, item, false))
         .collect()
 }
 
@@ -2196,7 +2200,11 @@ fn text_member(name: impl Into<String>, declaration: impl Into<String>) -> ApiMe
     }
 }
 
-fn extract_associated_member(krate: &Crate, item: &Item) -> Option<ApiMember> {
+fn extract_associated_member(
+    krate: &Crate,
+    item: &Item,
+    function_is_public: bool,
+) -> Option<ApiMember> {
     match &item.inner {
         ItemEnum::Function(function) => Some(api_member(
             krate,
@@ -2205,7 +2213,7 @@ fn extract_associated_member(krate: &Crate, item: &Item) -> Option<ApiMember> {
             render_function_declaration(
                 item.name.as_deref().unwrap_or("unknown_fn"),
                 function,
-                false,
+                function_is_public,
             ),
         )),
         ItemEnum::AssocConst { type_, value } => Some(api_member(

--- a/eng/tools/generate_api/src/extract/tests.rs
+++ b/eng/tools/generate_api/src/extract/tests.rs
@@ -1427,7 +1427,7 @@ fn extracts_inherent_impl_blocks_for_enum_methods() {
     assert_eq!(extracted[0].declaration, "impl Status {");
     assert_eq!(
         extracted[0].members[0].declaration,
-        "fn is_ready(&self) -> bool;"
+        "pub fn is_ready(&self) -> bool;"
     );
 }
 

--- a/sdk/canary/azure_canary/api/API.md
+++ b/sdk/canary/azure_canary/api/API.md
@@ -28,8 +28,8 @@ pub mod constant_example {
     }
     impl Temperature {
         const ABSOLUTE_ZERO_C: f64 = -273.15;
-        fn is_below_freezing(&self) -> bool;
-        fn new(value: f64, unit: TemperatureUnit) -> Self;
+        pub fn is_below_freezing(&self) -> bool;
+        pub fn new(value: f64, unit: TemperatureUnit) -> Self;
     }
     #[derive(Clone, Copy, Debug, PartialEq)]
     pub enum TemperatureUnit {
@@ -74,8 +74,8 @@ pub mod enum_example {
         Complex { subject: String, content: String, urgent: bool },
     }
     impl Message {
-        fn as_string(&self) -> String;
-        fn text(content: &str) -> Self;
+        pub fn as_string(&self) -> String;
+        pub fn text(content: &str) -> Self;
     }
     #[derive(Clone, Debug, PartialEq)]
     pub enum Status {
@@ -99,7 +99,7 @@ pub mod function_example {
         pub count: u32,
     }
     impl Counter {
-        fn increment(&mut self);
+        pub fn increment(&mut self);
     }
 }
 pub mod modules_example {
@@ -133,7 +133,7 @@ pub mod modules_example {
             pub is_active: bool,
         }
         impl User {
-            fn new(username: String, email: String) -> Self;
+            pub fn new(username: String, email: String) -> Self;
         }
         pub mod auth {
             pub fn verify_access(role: &Role, resource: &str) -> bool;
@@ -174,7 +174,7 @@ pub mod struct_example {
         pub additional_text: Option<&'a str>,
     }
     impl<'a> Borrowed<'a> {
-        fn new(text: &'a str) -> Self;
+        pub fn new(text: &'a str) -> Self;
     }
     #[derive(Clone, Debug)]
     pub struct Container<T> {
@@ -188,7 +188,7 @@ pub mod struct_example {
         pub position: String,
     }
     impl Employee {
-        fn full_description(&self) -> String;
+        pub fn full_description(&self) -> String;
     }
     #[derive(Clone, Copy, Debug)]
     pub struct Empty;
@@ -199,14 +199,14 @@ pub mod struct_example {
         pub email: Option<String>,
     }
     impl Person {
-        fn new(name: String, age: u32) -> Self;
-        fn with_email(self, email: String) -> Self;
+        pub fn new(name: String, age: u32) -> Self;
+        pub fn with_email(self, email: String) -> Self;
     }
     #[derive(Clone, Copy, Debug, PartialEq)]
     pub struct Point2D(pub f32, pub f32);
     impl Point2D {
-        fn distance_to(&self, other: &Self) -> f32;
-        fn origin() -> Self;
+        pub fn distance_to(&self, other: &Self) -> f32;
+        pub fn origin() -> Self;
     }
 }
 pub mod struct_fields_example {

--- a/sdk/canary/azure_canary/api/API.metadata.yml
+++ b/sdk/canary/azure_canary/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: ff3eba1280c67aa3ff45aec19f0b04a6315ca5b82cc8a6e77f69de07bea3454c
+apiMdSha256: 74a21657a4dcaed19027aba1df7fdd9ac2f3dd4d6d0a65948732e77817428ad5
 packageVersion: 0.1.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/canary/azure_canary_core/api/API.metadata.yml
+++ b/sdk/canary/azure_canary_core/api/API.metadata.yml
@@ -1,4 +1,4 @@
 apiMdSha256: a1ba1e9669093caeadd55cdbaf9be0e653008c1d93357e3f771a6431c773f8ea
 packageVersion: 0.1.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/core/azure_core/api/API.md
+++ b/sdk/core/azure_core/api/API.md
@@ -52,28 +52,28 @@ pub async fn sleep(duration: crate::time::Duration);
 pub struct Error {
 }
 impl Error {
-    fn downcast_mut<T: std::error::Error + 'static>(&mut self) -> Option<&mut T>;
-    fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T>;
-    fn get_mut(&mut self) -> Option<&mut dyn std::error::Error + Send + Sync + 'static>;
-    fn get_ref(&self) -> Option<&dyn std::error::Error + Send + Sync + 'static>;
+    pub fn downcast_mut<T: std::error::Error + 'static>(&mut self) -> Option<&mut T>;
+    pub fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T>;
+    pub fn get_mut(&mut self) -> Option<&mut dyn std::error::Error + Send + Sync + 'static>;
+    pub fn get_ref(&self) -> Option<&dyn std::error::Error + Send + Sync + 'static>;
     #[cfg(feature = "http")]
-    fn http_status(&self) -> Option<StatusCode>;
-    fn into_downcast<T: std::error::Error + 'static>(self) -> std::result::Result<T, Self>;
-    fn into_inner(self) -> std::result::Result<Box<dyn std::error::Error + Send + Sync>, Self>;
-    fn kind(&self) -> &ErrorKind;
-    fn new<E>(kind: ErrorKind, error: E) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>;
+    pub fn http_status(&self) -> Option<StatusCode>;
+    pub fn into_downcast<T: std::error::Error + 'static>(self) -> std::result::Result<T, Self>;
+    pub fn into_inner(self) -> std::result::Result<Box<dyn std::error::Error + Send + Sync>, Self>;
+    pub fn kind(&self) -> &ErrorKind;
+    pub fn new<E>(kind: ErrorKind, error: E) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>;
     #[must_use]
-    fn with_context<C>(self, message: C) -> Self where C: Into<Cow<'static, str>>;
+    pub fn with_context<C>(self, message: C) -> Self where C: Into<Cow<'static, str>>;
     #[must_use]
-    fn with_context_fn<F, C>(self, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+    pub fn with_context_fn<F, C>(self, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
     #[must_use]
-    fn with_error<E, C>(kind: ErrorKind, error: E, message: C) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, C: Into<Cow<'static, str>>;
+    pub fn with_error<E, C>(kind: ErrorKind, error: E, message: C) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, C: Into<Cow<'static, str>>;
     #[must_use]
-    fn with_error_fn<E, F, C>(kind: ErrorKind, error: E, f: F) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+    pub fn with_error_fn<E, F, C>(kind: ErrorKind, error: E, f: F) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, F: FnOnce() -> C, C: Into<Cow<'static, str>>;
     #[must_use]
-    fn with_message<C>(kind: ErrorKind, message: C) -> Self where C: Into<Cow<'static, str>>;
+    pub fn with_message<C>(kind: ErrorKind, message: C) -> Self where C: Into<Cow<'static, str>>;
     #[must_use]
-    fn with_message_fn<F, C>(kind: ErrorKind, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+    pub fn with_message_fn<F, C>(kind: ErrorKind, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
 }
 impl Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -149,10 +149,10 @@ pub mod cloud {
     #[derive(Clone, Debug, Default, Eq, PartialEq)]
     pub struct Audiences(/* private fields */);
     impl Audiences {
-        fn get<T: 'static>(&self) -> Option<&str>;
-        fn insert<T: 'static>(&mut self, audience: String);
-        fn new() -> Self;
-        fn with<T: 'static>(self, audience: String) -> Self;
+        pub fn get<T: 'static>(&self) -> Option<&str>;
+        pub fn insert<T: 'static>(&mut self, audience: String);
+        pub fn new() -> Self;
+        pub fn with<T: 'static>(self, audience: String) -> Self;
     }
     #[derive(Clone, Debug, Default, Eq, PartialEq)]
     #[non_exhaustive]
@@ -180,13 +180,13 @@ pub mod credentials {
         pub expires_on: typespec_client_core::time::OffsetDateTime,
     }
     impl AccessToken {
-        fn new<T>(token: T, expires_on: OffsetDateTime) -> Self where T: Into<Secret>;
+        pub fn new<T>(token: T, expires_on: OffsetDateTime) -> Self where T: Into<Secret>;
     }
     #[derive(Clone, Eq, serde::Deserialize, serde::Serialize)]
     pub struct Secret(/* private fields */);
     impl Secret {
-        fn new<T>(access_token: T) -> Self where T: Into<Cow<'static, str>>;
-        fn secret(&self) -> &str;
+        pub fn new<T>(access_token: T) -> Self where T: Into<Cow<'static, str>>;
+        pub fn secret(&self) -> &str;
     }
     impl Debug for Secret {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
@@ -203,8 +203,8 @@ pub mod credentials {
     #[derive(Clone, Eq)]
     pub struct SecretBytes(/* private fields */);
     impl SecretBytes {
-        fn bytes(&self) -> &[u8];
-        fn new<impl Into<Vec<u8>>: Into<Vec<u8>>>(bytes: impl Into<Vec<u8>>) -> Self;
+        pub fn bytes(&self) -> &[u8];
+        pub fn new<impl Into<Vec<u8>>: Into<Vec<u8>>>(bytes: impl Into<Vec<u8>>) -> Self;
     }
     impl Debug for SecretBytes {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -243,28 +243,28 @@ pub mod error {
     pub struct Error {
     }
     impl Error {
-        fn downcast_mut<T: std::error::Error + 'static>(&mut self) -> Option<&mut T>;
-        fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T>;
-        fn get_mut(&mut self) -> Option<&mut dyn std::error::Error + Send + Sync + 'static>;
-        fn get_ref(&self) -> Option<&dyn std::error::Error + Send + Sync + 'static>;
+        pub fn downcast_mut<T: std::error::Error + 'static>(&mut self) -> Option<&mut T>;
+        pub fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T>;
+        pub fn get_mut(&mut self) -> Option<&mut dyn std::error::Error + Send + Sync + 'static>;
+        pub fn get_ref(&self) -> Option<&dyn std::error::Error + Send + Sync + 'static>;
         #[cfg(feature = "http")]
-        fn http_status(&self) -> Option<StatusCode>;
-        fn into_downcast<T: std::error::Error + 'static>(self) -> std::result::Result<T, Self>;
-        fn into_inner(self) -> std::result::Result<Box<dyn std::error::Error + Send + Sync>, Self>;
-        fn kind(&self) -> &ErrorKind;
-        fn new<E>(kind: ErrorKind, error: E) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>;
+        pub fn http_status(&self) -> Option<StatusCode>;
+        pub fn into_downcast<T: std::error::Error + 'static>(self) -> std::result::Result<T, Self>;
+        pub fn into_inner(self) -> std::result::Result<Box<dyn std::error::Error + Send + Sync>, Self>;
+        pub fn kind(&self) -> &ErrorKind;
+        pub fn new<E>(kind: ErrorKind, error: E) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>;
         #[must_use]
-        fn with_context<C>(self, message: C) -> Self where C: Into<Cow<'static, str>>;
+        pub fn with_context<C>(self, message: C) -> Self where C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_context_fn<F, C>(self, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+        pub fn with_context_fn<F, C>(self, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_error<E, C>(kind: ErrorKind, error: E, message: C) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, C: Into<Cow<'static, str>>;
+        pub fn with_error<E, C>(kind: ErrorKind, error: E, message: C) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_error_fn<E, F, C>(kind: ErrorKind, error: E, f: F) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+        pub fn with_error_fn<E, F, C>(kind: ErrorKind, error: E, f: F) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, F: FnOnce() -> C, C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_message<C>(kind: ErrorKind, message: C) -> Self where C: Into<Cow<'static, str>>;
+        pub fn with_message<C>(kind: ErrorKind, message: C) -> Self where C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_message_fn<F, C>(kind: ErrorKind, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+        pub fn with_message_fn<F, C>(kind: ErrorKind, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
     }
     impl Debug for Error {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -339,7 +339,7 @@ pub mod error {
         Other,
     }
     impl ErrorKind {
-        fn into_error(self) -> Error;
+        pub fn into_error(self) -> Error;
     }
     impl Display for ErrorKind {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -391,13 +391,13 @@ pub mod http {
     pub struct AsyncRawResponse {
     }
     impl AsyncRawResponse {
-        fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
-        fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, bytes: impl Into<Bytes>) -> Self;
-        fn headers(&self) -> &Headers;
-        fn into_body(self) -> AsyncResponseBody;
-        fn new(status: StatusCode, headers: Headers, stream: PinnedStream) -> Self;
-        fn status(&self) -> StatusCode;
-        async fn try_into_raw_response(self) -> crate::Result<RawResponse>;
+        pub fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
+        pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, bytes: impl Into<Bytes>) -> Self;
+        pub fn headers(&self) -> &Headers;
+        pub fn into_body(self) -> AsyncResponseBody;
+        pub fn new(status: StatusCode, headers: Headers, stream: PinnedStream) -> Self;
+        pub fn status(&self) -> StatusCode;
+        pub async fn try_into_raw_response(self) -> crate::Result<RawResponse>;
     }
     impl<T> From<AsyncRawResponse> for AsyncResponse<T> {
         fn from(raw: AsyncRawResponse) -> Self;
@@ -408,10 +408,10 @@ pub mod http {
     pub struct AsyncResponse<T = ()> {
     }
     impl<T> AsyncResponse<T> {
-        fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
-        fn headers(&self) -> &Headers;
-        fn into_body(self) -> AsyncResponseBody;
-        fn status(&self) -> StatusCode;
+        pub fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
+        pub fn headers(&self) -> &Headers;
+        pub fn into_body(self) -> AsyncResponseBody;
+        pub fn status(&self) -> StatusCode;
     }
     impl<T> Debug for AsyncResponse<T> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -419,9 +419,9 @@ pub mod http {
     #[pin_project]
     pub struct AsyncResponseBody(/* private fields */);
     impl AsyncResponseBody {
-        async fn collect(self) -> crate::Result<Bytes>;
-        async fn collect_into(self, buffer: &mut [u8]) -> crate::Result<usize>;
-        async fn collect_string(self) -> crate::Result<String>;
+        pub async fn collect(self) -> crate::Result<Bytes>;
+        pub async fn collect_into(self, buffer: &mut [u8]) -> crate::Result<usize>;
+        pub async fn collect_string(self) -> crate::Result<String>;
     }
     impl Debug for AsyncResponseBody {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -449,19 +449,19 @@ pub mod http {
     pub struct Context<'a> {
     }
     impl<'a> Context<'a> {
-        fn insert<E>(&mut self, entity: E) -> Option<Arc<E>> where E: Send + Sync + 'static;
-        fn into_owned(self) -> Context<'static>;
-        fn is_empty(&self) -> bool;
-        fn new() -> Self;
+        pub fn insert<E>(&mut self, entity: E) -> Option<Arc<E>> where E: Send + Sync + 'static;
+        pub fn into_owned(self) -> Context<'static>;
+        pub fn is_empty(&self) -> bool;
+        pub fn new() -> Self;
         #[must_use]
-        fn to_borrowed<'b>(&self) -> Context<'b> where 'a: 'b;
+        pub fn to_borrowed<'b>(&self) -> Context<'b> where 'a: 'b;
         #[must_use]
-        fn to_owned(&self) -> Context<'static>;
-        fn value<E>(&self) -> Option<&E> where E: Send + Sync + 'static;
+        pub fn to_owned(&self) -> Context<'static>;
+        pub fn value<E>(&self) -> Option<&E> where E: Send + Sync + 'static;
         #[must_use]
-        fn with_context<'b>(context: &'a Context<'_>) -> Context<'b> where 'a: 'b;
+        pub fn with_context<'b>(context: &'a Context<'_>) -> Context<'b> where 'a: 'b;
         #[must_use]
-        fn with_value<E>(self, entity: E) -> Self where E: Send + Sync + 'static;
+        pub fn with_value<E>(self, entity: E) -> Self where E: Send + Sync + 'static;
     }
     impl Default for Context<'_> {
         fn default() -> Self;
@@ -540,9 +540,9 @@ pub mod http {
     #[derive(Clone, Debug)]
     pub struct Pipeline(/* private fields */);
     impl Pipeline {
-        fn new(crate_name: Option<&'static str>, crate_version: Option<&'static str>, options: ClientOptions, per_call_policies: Vec<Arc<dyn Policy>>, per_try_policies: Vec<Arc<dyn Policy>>, pipeline_options: Option<PipelineOptions>) -> Self;
-        async fn send(&self, ctx: &http::Context<'_>, request: &mut http::Request, options: Option<PipelineSendOptions>) -> crate::Result<http::RawResponse>;
-        async fn stream(&self, ctx: &http::Context<'_>, request: &mut http::Request, options: Option<PipelineStreamOptions>) -> crate::Result<http::AsyncRawResponse>;
+        pub fn new(crate_name: Option<&'static str>, crate_version: Option<&'static str>, options: ClientOptions, per_call_policies: Vec<Arc<dyn Policy>>, per_try_policies: Vec<Arc<dyn Policy>>, pipeline_options: Option<PipelineOptions>) -> Self;
+        pub async fn send(&self, ctx: &http::Context<'_>, request: &mut http::Request, options: Option<PipelineSendOptions>) -> crate::Result<http::RawResponse>;
+        pub async fn stream(&self, ctx: &http::Context<'_>, request: &mut http::Request, options: Option<PipelineStreamOptions>) -> crate::Result<http::AsyncRawResponse>;
     }
     #[derive(Clone, Debug)]
     pub struct PipelineOptions {
@@ -565,43 +565,43 @@ pub mod http {
     pub struct QueryBuilder<'a> {
     }
     impl<'a> QueryBuilder<'a> {
-        fn append_key_only<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>) -> &mut Self;
-        fn append_pair<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>, impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>, value: impl Into<Cow<'a, str>>) -> &mut Self;
-        fn build(self);
-        fn set_pair<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>, impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>, value: impl Into<Cow<'a, str>>) -> &mut Self;
+        pub fn append_key_only<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>) -> &mut Self;
+        pub fn append_pair<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>, impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>, value: impl Into<Cow<'a, str>>) -> &mut Self;
+        pub fn build(self);
+        pub fn set_pair<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>, impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>, value: impl Into<Cow<'a, str>>) -> &mut Self;
     }
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct RawResponse {
     }
     impl RawResponse {
-        fn body(&self) -> &ResponseBody;
-        fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
-        fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, body: impl Into<Bytes>) -> Self;
-        fn headers(&self) -> &Headers;
-        fn into_body(self) -> ResponseBody;
-        fn status(&self) -> StatusCode;
+        pub fn body(&self) -> &ResponseBody;
+        pub fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
+        pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, body: impl Into<Bytes>) -> Self;
+        pub fn headers(&self) -> &Headers;
+        pub fn into_body(self) -> ResponseBody;
+        pub fn status(&self) -> StatusCode;
     }
     #[derive(Clone)]
     pub struct Request {
     }
     impl Request {
-        fn add_mandatory_header<T: Header>(&mut self, item: &T);
-        fn add_optional_header<T: Header>(&mut self, item: &Option<T>);
-        fn body(&self) -> &Body;
-        fn body_mut(&mut self) -> &mut Body;
-        fn headers(&self) -> &Headers;
-        fn headers_mut(&mut self) -> &mut Headers;
-        fn insert_header<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
-        fn insert_headers<T: AsHeaders>(&mut self, headers: &T) -> Result<(), <T as >::Error>;
-        fn method(&self) -> Method;
-        fn new(url: Url, method: Method) -> Self;
-        fn path_and_query(&self) -> String;
-        fn set_body<impl Into<Body>: Into<Body>>(&mut self, body: impl Into<Body>);
+        pub fn add_mandatory_header<T: Header>(&mut self, item: &T);
+        pub fn add_optional_header<T: Header>(&mut self, item: &Option<T>);
+        pub fn body(&self) -> &Body;
+        pub fn body_mut(&mut self) -> &mut Body;
+        pub fn headers(&self) -> &Headers;
+        pub fn headers_mut(&mut self) -> &mut Headers;
+        pub fn insert_header<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
+        pub fn insert_headers<T: AsHeaders>(&mut self, headers: &T) -> Result<(), <T as >::Error>;
+        pub fn method(&self) -> Method;
+        pub fn new(url: Url, method: Method) -> Self;
+        pub fn path_and_query(&self) -> String;
+        pub fn set_body<impl Into<Body>: Into<Body>>(&mut self, body: impl Into<Body>);
         #[cfg(feature = "json")]
-        fn set_json<T>(&mut self, data: &T) -> crate::Result<()> where T: ?Sized + Serialize;
-        fn set_method(&mut self, method: Method);
-        fn url(&self) -> &Url;
-        fn url_mut(&mut self) -> &mut Url;
+        pub fn set_json<T>(&mut self, data: &T) -> crate::Result<()> where T: ?Sized + Serialize;
+        pub fn set_method(&mut self, method: Method);
+        pub fn url(&self) -> &Url;
+        pub fn url_mut(&mut self) -> &mut Url;
     }
     impl Debug for Request {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -611,14 +611,14 @@ pub mod http {
     pub struct RequestContent<T, F = crate::http::JsonFormat> {
     }
     impl<T, F> RequestContent<T, F> {
-        fn body(&self) -> &Body;
-        fn from(body: Vec<u8>) -> Self;
-        fn from_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + Unpin + Send + Sync + 'static;
-        fn from_seekable_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + AsyncSeek + Unpin + Send + Sync + 'static;
-        fn from_slice(body: &[u8]) -> Self;
-        fn from_static(body: &'static [u8]) -> Self;
+        pub fn body(&self) -> &Body;
+        pub fn from(body: Vec<u8>) -> Self;
+        pub fn from_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + Unpin + Send + Sync + 'static;
+        pub fn from_seekable_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + AsyncSeek + Unpin + Send + Sync + 'static;
+        pub fn from_slice(body: &[u8]) -> Self;
+        pub fn from_static(body: &'static [u8]) -> Self;
         #[allow(clippy::should_implement_trait)]
-        fn from_str(body: &str) -> Self;
+        pub fn from_str(body: &str) -> Self;
     }
     impl<T, F> From<Box<dyn SeekableStream>> for RequestContent<T, F> {
         fn from(stream: Box<dyn SeekableStream>) -> Self;
@@ -744,15 +744,15 @@ pub mod http {
     pub struct Response<T, F = crate::http::JsonFormat> {
     }
     impl<T, F> Response<T, F> {
-        fn body(&self) -> &ResponseBody;
-        fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
-        fn headers(&self) -> &Headers;
-        fn into_body(self) -> ResponseBody;
-        fn status(&self) -> StatusCode;
-        fn to_raw_response(&self) -> RawResponse;
+        pub fn body(&self) -> &ResponseBody;
+        pub fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
+        pub fn headers(&self) -> &Headers;
+        pub fn into_body(self) -> ResponseBody;
+        pub fn status(&self) -> StatusCode;
+        pub fn to_raw_response(&self) -> RawResponse;
     }
     impl<T: DeserializeWith<F>, F: Format> Response<T, F> {
-        fn into_model(self) -> crate::Result<T>;
+        pub fn into_model(self) -> crate::Result<T>;
     }
     impl<T, F> Debug for Response<T, F> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -767,18 +767,18 @@ pub mod http {
     pub struct RetryOptions {
     }
     impl RetryOptions {
-        fn custom<T: RetryPolicy + 'static>(policy: Arc<T>) -> Self;
-        fn exponential(options: ExponentialRetryOptions) -> Self;
-        fn fixed(options: FixedRetryOptions) -> Self;
-        fn none() -> Self;
+        pub fn custom<T: RetryPolicy + 'static>(policy: Arc<T>) -> Self;
+        pub fn exponential(options: ExponentialRetryOptions) -> Self;
+        pub fn fixed(options: FixedRetryOptions) -> Self;
+        pub fn none() -> Self;
     }
     #[derive(Clone, Debug)]
     pub struct Transport {
     }
     impl Transport {
-        fn new(http_client: Arc<dyn HttpClient>) -> Self;
-        async fn send(&self, ctx: &Context<'_>, request: &mut Request) -> Result<AsyncRawResponse>;
-        fn with_policy(policy: Arc<dyn Policy>) -> Self;
+        pub fn new(http_client: Arc<dyn HttpClient>) -> Self;
+        pub async fn send(&self, ctx: &Context<'_>, request: &mut Request) -> Result<AsyncRawResponse>;
+        pub fn with_policy(policy: Arc<dyn Policy>) -> Self;
     }
     impl Default for Transport {
         fn default() -> Self;
@@ -800,10 +800,10 @@ pub mod http {
         SeekableStream(Box<dyn SeekableStream>),
     }
     impl Body {
-        fn is_empty(&self) -> Option<bool>;
-        fn len(&self) -> Option<u64>;
-        async fn reset(&mut self) -> crate::Result<()>;
-        fn take(&mut self) -> Body;
+        pub fn is_empty(&self) -> Option<bool>;
+        pub fn len(&self) -> Option<u64>;
+        pub async fn reset(&mut self) -> crate::Result<()>;
+        pub fn take(&mut self) -> Body;
     }
     impl Debug for Body {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -837,8 +837,8 @@ pub mod http {
         Put,
     }
     impl Method {
-        const fn as_str(&self) -> &'static str;
-        fn is_safe(&self) -> bool;
+        pub const fn as_str(&self) -> &'static str;
+        pub fn is_safe(&self) -> bool;
     }
     impl AsRef<str> for Method {
         fn as_ref(&self) -> &'static str;
@@ -926,12 +926,12 @@ pub mod http {
         UnknownValue(u16),
     }
     impl StatusCode {
-        fn canonical_reason(&self) -> Cow<'static, str>;
-        fn is_client_error(&self) -> bool;
-        fn is_informational(&self) -> bool;
-        fn is_redirection(&self) -> bool;
-        fn is_server_error(&self) -> bool;
-        fn is_success(&self) -> bool;
+        pub fn canonical_reason(&self) -> Cow<'static, str>;
+        pub fn is_client_error(&self) -> bool;
+        pub fn is_informational(&self) -> bool;
+        pub fn is_redirection(&self) -> bool;
+        pub fn is_server_error(&self) -> bool;
+        pub fn is_success(&self) -> bool;
     }
     impl Deref for StatusCode {
         type Target = u16;
@@ -988,10 +988,10 @@ pub mod http {
         pub struct HeaderName {
         }
         impl HeaderName {
-            fn as_str(&self) -> &str;
-            const fn from_static(s: &'static str) -> Self;
-            const fn from_static_standard(s: &'static str) -> Self;
-            fn is_standard(&self) -> bool;
+            pub fn as_str(&self) -> &str;
+            pub const fn from_static(s: &'static str) -> Self;
+            pub const fn from_static_standard(s: &'static str) -> Self;
+            pub fn is_standard(&self) -> bool;
         }
         impl From<&'static str> for HeaderName {
             fn from(s: &'static str) -> Self;
@@ -1011,9 +1011,9 @@ pub mod http {
         #[derive(Clone, Eq, PartialEq)]
         pub struct HeaderValue(/* private fields */);
         impl HeaderValue {
-            fn as_str(&self) -> &str;
-            fn from_cow<C>(c: C) -> Self where C: Into<Cow<'static, str>>;
-            const fn from_static(s: &'static str) -> Self;
+            pub fn as_str(&self) -> &str;
+            pub fn from_cow<C>(c: C) -> Self where C: Into<Cow<'static, str>>;
+            pub const fn from_static(s: &'static str) -> Self;
         }
         impl Debug for HeaderValue {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1030,20 +1030,20 @@ pub mod http {
         #[derive(Clone, Default, Eq, PartialEq)]
         pub struct Headers(/* private fields */);
         impl Headers {
-            fn add<H>(&mut self, header: H) -> Result<(), <H as >::Error> where H: AsHeaders;
-            fn get<H: FromHeaders>(&self) -> crate::Result<H>;
-            fn get_as<V, E>(&self, key: &HeaderName) -> crate::Result<V> where V: FromStr<Err = E>, E: std::error::Error + Send + Sync + 'static;
-            fn get_optional<H: FromHeaders>(&self) -> Result<Option<H>, <H as >::Error>;
-            fn get_optional_as<V, E>(&self, key: &HeaderName) -> crate::Result<Option<V>> where V: FromStr<Err = E>, E: std::error::Error + Send + Sync + 'static;
-            fn get_optional_str(&self, key: &HeaderName) -> Option<&str>;
-            fn get_optional_string(&self, key: &HeaderName) -> Option<String>;
-            fn get_optional_with<'a, V, F, E>(&self, key: &HeaderName, parser: F) -> crate::Result<Option<V>> where F: FnOnce(&'a HeaderValue) -> Result<V, E>, E: std::error::Error + Send + Sync + 'static;
-            fn get_str(&self, key: &HeaderName) -> crate::Result<&str>;
-            fn get_with<'a, V, F, E>(&self, key: &HeaderName, parser: F) -> crate::Result<V> where F: FnOnce(&'a HeaderValue) -> Result<V, E>, E: std::error::Error + Send + Sync + 'static;
-            fn insert<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
-            fn iter(&self) -> impl Iterator<Item = (&HeaderName, &HeaderValue)>;
-            fn new() -> Self;
-            fn remove<K>(&mut self, key: K) -> Option<HeaderValue> where K: Into<HeaderName>;
+            pub fn add<H>(&mut self, header: H) -> Result<(), <H as >::Error> where H: AsHeaders;
+            pub fn get<H: FromHeaders>(&self) -> crate::Result<H>;
+            pub fn get_as<V, E>(&self, key: &HeaderName) -> crate::Result<V> where V: FromStr<Err = E>, E: std::error::Error + Send + Sync + 'static;
+            pub fn get_optional<H: FromHeaders>(&self) -> Result<Option<H>, <H as >::Error>;
+            pub fn get_optional_as<V, E>(&self, key: &HeaderName) -> crate::Result<Option<V>> where V: FromStr<Err = E>, E: std::error::Error + Send + Sync + 'static;
+            pub fn get_optional_str(&self, key: &HeaderName) -> Option<&str>;
+            pub fn get_optional_string(&self, key: &HeaderName) -> Option<String>;
+            pub fn get_optional_with<'a, V, F, E>(&self, key: &HeaderName, parser: F) -> crate::Result<Option<V>> where F: FnOnce(&'a HeaderValue) -> Result<V, E>, E: std::error::Error + Send + Sync + 'static;
+            pub fn get_str(&self, key: &HeaderName) -> crate::Result<&str>;
+            pub fn get_with<'a, V, F, E>(&self, key: &HeaderName, parser: F) -> crate::Result<V> where F: FnOnce(&'a HeaderValue) -> Result<V, E>, E: std::error::Error + Send + Sync + 'static;
+            pub fn insert<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
+            pub fn iter(&self) -> impl Iterator<Item = (&HeaderName, &HeaderValue)>;
+            pub fn new() -> Self;
+            pub fn remove<K>(&mut self, key: K) -> Option<HeaderValue> where K: Into<HeaderName>;
         }
         impl Debug for Headers {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1099,10 +1099,10 @@ pub mod http {
         pub struct ItemIterator<P> where P: Page + Send {
         }
         impl<P> ItemIterator<P> where P: Page + Send {
-            fn continuation(&self) -> Option<&PagerContinuation>;
-            fn into_continuation(self) -> Option<PagerContinuation>;
-            fn into_pages(self) -> PageIterator<P>;
-            fn new<F: Fn(PagerState, PagerOptions<'static>) -> PagerResultFuture<P> + Send + 'static>(make_request: F, options: Option<PagerOptions<'static>>) -> Self;
+            pub fn continuation(&self) -> Option<&PagerContinuation>;
+            pub fn into_continuation(self) -> Option<PagerContinuation>;
+            pub fn into_pages(self) -> PageIterator<P>;
+            pub fn new<F: Fn(PagerState, PagerOptions<'static>) -> PagerResultFuture<P> + Send + 'static>(make_request: F, options: Option<PagerOptions<'static>>) -> Self;
         }
         impl<P> Debug for ItemIterator<P> where P: Page + Send {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1119,9 +1119,9 @@ pub mod http {
         pub struct PageIterator<P> where P: Send {
         }
         impl<P> PageIterator<P> where P: Send {
-            fn continuation(&self) -> Option<&PagerContinuation>;
-            fn into_continuation(self) -> Option<PagerContinuation>;
-            fn new<F: Fn(PagerState, PagerOptions<'static>) -> PagerResultFuture<P> + Send + 'static>(make_request: F, options: Option<PagerOptions<'static>>) -> Self;
+            pub fn continuation(&self) -> Option<&PagerContinuation>;
+            pub fn into_continuation(self) -> Option<PagerContinuation>;
+            pub fn new<F: Fn(PagerState, PagerOptions<'static>) -> PagerResultFuture<P> + Send + 'static>(make_request: F, options: Option<PagerOptions<'static>>) -> Self;
         }
         impl<P> Debug for PageIterator<P> where P: Send {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1168,7 +1168,7 @@ pub mod http {
             Done { response: P },
         }
         impl<P, F> PagerResult<crate::http::response::Response<P, F>> {
-            fn from_response_header(response: Response<P, F>, header_name: &HeaderName) -> Self;
+            pub fn from_response_header(response: Response<P, F>, header_name: &HeaderName) -> Self;
         }
         impl<P> Debug for PagerResult<P> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1195,8 +1195,8 @@ pub mod http {
         #[derive(Debug)]
         pub struct ClientRequestIdPolicy(/* private fields */);
         impl ClientRequestIdPolicy {
-            const fn new() -> Self;
-            const fn with_header_name(header: &'static str) -> Self;
+            pub const fn new() -> Self;
+            pub const fn with_header_name(header: &'static str) -> Self;
         }
         impl Default for ClientRequestIdPolicy {
             fn default() -> Self;
@@ -1212,7 +1212,7 @@ pub mod http {
         pub struct PublicApiInstrumentationInformation {
         }
         impl PublicApiInstrumentationInformation {
-            fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(api_name: impl Into<Cow<'static, str>>, attributes: Vec<Attribute>) -> Self;
+            pub fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(api_name: impl Into<Cow<'static, str>>, attributes: Vec<Attribute>) -> Self;
         }
         #[derive(Clone, Debug, Default, Eq, PartialEq)]
         pub struct RetryHeaders {
@@ -1227,7 +1227,7 @@ pub mod http {
         pub struct TransportPolicy {
         }
         impl TransportPolicy {
-            fn new(transport: Transport) -> Self;
+            pub fn new(transport: Transport) -> Self;
         }
         impl Policy for TransportPolicy {
             #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]
@@ -1237,7 +1237,7 @@ pub mod http {
         pub struct UserAgentPolicy {
         }
         impl<'a> UserAgentPolicy {
-            fn new(crate_name: Option<&'a str>, crate_version: Option<&'a str>, options: &UserAgentOptions) -> Self;
+            pub fn new(crate_name: Option<&'a str>, crate_version: Option<&'a str>, options: &UserAgentOptions) -> Self;
         }
         impl Policy for UserAgentPolicy {
             #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]
@@ -1263,9 +1263,9 @@ pub mod http {
             pub struct BearerTokenAuthorizationPolicy {
             }
             impl BearerTokenAuthorizationPolicy {
-                fn new<A, B>(credential: Arc<dyn TokenCredential>, scopes: A) -> Self where A: IntoIterator<Item = B>, B: Into<String>;
-                fn with_on_challenge(self, on_challenge: Arc<dyn OnChallenge>) -> Self;
-                fn with_on_request(self, on_request: Arc<dyn OnRequest>) -> Self;
+                pub fn new<A, B>(credential: Arc<dyn TokenCredential>, scopes: A) -> Self where A: IntoIterator<Item = B>, B: Into<String>;
+                pub fn with_on_challenge(self, on_challenge: Arc<dyn OnChallenge>) -> Self;
+                pub fn with_on_request(self, on_request: Arc<dyn OnRequest>) -> Self;
             }
             impl Policy for BearerTokenAuthorizationPolicy {
                 #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]
@@ -1295,7 +1295,7 @@ pub mod http {
         pub struct Poller<M, F = crate::http::JsonFormat> where M: StatusMonitor, F: Format {
         }
         impl<M, F> Poller<M, F> where M: StatusMonitor, F: Format + Send {
-            fn new<Fun>(make_request: Fun, options: Option<PollerOptions<'static>>) -> Self where M: Send + 'static, <M as >::Output: Send + 'static, <M as >::Format: Send + 'static, Fun: Fn(PollerState, PollerOptions<'static>) -> PollerResultFuture<M, F> + Send + 'static;
+            pub fn new<Fun>(make_request: Fun, options: Option<PollerOptions<'static>>) -> Self where M: Send + 'static, <M as >::Output: Send + 'static, <M as >::Format: Send + 'static, Fun: Fn(PollerState, PollerOptions<'static>) -> PollerResultFuture<M, F> + Send + 'static;
         }
         impl<M, F> Debug for Poller<M, F> where M: StatusMonitor, F: Format {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1316,7 +1316,7 @@ pub mod http {
         }
         impl<'a> PollerOptions<'a> {
             #[must_use]
-            fn into_owned(self) -> PollerOptions<'static>;
+            pub fn into_owned(self) -> PollerOptions<'static>;
         }
         impl Default for PollerOptions<'_> {
             fn default() -> Self;
@@ -1374,23 +1374,23 @@ pub mod http {
         pub struct Request {
         }
         impl Request {
-            fn add_mandatory_header<T: Header>(&mut self, item: &T);
-            fn add_optional_header<T: Header>(&mut self, item: &Option<T>);
-            fn body(&self) -> &Body;
-            fn body_mut(&mut self) -> &mut Body;
-            fn headers(&self) -> &Headers;
-            fn headers_mut(&mut self) -> &mut Headers;
-            fn insert_header<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
-            fn insert_headers<T: AsHeaders>(&mut self, headers: &T) -> Result<(), <T as >::Error>;
-            fn method(&self) -> Method;
-            fn new(url: Url, method: Method) -> Self;
-            fn path_and_query(&self) -> String;
-            fn set_body<impl Into<Body>: Into<Body>>(&mut self, body: impl Into<Body>);
+            pub fn add_mandatory_header<T: Header>(&mut self, item: &T);
+            pub fn add_optional_header<T: Header>(&mut self, item: &Option<T>);
+            pub fn body(&self) -> &Body;
+            pub fn body_mut(&mut self) -> &mut Body;
+            pub fn headers(&self) -> &Headers;
+            pub fn headers_mut(&mut self) -> &mut Headers;
+            pub fn insert_header<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
+            pub fn insert_headers<T: AsHeaders>(&mut self, headers: &T) -> Result<(), <T as >::Error>;
+            pub fn method(&self) -> Method;
+            pub fn new(url: Url, method: Method) -> Self;
+            pub fn path_and_query(&self) -> String;
+            pub fn set_body<impl Into<Body>: Into<Body>>(&mut self, body: impl Into<Body>);
             #[cfg(feature = "json")]
-            fn set_json<T>(&mut self, data: &T) -> crate::Result<()> where T: ?Sized + Serialize;
-            fn set_method(&mut self, method: Method);
-            fn url(&self) -> &Url;
-            fn url_mut(&mut self) -> &mut Url;
+            pub fn set_json<T>(&mut self, data: &T) -> crate::Result<()> where T: ?Sized + Serialize;
+            pub fn set_method(&mut self, method: Method);
+            pub fn url(&self) -> &Url;
+            pub fn url_mut(&mut self) -> &mut Url;
         }
         impl Debug for Request {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1400,14 +1400,14 @@ pub mod http {
         pub struct RequestContent<T, F = crate::http::JsonFormat> {
         }
         impl<T, F> RequestContent<T, F> {
-            fn body(&self) -> &Body;
-            fn from(body: Vec<u8>) -> Self;
-            fn from_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + Unpin + Send + Sync + 'static;
-            fn from_seekable_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + AsyncSeek + Unpin + Send + Sync + 'static;
-            fn from_slice(body: &[u8]) -> Self;
-            fn from_static(body: &'static [u8]) -> Self;
+            pub fn body(&self) -> &Body;
+            pub fn from(body: Vec<u8>) -> Self;
+            pub fn from_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + Unpin + Send + Sync + 'static;
+            pub fn from_seekable_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + AsyncSeek + Unpin + Send + Sync + 'static;
+            pub fn from_slice(body: &[u8]) -> Self;
+            pub fn from_static(body: &'static [u8]) -> Self;
             #[allow(clippy::should_implement_trait)]
-            fn from_str(body: &str) -> Self;
+            pub fn from_str(body: &str) -> Self;
         }
         impl<T, F> From<Box<dyn SeekableStream>> for RequestContent<T, F> {
             fn from(stream: Box<dyn SeekableStream>) -> Self;
@@ -1535,10 +1535,10 @@ pub mod http {
             SeekableStream(Box<dyn SeekableStream>),
         }
         impl Body {
-            fn is_empty(&self) -> Option<bool>;
-            fn len(&self) -> Option<u64>;
-            async fn reset(&mut self) -> crate::Result<()>;
-            fn take(&mut self) -> Body;
+            pub fn is_empty(&self) -> Option<bool>;
+            pub fn len(&self) -> Option<u64>;
+            pub async fn reset(&mut self) -> crate::Result<()>;
+            pub fn take(&mut self) -> Body;
         }
         impl Debug for Body {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1565,8 +1565,8 @@ pub mod http {
             #[derive(Clone, Debug)]
             pub struct ClientRequestId(/* private fields */);
             impl ClientRequestId {
-                const fn from_static(s: &'static str) -> Self;
-                fn new<S>(s: S) -> Self where S: Into<std::borrow::Cow<'static, str>>;
+                pub const fn from_static(s: &'static str) -> Self;
+                pub fn new<S>(s: S) -> Self where S: Into<std::borrow::Cow<'static, str>>;
             }
             impl Header for ClientRequestId {
                 fn name(&self) -> $crate::http::headers::HeaderName;
@@ -1578,8 +1578,8 @@ pub mod http {
             #[derive(Clone, Debug)]
             pub struct ContentType(/* private fields */);
             impl ContentType {
-                const fn from_static(s: &'static str) -> Self;
-                fn new<S>(s: S) -> Self where S: Into<std::borrow::Cow<'static, str>>;
+                pub const fn from_static(s: &'static str) -> Self;
+                pub fn new<S>(s: S) -> Self where S: Into<std::borrow::Cow<'static, str>>;
             }
             impl ContentType {
                 const APPLICATION_JSON: ContentType = _;
@@ -1596,8 +1596,8 @@ pub mod http {
             #[derive(Clone, Debug)]
             pub struct ContentType(/* private fields */);
             impl ContentType {
-                const fn from_static(s: &'static str) -> Self;
-                fn new<S>(s: S) -> Self where S: Into<std::borrow::Cow<'static, str>>;
+                pub const fn from_static(s: &'static str) -> Self;
+                pub fn new<S>(s: S) -> Self where S: Into<std::borrow::Cow<'static, str>>;
             }
             impl ContentType {
                 const APPLICATION_JSON: ContentType = _;
@@ -1616,13 +1616,13 @@ pub mod http {
         pub struct AsyncRawResponse {
         }
         impl AsyncRawResponse {
-            fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
-            fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, bytes: impl Into<Bytes>) -> Self;
-            fn headers(&self) -> &Headers;
-            fn into_body(self) -> AsyncResponseBody;
-            fn new(status: StatusCode, headers: Headers, stream: PinnedStream) -> Self;
-            fn status(&self) -> StatusCode;
-            async fn try_into_raw_response(self) -> crate::Result<RawResponse>;
+            pub fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
+            pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, bytes: impl Into<Bytes>) -> Self;
+            pub fn headers(&self) -> &Headers;
+            pub fn into_body(self) -> AsyncResponseBody;
+            pub fn new(status: StatusCode, headers: Headers, stream: PinnedStream) -> Self;
+            pub fn status(&self) -> StatusCode;
+            pub async fn try_into_raw_response(self) -> crate::Result<RawResponse>;
         }
         impl<T> From<AsyncRawResponse> for AsyncResponse<T> {
             fn from(raw: AsyncRawResponse) -> Self;
@@ -1633,10 +1633,10 @@ pub mod http {
         pub struct AsyncResponse<T = ()> {
         }
         impl<T> AsyncResponse<T> {
-            fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
-            fn headers(&self) -> &Headers;
-            fn into_body(self) -> AsyncResponseBody;
-            fn status(&self) -> StatusCode;
+            pub fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
+            pub fn headers(&self) -> &Headers;
+            pub fn into_body(self) -> AsyncResponseBody;
+            pub fn status(&self) -> StatusCode;
         }
         impl<T> Debug for AsyncResponse<T> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1644,9 +1644,9 @@ pub mod http {
         #[pin_project]
         pub struct AsyncResponseBody(/* private fields */);
         impl AsyncResponseBody {
-            async fn collect(self) -> crate::Result<Bytes>;
-            async fn collect_into(self, buffer: &mut [u8]) -> crate::Result<usize>;
-            async fn collect_string(self) -> crate::Result<String>;
+            pub async fn collect(self) -> crate::Result<Bytes>;
+            pub async fn collect_into(self, buffer: &mut [u8]) -> crate::Result<usize>;
+            pub async fn collect_string(self) -> crate::Result<String>;
         }
         impl Debug for AsyncResponseBody {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1659,26 +1659,26 @@ pub mod http {
         pub struct RawResponse {
         }
         impl RawResponse {
-            fn body(&self) -> &ResponseBody;
-            fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
-            fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, body: impl Into<Bytes>) -> Self;
-            fn headers(&self) -> &Headers;
-            fn into_body(self) -> ResponseBody;
-            fn status(&self) -> StatusCode;
+            pub fn body(&self) -> &ResponseBody;
+            pub fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
+            pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, body: impl Into<Bytes>) -> Self;
+            pub fn headers(&self) -> &Headers;
+            pub fn into_body(self) -> ResponseBody;
+            pub fn status(&self) -> StatusCode;
         }
         #[cfg(feature = "json")]
         pub struct Response<T, F = crate::http::JsonFormat> {
         }
         impl<T, F> Response<T, F> {
-            fn body(&self) -> &ResponseBody;
-            fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
-            fn headers(&self) -> &Headers;
-            fn into_body(self) -> ResponseBody;
-            fn status(&self) -> StatusCode;
-            fn to_raw_response(&self) -> RawResponse;
+            pub fn body(&self) -> &ResponseBody;
+            pub fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
+            pub fn headers(&self) -> &Headers;
+            pub fn into_body(self) -> ResponseBody;
+            pub fn status(&self) -> StatusCode;
+            pub fn to_raw_response(&self) -> RawResponse;
         }
         impl<T: DeserializeWith<F>, F: Format> Response<T, F> {
-            fn into_model(self) -> crate::Result<T>;
+            pub fn into_model(self) -> crate::Result<T>;
         }
         impl<T, F> Debug for Response<T, F> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1692,12 +1692,12 @@ pub mod http {
         #[derive(Clone, Eq, PartialEq)]
         pub struct ResponseBody(/* private fields */);
         impl ResponseBody {
-            fn from_bytes<impl Into<Bytes>: Into<Bytes>>(bytes: impl Into<Bytes>) -> Self;
-            fn into_string(self) -> crate::Result<String>;
+            pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(bytes: impl Into<Bytes>) -> Self;
+            pub fn into_string(self) -> crate::Result<String>;
             #[cfg(feature = "json")]
-            fn json<T>(&self) -> crate::Result<T> where T: DeserializeOwned;
+            pub fn json<T>(&self) -> crate::Result<T> where T: DeserializeOwned;
             #[cfg(feature = "xml")]
-            fn xml<T>(&self) -> crate::Result<T> where T: DeserializeOwned;
+            pub fn xml<T>(&self) -> crate::Result<T> where T: DeserializeOwned;
         }
         impl AsRef<[u8]> for ResponseBody {
             #[inline]
@@ -1730,8 +1730,8 @@ pub mod stream {
     pub struct BytesStream {
     }
     impl BytesStream {
-        fn new<impl Into<Bytes>: Into<Bytes>>(bytes: impl Into<Bytes>) -> Self;
-        fn new_empty() -> Self;
+        pub fn new<impl Into<Bytes>: Into<Bytes>>(bytes: impl Into<Bytes>) -> Self;
+        pub fn new_empty() -> Self;
     }
     impl AsyncRead for BytesStream {
         fn poll_read(self: Pin<&mut Self>, _cx: &mut std::task::Context<'_>, buf: &mut [u8]) -> Poll<std::io::Result<usize>>;
@@ -1757,7 +1757,7 @@ pub mod stream {
     pub struct ReadStream<R> {
     }
     impl<R> ReadStream<R> {
-        fn new(reader: R, len: Option<u64>) -> Self;
+        pub fn new(reader: R, len: Option<u64>) -> Self;
     }
     impl<R> AsyncRead for ReadStream<R> where R: AsyncRead + Unpin {
         fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<std::io::Result<usize>>;
@@ -1776,7 +1776,7 @@ pub mod stream {
     pub struct SeekableReadStream<R> {
     }
     impl<R> SeekableReadStream<R> {
-        fn new(reader: R, len: Option<u64>) -> Self;
+        pub fn new(reader: R, len: Option<u64>) -> Self;
     }
     impl<R> AsyncRead for SeekableReadStream<R> where R: AsyncRead + AsyncSeek + Unpin {
         fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<std::io::Result<usize>>;
@@ -1837,8 +1837,8 @@ pub mod test {
         Live,
     }
     impl TestMode {
-        fn current() -> typespec::Result<Self>;
-        fn current_opt() -> typespec::Result<Option<Self>>;
+        pub fn current() -> typespec::Result<Self>;
+        pub fn current_opt() -> typespec::Result<Option<Self>>;
     }
     impl Debug for TestMode {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;

--- a/sdk/core/azure_core/api/API.metadata.yml
+++ b/sdk/core/azure_core/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: 7bb3e3e0c872f79a7fbbe3b57d7dc70f490f8eabd5287c457b232286591f372f
+apiMdSha256: e19d1ba96a0a287827ec2062c4f6868c286f04acf62050f31a317a74678236de
 packageVersion: 1.2.0-beta.1
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/core/azure_core_amqp/api/API.md
+++ b/sdk/core/azure_core_amqp/api/API.md
@@ -23,7 +23,7 @@ pub use azure_core_amqp::error::*;
 pub struct AmqpClaimsBasedSecurity {
 }
 impl AmqpClaimsBasedSecurity {
-    fn new(session: AmqpSession) -> Result<Self>;
+    pub fn new(session: AmqpSession) -> Result<Self>;
 }
 impl AmqpClaimsBasedSecurityApis for AmqpClaimsBasedSecurity {
     #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]
@@ -39,16 +39,16 @@ pub struct AmqpComposite {
 }
 #[cfg(feature = "ffi")]
 impl AmqpComposite {
-    fn descriptor(&self) -> &AmqpDescriptor;
-    fn new<impl Into<AmqpDescriptor>: Into<AmqpDescriptor>, impl Into<AmqpList>: Into<AmqpList>>(descriptor: impl Into<AmqpDescriptor>, value: impl Into<AmqpList>) -> Self;
-    fn value(&self) -> &AmqpList;
-    fn value_mut(&mut self) -> &mut AmqpList;
+    pub fn descriptor(&self) -> &AmqpDescriptor;
+    pub fn new<impl Into<AmqpDescriptor>: Into<AmqpDescriptor>, impl Into<AmqpList>: Into<AmqpList>>(descriptor: impl Into<AmqpDescriptor>, value: impl Into<AmqpList>) -> Self;
+    pub fn value(&self) -> &AmqpList;
+    pub fn value_mut(&mut self) -> &mut AmqpList;
 }
 #[derive(Default)]
 pub struct AmqpConnection {
 }
 impl AmqpConnection {
-    fn new() -> Self;
+    pub fn new() -> Self;
 }
 impl AmqpConnectionApis for AmqpConnection {
     #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]
@@ -90,7 +90,7 @@ pub struct AmqpDescribed {
     pub value: AmqpValue,
 }
 impl AmqpDescribed {
-    fn new<impl Into<AmqpDescriptor>: Into<AmqpDescriptor>, impl Into<AmqpValue>: Into<AmqpValue>>(descriptor: impl Into<AmqpDescriptor>, value: impl Into<AmqpValue>) -> Self;
+    pub fn new<impl Into<AmqpDescriptor>: Into<AmqpDescriptor>, impl Into<AmqpValue>: Into<AmqpValue>>(descriptor: impl Into<AmqpDescriptor>, value: impl Into<AmqpValue>) -> Self;
 }
 impl From<&AmqpValue> for Box<AmqpDescribed> {
     fn from(v: &AmqpValue) -> Self;
@@ -113,12 +113,12 @@ impl PartialEq<Described<Value>> for crate::value::AmqpDescribed {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AmqpList(pub Vec<AmqpValue>);
 impl AmqpList {
-    fn is_empty(&self) -> bool;
-    fn iter(&self) -> impl Iterator<Item = &AmqpValue>;
-    fn len(&self) -> usize;
-    fn new() -> Self;
-    fn push(&mut self, value: AmqpValue);
-    fn with_capacity(size: usize) -> Self;
+    pub fn is_empty(&self) -> bool;
+    pub fn iter(&self) -> impl Iterator<Item = &AmqpValue>;
+    pub fn len(&self) -> usize;
+    pub fn new() -> Self;
+    pub fn push(&mut self, value: AmqpValue);
+    pub fn with_capacity(size: usize) -> Self;
 }
 impl From<&AmqpList> for fe2o3_amqp_types::primitives::Value {
     fn from(value: &AmqpList) -> Self;
@@ -169,7 +169,7 @@ impl<V> FromIterator<V> for AmqpList where V: Into<AmqpValue> {
 pub struct AmqpManagement {
 }
 impl AmqpManagement {
-    fn new(session: AmqpSession, client_node_name: String, access_token: AccessToken) -> Result<Self>;
+    pub fn new(session: AmqpSession, client_node_name: String, access_token: AccessToken) -> Result<Self>;
 }
 impl AmqpManagementApis for AmqpManagement {
     #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]
@@ -190,11 +190,11 @@ pub struct AmqpMessage {
     pub footer: Option<AmqpAnnotations>,
 }
 impl AmqpMessage {
-    fn add_message_annotation<impl Into<AmqpValue>: Into<AmqpValue>>(&mut self, name: AmqpSymbol, value: impl Into<AmqpValue>);
-    fn builder() -> builders::AmqpMessageBuilder;
-    fn serialize(message: &AmqpMessage) -> Result<Vec<u8>>;
-    fn set_message_body<impl Into<AmqpMessageBody>: Into<AmqpMessageBody>>(&mut self, body: impl Into<AmqpMessageBody>);
-    fn set_message_id<impl Into<AmqpMessageId>: Into<AmqpMessageId>>(&mut self, message_id: impl Into<AmqpMessageId>);
+    pub fn add_message_annotation<impl Into<AmqpValue>: Into<AmqpValue>>(&mut self, name: AmqpSymbol, value: impl Into<AmqpValue>);
+    pub fn builder() -> builders::AmqpMessageBuilder;
+    pub fn serialize(message: &AmqpMessage) -> Result<Vec<u8>>;
+    pub fn set_message_body<impl Into<AmqpMessageBody>: Into<AmqpMessageBody>>(&mut self, body: impl Into<AmqpMessageBody>);
+    pub fn set_message_id<impl Into<AmqpMessageId>: Into<AmqpMessageId>>(&mut self, message_id: impl Into<AmqpMessageId>);
 }
 impl AsRef<AmqpMessage> for AmqpMessage {
     fn as_ref(&self) -> &AmqpMessage;
@@ -243,14 +243,14 @@ impl From<Vec<u8>> for AmqpMessage {
 pub struct AmqpOrderedMap<K, V> where K: PartialEq, V: Clone {
 }
 impl<K, V> AmqpOrderedMap<K, V> where K: PartialEq + Clone, V: Clone {
-    fn contains_key<Q>(&self, key: &Q) -> bool where K: Borrow<Q>, Q: PartialEq<K> + ?Sized;
-    fn get<Q>(&self, key: &Q) -> Option<&V> where K: Borrow<Q>, Q: PartialEq<K> + ?Sized;
-    fn insert(&mut self, key: K, value: V);
-    fn is_empty(&self) -> bool;
-    fn iter(&self) -> impl Iterator<Item = (&K, &V)> + '_;
-    fn len(&self) -> usize;
-    fn new() -> Self;
-    fn remove<Q>(&mut self, key: &Q) -> Option<V> where K: Borrow<Q>, Q: PartialEq<K> + ?Sized;
+    pub fn contains_key<Q>(&self, key: &Q) -> bool where K: Borrow<Q>, Q: PartialEq<K> + ?Sized;
+    pub fn get<Q>(&self, key: &Q) -> Option<&V> where K: Borrow<Q>, Q: PartialEq<K> + ?Sized;
+    pub fn insert(&mut self, key: K, value: V);
+    pub fn is_empty(&self) -> bool;
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> + '_;
+    pub fn len(&self) -> usize;
+    pub fn new() -> Self;
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<V> where K: Borrow<Q>, Q: PartialEq<K> + ?Sized;
 }
 impl From<&AmqpValue> for AmqpOrderedMap<AmqpValue, AmqpValue> {
     fn from(v: &AmqpValue) -> Self;
@@ -294,7 +294,7 @@ impl<K, V> IntoIterator for AmqpOrderedMap<K, V> where K: PartialEq, V: Clone {
 pub struct AmqpReceiver {
 }
 impl AmqpReceiver {
-    fn new() -> Self;
+    pub fn new() -> Self;
 }
 impl AmqpReceiverApis for AmqpReceiver {
     #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]
@@ -333,7 +333,7 @@ pub struct AmqpSendOptions {
 pub struct AmqpSender {
 }
 impl AmqpSender {
-    fn new() -> Self;
+    pub fn new() -> Self;
 }
 impl AmqpSenderApis for AmqpSender {
     #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]
@@ -365,7 +365,7 @@ pub struct AmqpSenderOptions {
 pub struct AmqpSession {
 }
 impl AmqpSession {
-    fn new() -> Self;
+    pub fn new() -> Self;
 }
 impl AmqpSessionApis for AmqpSession {
     #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]
@@ -385,7 +385,7 @@ pub struct AmqpSessionOptions {
     pub buffer_size: Option<usize>,
 }
 impl AmqpSessionOptions {
-    fn with_unbounded_windows() -> Self;
+    pub fn with_unbounded_windows() -> Self;
 }
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AmqpSource {
@@ -402,7 +402,7 @@ pub struct AmqpSource {
     pub capabilities: Option<Vec<crate::value::AmqpSymbol>>,
 }
 impl AmqpSource {
-    fn builder() -> builders::AmqpSourceBuilder;
+    pub fn builder() -> builders::AmqpSourceBuilder;
 }
 #[cfg(feature = "ffi")]
 impl From<AmqpList> for AmqpSource {
@@ -518,7 +518,7 @@ pub struct AmqpTarget {
     pub capabilities: Option<Vec<crate::value::AmqpValue>>,
 }
 impl AmqpTarget {
-    fn builder() -> builders::AmqpTargetBuilder;
+    pub fn builder() -> builders::AmqpTargetBuilder;
 }
 #[cfg(feature = "ffi")]
 impl From<AmqpList> for AmqpTarget {
@@ -1435,46 +1435,46 @@ pub mod builder {
     pub struct AmqpMessageBuilder {
     }
     impl AmqpMessageBuilder {
-        fn add_application_property<impl Into<AmqpSimpleValue>: Into<AmqpSimpleValue>>(self, key: String, value: impl Into<AmqpSimpleValue>) -> Self;
-        fn add_message_body_binary(self, body: Vec<u8>) -> Self;
-        fn add_message_body_sequence(self, body: AmqpList) -> Self;
-        fn build(&self) -> AmqpMessage;
-        fn with_application_properties(self, application_properties: AmqpApplicationProperties) -> Self;
-        fn with_body<impl Into<AmqpMessageBody>: Into<AmqpMessageBody>>(self, body: impl Into<AmqpMessageBody>) -> Self;
-        fn with_delivery_annotations(self, delivery_annotations: AmqpAnnotations) -> Self;
-        fn with_footer(self, footer: AmqpAnnotations) -> Self;
-        fn with_header(self, header: AmqpMessageHeader) -> Self;
-        fn with_message_annotations(self, message_annotations: AmqpAnnotations) -> Self;
-        fn with_properties<T>(self, properties: T) -> Self where T: Into<AmqpMessageProperties>;
+        pub fn add_application_property<impl Into<AmqpSimpleValue>: Into<AmqpSimpleValue>>(self, key: String, value: impl Into<AmqpSimpleValue>) -> Self;
+        pub fn add_message_body_binary(self, body: Vec<u8>) -> Self;
+        pub fn add_message_body_sequence(self, body: AmqpList) -> Self;
+        pub fn build(&self) -> AmqpMessage;
+        pub fn with_application_properties(self, application_properties: AmqpApplicationProperties) -> Self;
+        pub fn with_body<impl Into<AmqpMessageBody>: Into<AmqpMessageBody>>(self, body: impl Into<AmqpMessageBody>) -> Self;
+        pub fn with_delivery_annotations(self, delivery_annotations: AmqpAnnotations) -> Self;
+        pub fn with_footer(self, footer: AmqpAnnotations) -> Self;
+        pub fn with_header(self, header: AmqpMessageHeader) -> Self;
+        pub fn with_message_annotations(self, message_annotations: AmqpAnnotations) -> Self;
+        pub fn with_properties<T>(self, properties: T) -> Self where T: Into<AmqpMessageProperties>;
     }
     pub struct AmqpSourceBuilder {
     }
     impl AmqpSourceBuilder {
-        fn add_to_filter<impl Into<AmqpValue>: Into<AmqpValue>>(self, key: AmqpSymbol, value: impl Into<AmqpValue>) -> Self;
-        fn build(&self) -> AmqpSource;
-        fn with_address(self, address: String) -> Self;
-        fn with_capabilities(self, capabilities: Vec<AmqpSymbol>) -> Self;
-        fn with_default_outcome(self, default_outcome: AmqpOutcome) -> Self;
-        fn with_distribution_mode(self, distribution_mode: DistributionMode) -> Self;
-        fn with_durable(self, durable: TerminusDurability) -> Self;
-        fn with_dynamic(self, dynamic: bool) -> Self;
-        fn with_dynamic_node_properties<impl Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>: Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>>(self, dynamic_node_properties: impl Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>) -> Self;
-        fn with_expiry_policy(self, expiry_policy: TerminusExpiryPolicy) -> Self;
-        fn with_filter<impl Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>: Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>>(self, filter: impl Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>) -> Self;
-        fn with_outcomes(self, outcomes: Vec<AmqpSymbol>) -> Self;
-        fn with_timeout(self, timeout: u32) -> Self;
+        pub fn add_to_filter<impl Into<AmqpValue>: Into<AmqpValue>>(self, key: AmqpSymbol, value: impl Into<AmqpValue>) -> Self;
+        pub fn build(&self) -> AmqpSource;
+        pub fn with_address(self, address: String) -> Self;
+        pub fn with_capabilities(self, capabilities: Vec<AmqpSymbol>) -> Self;
+        pub fn with_default_outcome(self, default_outcome: AmqpOutcome) -> Self;
+        pub fn with_distribution_mode(self, distribution_mode: DistributionMode) -> Self;
+        pub fn with_durable(self, durable: TerminusDurability) -> Self;
+        pub fn with_dynamic(self, dynamic: bool) -> Self;
+        pub fn with_dynamic_node_properties<impl Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>: Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>>(self, dynamic_node_properties: impl Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>) -> Self;
+        pub fn with_expiry_policy(self, expiry_policy: TerminusExpiryPolicy) -> Self;
+        pub fn with_filter<impl Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>: Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>>(self, filter: impl Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>) -> Self;
+        pub fn with_outcomes(self, outcomes: Vec<AmqpSymbol>) -> Self;
+        pub fn with_timeout(self, timeout: u32) -> Self;
     }
     pub struct AmqpTargetBuilder {
     }
     impl AmqpTargetBuilder {
-        fn build(&self) -> AmqpTarget;
-        fn with_address(self, address: String) -> Self;
-        fn with_capabilities(self, capabilities: Vec<AmqpValue>) -> Self;
-        fn with_durable(self, durable: TerminusDurability) -> Self;
-        fn with_dynamic(self, dynamic: bool) -> Self;
-        fn with_dynamic_node_properties<impl Into<AmqpOrderedMap<String, AmqpValue>>: Into<AmqpOrderedMap<String, AmqpValue>>>(self, dynamic_node_properties: impl Into<AmqpOrderedMap<String, AmqpValue>>) -> Self;
-        fn with_expiry_policy(self, expiry_policy: TerminusExpiryPolicy) -> Self;
-        fn with_timeout(self, timeout: u32) -> Self;
+        pub fn build(&self) -> AmqpTarget;
+        pub fn with_address(self, address: String) -> Self;
+        pub fn with_capabilities(self, capabilities: Vec<AmqpValue>) -> Self;
+        pub fn with_durable(self, durable: TerminusDurability) -> Self;
+        pub fn with_dynamic(self, dynamic: bool) -> Self;
+        pub fn with_dynamic_node_properties<impl Into<AmqpOrderedMap<String, AmqpValue>>: Into<AmqpOrderedMap<String, AmqpValue>>>(self, dynamic_node_properties: impl Into<AmqpOrderedMap<String, AmqpValue>>) -> Self;
+        pub fn with_expiry_policy(self, expiry_policy: TerminusExpiryPolicy) -> Self;
+        pub fn with_timeout(self, timeout: u32) -> Self;
     }
 }
 pub mod error {
@@ -1485,7 +1485,7 @@ pub mod error {
         pub info: crate::AmqpOrderedMap<crate::AmqpSymbol, crate::AmqpValue>,
     }
     impl AmqpDescribedError {
-        fn new(condition: AmqpErrorCondition, description: Option<String>, info: AmqpOrderedMap<AmqpSymbol, AmqpValue>) -> Self;
+        pub fn new(condition: AmqpErrorCondition, description: Option<String>, info: AmqpOrderedMap<AmqpSymbol, AmqpValue>) -> Self;
     }
     impl From<AmqpDescribedError> for fe2o3_amqp_types::definitions::Error {
         fn from(e: AmqpDescribedError) -> Self;
@@ -1496,12 +1496,12 @@ pub mod error {
     pub struct AmqpError {
     }
     impl AmqpError {
-        fn kind(&self) -> &AmqpErrorKind;
+        pub fn kind(&self) -> &AmqpErrorKind;
         #[cfg(feature = "test")]
-        fn new_described_error(condition: AmqpErrorCondition, description: Option<String>, info: AmqpOrderedMap<AmqpSymbol, AmqpValue>) -> Self;
+        pub fn new_described_error(condition: AmqpErrorCondition, description: Option<String>, info: AmqpOrderedMap<AmqpSymbol, AmqpValue>) -> Self;
         #[cfg(feature = "test")]
-        fn new_management_error(status_code: azure_core::http::StatusCode, description: Option<String>) -> Self;
-        fn with_message<C>(message: C) -> AmqpError where C: Into<Cow<'static, str>>;
+        pub fn new_management_error(status_code: azure_core::http::StatusCode, description: Option<String>) -> Self;
+        pub fn with_message<C>(message: C) -> AmqpError where C: Into<Cow<'static, str>>;
     }
     impl Debug for AmqpError {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
@@ -1665,8 +1665,8 @@ pub mod message {
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct AmqpAnnotations(pub crate::value::AmqpOrderedMap<AmqpAnnotationKey, crate::value::AmqpValue>);
     impl AmqpAnnotations {
-        fn insert<impl Into<AmqpAnnotationKey>: Into<AmqpAnnotationKey>, impl Into<AmqpValue>: Into<AmqpValue>>(&mut self, key: impl Into<AmqpAnnotationKey>, value: impl Into<AmqpValue>);
-        fn new() -> Self;
+        pub fn insert<impl Into<AmqpAnnotationKey>: Into<AmqpAnnotationKey>, impl Into<AmqpValue>: Into<AmqpValue>>(&mut self, key: impl Into<AmqpAnnotationKey>, value: impl Into<AmqpValue>);
+        pub fn new() -> Self;
     }
     impl From<&AmqpAnnotations> for fe2o3_amqp_types::messaging::Annotations {
         fn from(annotations: &AmqpAnnotations) -> Self;
@@ -1704,8 +1704,8 @@ pub mod message {
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct AmqpApplicationProperties(pub crate::value::AmqpOrderedMap<String, crate::simple_value::AmqpSimpleValue>);
     impl AmqpApplicationProperties {
-        fn insert<impl Into<AmqpSimpleValue>: Into<AmqpSimpleValue>>(&mut self, key: String, value: impl Into<AmqpSimpleValue>);
-        fn new() -> Self;
+        pub fn insert<impl Into<AmqpSimpleValue>: Into<AmqpSimpleValue>>(&mut self, key: String, value: impl Into<AmqpSimpleValue>);
+        pub fn new() -> Self;
     }
     impl From<&AmqpApplicationProperties> for fe2o3_amqp_types::messaging::ApplicationProperties {
         fn from(application_properties: &AmqpApplicationProperties) -> Self;
@@ -1790,9 +1790,9 @@ pub mod message {
     pub struct AmqpSourceFilter {
     }
     impl AmqpSourceFilter {
-        fn code(&self) -> u64;
-        fn description(&self) -> &'static str;
-        fn selector_filter() -> AmqpSourceFilter;
+        pub fn code(&self) -> u64;
+        pub fn description(&self) -> &'static str;
+        pub fn selector_filter() -> AmqpSourceFilter;
     }
     #[derive(Clone, Debug, PartialEq)]
     pub enum AmqpAnnotationKey {

--- a/sdk/core/azure_core_amqp/api/API.metadata.yml
+++ b/sdk/core/azure_core_amqp/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: ab66b4a40d9143d634f82077c6c5f9041f9b1b02bea8f2c28b2e284656d9788a
+apiMdSha256: e6607b16943502834fde219f268cb8cc031a56633aed2b5c0ba74333e7aac98c
 packageVersion: 1.2.0-beta.1
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/core/azure_core_examples/api/API.md
+++ b/sdk/core/azure_core_examples/api/API.md
@@ -12,28 +12,28 @@
 pub struct Error {
 }
 impl Error {
-    fn downcast_mut<T: std::error::Error + 'static>(&mut self) -> Option<&mut T>;
-    fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T>;
-    fn get_mut(&mut self) -> Option<&mut dyn std::error::Error + Send + Sync + 'static>;
-    fn get_ref(&self) -> Option<&dyn std::error::Error + Send + Sync + 'static>;
+    pub fn downcast_mut<T: std::error::Error + 'static>(&mut self) -> Option<&mut T>;
+    pub fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T>;
+    pub fn get_mut(&mut self) -> Option<&mut dyn std::error::Error + Send + Sync + 'static>;
+    pub fn get_ref(&self) -> Option<&dyn std::error::Error + Send + Sync + 'static>;
     #[cfg(feature = "http")]
-    fn http_status(&self) -> Option<StatusCode>;
-    fn into_downcast<T: std::error::Error + 'static>(self) -> std::result::Result<T, Self>;
-    fn into_inner(self) -> std::result::Result<Box<dyn std::error::Error + Send + Sync>, Self>;
-    fn kind(&self) -> &ErrorKind;
-    fn new<E>(kind: ErrorKind, error: E) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>;
+    pub fn http_status(&self) -> Option<StatusCode>;
+    pub fn into_downcast<T: std::error::Error + 'static>(self) -> std::result::Result<T, Self>;
+    pub fn into_inner(self) -> std::result::Result<Box<dyn std::error::Error + Send + Sync>, Self>;
+    pub fn kind(&self) -> &ErrorKind;
+    pub fn new<E>(kind: ErrorKind, error: E) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>;
     #[must_use]
-    fn with_context<C>(self, message: C) -> Self where C: Into<Cow<'static, str>>;
+    pub fn with_context<C>(self, message: C) -> Self where C: Into<Cow<'static, str>>;
     #[must_use]
-    fn with_context_fn<F, C>(self, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+    pub fn with_context_fn<F, C>(self, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
     #[must_use]
-    fn with_error<E, C>(kind: ErrorKind, error: E, message: C) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, C: Into<Cow<'static, str>>;
+    pub fn with_error<E, C>(kind: ErrorKind, error: E, message: C) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, C: Into<Cow<'static, str>>;
     #[must_use]
-    fn with_error_fn<E, F, C>(kind: ErrorKind, error: E, f: F) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+    pub fn with_error_fn<E, F, C>(kind: ErrorKind, error: E, f: F) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, F: FnOnce() -> C, C: Into<Cow<'static, str>>;
     #[must_use]
-    fn with_message<C>(kind: ErrorKind, message: C) -> Self where C: Into<Cow<'static, str>>;
+    pub fn with_message<C>(kind: ErrorKind, message: C) -> Self where C: Into<Cow<'static, str>>;
     #[must_use]
-    fn with_message_fn<F, C>(kind: ErrorKind, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+    pub fn with_message_fn<F, C>(kind: ErrorKind, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
 }
 impl Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -77,8 +77,8 @@ pub mod certificates {
     pub struct CertificateClient {
     }
     impl CertificateClient {
-        fn begin_create_certificate(&self, certificate_name: &str, parameters: RequestContent<CreateCertificateParameters>, _options: Option<()>) -> Result<Poller<CertificateOperation>>;
-        fn new(endpoint: &str, _credential: Arc<dyn TokenCredential>, options: Option<CertificateClientOptions>) -> Result<Self>;
+        pub fn begin_create_certificate(&self, certificate_name: &str, parameters: RequestContent<CreateCertificateParameters>, _options: Option<()>) -> Result<Poller<CertificateOperation>>;
+        pub fn new(endpoint: &str, _credential: Arc<dyn TokenCredential>, options: Option<CertificateClientOptions>) -> Result<Self>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct CertificateClientOptions {
@@ -143,9 +143,9 @@ pub mod client {
     pub struct TestServiceClient {
     }
     impl TestServiceClient {
-        fn endpoint(&self) -> &Url;
-        async fn get(&self, path: &str, options: Option<TestServiceClientGetMethodOptions<'_>>) -> Result<RawResponse>;
-        fn new(endpoint: &str, _credential: Arc<dyn TokenCredential>, options: Option<TestServiceClientOptions>) -> Result<Self>;
+        pub fn endpoint(&self) -> &Url;
+        pub async fn get(&self, path: &str, options: Option<TestServiceClientGetMethodOptions<'_>>) -> Result<RawResponse>;
+        pub fn new(endpoint: &str, _credential: Arc<dyn TokenCredential>, options: Option<TestServiceClientOptions>) -> Result<Self>;
     }
     #[derive(Debug, Default)]
     pub struct TestServiceClientGetMethodOptions<'a> {
@@ -168,13 +168,13 @@ pub mod credentials {
         pub expires_on: typespec_client_core::time::OffsetDateTime,
     }
     impl AccessToken {
-        fn new<T>(token: T, expires_on: OffsetDateTime) -> Self where T: Into<Secret>;
+        pub fn new<T>(token: T, expires_on: OffsetDateTime) -> Self where T: Into<Secret>;
     }
     #[derive(Clone, Eq, serde::Deserialize, serde::Serialize)]
     pub struct Secret(/* private fields */);
     impl Secret {
-        fn new<T>(access_token: T) -> Self where T: Into<Cow<'static, str>>;
-        fn secret(&self) -> &str;
+        pub fn new<T>(access_token: T) -> Self where T: Into<Cow<'static, str>>;
+        pub fn secret(&self) -> &str;
     }
     impl Debug for Secret {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
@@ -191,8 +191,8 @@ pub mod credentials {
     #[derive(Clone, Eq)]
     pub struct SecretBytes(/* private fields */);
     impl SecretBytes {
-        fn bytes(&self) -> &[u8];
-        fn new<impl Into<Vec<u8>>: Into<Vec<u8>>>(bytes: impl Into<Vec<u8>>) -> Self;
+        pub fn bytes(&self) -> &[u8];
+        pub fn new<impl Into<Vec<u8>>: Into<Vec<u8>>>(bytes: impl Into<Vec<u8>>) -> Self;
     }
     impl Debug for SecretBytes {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -231,28 +231,28 @@ pub mod error {
     pub struct Error {
     }
     impl Error {
-        fn downcast_mut<T: std::error::Error + 'static>(&mut self) -> Option<&mut T>;
-        fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T>;
-        fn get_mut(&mut self) -> Option<&mut dyn std::error::Error + Send + Sync + 'static>;
-        fn get_ref(&self) -> Option<&dyn std::error::Error + Send + Sync + 'static>;
+        pub fn downcast_mut<T: std::error::Error + 'static>(&mut self) -> Option<&mut T>;
+        pub fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T>;
+        pub fn get_mut(&mut self) -> Option<&mut dyn std::error::Error + Send + Sync + 'static>;
+        pub fn get_ref(&self) -> Option<&dyn std::error::Error + Send + Sync + 'static>;
         #[cfg(feature = "http")]
-        fn http_status(&self) -> Option<StatusCode>;
-        fn into_downcast<T: std::error::Error + 'static>(self) -> std::result::Result<T, Self>;
-        fn into_inner(self) -> std::result::Result<Box<dyn std::error::Error + Send + Sync>, Self>;
-        fn kind(&self) -> &ErrorKind;
-        fn new<E>(kind: ErrorKind, error: E) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>;
+        pub fn http_status(&self) -> Option<StatusCode>;
+        pub fn into_downcast<T: std::error::Error + 'static>(self) -> std::result::Result<T, Self>;
+        pub fn into_inner(self) -> std::result::Result<Box<dyn std::error::Error + Send + Sync>, Self>;
+        pub fn kind(&self) -> &ErrorKind;
+        pub fn new<E>(kind: ErrorKind, error: E) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>;
         #[must_use]
-        fn with_context<C>(self, message: C) -> Self where C: Into<Cow<'static, str>>;
+        pub fn with_context<C>(self, message: C) -> Self where C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_context_fn<F, C>(self, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+        pub fn with_context_fn<F, C>(self, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_error<E, C>(kind: ErrorKind, error: E, message: C) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, C: Into<Cow<'static, str>>;
+        pub fn with_error<E, C>(kind: ErrorKind, error: E, message: C) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_error_fn<E, F, C>(kind: ErrorKind, error: E, f: F) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+        pub fn with_error_fn<E, F, C>(kind: ErrorKind, error: E, f: F) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, F: FnOnce() -> C, C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_message<C>(kind: ErrorKind, message: C) -> Self where C: Into<Cow<'static, str>>;
+        pub fn with_message<C>(kind: ErrorKind, message: C) -> Self where C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_message_fn<F, C>(kind: ErrorKind, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+        pub fn with_message_fn<F, C>(kind: ErrorKind, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
     }
     impl Debug for Error {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -327,7 +327,7 @@ pub mod error {
         Other,
     }
     impl ErrorKind {
-        fn into_error(self) -> Error;
+        pub fn into_error(self) -> Error;
     }
     impl Display for ErrorKind {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -359,13 +359,13 @@ pub mod http {
     pub struct AsyncRawResponse {
     }
     impl AsyncRawResponse {
-        fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
-        fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, bytes: impl Into<Bytes>) -> Self;
-        fn headers(&self) -> &Headers;
-        fn into_body(self) -> AsyncResponseBody;
-        fn new(status: StatusCode, headers: Headers, stream: PinnedStream) -> Self;
-        fn status(&self) -> StatusCode;
-        async fn try_into_raw_response(self) -> crate::Result<RawResponse>;
+        pub fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
+        pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, bytes: impl Into<Bytes>) -> Self;
+        pub fn headers(&self) -> &Headers;
+        pub fn into_body(self) -> AsyncResponseBody;
+        pub fn new(status: StatusCode, headers: Headers, stream: PinnedStream) -> Self;
+        pub fn status(&self) -> StatusCode;
+        pub async fn try_into_raw_response(self) -> crate::Result<RawResponse>;
     }
     impl<T> From<AsyncRawResponse> for AsyncResponse<T> {
         fn from(raw: AsyncRawResponse) -> Self;
@@ -376,10 +376,10 @@ pub mod http {
     pub struct AsyncResponse<T = ()> {
     }
     impl<T> AsyncResponse<T> {
-        fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
-        fn headers(&self) -> &Headers;
-        fn into_body(self) -> AsyncResponseBody;
-        fn status(&self) -> StatusCode;
+        pub fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
+        pub fn headers(&self) -> &Headers;
+        pub fn into_body(self) -> AsyncResponseBody;
+        pub fn status(&self) -> StatusCode;
     }
     impl<T> Debug for AsyncResponse<T> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -387,9 +387,9 @@ pub mod http {
     #[pin_project]
     pub struct AsyncResponseBody(/* private fields */);
     impl AsyncResponseBody {
-        async fn collect(self) -> crate::Result<Bytes>;
-        async fn collect_into(self, buffer: &mut [u8]) -> crate::Result<usize>;
-        async fn collect_string(self) -> crate::Result<String>;
+        pub async fn collect(self) -> crate::Result<Bytes>;
+        pub async fn collect_into(self, buffer: &mut [u8]) -> crate::Result<usize>;
+        pub async fn collect_string(self) -> crate::Result<String>;
     }
     impl Debug for AsyncResponseBody {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -417,19 +417,19 @@ pub mod http {
     pub struct Context<'a> {
     }
     impl<'a> Context<'a> {
-        fn insert<E>(&mut self, entity: E) -> Option<Arc<E>> where E: Send + Sync + 'static;
-        fn into_owned(self) -> Context<'static>;
-        fn is_empty(&self) -> bool;
-        fn new() -> Self;
+        pub fn insert<E>(&mut self, entity: E) -> Option<Arc<E>> where E: Send + Sync + 'static;
+        pub fn into_owned(self) -> Context<'static>;
+        pub fn is_empty(&self) -> bool;
+        pub fn new() -> Self;
         #[must_use]
-        fn to_borrowed<'b>(&self) -> Context<'b> where 'a: 'b;
+        pub fn to_borrowed<'b>(&self) -> Context<'b> where 'a: 'b;
         #[must_use]
-        fn to_owned(&self) -> Context<'static>;
-        fn value<E>(&self) -> Option<&E> where E: Send + Sync + 'static;
+        pub fn to_owned(&self) -> Context<'static>;
+        pub fn value<E>(&self) -> Option<&E> where E: Send + Sync + 'static;
         #[must_use]
-        fn with_context<'b>(context: &'a Context<'_>) -> Context<'b> where 'a: 'b;
+        pub fn with_context<'b>(context: &'a Context<'_>) -> Context<'b> where 'a: 'b;
         #[must_use]
-        fn with_value<E>(self, entity: E) -> Self where E: Send + Sync + 'static;
+        pub fn with_value<E>(self, entity: E) -> Self where E: Send + Sync + 'static;
     }
     impl Default for Context<'_> {
         fn default() -> Self;
@@ -508,9 +508,9 @@ pub mod http {
     #[derive(Clone, Debug)]
     pub struct Pipeline(/* private fields */);
     impl Pipeline {
-        fn new(crate_name: Option<&'static str>, crate_version: Option<&'static str>, options: ClientOptions, per_call_policies: Vec<Arc<dyn Policy>>, per_try_policies: Vec<Arc<dyn Policy>>, pipeline_options: Option<PipelineOptions>) -> Self;
-        async fn send(&self, ctx: &http::Context<'_>, request: &mut http::Request, options: Option<PipelineSendOptions>) -> crate::Result<http::RawResponse>;
-        async fn stream(&self, ctx: &http::Context<'_>, request: &mut http::Request, options: Option<PipelineStreamOptions>) -> crate::Result<http::AsyncRawResponse>;
+        pub fn new(crate_name: Option<&'static str>, crate_version: Option<&'static str>, options: ClientOptions, per_call_policies: Vec<Arc<dyn Policy>>, per_try_policies: Vec<Arc<dyn Policy>>, pipeline_options: Option<PipelineOptions>) -> Self;
+        pub async fn send(&self, ctx: &http::Context<'_>, request: &mut http::Request, options: Option<PipelineSendOptions>) -> crate::Result<http::RawResponse>;
+        pub async fn stream(&self, ctx: &http::Context<'_>, request: &mut http::Request, options: Option<PipelineStreamOptions>) -> crate::Result<http::AsyncRawResponse>;
     }
     #[derive(Clone, Debug)]
     pub struct PipelineOptions {
@@ -533,43 +533,43 @@ pub mod http {
     pub struct QueryBuilder<'a> {
     }
     impl<'a> QueryBuilder<'a> {
-        fn append_key_only<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>) -> &mut Self;
-        fn append_pair<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>, impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>, value: impl Into<Cow<'a, str>>) -> &mut Self;
-        fn build(self);
-        fn set_pair<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>, impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>, value: impl Into<Cow<'a, str>>) -> &mut Self;
+        pub fn append_key_only<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>) -> &mut Self;
+        pub fn append_pair<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>, impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>, value: impl Into<Cow<'a, str>>) -> &mut Self;
+        pub fn build(self);
+        pub fn set_pair<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>, impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>, value: impl Into<Cow<'a, str>>) -> &mut Self;
     }
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct RawResponse {
     }
     impl RawResponse {
-        fn body(&self) -> &ResponseBody;
-        fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
-        fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, body: impl Into<Bytes>) -> Self;
-        fn headers(&self) -> &Headers;
-        fn into_body(self) -> ResponseBody;
-        fn status(&self) -> StatusCode;
+        pub fn body(&self) -> &ResponseBody;
+        pub fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
+        pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, body: impl Into<Bytes>) -> Self;
+        pub fn headers(&self) -> &Headers;
+        pub fn into_body(self) -> ResponseBody;
+        pub fn status(&self) -> StatusCode;
     }
     #[derive(Clone)]
     pub struct Request {
     }
     impl Request {
-        fn add_mandatory_header<T: Header>(&mut self, item: &T);
-        fn add_optional_header<T: Header>(&mut self, item: &Option<T>);
-        fn body(&self) -> &Body;
-        fn body_mut(&mut self) -> &mut Body;
-        fn headers(&self) -> &Headers;
-        fn headers_mut(&mut self) -> &mut Headers;
-        fn insert_header<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
-        fn insert_headers<T: AsHeaders>(&mut self, headers: &T) -> Result<(), <T as >::Error>;
-        fn method(&self) -> Method;
-        fn new(url: Url, method: Method) -> Self;
-        fn path_and_query(&self) -> String;
-        fn set_body<impl Into<Body>: Into<Body>>(&mut self, body: impl Into<Body>);
+        pub fn add_mandatory_header<T: Header>(&mut self, item: &T);
+        pub fn add_optional_header<T: Header>(&mut self, item: &Option<T>);
+        pub fn body(&self) -> &Body;
+        pub fn body_mut(&mut self) -> &mut Body;
+        pub fn headers(&self) -> &Headers;
+        pub fn headers_mut(&mut self) -> &mut Headers;
+        pub fn insert_header<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
+        pub fn insert_headers<T: AsHeaders>(&mut self, headers: &T) -> Result<(), <T as >::Error>;
+        pub fn method(&self) -> Method;
+        pub fn new(url: Url, method: Method) -> Self;
+        pub fn path_and_query(&self) -> String;
+        pub fn set_body<impl Into<Body>: Into<Body>>(&mut self, body: impl Into<Body>);
         #[cfg(feature = "json")]
-        fn set_json<T>(&mut self, data: &T) -> crate::Result<()> where T: ?Sized + Serialize;
-        fn set_method(&mut self, method: Method);
-        fn url(&self) -> &Url;
-        fn url_mut(&mut self) -> &mut Url;
+        pub fn set_json<T>(&mut self, data: &T) -> crate::Result<()> where T: ?Sized + Serialize;
+        pub fn set_method(&mut self, method: Method);
+        pub fn url(&self) -> &Url;
+        pub fn url_mut(&mut self) -> &mut Url;
     }
     impl Debug for Request {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -579,14 +579,14 @@ pub mod http {
     pub struct RequestContent<T, F = crate::http::JsonFormat> {
     }
     impl<T, F> RequestContent<T, F> {
-        fn body(&self) -> &Body;
-        fn from(body: Vec<u8>) -> Self;
-        fn from_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + Unpin + Send + Sync + 'static;
-        fn from_seekable_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + AsyncSeek + Unpin + Send + Sync + 'static;
-        fn from_slice(body: &[u8]) -> Self;
-        fn from_static(body: &'static [u8]) -> Self;
+        pub fn body(&self) -> &Body;
+        pub fn from(body: Vec<u8>) -> Self;
+        pub fn from_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + Unpin + Send + Sync + 'static;
+        pub fn from_seekable_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + AsyncSeek + Unpin + Send + Sync + 'static;
+        pub fn from_slice(body: &[u8]) -> Self;
+        pub fn from_static(body: &'static [u8]) -> Self;
         #[allow(clippy::should_implement_trait)]
-        fn from_str(body: &str) -> Self;
+        pub fn from_str(body: &str) -> Self;
     }
     impl<T, F> From<Box<dyn SeekableStream>> for RequestContent<T, F> {
         fn from(stream: Box<dyn SeekableStream>) -> Self;
@@ -712,15 +712,15 @@ pub mod http {
     pub struct Response<T, F = crate::http::JsonFormat> {
     }
     impl<T, F> Response<T, F> {
-        fn body(&self) -> &ResponseBody;
-        fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
-        fn headers(&self) -> &Headers;
-        fn into_body(self) -> ResponseBody;
-        fn status(&self) -> StatusCode;
-        fn to_raw_response(&self) -> RawResponse;
+        pub fn body(&self) -> &ResponseBody;
+        pub fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
+        pub fn headers(&self) -> &Headers;
+        pub fn into_body(self) -> ResponseBody;
+        pub fn status(&self) -> StatusCode;
+        pub fn to_raw_response(&self) -> RawResponse;
     }
     impl<T: DeserializeWith<F>, F: Format> Response<T, F> {
-        fn into_model(self) -> crate::Result<T>;
+        pub fn into_model(self) -> crate::Result<T>;
     }
     impl<T, F> Debug for Response<T, F> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -735,18 +735,18 @@ pub mod http {
     pub struct RetryOptions {
     }
     impl RetryOptions {
-        fn custom<T: RetryPolicy + 'static>(policy: Arc<T>) -> Self;
-        fn exponential(options: ExponentialRetryOptions) -> Self;
-        fn fixed(options: FixedRetryOptions) -> Self;
-        fn none() -> Self;
+        pub fn custom<T: RetryPolicy + 'static>(policy: Arc<T>) -> Self;
+        pub fn exponential(options: ExponentialRetryOptions) -> Self;
+        pub fn fixed(options: FixedRetryOptions) -> Self;
+        pub fn none() -> Self;
     }
     #[derive(Clone, Debug)]
     pub struct Transport {
     }
     impl Transport {
-        fn new(http_client: Arc<dyn HttpClient>) -> Self;
-        async fn send(&self, ctx: &Context<'_>, request: &mut Request) -> Result<AsyncRawResponse>;
-        fn with_policy(policy: Arc<dyn Policy>) -> Self;
+        pub fn new(http_client: Arc<dyn HttpClient>) -> Self;
+        pub async fn send(&self, ctx: &Context<'_>, request: &mut Request) -> Result<AsyncRawResponse>;
+        pub fn with_policy(policy: Arc<dyn Policy>) -> Self;
     }
     impl Default for Transport {
         fn default() -> Self;
@@ -768,10 +768,10 @@ pub mod http {
         SeekableStream(Box<dyn SeekableStream>),
     }
     impl Body {
-        fn is_empty(&self) -> Option<bool>;
-        fn len(&self) -> Option<u64>;
-        async fn reset(&mut self) -> crate::Result<()>;
-        fn take(&mut self) -> Body;
+        pub fn is_empty(&self) -> Option<bool>;
+        pub fn len(&self) -> Option<u64>;
+        pub async fn reset(&mut self) -> crate::Result<()>;
+        pub fn take(&mut self) -> Body;
     }
     impl Debug for Body {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -805,8 +805,8 @@ pub mod http {
         Put,
     }
     impl Method {
-        const fn as_str(&self) -> &'static str;
-        fn is_safe(&self) -> bool;
+        pub const fn as_str(&self) -> &'static str;
+        pub fn is_safe(&self) -> bool;
     }
     impl AsRef<str> for Method {
         fn as_ref(&self) -> &'static str;
@@ -894,12 +894,12 @@ pub mod http {
         UnknownValue(u16),
     }
     impl StatusCode {
-        fn canonical_reason(&self) -> Cow<'static, str>;
-        fn is_client_error(&self) -> bool;
-        fn is_informational(&self) -> bool;
-        fn is_redirection(&self) -> bool;
-        fn is_server_error(&self) -> bool;
-        fn is_success(&self) -> bool;
+        pub fn canonical_reason(&self) -> Cow<'static, str>;
+        pub fn is_client_error(&self) -> bool;
+        pub fn is_informational(&self) -> bool;
+        pub fn is_redirection(&self) -> bool;
+        pub fn is_server_error(&self) -> bool;
+        pub fn is_success(&self) -> bool;
     }
     impl Deref for StatusCode {
         type Target = u16;
@@ -956,10 +956,10 @@ pub mod http {
         pub struct HeaderName {
         }
         impl HeaderName {
-            fn as_str(&self) -> &str;
-            const fn from_static(s: &'static str) -> Self;
-            const fn from_static_standard(s: &'static str) -> Self;
-            fn is_standard(&self) -> bool;
+            pub fn as_str(&self) -> &str;
+            pub const fn from_static(s: &'static str) -> Self;
+            pub const fn from_static_standard(s: &'static str) -> Self;
+            pub fn is_standard(&self) -> bool;
         }
         impl From<&'static str> for HeaderName {
             fn from(s: &'static str) -> Self;
@@ -979,9 +979,9 @@ pub mod http {
         #[derive(Clone, Eq, PartialEq)]
         pub struct HeaderValue(/* private fields */);
         impl HeaderValue {
-            fn as_str(&self) -> &str;
-            fn from_cow<C>(c: C) -> Self where C: Into<Cow<'static, str>>;
-            const fn from_static(s: &'static str) -> Self;
+            pub fn as_str(&self) -> &str;
+            pub fn from_cow<C>(c: C) -> Self where C: Into<Cow<'static, str>>;
+            pub const fn from_static(s: &'static str) -> Self;
         }
         impl Debug for HeaderValue {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -998,20 +998,20 @@ pub mod http {
         #[derive(Clone, Default, Eq, PartialEq)]
         pub struct Headers(/* private fields */);
         impl Headers {
-            fn add<H>(&mut self, header: H) -> Result<(), <H as >::Error> where H: AsHeaders;
-            fn get<H: FromHeaders>(&self) -> crate::Result<H>;
-            fn get_as<V, E>(&self, key: &HeaderName) -> crate::Result<V> where V: FromStr<Err = E>, E: std::error::Error + Send + Sync + 'static;
-            fn get_optional<H: FromHeaders>(&self) -> Result<Option<H>, <H as >::Error>;
-            fn get_optional_as<V, E>(&self, key: &HeaderName) -> crate::Result<Option<V>> where V: FromStr<Err = E>, E: std::error::Error + Send + Sync + 'static;
-            fn get_optional_str(&self, key: &HeaderName) -> Option<&str>;
-            fn get_optional_string(&self, key: &HeaderName) -> Option<String>;
-            fn get_optional_with<'a, V, F, E>(&self, key: &HeaderName, parser: F) -> crate::Result<Option<V>> where F: FnOnce(&'a HeaderValue) -> Result<V, E>, E: std::error::Error + Send + Sync + 'static;
-            fn get_str(&self, key: &HeaderName) -> crate::Result<&str>;
-            fn get_with<'a, V, F, E>(&self, key: &HeaderName, parser: F) -> crate::Result<V> where F: FnOnce(&'a HeaderValue) -> Result<V, E>, E: std::error::Error + Send + Sync + 'static;
-            fn insert<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
-            fn iter(&self) -> impl Iterator<Item = (&HeaderName, &HeaderValue)>;
-            fn new() -> Self;
-            fn remove<K>(&mut self, key: K) -> Option<HeaderValue> where K: Into<HeaderName>;
+            pub fn add<H>(&mut self, header: H) -> Result<(), <H as >::Error> where H: AsHeaders;
+            pub fn get<H: FromHeaders>(&self) -> crate::Result<H>;
+            pub fn get_as<V, E>(&self, key: &HeaderName) -> crate::Result<V> where V: FromStr<Err = E>, E: std::error::Error + Send + Sync + 'static;
+            pub fn get_optional<H: FromHeaders>(&self) -> Result<Option<H>, <H as >::Error>;
+            pub fn get_optional_as<V, E>(&self, key: &HeaderName) -> crate::Result<Option<V>> where V: FromStr<Err = E>, E: std::error::Error + Send + Sync + 'static;
+            pub fn get_optional_str(&self, key: &HeaderName) -> Option<&str>;
+            pub fn get_optional_string(&self, key: &HeaderName) -> Option<String>;
+            pub fn get_optional_with<'a, V, F, E>(&self, key: &HeaderName, parser: F) -> crate::Result<Option<V>> where F: FnOnce(&'a HeaderValue) -> Result<V, E>, E: std::error::Error + Send + Sync + 'static;
+            pub fn get_str(&self, key: &HeaderName) -> crate::Result<&str>;
+            pub fn get_with<'a, V, F, E>(&self, key: &HeaderName, parser: F) -> crate::Result<V> where F: FnOnce(&'a HeaderValue) -> Result<V, E>, E: std::error::Error + Send + Sync + 'static;
+            pub fn insert<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
+            pub fn iter(&self) -> impl Iterator<Item = (&HeaderName, &HeaderValue)>;
+            pub fn new() -> Self;
+            pub fn remove<K>(&mut self, key: K) -> Option<HeaderValue> where K: Into<HeaderName>;
         }
         impl Debug for Headers {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1067,10 +1067,10 @@ pub mod http {
         pub struct ItemIterator<P> where P: Page + Send {
         }
         impl<P> ItemIterator<P> where P: Page + Send {
-            fn continuation(&self) -> Option<&PagerContinuation>;
-            fn into_continuation(self) -> Option<PagerContinuation>;
-            fn into_pages(self) -> PageIterator<P>;
-            fn new<F: Fn(PagerState, PagerOptions<'static>) -> PagerResultFuture<P> + Send + 'static>(make_request: F, options: Option<PagerOptions<'static>>) -> Self;
+            pub fn continuation(&self) -> Option<&PagerContinuation>;
+            pub fn into_continuation(self) -> Option<PagerContinuation>;
+            pub fn into_pages(self) -> PageIterator<P>;
+            pub fn new<F: Fn(PagerState, PagerOptions<'static>) -> PagerResultFuture<P> + Send + 'static>(make_request: F, options: Option<PagerOptions<'static>>) -> Self;
         }
         impl<P> Debug for ItemIterator<P> where P: Page + Send {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1087,9 +1087,9 @@ pub mod http {
         pub struct PageIterator<P> where P: Send {
         }
         impl<P> PageIterator<P> where P: Send {
-            fn continuation(&self) -> Option<&PagerContinuation>;
-            fn into_continuation(self) -> Option<PagerContinuation>;
-            fn new<F: Fn(PagerState, PagerOptions<'static>) -> PagerResultFuture<P> + Send + 'static>(make_request: F, options: Option<PagerOptions<'static>>) -> Self;
+            pub fn continuation(&self) -> Option<&PagerContinuation>;
+            pub fn into_continuation(self) -> Option<PagerContinuation>;
+            pub fn new<F: Fn(PagerState, PagerOptions<'static>) -> PagerResultFuture<P> + Send + 'static>(make_request: F, options: Option<PagerOptions<'static>>) -> Self;
         }
         impl<P> Debug for PageIterator<P> where P: Send {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1136,7 +1136,7 @@ pub mod http {
             Done { response: P },
         }
         impl<P, F> PagerResult<crate::http::response::Response<P, F>> {
-            fn from_response_header(response: Response<P, F>, header_name: &HeaderName) -> Self;
+            pub fn from_response_header(response: Response<P, F>, header_name: &HeaderName) -> Self;
         }
         impl<P> Debug for PagerResult<P> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1163,8 +1163,8 @@ pub mod http {
         #[derive(Debug)]
         pub struct ClientRequestIdPolicy(/* private fields */);
         impl ClientRequestIdPolicy {
-            const fn new() -> Self;
-            const fn with_header_name(header: &'static str) -> Self;
+            pub const fn new() -> Self;
+            pub const fn with_header_name(header: &'static str) -> Self;
         }
         impl Default for ClientRequestIdPolicy {
             fn default() -> Self;
@@ -1180,7 +1180,7 @@ pub mod http {
         pub struct PublicApiInstrumentationInformation {
         }
         impl PublicApiInstrumentationInformation {
-            fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(api_name: impl Into<Cow<'static, str>>, attributes: Vec<Attribute>) -> Self;
+            pub fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(api_name: impl Into<Cow<'static, str>>, attributes: Vec<Attribute>) -> Self;
         }
         #[derive(Clone, Debug, Default, Eq, PartialEq)]
         pub struct RetryHeaders {
@@ -1195,7 +1195,7 @@ pub mod http {
         pub struct TransportPolicy {
         }
         impl TransportPolicy {
-            fn new(transport: Transport) -> Self;
+            pub fn new(transport: Transport) -> Self;
         }
         impl Policy for TransportPolicy {
             #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]
@@ -1205,7 +1205,7 @@ pub mod http {
         pub struct UserAgentPolicy {
         }
         impl<'a> UserAgentPolicy {
-            fn new(crate_name: Option<&'a str>, crate_version: Option<&'a str>, options: &UserAgentOptions) -> Self;
+            pub fn new(crate_name: Option<&'a str>, crate_version: Option<&'a str>, options: &UserAgentOptions) -> Self;
         }
         impl Policy for UserAgentPolicy {
             #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]
@@ -1231,9 +1231,9 @@ pub mod http {
             pub struct BearerTokenAuthorizationPolicy {
             }
             impl BearerTokenAuthorizationPolicy {
-                fn new<A, B>(credential: Arc<dyn TokenCredential>, scopes: A) -> Self where A: IntoIterator<Item = B>, B: Into<String>;
-                fn with_on_challenge(self, on_challenge: Arc<dyn OnChallenge>) -> Self;
-                fn with_on_request(self, on_request: Arc<dyn OnRequest>) -> Self;
+                pub fn new<A, B>(credential: Arc<dyn TokenCredential>, scopes: A) -> Self where A: IntoIterator<Item = B>, B: Into<String>;
+                pub fn with_on_challenge(self, on_challenge: Arc<dyn OnChallenge>) -> Self;
+                pub fn with_on_request(self, on_request: Arc<dyn OnRequest>) -> Self;
             }
             impl Policy for BearerTokenAuthorizationPolicy {
                 #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]
@@ -1263,7 +1263,7 @@ pub mod http {
         pub struct Poller<M, F = crate::http::JsonFormat> where M: StatusMonitor, F: Format {
         }
         impl<M, F> Poller<M, F> where M: StatusMonitor, F: Format + Send {
-            fn new<Fun>(make_request: Fun, options: Option<PollerOptions<'static>>) -> Self where M: Send + 'static, <M as >::Output: Send + 'static, <M as >::Format: Send + 'static, Fun: Fn(PollerState, PollerOptions<'static>) -> PollerResultFuture<M, F> + Send + 'static;
+            pub fn new<Fun>(make_request: Fun, options: Option<PollerOptions<'static>>) -> Self where M: Send + 'static, <M as >::Output: Send + 'static, <M as >::Format: Send + 'static, Fun: Fn(PollerState, PollerOptions<'static>) -> PollerResultFuture<M, F> + Send + 'static;
         }
         impl<M, F> Debug for Poller<M, F> where M: StatusMonitor, F: Format {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1284,7 +1284,7 @@ pub mod http {
         }
         impl<'a> PollerOptions<'a> {
             #[must_use]
-            fn into_owned(self) -> PollerOptions<'static>;
+            pub fn into_owned(self) -> PollerOptions<'static>;
         }
         impl Default for PollerOptions<'_> {
             fn default() -> Self;
@@ -1342,23 +1342,23 @@ pub mod http {
         pub struct Request {
         }
         impl Request {
-            fn add_mandatory_header<T: Header>(&mut self, item: &T);
-            fn add_optional_header<T: Header>(&mut self, item: &Option<T>);
-            fn body(&self) -> &Body;
-            fn body_mut(&mut self) -> &mut Body;
-            fn headers(&self) -> &Headers;
-            fn headers_mut(&mut self) -> &mut Headers;
-            fn insert_header<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
-            fn insert_headers<T: AsHeaders>(&mut self, headers: &T) -> Result<(), <T as >::Error>;
-            fn method(&self) -> Method;
-            fn new(url: Url, method: Method) -> Self;
-            fn path_and_query(&self) -> String;
-            fn set_body<impl Into<Body>: Into<Body>>(&mut self, body: impl Into<Body>);
+            pub fn add_mandatory_header<T: Header>(&mut self, item: &T);
+            pub fn add_optional_header<T: Header>(&mut self, item: &Option<T>);
+            pub fn body(&self) -> &Body;
+            pub fn body_mut(&mut self) -> &mut Body;
+            pub fn headers(&self) -> &Headers;
+            pub fn headers_mut(&mut self) -> &mut Headers;
+            pub fn insert_header<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
+            pub fn insert_headers<T: AsHeaders>(&mut self, headers: &T) -> Result<(), <T as >::Error>;
+            pub fn method(&self) -> Method;
+            pub fn new(url: Url, method: Method) -> Self;
+            pub fn path_and_query(&self) -> String;
+            pub fn set_body<impl Into<Body>: Into<Body>>(&mut self, body: impl Into<Body>);
             #[cfg(feature = "json")]
-            fn set_json<T>(&mut self, data: &T) -> crate::Result<()> where T: ?Sized + Serialize;
-            fn set_method(&mut self, method: Method);
-            fn url(&self) -> &Url;
-            fn url_mut(&mut self) -> &mut Url;
+            pub fn set_json<T>(&mut self, data: &T) -> crate::Result<()> where T: ?Sized + Serialize;
+            pub fn set_method(&mut self, method: Method);
+            pub fn url(&self) -> &Url;
+            pub fn url_mut(&mut self) -> &mut Url;
         }
         impl Debug for Request {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1368,14 +1368,14 @@ pub mod http {
         pub struct RequestContent<T, F = crate::http::JsonFormat> {
         }
         impl<T, F> RequestContent<T, F> {
-            fn body(&self) -> &Body;
-            fn from(body: Vec<u8>) -> Self;
-            fn from_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + Unpin + Send + Sync + 'static;
-            fn from_seekable_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + AsyncSeek + Unpin + Send + Sync + 'static;
-            fn from_slice(body: &[u8]) -> Self;
-            fn from_static(body: &'static [u8]) -> Self;
+            pub fn body(&self) -> &Body;
+            pub fn from(body: Vec<u8>) -> Self;
+            pub fn from_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + Unpin + Send + Sync + 'static;
+            pub fn from_seekable_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + AsyncSeek + Unpin + Send + Sync + 'static;
+            pub fn from_slice(body: &[u8]) -> Self;
+            pub fn from_static(body: &'static [u8]) -> Self;
             #[allow(clippy::should_implement_trait)]
-            fn from_str(body: &str) -> Self;
+            pub fn from_str(body: &str) -> Self;
         }
         impl<T, F> From<Box<dyn SeekableStream>> for RequestContent<T, F> {
             fn from(stream: Box<dyn SeekableStream>) -> Self;
@@ -1503,10 +1503,10 @@ pub mod http {
             SeekableStream(Box<dyn SeekableStream>),
         }
         impl Body {
-            fn is_empty(&self) -> Option<bool>;
-            fn len(&self) -> Option<u64>;
-            async fn reset(&mut self) -> crate::Result<()>;
-            fn take(&mut self) -> Body;
+            pub fn is_empty(&self) -> Option<bool>;
+            pub fn len(&self) -> Option<u64>;
+            pub async fn reset(&mut self) -> crate::Result<()>;
+            pub fn take(&mut self) -> Body;
         }
         impl Debug for Body {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1533,8 +1533,8 @@ pub mod http {
             #[derive(Clone, Debug)]
             pub struct ClientRequestId(/* private fields */);
             impl ClientRequestId {
-                const fn from_static(s: &'static str) -> Self;
-                fn new<S>(s: S) -> Self where S: Into<std::borrow::Cow<'static, str>>;
+                pub const fn from_static(s: &'static str) -> Self;
+                pub fn new<S>(s: S) -> Self where S: Into<std::borrow::Cow<'static, str>>;
             }
             impl Header for ClientRequestId {
                 fn name(&self) -> $crate::http::headers::HeaderName;
@@ -1546,8 +1546,8 @@ pub mod http {
             #[derive(Clone, Debug)]
             pub struct ContentType(/* private fields */);
             impl ContentType {
-                const fn from_static(s: &'static str) -> Self;
-                fn new<S>(s: S) -> Self where S: Into<std::borrow::Cow<'static, str>>;
+                pub const fn from_static(s: &'static str) -> Self;
+                pub fn new<S>(s: S) -> Self where S: Into<std::borrow::Cow<'static, str>>;
             }
             impl ContentType {
                 const APPLICATION_JSON: ContentType = _;
@@ -1564,8 +1564,8 @@ pub mod http {
             #[derive(Clone, Debug)]
             pub struct ContentType(/* private fields */);
             impl ContentType {
-                const fn from_static(s: &'static str) -> Self;
-                fn new<S>(s: S) -> Self where S: Into<std::borrow::Cow<'static, str>>;
+                pub const fn from_static(s: &'static str) -> Self;
+                pub fn new<S>(s: S) -> Self where S: Into<std::borrow::Cow<'static, str>>;
             }
             impl ContentType {
                 const APPLICATION_JSON: ContentType = _;
@@ -1584,13 +1584,13 @@ pub mod http {
         pub struct AsyncRawResponse {
         }
         impl AsyncRawResponse {
-            fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
-            fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, bytes: impl Into<Bytes>) -> Self;
-            fn headers(&self) -> &Headers;
-            fn into_body(self) -> AsyncResponseBody;
-            fn new(status: StatusCode, headers: Headers, stream: PinnedStream) -> Self;
-            fn status(&self) -> StatusCode;
-            async fn try_into_raw_response(self) -> crate::Result<RawResponse>;
+            pub fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
+            pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, bytes: impl Into<Bytes>) -> Self;
+            pub fn headers(&self) -> &Headers;
+            pub fn into_body(self) -> AsyncResponseBody;
+            pub fn new(status: StatusCode, headers: Headers, stream: PinnedStream) -> Self;
+            pub fn status(&self) -> StatusCode;
+            pub async fn try_into_raw_response(self) -> crate::Result<RawResponse>;
         }
         impl<T> From<AsyncRawResponse> for AsyncResponse<T> {
             fn from(raw: AsyncRawResponse) -> Self;
@@ -1601,10 +1601,10 @@ pub mod http {
         pub struct AsyncResponse<T = ()> {
         }
         impl<T> AsyncResponse<T> {
-            fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
-            fn headers(&self) -> &Headers;
-            fn into_body(self) -> AsyncResponseBody;
-            fn status(&self) -> StatusCode;
+            pub fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
+            pub fn headers(&self) -> &Headers;
+            pub fn into_body(self) -> AsyncResponseBody;
+            pub fn status(&self) -> StatusCode;
         }
         impl<T> Debug for AsyncResponse<T> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1612,9 +1612,9 @@ pub mod http {
         #[pin_project]
         pub struct AsyncResponseBody(/* private fields */);
         impl AsyncResponseBody {
-            async fn collect(self) -> crate::Result<Bytes>;
-            async fn collect_into(self, buffer: &mut [u8]) -> crate::Result<usize>;
-            async fn collect_string(self) -> crate::Result<String>;
+            pub async fn collect(self) -> crate::Result<Bytes>;
+            pub async fn collect_into(self, buffer: &mut [u8]) -> crate::Result<usize>;
+            pub async fn collect_string(self) -> crate::Result<String>;
         }
         impl Debug for AsyncResponseBody {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1627,26 +1627,26 @@ pub mod http {
         pub struct RawResponse {
         }
         impl RawResponse {
-            fn body(&self) -> &ResponseBody;
-            fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
-            fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, body: impl Into<Bytes>) -> Self;
-            fn headers(&self) -> &Headers;
-            fn into_body(self) -> ResponseBody;
-            fn status(&self) -> StatusCode;
+            pub fn body(&self) -> &ResponseBody;
+            pub fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
+            pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, body: impl Into<Bytes>) -> Self;
+            pub fn headers(&self) -> &Headers;
+            pub fn into_body(self) -> ResponseBody;
+            pub fn status(&self) -> StatusCode;
         }
         #[cfg(feature = "json")]
         pub struct Response<T, F = crate::http::JsonFormat> {
         }
         impl<T, F> Response<T, F> {
-            fn body(&self) -> &ResponseBody;
-            fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
-            fn headers(&self) -> &Headers;
-            fn into_body(self) -> ResponseBody;
-            fn status(&self) -> StatusCode;
-            fn to_raw_response(&self) -> RawResponse;
+            pub fn body(&self) -> &ResponseBody;
+            pub fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
+            pub fn headers(&self) -> &Headers;
+            pub fn into_body(self) -> ResponseBody;
+            pub fn status(&self) -> StatusCode;
+            pub fn to_raw_response(&self) -> RawResponse;
         }
         impl<T: DeserializeWith<F>, F: Format> Response<T, F> {
-            fn into_model(self) -> crate::Result<T>;
+            pub fn into_model(self) -> crate::Result<T>;
         }
         impl<T, F> Debug for Response<T, F> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1660,12 +1660,12 @@ pub mod http {
         #[derive(Clone, Eq, PartialEq)]
         pub struct ResponseBody(/* private fields */);
         impl ResponseBody {
-            fn from_bytes<impl Into<Bytes>: Into<Bytes>>(bytes: impl Into<Bytes>) -> Self;
-            fn into_string(self) -> crate::Result<String>;
+            pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(bytes: impl Into<Bytes>) -> Self;
+            pub fn into_string(self) -> crate::Result<String>;
             #[cfg(feature = "json")]
-            fn json<T>(&self) -> crate::Result<T> where T: DeserializeOwned;
+            pub fn json<T>(&self) -> crate::Result<T> where T: DeserializeOwned;
             #[cfg(feature = "xml")]
-            fn xml<T>(&self) -> crate::Result<T> where T: DeserializeOwned;
+            pub fn xml<T>(&self) -> crate::Result<T> where T: DeserializeOwned;
         }
         impl AsRef<[u8]> for ResponseBody {
             #[inline]
@@ -1688,7 +1688,7 @@ pub mod http {
 pub mod identity {
     pub struct DeveloperToolsCredential;
     impl DeveloperToolsCredential {
-        fn new(_options: Option<DeveloperToolsCredentialOptions>) -> azure_core::Result<Arc<Self>>;
+        pub fn new(_options: Option<DeveloperToolsCredentialOptions>) -> azure_core::Result<Arc<Self>>;
     }
     impl Debug for DeveloperToolsCredential {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1702,7 +1702,7 @@ pub mod identity {
     #[derive(Clone, Debug, Default)]
     pub struct MockCredential;
     impl MockCredential {
-        fn new() -> azure_core::Result<Arc<Self>>;
+        pub fn new() -> azure_core::Result<Arc<Self>>;
     }
     impl TokenCredential for MockCredential {
         #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]
@@ -1721,11 +1721,11 @@ pub mod secrets {
     pub struct SecretClient {
     }
     impl SecretClient {
-        async fn get_secret(&self, secret_name: &str, _options: Option<()>) -> Result<Response<Secret>>;
-        fn list_secret_properties(&self, _options: Option<SecretClientListSecretPropertiesOptions<'_>>) -> Result<Pager<ListSecretPropertiesResult>>;
-        fn new(endpoint: &str, _credential: Arc<dyn TokenCredential>, options: Option<SecretClientOptions>) -> Result<Self>;
-        async fn set_secret(&self, secret_name: &str, body: RequestContent<SetSecretParameters>, _options: Option<()>) -> Result<Response<Secret>>;
-        async fn update_secret_properties(&self, _secret_name: &str, _body: RequestContent<UpdateSecretPropertiesParameters>, _options: Option<()>) -> Result<Response<Secret>>;
+        pub async fn get_secret(&self, secret_name: &str, _options: Option<()>) -> Result<Response<Secret>>;
+        pub fn list_secret_properties(&self, _options: Option<SecretClientListSecretPropertiesOptions<'_>>) -> Result<Pager<ListSecretPropertiesResult>>;
+        pub fn new(endpoint: &str, _credential: Arc<dyn TokenCredential>, options: Option<SecretClientOptions>) -> Result<Self>;
+        pub async fn set_secret(&self, secret_name: &str, body: RequestContent<SetSecretParameters>, _options: Option<()>) -> Result<Response<Secret>>;
+        pub async fn update_secret_properties(&self, _secret_name: &str, _body: RequestContent<UpdateSecretPropertiesParameters>, _options: Option<()>) -> Result<Response<Secret>>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct SecretClientOptions {

--- a/sdk/core/azure_core_examples/api/API.metadata.yml
+++ b/sdk/core/azure_core_examples/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: 79ee5eb98adde9c986eb0355ca50b58f8a19ecff035803a44380ffe273acf731
+apiMdSha256: 5151e71859414f3ae36151f3c6b7fbd8b6e9594a3da623919a7d39617d55ef9b
 packageVersion: 0.1.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/core/azure_core_macros/api/API.metadata.yml
+++ b/sdk/core/azure_core_macros/api/API.metadata.yml
@@ -1,4 +1,4 @@
 apiMdSha256: 7cd6acb5f81678336e0c3d7e5183196df686895be287f33dd3197708297aad5b
 packageVersion: 1.1.0-beta.1
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/core/azure_core_opentelemetry/api/API.md
+++ b/sdk/core/azure_core_opentelemetry/api/API.md
@@ -15,8 +15,8 @@
 pub struct OpenTelemetryTracerProvider {
 }
 impl OpenTelemetryTracerProvider {
-    fn from_global_provider() -> Arc<Self>;
-    fn new(provider: Arc<dyn ObjectSafeTracerProvider + Send + Sync>) -> Arc<Self>;
+    pub fn from_global_provider() -> Arc<Self>;
+    pub fn new(provider: Arc<dyn ObjectSafeTracerProvider + Send + Sync>) -> Arc<Self>;
 }
 impl Debug for OpenTelemetryTracerProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;

--- a/sdk/core/azure_core_opentelemetry/api/API.metadata.yml
+++ b/sdk/core/azure_core_opentelemetry/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: f198343371abbc5df94ed4fc2a2524f96163e125e6ac67954d299356821210b1
+apiMdSha256: 1d568170a2ed20c23e2ac82fd35b6c37be33c6fb836b7fac5daf4db8bc17b868
 packageVersion: 1.1.0-beta.1
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/core/azure_core_test/api/API.md
+++ b/sdk/core/azure_core_test/api/API.md
@@ -175,18 +175,18 @@ impl Sanitizer for OAuthResponseSanitizer {
 pub struct Recording {
 }
 impl Recording {
-    async fn add_sanitizer<S>(&self, sanitizer: S) -> azure_core::Result<()> where S: Sanitizer, azure_core::Error: From<<S as AsHeaders>::Error>;
-    fn credential(&self) -> Arc<dyn TokenCredential>;
-    fn instrument(&self, options: &mut ClientOptions);
-    fn instrument_perf(&self, options: &mut ClientOptions) -> azure_core::Result<()>;
-    fn random<T>(&self) -> T where StandardUniform: Distribution<T>;
-    fn random_string<const LEN: usize>(&self, prefix: Option<&str>) -> String;
-    async fn remove_sanitizers(&self, sanitizers: &[&str]) -> azure_core::Result<()>;
-    async fn set_matcher(&self, matcher: Matcher) -> azure_core::Result<()>;
-    fn skip(&self, skip: Skip) -> azure_core::Result<SkipGuard<'_>>;
-    fn test_mode(&self) -> TestMode;
-    fn var<K>(&self, key: K, options: Option<VarOptions>) -> String where K: AsRef<str>;
-    fn var_opt<K>(&self, key: K, options: Option<VarOptions>) -> Option<String> where K: AsRef<str>;
+    pub async fn add_sanitizer<S>(&self, sanitizer: S) -> azure_core::Result<()> where S: Sanitizer, azure_core::Error: From<<S as AsHeaders>::Error>;
+    pub fn credential(&self) -> Arc<dyn TokenCredential>;
+    pub fn instrument(&self, options: &mut ClientOptions);
+    pub fn instrument_perf(&self, options: &mut ClientOptions) -> azure_core::Result<()>;
+    pub fn random<T>(&self) -> T where StandardUniform: Distribution<T>;
+    pub fn random_string<const LEN: usize>(&self, prefix: Option<&str>) -> String;
+    pub async fn remove_sanitizers(&self, sanitizers: &[&str]) -> azure_core::Result<()>;
+    pub async fn set_matcher(&self, matcher: Matcher) -> azure_core::Result<()>;
+    pub fn skip(&self, skip: Skip) -> azure_core::Result<SkipGuard<'_>>;
+    pub fn test_mode(&self) -> TestMode;
+    pub fn var<K>(&self, key: K, options: Option<VarOptions>) -> String where K: AsRef<str>;
+    pub fn var_opt<K>(&self, key: K, options: Option<VarOptions>) -> Option<String> where K: AsRef<str>;
 }
 impl Drop for Recording {
     fn drop(&mut self);
@@ -232,13 +232,13 @@ impl Drop for SkipGuard<'_> {
 pub struct TestContext {
 }
 impl TestContext {
-    fn crate_dir(&self) -> &'static Path;
-    fn module_name(&self) -> &'static str;
-    fn name(&self) -> &'static str;
-    fn recording(&self) -> &Recording;
-    fn repo_dir(&self) -> &'static Path;
-    fn service_dir(&self) -> &'static str;
-    fn test_data_dir(&self) -> PathBuf;
+    pub fn crate_dir(&self) -> &'static Path;
+    pub fn module_name(&self) -> &'static str;
+    pub fn name(&self) -> &'static str;
+    pub fn recording(&self) -> &Recording;
+    pub fn repo_dir(&self) -> &'static Path;
+    pub fn service_dir(&self) -> &'static str;
+    pub fn test_data_dir(&self) -> PathBuf;
 }
 #[derive(Clone, Debug, Default, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -310,7 +310,7 @@ pub enum ErrorKind {
     Other,
 }
 impl ErrorKind {
-    fn into_error(self) -> Error;
+    pub fn into_error(self) -> Error;
 }
 impl Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -361,8 +361,8 @@ pub enum TestMode {
     Live,
 }
 impl TestMode {
-    fn current() -> typespec::Result<Self>;
-    fn current_opt() -> typespec::Result<Option<Self>>;
+    pub fn current() -> typespec::Result<Self>;
+    pub fn current_opt() -> typespec::Result<Option<Self>>;
 }
 impl Debug for TestMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -394,7 +394,7 @@ pub mod credentials {
     #[derive(Clone, Debug, Default)]
     pub struct MockCredential;
     impl MockCredential {
-        fn new() -> azure_core::Result<Arc<Self>>;
+        pub fn new() -> azure_core::Result<Arc<Self>>;
     }
     impl TokenCredential for MockCredential {
         #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]
@@ -404,7 +404,7 @@ pub mod credentials {
 pub mod http {
     pub struct MockHttpClient<C>(/* private fields */);
     impl<C> MockHttpClient<C> where C: FnMut(&azure_core::http::request::Request) -> futures::future::BoxFuture<'_, azure_core::Result<azure_core::http::AsyncRawResponse>> + Send + Sync {
-        fn new(client: C) -> Self;
+        pub fn new(client: C) -> Self;
     }
     impl<C> Debug for MockHttpClient<C> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -423,10 +423,10 @@ pub mod perf {
     pub struct PerfRunner<T: PerfTestFactory> {
     }
     impl<T: PerfTestFactory> PerfRunner<T> {
-        fn new(package_dir: &'static str, module_name: &'static str) -> std::result::Result<Self, clap::Error>;
-        async fn run(&self) -> azure_core::Result<()>;
-        async fn run_test_for(&self, test_instances: &[Arc<dyn PerfTest>], test_contexts: &[Arc<TestContext>], duration: Duration, track_latency: bool) -> azure_core::Result<(f64, Vec<tokio::time::Duration>)>;
-        fn with_command_line(package_dir: &'static str, module_name: &'static str, args: Vec<&str>) -> std::result::Result<Self, clap::Error>;
+        pub fn new(package_dir: &'static str, module_name: &'static str) -> std::result::Result<Self, clap::Error>;
+        pub async fn run(&self) -> azure_core::Result<()>;
+        pub async fn run_test_for(&self, test_instances: &[Arc<dyn PerfTest>], test_contexts: &[Arc<TestContext>], duration: Duration, track_latency: bool) -> azure_core::Result<(f64, Vec<tokio::time::Duration>)>;
+        pub fn with_command_line(package_dir: &'static str, module_name: &'static str, args: Vec<&str>) -> std::result::Result<Self, clap::Error>;
     }
     #[async_trait]
     pub trait PerfTest: Send + Sync {
@@ -450,12 +450,12 @@ pub mod proxy {
     pub struct Proxy {
     }
     impl Proxy {
-        async fn stop(&mut self) -> Result<()>;
-        async fn wait(&mut self) -> Result<ExitStatus>;
+        pub async fn stop(&mut self) -> Result<()>;
+        pub async fn wait(&mut self) -> Result<ExitStatus>;
     }
     impl Proxy {
-        fn endpoint(&self) -> &Url;
-        fn existing() -> Result<Self>;
+        pub fn endpoint(&self) -> &Url;
+        pub fn existing() -> Result<Self>;
     }
     impl Drop for Proxy {
         fn drop(&mut self);
@@ -498,10 +498,10 @@ pub mod stream {
     }
     impl<I, const LENGTH: usize, const CHUNK: usize> GeneratedStream<I, LENGTH, CHUNK> where I: Iterator<Item = u8> + Clone {
         #[allow(clippy::should_implement_trait)]
-        fn from_iter(iter: I) -> Self;
+        pub fn from_iter(iter: I) -> Self;
     }
     impl<const LENGTH: usize, const CHUNK: usize> GeneratedStream<std::ops::Range<u8>, LENGTH, CHUNK> {
-        fn new() -> GeneratedStream<Range<u8>, LENGTH, CHUNK>;
+        pub fn new() -> GeneratedStream<Range<u8>, LENGTH, CHUNK>;
     }
     impl<I, const LENGTH: usize, const CHUNK: usize> AsyncRead for GeneratedStream<I, LENGTH, CHUNK> where I: Clone, std::iter::Cycle<I>: Iterator<Item = u8> + Unpin {
         fn poll_read(self: Pin<&mut Self>, _cx: &mut std::task::Context<'_>, buf: &mut [u8]) -> Poll<std::io::Result<usize>>;
@@ -612,7 +612,7 @@ pub mod tracing {
     pub struct MockTracingProvider {
     }
     impl MockTracingProvider {
-        fn new() -> Self;
+        pub fn new() -> Self;
     }
     impl Default for MockTracingProvider {
         fn default() -> Self;

--- a/sdk/core/azure_core_test/api/API.metadata.yml
+++ b/sdk/core/azure_core_test/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: 7467227eb581c70a681dfea858595c8c114cee9c9c1101cca005a123b9820c5f
+apiMdSha256: bbe316d64bcc9d4db6e6f1f49ef6f2ede41d7333184bd2099ae58609a486cb8e
 packageVersion: 0.2.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/core/azure_core_test_macros/api/API.metadata.yml
+++ b/sdk/core/azure_core_test_macros/api/API.metadata.yml
@@ -1,4 +1,4 @@
 apiMdSha256: a76b61ac35c7c0ccbaa93548b7c99b788e854446b7c8ee9004eff3503c4167f4
 packageVersion: 0.2.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/core/typespec/api/API.md
+++ b/sdk/core/typespec/api/API.md
@@ -23,28 +23,28 @@ pub mod error {
     pub struct Error {
     }
     impl Error {
-        fn downcast_mut<T: std::error::Error + 'static>(&mut self) -> Option<&mut T>;
-        fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T>;
-        fn get_mut(&mut self) -> Option<&mut dyn std::error::Error + Send + Sync + 'static>;
-        fn get_ref(&self) -> Option<&dyn std::error::Error + Send + Sync + 'static>;
+        pub fn downcast_mut<T: std::error::Error + 'static>(&mut self) -> Option<&mut T>;
+        pub fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T>;
+        pub fn get_mut(&mut self) -> Option<&mut dyn std::error::Error + Send + Sync + 'static>;
+        pub fn get_ref(&self) -> Option<&dyn std::error::Error + Send + Sync + 'static>;
         #[cfg(feature = "http")]
-        fn http_status(&self) -> Option<StatusCode>;
-        fn into_downcast<T: std::error::Error + 'static>(self) -> std::result::Result<T, Self>;
-        fn into_inner(self) -> std::result::Result<Box<dyn std::error::Error + Send + Sync>, Self>;
-        fn kind(&self) -> &ErrorKind;
-        fn new<E>(kind: ErrorKind, error: E) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>;
+        pub fn http_status(&self) -> Option<StatusCode>;
+        pub fn into_downcast<T: std::error::Error + 'static>(self) -> std::result::Result<T, Self>;
+        pub fn into_inner(self) -> std::result::Result<Box<dyn std::error::Error + Send + Sync>, Self>;
+        pub fn kind(&self) -> &ErrorKind;
+        pub fn new<E>(kind: ErrorKind, error: E) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>;
         #[must_use]
-        fn with_context<C>(self, message: C) -> Self where C: Into<Cow<'static, str>>;
+        pub fn with_context<C>(self, message: C) -> Self where C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_context_fn<F, C>(self, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+        pub fn with_context_fn<F, C>(self, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_error<E, C>(kind: ErrorKind, error: E, message: C) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, C: Into<Cow<'static, str>>;
+        pub fn with_error<E, C>(kind: ErrorKind, error: E, message: C) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_error_fn<E, F, C>(kind: ErrorKind, error: E, f: F) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+        pub fn with_error_fn<E, F, C>(kind: ErrorKind, error: E, f: F) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, F: FnOnce() -> C, C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_message<C>(kind: ErrorKind, message: C) -> Self where C: Into<Cow<'static, str>>;
+        pub fn with_message<C>(kind: ErrorKind, message: C) -> Self where C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_message_fn<F, C>(kind: ErrorKind, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+        pub fn with_message_fn<F, C>(kind: ErrorKind, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
     }
     impl Debug for Error {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -90,7 +90,7 @@ pub mod error {
         Other,
     }
     impl ErrorKind {
-        fn into_error(self) -> Error;
+        pub fn into_error(self) -> Error;
     }
     impl Display for ErrorKind {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -175,12 +175,12 @@ pub mod http {
         UnknownValue(u16),
     }
     impl StatusCode {
-        fn canonical_reason(&self) -> Cow<'static, str>;
-        fn is_client_error(&self) -> bool;
-        fn is_informational(&self) -> bool;
-        fn is_redirection(&self) -> bool;
-        fn is_server_error(&self) -> bool;
-        fn is_success(&self) -> bool;
+        pub fn canonical_reason(&self) -> Cow<'static, str>;
+        pub fn is_client_error(&self) -> bool;
+        pub fn is_informational(&self) -> bool;
+        pub fn is_redirection(&self) -> bool;
+        pub fn is_server_error(&self) -> bool;
+        pub fn is_success(&self) -> bool;
     }
     impl Deref for StatusCode {
         type Target = u16;
@@ -213,10 +213,10 @@ pub mod http {
         pub struct HeaderName {
         }
         impl HeaderName {
-            fn as_str(&self) -> &str;
-            const fn from_static(s: &'static str) -> Self;
-            const fn from_static_standard(s: &'static str) -> Self;
-            fn is_standard(&self) -> bool;
+            pub fn as_str(&self) -> &str;
+            pub const fn from_static(s: &'static str) -> Self;
+            pub const fn from_static_standard(s: &'static str) -> Self;
+            pub fn is_standard(&self) -> bool;
         }
         impl From<&'static str> for HeaderName {
             fn from(s: &'static str) -> Self;
@@ -236,9 +236,9 @@ pub mod http {
         #[derive(Clone, Eq, PartialEq)]
         pub struct HeaderValue(/* private fields */);
         impl HeaderValue {
-            fn as_str(&self) -> &str;
-            fn from_cow<C>(c: C) -> Self where C: Into<Cow<'static, str>>;
-            const fn from_static(s: &'static str) -> Self;
+            pub fn as_str(&self) -> &str;
+            pub fn from_cow<C>(c: C) -> Self where C: Into<Cow<'static, str>>;
+            pub const fn from_static(s: &'static str) -> Self;
         }
         impl Debug for HeaderValue {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -255,20 +255,20 @@ pub mod http {
         #[derive(Clone, Default, Eq, PartialEq)]
         pub struct Headers(/* private fields */);
         impl Headers {
-            fn add<H>(&mut self, header: H) -> Result<(), <H as >::Error> where H: AsHeaders;
-            fn get<H: FromHeaders>(&self) -> crate::Result<H>;
-            fn get_as<V, E>(&self, key: &HeaderName) -> crate::Result<V> where V: FromStr<Err = E>, E: std::error::Error + Send + Sync + 'static;
-            fn get_optional<H: FromHeaders>(&self) -> Result<Option<H>, <H as >::Error>;
-            fn get_optional_as<V, E>(&self, key: &HeaderName) -> crate::Result<Option<V>> where V: FromStr<Err = E>, E: std::error::Error + Send + Sync + 'static;
-            fn get_optional_str(&self, key: &HeaderName) -> Option<&str>;
-            fn get_optional_string(&self, key: &HeaderName) -> Option<String>;
-            fn get_optional_with<'a, V, F, E>(&self, key: &HeaderName, parser: F) -> crate::Result<Option<V>> where F: FnOnce(&'a HeaderValue) -> Result<V, E>, E: std::error::Error + Send + Sync + 'static;
-            fn get_str(&self, key: &HeaderName) -> crate::Result<&str>;
-            fn get_with<'a, V, F, E>(&self, key: &HeaderName, parser: F) -> crate::Result<V> where F: FnOnce(&'a HeaderValue) -> Result<V, E>, E: std::error::Error + Send + Sync + 'static;
-            fn insert<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
-            fn iter(&self) -> impl Iterator<Item = (&HeaderName, &HeaderValue)>;
-            fn new() -> Self;
-            fn remove<K>(&mut self, key: K) -> Option<HeaderValue> where K: Into<HeaderName>;
+            pub fn add<H>(&mut self, header: H) -> Result<(), <H as >::Error> where H: AsHeaders;
+            pub fn get<H: FromHeaders>(&self) -> crate::Result<H>;
+            pub fn get_as<V, E>(&self, key: &HeaderName) -> crate::Result<V> where V: FromStr<Err = E>, E: std::error::Error + Send + Sync + 'static;
+            pub fn get_optional<H: FromHeaders>(&self) -> Result<Option<H>, <H as >::Error>;
+            pub fn get_optional_as<V, E>(&self, key: &HeaderName) -> crate::Result<Option<V>> where V: FromStr<Err = E>, E: std::error::Error + Send + Sync + 'static;
+            pub fn get_optional_str(&self, key: &HeaderName) -> Option<&str>;
+            pub fn get_optional_string(&self, key: &HeaderName) -> Option<String>;
+            pub fn get_optional_with<'a, V, F, E>(&self, key: &HeaderName, parser: F) -> crate::Result<Option<V>> where F: FnOnce(&'a HeaderValue) -> Result<V, E>, E: std::error::Error + Send + Sync + 'static;
+            pub fn get_str(&self, key: &HeaderName) -> crate::Result<&str>;
+            pub fn get_with<'a, V, F, E>(&self, key: &HeaderName, parser: F) -> crate::Result<V> where F: FnOnce(&'a HeaderValue) -> Result<V, E>, E: std::error::Error + Send + Sync + 'static;
+            pub fn insert<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
+            pub fn iter(&self) -> impl Iterator<Item = (&HeaderName, &HeaderValue)>;
+            pub fn new() -> Self;
+            pub fn remove<K>(&mut self, key: K) -> Option<HeaderValue> where K: Into<HeaderName>;
         }
         impl Debug for Headers {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -302,22 +302,22 @@ pub mod http {
         pub struct RawResponse {
         }
         impl RawResponse {
-            fn body(&self) -> &ResponseBody;
-            fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
-            fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, body: impl Into<Bytes>) -> Self;
-            fn headers(&self) -> &Headers;
-            fn into_body(self) -> ResponseBody;
-            fn status(&self) -> StatusCode;
+            pub fn body(&self) -> &ResponseBody;
+            pub fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
+            pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, body: impl Into<Bytes>) -> Self;
+            pub fn headers(&self) -> &Headers;
+            pub fn into_body(self) -> ResponseBody;
+            pub fn status(&self) -> StatusCode;
         }
         #[derive(Clone, Eq, PartialEq)]
         pub struct ResponseBody(/* private fields */);
         impl ResponseBody {
-            fn from_bytes<impl Into<Bytes>: Into<Bytes>>(bytes: impl Into<Bytes>) -> Self;
-            fn into_string(self) -> crate::Result<String>;
+            pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(bytes: impl Into<Bytes>) -> Self;
+            pub fn into_string(self) -> crate::Result<String>;
             #[cfg(feature = "json")]
-            fn json<T>(&self) -> crate::Result<T> where T: DeserializeOwned;
+            pub fn json<T>(&self) -> crate::Result<T> where T: DeserializeOwned;
             #[cfg(feature = "xml")]
-            fn xml<T>(&self) -> crate::Result<T> where T: DeserializeOwned;
+            pub fn xml<T>(&self) -> crate::Result<T> where T: DeserializeOwned;
         }
         impl AsRef<[u8]> for ResponseBody {
             #[inline]

--- a/sdk/core/typespec/api/API.metadata.yml
+++ b/sdk/core/typespec/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: 982a65201ceef5b85fe62b3808e05850652694b4a64ed8869485d68df3d2c02e
+apiMdSha256: 71cc0fd5b150bfc63a24b042c87220feec350e24f3f93225c272e5ecc9fbbcc5
 packageVersion: 1.2.0-beta.1
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/core/typespec_client_core/api/API.md
+++ b/sdk/core/typespec_client_core/api/API.md
@@ -49,28 +49,28 @@ macro_rules! request_query {
 pub struct Error {
 }
 impl Error {
-    fn downcast_mut<T: std::error::Error + 'static>(&mut self) -> Option<&mut T>;
-    fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T>;
-    fn get_mut(&mut self) -> Option<&mut dyn std::error::Error + Send + Sync + 'static>;
-    fn get_ref(&self) -> Option<&dyn std::error::Error + Send + Sync + 'static>;
+    pub fn downcast_mut<T: std::error::Error + 'static>(&mut self) -> Option<&mut T>;
+    pub fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T>;
+    pub fn get_mut(&mut self) -> Option<&mut dyn std::error::Error + Send + Sync + 'static>;
+    pub fn get_ref(&self) -> Option<&dyn std::error::Error + Send + Sync + 'static>;
     #[cfg(feature = "http")]
-    fn http_status(&self) -> Option<StatusCode>;
-    fn into_downcast<T: std::error::Error + 'static>(self) -> std::result::Result<T, Self>;
-    fn into_inner(self) -> std::result::Result<Box<dyn std::error::Error + Send + Sync>, Self>;
-    fn kind(&self) -> &ErrorKind;
-    fn new<E>(kind: ErrorKind, error: E) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>;
+    pub fn http_status(&self) -> Option<StatusCode>;
+    pub fn into_downcast<T: std::error::Error + 'static>(self) -> std::result::Result<T, Self>;
+    pub fn into_inner(self) -> std::result::Result<Box<dyn std::error::Error + Send + Sync>, Self>;
+    pub fn kind(&self) -> &ErrorKind;
+    pub fn new<E>(kind: ErrorKind, error: E) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>;
     #[must_use]
-    fn with_context<C>(self, message: C) -> Self where C: Into<Cow<'static, str>>;
+    pub fn with_context<C>(self, message: C) -> Self where C: Into<Cow<'static, str>>;
     #[must_use]
-    fn with_context_fn<F, C>(self, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+    pub fn with_context_fn<F, C>(self, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
     #[must_use]
-    fn with_error<E, C>(kind: ErrorKind, error: E, message: C) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, C: Into<Cow<'static, str>>;
+    pub fn with_error<E, C>(kind: ErrorKind, error: E, message: C) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, C: Into<Cow<'static, str>>;
     #[must_use]
-    fn with_error_fn<E, F, C>(kind: ErrorKind, error: E, f: F) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+    pub fn with_error_fn<E, F, C>(kind: ErrorKind, error: E, f: F) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, F: FnOnce() -> C, C: Into<Cow<'static, str>>;
     #[must_use]
-    fn with_message<C>(kind: ErrorKind, message: C) -> Self where C: Into<Cow<'static, str>>;
+    pub fn with_message<C>(kind: ErrorKind, message: C) -> Self where C: Into<Cow<'static, str>>;
     #[must_use]
-    fn with_message_fn<F, C>(kind: ErrorKind, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+    pub fn with_message_fn<F, C>(kind: ErrorKind, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
 }
 impl Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -146,28 +146,28 @@ pub mod error {
     pub struct Error {
     }
     impl Error {
-        fn downcast_mut<T: std::error::Error + 'static>(&mut self) -> Option<&mut T>;
-        fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T>;
-        fn get_mut(&mut self) -> Option<&mut dyn std::error::Error + Send + Sync + 'static>;
-        fn get_ref(&self) -> Option<&dyn std::error::Error + Send + Sync + 'static>;
+        pub fn downcast_mut<T: std::error::Error + 'static>(&mut self) -> Option<&mut T>;
+        pub fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T>;
+        pub fn get_mut(&mut self) -> Option<&mut dyn std::error::Error + Send + Sync + 'static>;
+        pub fn get_ref(&self) -> Option<&dyn std::error::Error + Send + Sync + 'static>;
         #[cfg(feature = "http")]
-        fn http_status(&self) -> Option<StatusCode>;
-        fn into_downcast<T: std::error::Error + 'static>(self) -> std::result::Result<T, Self>;
-        fn into_inner(self) -> std::result::Result<Box<dyn std::error::Error + Send + Sync>, Self>;
-        fn kind(&self) -> &ErrorKind;
-        fn new<E>(kind: ErrorKind, error: E) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>;
+        pub fn http_status(&self) -> Option<StatusCode>;
+        pub fn into_downcast<T: std::error::Error + 'static>(self) -> std::result::Result<T, Self>;
+        pub fn into_inner(self) -> std::result::Result<Box<dyn std::error::Error + Send + Sync>, Self>;
+        pub fn kind(&self) -> &ErrorKind;
+        pub fn new<E>(kind: ErrorKind, error: E) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>;
         #[must_use]
-        fn with_context<C>(self, message: C) -> Self where C: Into<Cow<'static, str>>;
+        pub fn with_context<C>(self, message: C) -> Self where C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_context_fn<F, C>(self, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+        pub fn with_context_fn<F, C>(self, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_error<E, C>(kind: ErrorKind, error: E, message: C) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, C: Into<Cow<'static, str>>;
+        pub fn with_error<E, C>(kind: ErrorKind, error: E, message: C) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_error_fn<E, F, C>(kind: ErrorKind, error: E, f: F) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+        pub fn with_error_fn<E, F, C>(kind: ErrorKind, error: E, f: F) -> Self where E: Into<Box<dyn std::error::Error + Send + Sync>>, F: FnOnce() -> C, C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_message<C>(kind: ErrorKind, message: C) -> Self where C: Into<Cow<'static, str>>;
+        pub fn with_message<C>(kind: ErrorKind, message: C) -> Self where C: Into<Cow<'static, str>>;
         #[must_use]
-        fn with_message_fn<F, C>(kind: ErrorKind, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
+        pub fn with_message_fn<F, C>(kind: ErrorKind, f: F) -> Self where F: FnOnce() -> C, C: Into<Cow<'static, str>>;
     }
     impl Debug for Error {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -213,7 +213,7 @@ pub mod error {
         Other,
     }
     impl ErrorKind {
-        fn into_error(self) -> Error;
+        pub fn into_error(self) -> Error;
     }
     impl Display for ErrorKind {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -271,19 +271,19 @@ pub mod http {
     pub struct Context<'a> {
     }
     impl<'a> Context<'a> {
-        fn insert<E>(&mut self, entity: E) -> Option<Arc<E>> where E: Send + Sync + 'static;
-        fn into_owned(self) -> Context<'static>;
-        fn is_empty(&self) -> bool;
-        fn new() -> Self;
+        pub fn insert<E>(&mut self, entity: E) -> Option<Arc<E>> where E: Send + Sync + 'static;
+        pub fn into_owned(self) -> Context<'static>;
+        pub fn is_empty(&self) -> bool;
+        pub fn new() -> Self;
         #[must_use]
-        fn to_borrowed<'b>(&self) -> Context<'b> where 'a: 'b;
+        pub fn to_borrowed<'b>(&self) -> Context<'b> where 'a: 'b;
         #[must_use]
-        fn to_owned(&self) -> Context<'static>;
-        fn value<E>(&self) -> Option<&E> where E: Send + Sync + 'static;
+        pub fn to_owned(&self) -> Context<'static>;
+        pub fn value<E>(&self) -> Option<&E> where E: Send + Sync + 'static;
         #[must_use]
-        fn with_context<'b>(context: &'a Context<'_>) -> Context<'b> where 'a: 'b;
+        pub fn with_context<'b>(context: &'a Context<'_>) -> Context<'b> where 'a: 'b;
         #[must_use]
-        fn with_value<E>(self, entity: E) -> Self where E: Send + Sync + 'static;
+        pub fn with_value<E>(self, entity: E) -> Self where E: Send + Sync + 'static;
     }
     impl Default for Context<'_> {
         fn default() -> Self;
@@ -359,10 +359,10 @@ pub mod http {
     pub struct Pipeline {
     }
     impl Pipeline {
-        fn new(options: ClientOptions, per_call_policies: Vec<Arc<dyn Policy>>, per_try_policies: Vec<Arc<dyn Policy>>, pipeline_options: Option<PipelineOptions>) -> Self;
-        fn policies(&self) -> &[Arc<dyn Policy>];
-        async fn send(&self, ctx: &Context<'_>, request: &mut Request, _options: Option<PipelineSendOptions>) -> crate::Result<RawResponse>;
-        async fn stream(&self, ctx: &Context<'_>, request: &mut Request, _options: Option<PipelineStreamOptions>) -> crate::Result<AsyncRawResponse>;
+        pub fn new(options: ClientOptions, per_call_policies: Vec<Arc<dyn Policy>>, per_try_policies: Vec<Arc<dyn Policy>>, pipeline_options: Option<PipelineOptions>) -> Self;
+        pub fn policies(&self) -> &[Arc<dyn Policy>];
+        pub async fn send(&self, ctx: &Context<'_>, request: &mut Request, _options: Option<PipelineSendOptions>) -> crate::Result<RawResponse>;
+        pub async fn stream(&self, ctx: &Context<'_>, request: &mut Request, _options: Option<PipelineStreamOptions>) -> crate::Result<AsyncRawResponse>;
     }
     #[derive(Clone, Debug)]
     pub struct PipelineOptions {
@@ -379,38 +379,38 @@ pub mod http {
     pub struct QueryBuilder<'a> {
     }
     impl<'a> QueryBuilder<'a> {
-        fn append_key_only<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>) -> &mut Self;
-        fn append_pair<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>, impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>, value: impl Into<Cow<'a, str>>) -> &mut Self;
-        fn build(self);
-        fn set_pair<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>, impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>, value: impl Into<Cow<'a, str>>) -> &mut Self;
+        pub fn append_key_only<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>) -> &mut Self;
+        pub fn append_pair<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>, impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>, value: impl Into<Cow<'a, str>>) -> &mut Self;
+        pub fn build(self);
+        pub fn set_pair<impl Into<Cow<'a, str>>: Into<Cow<'a, str>>, impl Into<Cow<'a, str>>: Into<Cow<'a, str>>>(&mut self, key: impl Into<Cow<'a, str>>, value: impl Into<Cow<'a, str>>) -> &mut Self;
     }
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct RawResponse {
     }
     impl RawResponse {
-        fn body(&self) -> &ResponseBody;
-        fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
-        fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, body: impl Into<Bytes>) -> Self;
-        fn headers(&self) -> &Headers;
-        fn into_body(self) -> ResponseBody;
-        fn status(&self) -> StatusCode;
+        pub fn body(&self) -> &ResponseBody;
+        pub fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
+        pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, body: impl Into<Bytes>) -> Self;
+        pub fn headers(&self) -> &Headers;
+        pub fn into_body(self) -> ResponseBody;
+        pub fn status(&self) -> StatusCode;
     }
     #[derive(Clone, Debug, Default)]
     pub struct RetryOptions {
     }
     impl RetryOptions {
-        fn custom<T: RetryPolicy + 'static>(policy: Arc<T>) -> Self;
-        fn exponential(options: ExponentialRetryOptions) -> Self;
-        fn fixed(options: FixedRetryOptions) -> Self;
-        fn none() -> Self;
+        pub fn custom<T: RetryPolicy + 'static>(policy: Arc<T>) -> Self;
+        pub fn exponential(options: ExponentialRetryOptions) -> Self;
+        pub fn fixed(options: FixedRetryOptions) -> Self;
+        pub fn none() -> Self;
     }
     #[derive(Clone, Debug)]
     pub struct Transport {
     }
     impl Transport {
-        fn new(http_client: Arc<dyn HttpClient>) -> Self;
-        async fn send(&self, ctx: &Context<'_>, request: &mut Request) -> Result<AsyncRawResponse>;
-        fn with_policy(policy: Arc<dyn Policy>) -> Self;
+        pub fn new(http_client: Arc<dyn HttpClient>) -> Self;
+        pub async fn send(&self, ctx: &Context<'_>, request: &mut Request) -> Result<AsyncRawResponse>;
+        pub fn with_policy(policy: Arc<dyn Policy>) -> Self;
     }
     impl Default for Transport {
         fn default() -> Self;
@@ -433,8 +433,8 @@ pub mod http {
         Put,
     }
     impl Method {
-        const fn as_str(&self) -> &'static str;
-        fn is_safe(&self) -> bool;
+        pub const fn as_str(&self) -> &'static str;
+        pub fn is_safe(&self) -> bool;
     }
     impl AsRef<str> for Method {
         fn as_ref(&self) -> &'static str;
@@ -522,12 +522,12 @@ pub mod http {
         UnknownValue(u16),
     }
     impl StatusCode {
-        fn canonical_reason(&self) -> Cow<'static, str>;
-        fn is_client_error(&self) -> bool;
-        fn is_informational(&self) -> bool;
-        fn is_redirection(&self) -> bool;
-        fn is_server_error(&self) -> bool;
-        fn is_success(&self) -> bool;
+        pub fn canonical_reason(&self) -> Cow<'static, str>;
+        pub fn is_client_error(&self) -> bool;
+        pub fn is_informational(&self) -> bool;
+        pub fn is_redirection(&self) -> bool;
+        pub fn is_server_error(&self) -> bool;
+        pub fn is_success(&self) -> bool;
     }
     impl Deref for StatusCode {
         type Target = u16;
@@ -584,10 +584,10 @@ pub mod http {
         pub struct HeaderName {
         }
         impl HeaderName {
-            fn as_str(&self) -> &str;
-            const fn from_static(s: &'static str) -> Self;
-            const fn from_static_standard(s: &'static str) -> Self;
-            fn is_standard(&self) -> bool;
+            pub fn as_str(&self) -> &str;
+            pub const fn from_static(s: &'static str) -> Self;
+            pub const fn from_static_standard(s: &'static str) -> Self;
+            pub fn is_standard(&self) -> bool;
         }
         impl From<&'static str> for HeaderName {
             fn from(s: &'static str) -> Self;
@@ -607,9 +607,9 @@ pub mod http {
         #[derive(Clone, Eq, PartialEq)]
         pub struct HeaderValue(/* private fields */);
         impl HeaderValue {
-            fn as_str(&self) -> &str;
-            fn from_cow<C>(c: C) -> Self where C: Into<Cow<'static, str>>;
-            const fn from_static(s: &'static str) -> Self;
+            pub fn as_str(&self) -> &str;
+            pub fn from_cow<C>(c: C) -> Self where C: Into<Cow<'static, str>>;
+            pub const fn from_static(s: &'static str) -> Self;
         }
         impl Debug for HeaderValue {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -626,20 +626,20 @@ pub mod http {
         #[derive(Clone, Default, Eq, PartialEq)]
         pub struct Headers(/* private fields */);
         impl Headers {
-            fn add<H>(&mut self, header: H) -> Result<(), <H as >::Error> where H: AsHeaders;
-            fn get<H: FromHeaders>(&self) -> crate::Result<H>;
-            fn get_as<V, E>(&self, key: &HeaderName) -> crate::Result<V> where V: FromStr<Err = E>, E: std::error::Error + Send + Sync + 'static;
-            fn get_optional<H: FromHeaders>(&self) -> Result<Option<H>, <H as >::Error>;
-            fn get_optional_as<V, E>(&self, key: &HeaderName) -> crate::Result<Option<V>> where V: FromStr<Err = E>, E: std::error::Error + Send + Sync + 'static;
-            fn get_optional_str(&self, key: &HeaderName) -> Option<&str>;
-            fn get_optional_string(&self, key: &HeaderName) -> Option<String>;
-            fn get_optional_with<'a, V, F, E>(&self, key: &HeaderName, parser: F) -> crate::Result<Option<V>> where F: FnOnce(&'a HeaderValue) -> Result<V, E>, E: std::error::Error + Send + Sync + 'static;
-            fn get_str(&self, key: &HeaderName) -> crate::Result<&str>;
-            fn get_with<'a, V, F, E>(&self, key: &HeaderName, parser: F) -> crate::Result<V> where F: FnOnce(&'a HeaderValue) -> Result<V, E>, E: std::error::Error + Send + Sync + 'static;
-            fn insert<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
-            fn iter(&self) -> impl Iterator<Item = (&HeaderName, &HeaderValue)>;
-            fn new() -> Self;
-            fn remove<K>(&mut self, key: K) -> Option<HeaderValue> where K: Into<HeaderName>;
+            pub fn add<H>(&mut self, header: H) -> Result<(), <H as >::Error> where H: AsHeaders;
+            pub fn get<H: FromHeaders>(&self) -> crate::Result<H>;
+            pub fn get_as<V, E>(&self, key: &HeaderName) -> crate::Result<V> where V: FromStr<Err = E>, E: std::error::Error + Send + Sync + 'static;
+            pub fn get_optional<H: FromHeaders>(&self) -> Result<Option<H>, <H as >::Error>;
+            pub fn get_optional_as<V, E>(&self, key: &HeaderName) -> crate::Result<Option<V>> where V: FromStr<Err = E>, E: std::error::Error + Send + Sync + 'static;
+            pub fn get_optional_str(&self, key: &HeaderName) -> Option<&str>;
+            pub fn get_optional_string(&self, key: &HeaderName) -> Option<String>;
+            pub fn get_optional_with<'a, V, F, E>(&self, key: &HeaderName, parser: F) -> crate::Result<Option<V>> where F: FnOnce(&'a HeaderValue) -> Result<V, E>, E: std::error::Error + Send + Sync + 'static;
+            pub fn get_str(&self, key: &HeaderName) -> crate::Result<&str>;
+            pub fn get_with<'a, V, F, E>(&self, key: &HeaderName, parser: F) -> crate::Result<V> where F: FnOnce(&'a HeaderValue) -> Result<V, E>, E: std::error::Error + Send + Sync + 'static;
+            pub fn insert<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
+            pub fn iter(&self) -> impl Iterator<Item = (&HeaderName, &HeaderValue)>;
+            pub fn new() -> Self;
+            pub fn remove<K>(&mut self, key: K) -> Option<HeaderValue> where K: Into<HeaderName>;
         }
         impl Debug for Headers {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -695,7 +695,7 @@ pub mod http {
         pub struct TransportPolicy {
         }
         impl TransportPolicy {
-            fn new(transport: Transport) -> Self;
+            pub fn new(transport: Transport) -> Self;
         }
         impl Policy for TransportPolicy {
             #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]
@@ -722,23 +722,23 @@ pub mod http {
         pub struct Request {
         }
         impl Request {
-            fn add_mandatory_header<T: Header>(&mut self, item: &T);
-            fn add_optional_header<T: Header>(&mut self, item: &Option<T>);
-            fn body(&self) -> &Body;
-            fn body_mut(&mut self) -> &mut Body;
-            fn headers(&self) -> &Headers;
-            fn headers_mut(&mut self) -> &mut Headers;
-            fn insert_header<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
-            fn insert_headers<T: AsHeaders>(&mut self, headers: &T) -> Result<(), <T as >::Error>;
-            fn method(&self) -> Method;
-            fn new(url: Url, method: Method) -> Self;
-            fn path_and_query(&self) -> String;
-            fn set_body<impl Into<Body>: Into<Body>>(&mut self, body: impl Into<Body>);
+            pub fn add_mandatory_header<T: Header>(&mut self, item: &T);
+            pub fn add_optional_header<T: Header>(&mut self, item: &Option<T>);
+            pub fn body(&self) -> &Body;
+            pub fn body_mut(&mut self) -> &mut Body;
+            pub fn headers(&self) -> &Headers;
+            pub fn headers_mut(&mut self) -> &mut Headers;
+            pub fn insert_header<K, V>(&mut self, key: K, value: V) where K: Into<HeaderName>, V: Into<HeaderValue>;
+            pub fn insert_headers<T: AsHeaders>(&mut self, headers: &T) -> Result<(), <T as >::Error>;
+            pub fn method(&self) -> Method;
+            pub fn new(url: Url, method: Method) -> Self;
+            pub fn path_and_query(&self) -> String;
+            pub fn set_body<impl Into<Body>: Into<Body>>(&mut self, body: impl Into<Body>);
             #[cfg(feature = "json")]
-            fn set_json<T>(&mut self, data: &T) -> crate::Result<()> where T: ?Sized + Serialize;
-            fn set_method(&mut self, method: Method);
-            fn url(&self) -> &Url;
-            fn url_mut(&mut self) -> &mut Url;
+            pub fn set_json<T>(&mut self, data: &T) -> crate::Result<()> where T: ?Sized + Serialize;
+            pub fn set_method(&mut self, method: Method);
+            pub fn url(&self) -> &Url;
+            pub fn url_mut(&mut self) -> &mut Url;
         }
         impl Debug for Request {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -748,14 +748,14 @@ pub mod http {
         pub struct RequestContent<T, F = crate::http::JsonFormat> {
         }
         impl<T, F> RequestContent<T, F> {
-            fn body(&self) -> &Body;
-            fn from(body: Vec<u8>) -> Self;
-            fn from_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + Unpin + Send + Sync + 'static;
-            fn from_seekable_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + AsyncSeek + Unpin + Send + Sync + 'static;
-            fn from_slice(body: &[u8]) -> Self;
-            fn from_static(body: &'static [u8]) -> Self;
+            pub fn body(&self) -> &Body;
+            pub fn from(body: Vec<u8>) -> Self;
+            pub fn from_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + Unpin + Send + Sync + 'static;
+            pub fn from_seekable_reader<R>(reader: R, len: Option<u64>) -> Self where R: AsyncRead + AsyncSeek + Unpin + Send + Sync + 'static;
+            pub fn from_slice(body: &[u8]) -> Self;
+            pub fn from_static(body: &'static [u8]) -> Self;
             #[allow(clippy::should_implement_trait)]
-            fn from_str(body: &str) -> Self;
+            pub fn from_str(body: &str) -> Self;
         }
         impl<T, F> From<Box<dyn SeekableStream>> for RequestContent<T, F> {
             fn from(stream: Box<dyn SeekableStream>) -> Self;
@@ -883,10 +883,10 @@ pub mod http {
             SeekableStream(Box<dyn SeekableStream>),
         }
         impl Body {
-            fn is_empty(&self) -> Option<bool>;
-            fn len(&self) -> Option<u64>;
-            async fn reset(&mut self) -> crate::Result<()>;
-            fn take(&mut self) -> Body;
+            pub fn is_empty(&self) -> Option<bool>;
+            pub fn len(&self) -> Option<u64>;
+            pub async fn reset(&mut self) -> crate::Result<()>;
+            pub fn take(&mut self) -> Body;
         }
         impl Debug for Body {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -913,8 +913,8 @@ pub mod http {
             #[derive(Clone, Debug)]
             pub struct ContentType(/* private fields */);
             impl ContentType {
-                const fn from_static(s: &'static str) -> Self;
-                fn new<S>(s: S) -> Self where S: Into<std::borrow::Cow<'static, str>>;
+                pub const fn from_static(s: &'static str) -> Self;
+                pub fn new<S>(s: S) -> Self where S: Into<std::borrow::Cow<'static, str>>;
             }
             impl ContentType {
                 const APPLICATION_JSON: ContentType = _;
@@ -933,13 +933,13 @@ pub mod http {
         pub struct AsyncRawResponse {
         }
         impl AsyncRawResponse {
-            fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
-            fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, bytes: impl Into<Bytes>) -> Self;
-            fn headers(&self) -> &Headers;
-            fn into_body(self) -> AsyncResponseBody;
-            fn new(status: StatusCode, headers: Headers, stream: PinnedStream) -> Self;
-            fn status(&self) -> StatusCode;
-            async fn try_into_raw_response(self) -> crate::Result<RawResponse>;
+            pub fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
+            pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, bytes: impl Into<Bytes>) -> Self;
+            pub fn headers(&self) -> &Headers;
+            pub fn into_body(self) -> AsyncResponseBody;
+            pub fn new(status: StatusCode, headers: Headers, stream: PinnedStream) -> Self;
+            pub fn status(&self) -> StatusCode;
+            pub async fn try_into_raw_response(self) -> crate::Result<RawResponse>;
         }
         impl<T> From<AsyncRawResponse> for AsyncResponse<T> {
             fn from(raw: AsyncRawResponse) -> Self;
@@ -950,10 +950,10 @@ pub mod http {
         pub struct AsyncResponse<T = ()> {
         }
         impl<T> AsyncResponse<T> {
-            fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
-            fn headers(&self) -> &Headers;
-            fn into_body(self) -> AsyncResponseBody;
-            fn status(&self) -> StatusCode;
+            pub fn deconstruct(self) -> (StatusCode, Headers, AsyncResponseBody);
+            pub fn headers(&self) -> &Headers;
+            pub fn into_body(self) -> AsyncResponseBody;
+            pub fn status(&self) -> StatusCode;
         }
         impl<T> Debug for AsyncResponse<T> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -961,9 +961,9 @@ pub mod http {
         #[pin_project]
         pub struct AsyncResponseBody(/* private fields */);
         impl AsyncResponseBody {
-            async fn collect(self) -> crate::Result<Bytes>;
-            async fn collect_into(self, buffer: &mut [u8]) -> crate::Result<usize>;
-            async fn collect_string(self) -> crate::Result<String>;
+            pub async fn collect(self) -> crate::Result<Bytes>;
+            pub async fn collect_into(self, buffer: &mut [u8]) -> crate::Result<usize>;
+            pub async fn collect_string(self) -> crate::Result<String>;
         }
         impl Debug for AsyncResponseBody {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -976,26 +976,26 @@ pub mod http {
         pub struct RawResponse {
         }
         impl RawResponse {
-            fn body(&self) -> &ResponseBody;
-            fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
-            fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, body: impl Into<Bytes>) -> Self;
-            fn headers(&self) -> &Headers;
-            fn into_body(self) -> ResponseBody;
-            fn status(&self) -> StatusCode;
+            pub fn body(&self) -> &ResponseBody;
+            pub fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
+            pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(status: StatusCode, headers: Headers, body: impl Into<Bytes>) -> Self;
+            pub fn headers(&self) -> &Headers;
+            pub fn into_body(self) -> ResponseBody;
+            pub fn status(&self) -> StatusCode;
         }
         #[cfg(feature = "json")]
         pub struct Response<T, F = crate::http::JsonFormat> {
         }
         impl<T, F> Response<T, F> {
-            fn body(&self) -> &ResponseBody;
-            fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
-            fn headers(&self) -> &Headers;
-            fn into_body(self) -> ResponseBody;
-            fn status(&self) -> StatusCode;
-            fn to_raw_response(&self) -> RawResponse;
+            pub fn body(&self) -> &ResponseBody;
+            pub fn deconstruct(self) -> (StatusCode, Headers, ResponseBody);
+            pub fn headers(&self) -> &Headers;
+            pub fn into_body(self) -> ResponseBody;
+            pub fn status(&self) -> StatusCode;
+            pub fn to_raw_response(&self) -> RawResponse;
         }
         impl<T: DeserializeWith<F>, F: Format> Response<T, F> {
-            fn into_model(self) -> crate::Result<T>;
+            pub fn into_model(self) -> crate::Result<T>;
         }
         impl<T, F> Debug for Response<T, F> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1009,12 +1009,12 @@ pub mod http {
         #[derive(Clone, Eq, PartialEq)]
         pub struct ResponseBody(/* private fields */);
         impl ResponseBody {
-            fn from_bytes<impl Into<Bytes>: Into<Bytes>>(bytes: impl Into<Bytes>) -> Self;
-            fn into_string(self) -> crate::Result<String>;
+            pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(bytes: impl Into<Bytes>) -> Self;
+            pub fn into_string(self) -> crate::Result<String>;
             #[cfg(feature = "json")]
-            fn json<T>(&self) -> crate::Result<T> where T: DeserializeOwned;
+            pub fn json<T>(&self) -> crate::Result<T> where T: DeserializeOwned;
             #[cfg(feature = "xml")]
-            fn xml<T>(&self) -> crate::Result<T> where T: DeserializeOwned;
+            pub fn xml<T>(&self) -> crate::Result<T> where T: DeserializeOwned;
         }
         impl AsRef<[u8]> for ResponseBody {
             #[inline]
@@ -1047,8 +1047,8 @@ pub mod stream {
     pub struct BytesStream {
     }
     impl BytesStream {
-        fn new<impl Into<Bytes>: Into<Bytes>>(bytes: impl Into<Bytes>) -> Self;
-        fn new_empty() -> Self;
+        pub fn new<impl Into<Bytes>: Into<Bytes>>(bytes: impl Into<Bytes>) -> Self;
+        pub fn new_empty() -> Self;
     }
     impl AsyncRead for BytesStream {
         fn poll_read(self: Pin<&mut Self>, _cx: &mut std::task::Context<'_>, buf: &mut [u8]) -> Poll<std::io::Result<usize>>;
@@ -1074,7 +1074,7 @@ pub mod stream {
     pub struct ReadStream<R> {
     }
     impl<R> ReadStream<R> {
-        fn new(reader: R, len: Option<u64>) -> Self;
+        pub fn new(reader: R, len: Option<u64>) -> Self;
     }
     impl<R> AsyncRead for ReadStream<R> where R: AsyncRead + Unpin {
         fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<std::io::Result<usize>>;
@@ -1093,7 +1093,7 @@ pub mod stream {
     pub struct SeekableReadStream<R> {
     }
     impl<R> SeekableReadStream<R> {
-        fn new(reader: R, len: Option<u64>) -> Self;
+        pub fn new(reader: R, len: Option<u64>) -> Self;
     }
     impl<R> AsyncRead for SeekableReadStream<R> where R: AsyncRead + AsyncSeek + Unpin {
         fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<std::io::Result<usize>>;

--- a/sdk/core/typespec_client_core/api/API.metadata.yml
+++ b/sdk/core/typespec_client_core/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: 6bc7205ca225f52d7eda2464c7691d61a7d0408ac33037cd88e3b85e6d35f5ac
+apiMdSha256: 50dd1904748ca3fe7bd4d9c347392ec533034f4621c37c0efbe29b3309fd7f5e
 packageVersion: 1.2.0-beta.1
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/core/typespec_macros/api/API.metadata.yml
+++ b/sdk/core/typespec_macros/api/API.metadata.yml
@@ -1,4 +1,4 @@
 apiMdSha256: 0d2366fd9246288c89d1295dce5e2b0de3a4d937b1f712119fe749ee6c48e6ff
 packageVersion: 1.1.0-beta.1
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/cosmos/azure_data_cosmos/api/API.md
+++ b/sdk/cosmos/azure_data_cosmos/api/API.md
@@ -46,8 +46,8 @@ pub use azure_data_cosmos::models::transactional_batch::TransactionalBatch;
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct AccountEndpoint(/* private fields */);
 impl AccountEndpoint {
-    fn into_url(self) -> Url;
-    fn url(&self) -> &Url;
+    pub fn into_url(self) -> Url;
+    pub fn url(&self) -> &Url;
 }
 impl Display for AccountEndpoint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
@@ -65,24 +65,24 @@ pub struct AccountReference {
 }
 impl AccountReference {
     #[cfg(feature = "key_auth")]
-    fn with_authentication_key<impl Into<Secret>: Into<Secret>>(endpoint: AccountEndpoint, key: impl Into<Secret>) -> Self;
-    fn with_credential(endpoint: AccountEndpoint, credential: Arc<dyn TokenCredential>) -> Self;
+    pub fn with_authentication_key<impl Into<Secret>: Into<Secret>>(endpoint: AccountEndpoint, key: impl Into<Secret>) -> Self;
+    pub fn with_credential(endpoint: AccountEndpoint, credential: Arc<dyn TokenCredential>) -> Self;
 }
 #[derive(Clone, Debug)]
 pub struct CosmosRuntime(/* private fields */);
 impl CosmosRuntime {
-    fn builder() -> CosmosRuntimeBuilder;
+    pub fn builder() -> CosmosRuntimeBuilder;
 }
 #[derive(Clone, Debug, Default)]
 pub struct CosmosRuntimeBuilder(/* private fields */);
 impl CosmosRuntimeBuilder {
-    async fn build(self) -> crate::Result<CosmosRuntime>;
-    fn new() -> Self;
-    fn with_connection_pool(self, options: ConnectionPoolOptions) -> Self;
-    fn with_cpu_refresh_interval(self, interval: Duration) -> Self;
-    fn with_default_operation_options(self, options: OperationOptions) -> Self;
-    fn with_diagnostics_options(self, options: DiagnosticsOptions) -> Self;
-    fn with_user_agent_suffix(self, suffix: UserAgentSuffix) -> Self;
+    pub async fn build(self) -> crate::Result<CosmosRuntime>;
+    pub fn new() -> Self;
+    pub fn with_connection_pool(self, options: ConnectionPoolOptions) -> Self;
+    pub fn with_cpu_refresh_interval(self, interval: Duration) -> Self;
+    pub fn with_default_operation_options(self, options: OperationOptions) -> Self;
+    pub fn with_diagnostics_options(self, options: DiagnosticsOptions) -> Self;
+    pub fn with_user_agent_suffix(self, suffix: UserAgentSuffix) -> Self;
 }
 impl From<CosmosDriverRuntimeBuilder> for CosmosRuntimeBuilder {
     fn from(value: CosmosDriverRuntimeBuilder) -> Self;
@@ -93,9 +93,9 @@ pub struct PartitionKey(/* private fields */);
 impl PartitionKey {
     const NULL: PartitionKeyValue = PartitionKeyValue::NULL;
     const UNDEFINED: PartitionKeyValue = PartitionKeyValue::UNDEFINED;
-    fn is_empty(&self) -> bool;
-    fn len(&self) -> usize;
-    fn values(&self) -> &[PartitionKeyValue];
+    pub fn is_empty(&self) -> bool;
+    pub fn len(&self) -> usize;
+    pub fn values(&self) -> &[PartitionKeyValue];
 }
 impl AsHeaders for PartitionKey {
     type Error = CosmosError;
@@ -117,7 +117,7 @@ impl<T: Into<PartitionKeyValue>> From<T> for PartitionKey {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct ResourceId(/* private fields */);
 impl ResourceId {
-    fn as_str(&self) -> &str;
+    pub fn as_str(&self) -> &str;
 }
 impl AsRef<str> for ResourceId {
     fn as_ref(&self) -> &str;
@@ -161,7 +161,7 @@ pub enum ResourceIdentity {
     Rid(ResourceId),
 }
 impl ResourceIdentity {
-    fn is_rid(&self) -> bool;
+    pub fn is_rid(&self) -> bool;
 }
 impl From<&ResourceIdentity> for ResourceIdentity {
     fn from(identity: &ResourceIdentity) -> Self;
@@ -181,81 +181,81 @@ pub mod clients {
     }
     impl ContainerClient {
         #[cfg(feature = "control_plane")]
-        async fn begin_replace_throughput(&self, throughput: ThroughputProperties, options: Option<ThroughputOptions>) -> crate::Result<ThroughputPoller>;
-        async fn create_item<T: Serialize, impl Into<PartitionKey>: Into<PartitionKey>>(&self, partition_key: impl Into<PartitionKey>, item_id: &str, item: T, options: Option<ItemWriteOptions>) -> crate::Result<ItemResponse>;
+        pub async fn begin_replace_throughput(&self, throughput: ThroughputProperties, options: Option<ThroughputOptions>) -> crate::Result<ThroughputPoller>;
+        pub async fn create_item<T: Serialize, impl Into<PartitionKey>: Into<PartitionKey>>(&self, partition_key: impl Into<PartitionKey>, item_id: &str, item: T, options: Option<ItemWriteOptions>) -> crate::Result<ItemResponse>;
         #[cfg(feature = "control_plane")]
-        async fn delete(&self, options: Option<DeleteContainerOptions>) -> crate::Result<ResourceResponse<()>>;
-        async fn delete_item<impl Into<PartitionKey>: Into<PartitionKey>>(&self, partition_key: impl Into<PartitionKey>, item_id: &str, options: Option<ItemWriteOptions>) -> crate::Result<ItemResponse>;
-        async fn execute_transactional_batch(&self, batch: TransactionalBatch, options: Option<BatchOptions>) -> crate::Result<BatchResponse>;
-        async fn feed_range_from_partition_key<impl Into<PartitionKey>: Into<PartitionKey>>(&self, partition_key: impl Into<PartitionKey>, options: Option<ReadFeedRangesOptions>) -> crate::Result<Vec<FeedRange>>;
-        fn get_latest_session_token(&self, feed_ranges_to_session_tokens: &[(FeedRange, SessionToken)], target_feed_range: &FeedRange) -> crate::Result<SessionToken>;
+        pub async fn delete(&self, options: Option<DeleteContainerOptions>) -> crate::Result<ResourceResponse<()>>;
+        pub async fn delete_item<impl Into<PartitionKey>: Into<PartitionKey>>(&self, partition_key: impl Into<PartitionKey>, item_id: &str, options: Option<ItemWriteOptions>) -> crate::Result<ItemResponse>;
+        pub async fn execute_transactional_batch(&self, batch: TransactionalBatch, options: Option<BatchOptions>) -> crate::Result<BatchResponse>;
+        pub async fn feed_range_from_partition_key<impl Into<PartitionKey>: Into<PartitionKey>>(&self, partition_key: impl Into<PartitionKey>, options: Option<ReadFeedRangesOptions>) -> crate::Result<Vec<FeedRange>>;
+        pub fn get_latest_session_token(&self, feed_ranges_to_session_tokens: &[(FeedRange, SessionToken)], target_feed_range: &FeedRange) -> crate::Result<SessionToken>;
         #[cfg(feature = "preview_patch")]
-        async fn patch_item<impl Into<PartitionKey>: Into<PartitionKey>>(&self, partition_key: impl Into<PartitionKey>, item_id: &str, patch: PatchInstructions, options: Option<PatchItemOptions>) -> crate::Result<ItemResponse>;
-        async fn query_change_feed<T: DeserializeOwned + Send + 'static>(&self, scope: FeedScope, start_from: ChangeFeedStartFrom, options: Option<ChangeFeedOptions>) -> crate::Result<ChangeFeedPageIterator<ChangeFeedItem<T>>>;
-        async fn query_items<T: DeserializeOwned + Send + 'static, impl Into<Query>: Into<Query>>(&self, query: impl Into<Query>, scope: FeedScope, options: Option<QueryOptions>) -> crate::Result<QueryItemIterator<T>>;
-        async fn read(&self, options: Option<ReadContainerOptions>) -> crate::Result<ResourceResponse<ContainerProperties>>;
-        async fn read_feed_ranges(&self, options: Option<ReadFeedRangesOptions>) -> crate::Result<Vec<FeedRange>>;
-        async fn read_item<impl Into<PartitionKey>: Into<PartitionKey>>(&self, partition_key: impl Into<PartitionKey>, item_id: &str, options: Option<ItemReadOptions>) -> crate::Result<ItemResponse>;
+        pub async fn patch_item<impl Into<PartitionKey>: Into<PartitionKey>>(&self, partition_key: impl Into<PartitionKey>, item_id: &str, patch: PatchInstructions, options: Option<PatchItemOptions>) -> crate::Result<ItemResponse>;
+        pub async fn query_change_feed<T: DeserializeOwned + Send + 'static>(&self, scope: FeedScope, start_from: ChangeFeedStartFrom, options: Option<ChangeFeedOptions>) -> crate::Result<ChangeFeedPageIterator<ChangeFeedItem<T>>>;
+        pub async fn query_items<T: DeserializeOwned + Send + 'static, impl Into<Query>: Into<Query>>(&self, query: impl Into<Query>, scope: FeedScope, options: Option<QueryOptions>) -> crate::Result<QueryItemIterator<T>>;
+        pub async fn read(&self, options: Option<ReadContainerOptions>) -> crate::Result<ResourceResponse<ContainerProperties>>;
+        pub async fn read_feed_ranges(&self, options: Option<ReadFeedRangesOptions>) -> crate::Result<Vec<FeedRange>>;
+        pub async fn read_item<impl Into<PartitionKey>: Into<PartitionKey>>(&self, partition_key: impl Into<PartitionKey>, item_id: &str, options: Option<ItemReadOptions>) -> crate::Result<ItemResponse>;
         #[cfg(feature = "control_plane")]
-        async fn read_throughput(&self, options: Option<ThroughputOptions>) -> crate::Result<Option<ThroughputProperties>>;
+        pub async fn read_throughput(&self, options: Option<ThroughputOptions>) -> crate::Result<Option<ThroughputProperties>>;
         #[cfg(feature = "control_plane")]
-        async fn replace(&self, properties: ContainerProperties, options: Option<ReplaceContainerOptions>) -> crate::Result<ResourceResponse<ContainerProperties>>;
-        async fn replace_item<T: Serialize, impl Into<PartitionKey>: Into<PartitionKey>>(&self, partition_key: impl Into<PartitionKey>, item_id: &str, item: T, options: Option<ItemWriteOptions>) -> crate::Result<ItemResponse>;
-        async fn upsert_item<T: Serialize, impl Into<PartitionKey>: Into<PartitionKey>>(&self, partition_key: impl Into<PartitionKey>, item_id: &str, item: T, options: Option<ItemWriteOptions>) -> crate::Result<ItemResponse>;
+        pub async fn replace(&self, properties: ContainerProperties, options: Option<ReplaceContainerOptions>) -> crate::Result<ResourceResponse<ContainerProperties>>;
+        pub async fn replace_item<T: Serialize, impl Into<PartitionKey>: Into<PartitionKey>>(&self, partition_key: impl Into<PartitionKey>, item_id: &str, item: T, options: Option<ItemWriteOptions>) -> crate::Result<ItemResponse>;
+        pub async fn upsert_item<T: Serialize, impl Into<PartitionKey>: Into<PartitionKey>>(&self, partition_key: impl Into<PartitionKey>, item_id: &str, item: T, options: Option<ItemWriteOptions>) -> crate::Result<ItemResponse>;
     }
     #[derive(Clone, Debug)]
     pub struct CosmosClient {
     }
     impl CosmosClient {
-        fn builder() -> CosmosClientBuilder;
+        pub fn builder() -> CosmosClientBuilder;
         #[cfg(feature = "preview_dtx")]
-        async fn commit_distributed_write(&self, transaction: crate::clients::DistributedWriteTransaction) -> crate::Result<crate::clients::DistributedTransactionResponse>;
+        pub async fn commit_distributed_write(&self, transaction: crate::clients::DistributedWriteTransaction) -> crate::Result<crate::clients::DistributedTransactionResponse>;
         #[cfg(feature = "control_plane")]
-        async fn create_database(&self, id: &str, options: Option<CreateDatabaseOptions>) -> crate::Result<ResourceResponse<DatabaseProperties>>;
-        fn database_client<impl Into<ResourceIdentity>: Into<ResourceIdentity>>(&self, database: impl Into<ResourceIdentity>) -> DatabaseClient;
-        fn endpoint(&self) -> &Url;
+        pub async fn create_database(&self, id: &str, options: Option<CreateDatabaseOptions>) -> crate::Result<ResourceResponse<DatabaseProperties>>;
+        pub fn database_client<impl Into<ResourceIdentity>: Into<ResourceIdentity>>(&self, database: impl Into<ResourceIdentity>) -> DatabaseClient;
+        pub fn endpoint(&self) -> &Url;
         #[cfg(feature = "preview_dtx")]
-        async fn execute_distributed_read(&self, transaction: crate::clients::DistributedReadTransaction) -> crate::Result<crate::clients::DistributedTransactionResponse>;
+        pub async fn execute_distributed_read(&self, transaction: crate::clients::DistributedReadTransaction) -> crate::Result<crate::clients::DistributedTransactionResponse>;
         #[cfg(feature = "control_plane")]
-        async fn query_databases<impl Into<Query>: Into<Query>>(&self, query: impl Into<Query>, options: Option<QueryDatabasesOptions>) -> crate::Result<QueryItemIterator<DatabaseProperties>>;
+        pub async fn query_databases<impl Into<Query>: Into<Query>>(&self, query: impl Into<Query>, options: Option<QueryDatabasesOptions>) -> crate::Result<QueryItemIterator<DatabaseProperties>>;
     }
     #[derive(Default)]
     pub struct CosmosClientBuilder {
     }
     impl CosmosClientBuilder {
-        async fn build(self, account: AccountReference, routing_strategy: RoutingStrategy) -> crate::Result<CosmosClient>;
-        fn new() -> Self;
-        fn register_throughput_control_group(self, group: ThroughputControlGroupOptions) -> crate::Result<Self>;
-        fn with_backup_endpoints(self, endpoints: Vec<crate::AccountEndpoint>) -> Self;
-        fn with_binary_encoding_options(self, options: BinaryEncodingOptions) -> Self;
-        fn with_default_operation_options(self, options: OperationOptions) -> Self;
-        fn with_diagnostics_handler(self, handler: Arc<dyn DiagnosticsHandler>) -> Self;
+        pub async fn build(self, account: AccountReference, routing_strategy: RoutingStrategy) -> crate::Result<CosmosClient>;
+        pub fn new() -> Self;
+        pub fn register_throughput_control_group(self, group: ThroughputControlGroupOptions) -> crate::Result<Self>;
+        pub fn with_backup_endpoints(self, endpoints: Vec<crate::AccountEndpoint>) -> Self;
+        pub fn with_binary_encoding_options(self, options: BinaryEncodingOptions) -> Self;
+        pub fn with_default_operation_options(self, options: OperationOptions) -> Self;
+        pub fn with_diagnostics_handler(self, handler: Arc<dyn DiagnosticsHandler>) -> Self;
         #[cfg(feature = "fault_injection")]
-        fn with_fault_injection_rules(self, rules: Vec<Arc<azure_data_cosmos_driver::fault_injection::FaultInjectionRule>>) -> crate::Result<Self>;
-        fn with_partition_failover_options(self, options: PartitionFailoverOptions) -> Self;
-        fn with_partition_key_range_cache_enabled(self, enabled: bool) -> Self;
-        fn with_runtime(self, runtime: CosmosRuntime) -> Self;
-        fn with_user_agent_suffix(self, suffix: UserAgentSuffix) -> Self;
+        pub fn with_fault_injection_rules(self, rules: Vec<Arc<azure_data_cosmos_driver::fault_injection::FaultInjectionRule>>) -> crate::Result<Self>;
+        pub fn with_partition_failover_options(self, options: PartitionFailoverOptions) -> Self;
+        pub fn with_partition_key_range_cache_enabled(self, enabled: bool) -> Self;
+        pub fn with_runtime(self, runtime: CosmosRuntime) -> Self;
+        pub fn with_user_agent_suffix(self, suffix: UserAgentSuffix) -> Self;
     }
     pub struct DatabaseClient {
     }
     impl DatabaseClient {
         #[cfg(feature = "control_plane")]
-        async fn begin_replace_throughput(&self, throughput: ThroughputProperties, options: Option<ThroughputOptions>) -> crate::Result<ThroughputPoller>;
-        async fn container_client<impl Into<ResourceIdentity>: Into<ResourceIdentity>>(&self, container: impl Into<ResourceIdentity>, options: Option<ContainerClientOptions>) -> crate::Result<ContainerClient>;
+        pub async fn begin_replace_throughput(&self, throughput: ThroughputProperties, options: Option<ThroughputOptions>) -> crate::Result<ThroughputPoller>;
+        pub async fn container_client<impl Into<ResourceIdentity>: Into<ResourceIdentity>>(&self, container: impl Into<ResourceIdentity>, options: Option<ContainerClientOptions>) -> crate::Result<ContainerClient>;
         #[cfg(feature = "control_plane")]
-        async fn create_container(&self, properties: ContainerProperties, options: Option<CreateContainerOptions>) -> crate::Result<ResourceResponse<ContainerProperties>>;
+        pub async fn create_container(&self, properties: ContainerProperties, options: Option<CreateContainerOptions>) -> crate::Result<ResourceResponse<ContainerProperties>>;
         #[cfg(feature = "control_plane")]
-        async fn delete(&self, options: Option<DeleteDatabaseOptions>) -> crate::Result<ResourceResponse<()>>;
-        fn id(&self) -> &ResourceIdentity;
-        fn name(&self) -> Option<&str>;
+        pub async fn delete(&self, options: Option<DeleteDatabaseOptions>) -> crate::Result<ResourceResponse<()>>;
+        pub fn id(&self) -> &ResourceIdentity;
+        pub fn name(&self) -> Option<&str>;
         #[cfg(feature = "control_plane")]
-        async fn query_containers<impl Into<Query>: Into<Query>>(&self, query: impl Into<Query>, options: Option<QueryContainersOptions>) -> crate::Result<QueryItemIterator<ContainerProperties>>;
+        pub async fn query_containers<impl Into<Query>: Into<Query>>(&self, query: impl Into<Query>, options: Option<QueryContainersOptions>) -> crate::Result<QueryItemIterator<ContainerProperties>>;
         #[cfg(feature = "control_plane")]
-        async fn read(&self, options: Option<ReadDatabaseOptions>) -> crate::Result<ResourceResponse<DatabaseProperties>>;
+        pub async fn read(&self, options: Option<ReadDatabaseOptions>) -> crate::Result<ResourceResponse<DatabaseProperties>>;
         #[cfg(feature = "control_plane")]
-        async fn read_throughput(&self, options: Option<ThroughputOptions>) -> crate::Result<Option<ThroughputProperties>>;
-        fn rid(&self) -> Option<&ResourceId>;
+        pub async fn read_throughput(&self, options: Option<ThroughputOptions>) -> crate::Result<Option<ThroughputProperties>>;
+        pub fn rid(&self) -> Option<&ResourceId>;
     }
     #[cfg(feature = "preview_dtx")]
     #[derive(Clone, Debug)]
@@ -263,8 +263,8 @@ pub mod clients {
     }
     #[cfg(feature = "preview_dtx")]
     impl DistributedReadTransaction {
-        fn new() -> Self;
-        fn read_item<impl Into<PartitionKey>: Into<PartitionKey>, impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>>(self, container: &ContainerClient, partition_key: impl Into<PartitionKey>, item_id: impl Into<std::borrow::Cow<'static, str>>, options: Option<DistributedTransactionOperationOptions>) -> Self;
+        pub fn new() -> Self;
+        pub fn read_item<impl Into<PartitionKey>: Into<PartitionKey>, impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>>(self, container: &ContainerClient, partition_key: impl Into<PartitionKey>, item_id: impl Into<std::borrow::Cow<'static, str>>, options: Option<DistributedTransactionOperationOptions>) -> Self;
     }
     #[cfg(feature = "preview_dtx")]
     impl Default for DistributedReadTransaction {
@@ -279,8 +279,8 @@ pub mod clients {
     }
     #[cfg(feature = "preview_dtx")]
     impl DistributedTransactionOperationOptions {
-        fn with_precondition(self, precondition: Precondition) -> Self;
-        fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, session_token: impl Into<SessionToken>) -> Self;
+        pub fn with_precondition(self, precondition: Precondition) -> Self;
+        pub fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, session_token: impl Into<SessionToken>) -> Self;
     }
     #[cfg(feature = "preview_dtx")]
     #[derive(Clone, Copy, Debug)]
@@ -288,16 +288,16 @@ pub mod clients {
     }
     #[cfg(feature = "preview_dtx")]
     impl DistributedTransactionOperationResult<'_> {
-        fn etag(&self) -> Option<&azure_core::http::Etag>;
-        fn index(&self) -> usize;
-        fn is_completed_status_code(&self) -> bool;
-        fn is_success_status_code(&self) -> bool;
-        fn partition_key_range_id(&self) -> Option<&str>;
-        fn request_charge(&self) -> Option<f64>;
-        fn resource<T: DeserializeOwned>(&self) -> crate::Result<Option<T>>;
-        fn session_token(&self) -> Option<&SessionToken>;
-        fn status_code(&self) -> azure_core::http::StatusCode;
-        fn sub_status_code(&self) -> Option<crate::SubStatusCode>;
+        pub fn etag(&self) -> Option<&azure_core::http::Etag>;
+        pub fn index(&self) -> usize;
+        pub fn is_completed_status_code(&self) -> bool;
+        pub fn is_success_status_code(&self) -> bool;
+        pub fn partition_key_range_id(&self) -> Option<&str>;
+        pub fn request_charge(&self) -> Option<f64>;
+        pub fn resource<T: DeserializeOwned>(&self) -> crate::Result<Option<T>>;
+        pub fn session_token(&self) -> Option<&SessionToken>;
+        pub fn status_code(&self) -> azure_core::http::StatusCode;
+        pub fn sub_status_code(&self) -> Option<crate::SubStatusCode>;
     }
     #[cfg(feature = "preview_dtx")]
     #[derive(Clone, Default)]
@@ -309,9 +309,9 @@ pub mod clients {
     }
     #[cfg(feature = "preview_dtx")]
     impl DistributedTransactionPatchOperationOptions {
-        fn with_filter_predicate<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, predicate: impl Into<Cow<'static, str>>) -> Self;
-        fn with_precondition(self, precondition: Precondition) -> Self;
-        fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, session_token: impl Into<SessionToken>) -> Self;
+        pub fn with_filter_predicate<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, predicate: impl Into<Cow<'static, str>>) -> Self;
+        pub fn with_precondition(self, precondition: Precondition) -> Self;
+        pub fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, session_token: impl Into<SessionToken>) -> Self;
     }
     #[cfg(feature = "preview_dtx")]
     #[derive(Clone, Debug)]
@@ -319,21 +319,21 @@ pub mod clients {
     }
     #[cfg(feature = "preview_dtx")]
     impl DistributedTransactionResponse {
-        fn activity_id(&self) -> Option<&str>;
-        fn diagnostic_string(&self) -> Option<&str>;
-        fn diagnostics(&self) -> Option<Arc<DiagnosticsContext>>;
-        fn error_message(&self) -> Option<&str>;
-        fn headers(&self) -> &ResponseHeaders;
-        fn idempotency_token(&self) -> String;
-        fn is_completed_status_code(&self) -> bool;
-        fn is_empty(&self) -> bool;
-        fn is_retriable(&self) -> bool;
-        fn is_success_status_code(&self) -> bool;
-        fn len(&self) -> usize;
-        fn operation_result(&self, index: usize) -> Option<DistributedTransactionOperationResult<'_>>;
-        fn request_charge(&self) -> Option<f64>;
-        fn retry_after_ms(&self) -> Option<u64>;
-        fn status(&self) -> crate::CosmosStatus;
+        pub fn activity_id(&self) -> Option<&str>;
+        pub fn diagnostic_string(&self) -> Option<&str>;
+        pub fn diagnostics(&self) -> Option<Arc<DiagnosticsContext>>;
+        pub fn error_message(&self) -> Option<&str>;
+        pub fn headers(&self) -> &ResponseHeaders;
+        pub fn idempotency_token(&self) -> String;
+        pub fn is_completed_status_code(&self) -> bool;
+        pub fn is_empty(&self) -> bool;
+        pub fn is_retriable(&self) -> bool;
+        pub fn is_success_status_code(&self) -> bool;
+        pub fn len(&self) -> usize;
+        pub fn operation_result(&self, index: usize) -> Option<DistributedTransactionOperationResult<'_>>;
+        pub fn request_charge(&self) -> Option<f64>;
+        pub fn retry_after_ms(&self) -> Option<u64>;
+        pub fn status(&self) -> crate::CosmosStatus;
     }
     #[cfg(feature = "preview_dtx")]
     #[derive(Clone, Debug)]
@@ -341,12 +341,12 @@ pub mod clients {
     }
     #[cfg(feature = "preview_dtx")]
     impl DistributedWriteTransaction {
-        fn create_item<T: Serialize, impl Into<PartitionKey>: Into<PartitionKey>, impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>>(self, container: &ContainerClient, partition_key: impl Into<PartitionKey>, item_id: impl Into<std::borrow::Cow<'static, str>>, item: T, options: Option<DistributedTransactionOperationOptions>) -> crate::Result<Self>;
-        fn delete_item<impl Into<PartitionKey>: Into<PartitionKey>, impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>>(self, container: &ContainerClient, partition_key: impl Into<PartitionKey>, item_id: impl Into<std::borrow::Cow<'static, str>>, options: Option<DistributedTransactionOperationOptions>) -> Self;
-        fn new() -> Self;
-        fn patch_item<impl Into<PartitionKey>: Into<PartitionKey>, impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>>(self, container: &ContainerClient, partition_key: impl Into<PartitionKey>, item_id: impl Into<std::borrow::Cow<'static, str>>, patch: PatchInstructions, options: Option<DistributedTransactionPatchOperationOptions>) -> crate::Result<Self>;
-        fn replace_item<T: Serialize, impl Into<PartitionKey>: Into<PartitionKey>, impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>>(self, container: &ContainerClient, partition_key: impl Into<PartitionKey>, item_id: impl Into<std::borrow::Cow<'static, str>>, item: T, options: Option<DistributedTransactionOperationOptions>) -> crate::Result<Self>;
-        fn upsert_item<T: Serialize, impl Into<PartitionKey>: Into<PartitionKey>, impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>>(self, container: &ContainerClient, partition_key: impl Into<PartitionKey>, item_id: impl Into<std::borrow::Cow<'static, str>>, item: T, options: Option<DistributedTransactionOperationOptions>) -> crate::Result<Self>;
+        pub fn create_item<T: Serialize, impl Into<PartitionKey>: Into<PartitionKey>, impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>>(self, container: &ContainerClient, partition_key: impl Into<PartitionKey>, item_id: impl Into<std::borrow::Cow<'static, str>>, item: T, options: Option<DistributedTransactionOperationOptions>) -> crate::Result<Self>;
+        pub fn delete_item<impl Into<PartitionKey>: Into<PartitionKey>, impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>>(self, container: &ContainerClient, partition_key: impl Into<PartitionKey>, item_id: impl Into<std::borrow::Cow<'static, str>>, options: Option<DistributedTransactionOperationOptions>) -> Self;
+        pub fn new() -> Self;
+        pub fn patch_item<impl Into<PartitionKey>: Into<PartitionKey>, impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>>(self, container: &ContainerClient, partition_key: impl Into<PartitionKey>, item_id: impl Into<std::borrow::Cow<'static, str>>, patch: PatchInstructions, options: Option<DistributedTransactionPatchOperationOptions>) -> crate::Result<Self>;
+        pub fn replace_item<T: Serialize, impl Into<PartitionKey>: Into<PartitionKey>, impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>>(self, container: &ContainerClient, partition_key: impl Into<PartitionKey>, item_id: impl Into<std::borrow::Cow<'static, str>>, item: T, options: Option<DistributedTransactionOperationOptions>) -> crate::Result<Self>;
+        pub fn upsert_item<T: Serialize, impl Into<PartitionKey>: Into<PartitionKey>, impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>>(self, container: &ContainerClient, partition_key: impl Into<PartitionKey>, item_id: impl Into<std::borrow::Cow<'static, str>>, item: T, options: Option<DistributedTransactionOperationOptions>) -> crate::Result<Self>;
     }
     #[cfg(feature = "preview_dtx")]
     impl Default for DistributedWriteTransaction {
@@ -375,7 +375,7 @@ pub mod diagnostics {
     pub struct ClientLifetimeToken {
     }
     impl ClientLifetimeToken {
-        fn new<impl FnOnce() + Send + Sync + 'static: FnOnce() + Send + Sync + 'static>(on_drop: impl FnOnce() + Send + Sync + 'static) -> Self;
+        pub fn new<impl FnOnce() + Send + Sync + 'static: FnOnce() + Send + Sync + 'static>(on_drop: impl FnOnce() + Send + Sync + 'static) -> Self;
     }
     impl Debug for ClientLifetimeToken {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -387,46 +387,46 @@ pub mod diagnostics {
     pub struct CosmosClientInfo {
     }
     impl CosmosClientInfo {
-        fn server_address(&self) -> Option<&str>;
-        fn server_port(&self) -> Option<u16>;
+        pub fn server_address(&self) -> Option<&str>;
+        pub fn server_port(&self) -> Option<u16>;
     }
     #[derive(Clone, Debug, Default, Eq, PartialEq)]
     pub struct CosmosOperationContext {
     }
     impl CosmosOperationContext {
-        fn connection_mode(&self) -> Option<&str>;
-        fn consistency_level(&self) -> Option<&str>;
-        fn container_name(&self) -> Option<&str>;
-        fn database_name(&self) -> Option<&str>;
-        fn new() -> Self;
-        fn operation_name(&self) -> Option<&str>;
-        fn returned_item_count(&self) -> Option<u64>;
-        fn server_address(&self) -> Option<&str>;
+        pub fn connection_mode(&self) -> Option<&str>;
+        pub fn consistency_level(&self) -> Option<&str>;
+        pub fn container_name(&self) -> Option<&str>;
+        pub fn database_name(&self) -> Option<&str>;
+        pub fn new() -> Self;
+        pub fn operation_name(&self) -> Option<&str>;
+        pub fn returned_item_count(&self) -> Option<u64>;
+        pub fn server_address(&self) -> Option<&str>;
         #[must_use]
-        fn with_connection_mode<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, mode: impl Into<Cow<'static, str>>) -> Self;
+        pub fn with_connection_mode<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, mode: impl Into<Cow<'static, str>>) -> Self;
         #[must_use]
-        fn with_consistency_level<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, level: impl Into<Cow<'static, str>>) -> Self;
+        pub fn with_consistency_level<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, level: impl Into<Cow<'static, str>>) -> Self;
         #[must_use]
-        fn with_container_name<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, name: impl Into<Cow<'static, str>>) -> Self;
+        pub fn with_container_name<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, name: impl Into<Cow<'static, str>>) -> Self;
         #[must_use]
-        fn with_database_name<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, name: impl Into<Cow<'static, str>>) -> Self;
+        pub fn with_database_name<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, name: impl Into<Cow<'static, str>>) -> Self;
         #[must_use]
-        fn with_operation_name<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, name: impl Into<Cow<'static, str>>) -> Self;
+        pub fn with_operation_name<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, name: impl Into<Cow<'static, str>>) -> Self;
         #[must_use]
-        fn with_returned_item_count(self, count: u64) -> Self;
+        pub fn with_returned_item_count(self, count: u64) -> Self;
         #[must_use]
-        fn with_server_address<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, address: impl Into<Cow<'static, str>>) -> Self;
+        pub fn with_server_address<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, address: impl Into<Cow<'static, str>>) -> Self;
     }
     #[cfg(feature = "distributed_tracing")]
     pub struct CosmosTracingHandler {
     }
     #[cfg(feature = "distributed_tracing")]
     impl CosmosTracingHandler {
-        fn new() -> Self;
-        fn should_emit(&self, diagnostics: &DiagnosticsContext) -> bool;
-        fn thresholds(&self) -> &DiagnosticsThresholds;
-        fn with_thresholds(thresholds: DiagnosticsThresholds) -> Self;
-        fn with_thresholds_and_rate_limit(thresholds: DiagnosticsThresholds, rate_limit: RateLimiterConfig) -> Self;
+        pub fn new() -> Self;
+        pub fn should_emit(&self, diagnostics: &DiagnosticsContext) -> bool;
+        pub fn thresholds(&self) -> &DiagnosticsThresholds;
+        pub fn with_thresholds(thresholds: DiagnosticsThresholds) -> Self;
+        pub fn with_thresholds_and_rate_limit(thresholds: DiagnosticsThresholds, rate_limit: RateLimiterConfig) -> Self;
     }
     #[cfg(feature = "distributed_tracing")]
     impl Default for CosmosTracingHandler {
@@ -442,32 +442,32 @@ pub mod diagnostics {
     }
     #[doc(inline)]
     impl DiagnosticsContext {
-        fn activity_id(&self) -> &ActivityId;
-        fn compaction(&self) -> Option<&CompactionInfo>;
-        fn duration(&self) -> Duration;
-        fn effective_status(&self) -> Option<CosmosStatus>;
-        fn fault_injection_enabled(&self) -> bool;
-        fn hedge_diagnostics(&self) -> Option<&HedgeDiagnostics>;
-        fn hedging_started(&self) -> bool;
-        fn is_completed(&self) -> bool;
-        fn is_failure(&self) -> bool;
-        fn is_threshold_violated(&self, thresholds: &DiagnosticsThresholds) -> bool;
-        fn is_threshold_violated_for(&self, thresholds: &DiagnosticsThresholds, operation_name: Option<&str>) -> bool;
-        fn machine_id(&self) -> Option<&str>;
-        fn operation_name(&self) -> Option<&str>;
-        fn patch_tracking_id(&self) -> Option<PatchTrackingId>;
-        fn regions_contacted(&self) -> Vec<Region>;
-        fn request_count(&self) -> usize;
-        fn requested_regions(&self) -> Vec<RequestedRegion>;
-        fn requests(&self) -> Arc<Vec<RequestDiagnostics>>;
-        fn responded_regions(&self) -> Vec<&Region>;
-        fn retained_request_count(&self) -> usize;
-        fn status(&self) -> Option<&CosmosStatus>;
-        fn threshold_breach_for(&self, thresholds: &DiagnosticsThresholds, operation_name: Option<&str>) -> Option<ThresholdBreach>;
-        fn to_json_string(&self, verbosity: Option<DiagnosticsVerbosity>) -> &str;
-        fn total_request_charge(&self) -> RequestCharge;
-        fn total_requested_regions(&self) -> usize;
-        fn total_responded_regions(&self) -> usize;
+        pub fn activity_id(&self) -> &ActivityId;
+        pub fn compaction(&self) -> Option<&CompactionInfo>;
+        pub fn duration(&self) -> Duration;
+        pub fn effective_status(&self) -> Option<CosmosStatus>;
+        pub fn fault_injection_enabled(&self) -> bool;
+        pub fn hedge_diagnostics(&self) -> Option<&HedgeDiagnostics>;
+        pub fn hedging_started(&self) -> bool;
+        pub fn is_completed(&self) -> bool;
+        pub fn is_failure(&self) -> bool;
+        pub fn is_threshold_violated(&self, thresholds: &DiagnosticsThresholds) -> bool;
+        pub fn is_threshold_violated_for(&self, thresholds: &DiagnosticsThresholds, operation_name: Option<&str>) -> bool;
+        pub fn machine_id(&self) -> Option<&str>;
+        pub fn operation_name(&self) -> Option<&str>;
+        pub fn patch_tracking_id(&self) -> Option<PatchTrackingId>;
+        pub fn regions_contacted(&self) -> Vec<Region>;
+        pub fn request_count(&self) -> usize;
+        pub fn requested_regions(&self) -> Vec<RequestedRegion>;
+        pub fn requests(&self) -> Arc<Vec<RequestDiagnostics>>;
+        pub fn responded_regions(&self) -> Vec<&Region>;
+        pub fn retained_request_count(&self) -> usize;
+        pub fn status(&self) -> Option<&CosmosStatus>;
+        pub fn threshold_breach_for(&self, thresholds: &DiagnosticsThresholds, operation_name: Option<&str>) -> Option<ThresholdBreach>;
+        pub fn to_json_string(&self, verbosity: Option<DiagnosticsVerbosity>) -> &str;
+        pub fn total_request_charge(&self) -> RequestCharge;
+        pub fn total_requested_regions(&self) -> usize;
+        pub fn total_responded_regions(&self) -> usize;
     }
     #[doc(inline)]
     impl Clone for DiagnosticsContext {
@@ -492,13 +492,13 @@ pub mod diagnostics {
     pub struct DiagnosticsHandlerChain {
     }
     impl DiagnosticsHandlerChain {
-        fn from_handlers(handlers: Vec<Arc<dyn DiagnosticsHandler>>) -> Self;
-        fn handlers(&self) -> &[Arc<dyn DiagnosticsHandler>];
-        fn is_empty(&self) -> bool;
-        fn len(&self) -> usize;
-        fn new() -> Self;
+        pub fn from_handlers(handlers: Vec<Arc<dyn DiagnosticsHandler>>) -> Self;
+        pub fn handlers(&self) -> &[Arc<dyn DiagnosticsHandler>];
+        pub fn is_empty(&self) -> bool;
+        pub fn len(&self) -> usize;
+        pub fn new() -> Self;
         #[must_use]
-        fn with_handler(&self, handler: Arc<dyn DiagnosticsHandler>) -> Self;
+        pub fn with_handler(&self, handler: Arc<dyn DiagnosticsHandler>) -> Self;
     }
     impl Debug for DiagnosticsHandlerChain {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -513,19 +513,19 @@ pub mod diagnostics {
     }
     #[doc(inline)]
     impl DiagnosticsThresholds {
-        fn new() -> Self;
-        fn non_point_operation_latency(&self) -> Duration;
-        fn payload_size(&self) -> u64;
-        fn point_operation_latency(&self) -> Duration;
-        fn request_charge(&self) -> f64;
+        pub fn new() -> Self;
+        pub fn non_point_operation_latency(&self) -> Duration;
+        pub fn payload_size(&self) -> u64;
+        pub fn point_operation_latency(&self) -> Duration;
+        pub fn request_charge(&self) -> f64;
         #[must_use]
-        fn with_non_point_operation_latency(self, latency: Duration) -> Self;
+        pub fn with_non_point_operation_latency(self, latency: Duration) -> Self;
         #[must_use]
-        fn with_payload_size(self, payload_size: u64) -> Self;
+        pub fn with_payload_size(self, payload_size: u64) -> Self;
         #[must_use]
-        fn with_point_operation_latency(self, latency: Duration) -> Self;
+        pub fn with_point_operation_latency(self, latency: Duration) -> Self;
         #[must_use]
-        fn with_request_charge(self, request_charge: f64) -> Self;
+        pub fn with_request_charge(self, request_charge: f64) -> Self;
     }
     #[doc(inline)]
     impl Default for DiagnosticsThresholds {
@@ -553,14 +553,14 @@ pub mod diagnostics {
     pub struct SamplingLogHandler {
     }
     impl SamplingLogHandler {
-        fn new() -> Self;
-        fn should_log(&self, diagnostics: &DiagnosticsContext) -> bool;
-        fn thresholds(&self) -> &DiagnosticsThresholds;
-        fn with_handler(inner: Arc<dyn DiagnosticsHandler>) -> Self;
-        fn with_thresholds(thresholds: DiagnosticsThresholds) -> Self;
-        fn with_thresholds_and_handler(thresholds: DiagnosticsThresholds, inner: Arc<dyn DiagnosticsHandler>) -> Self;
-        fn with_thresholds_and_rate_limit(thresholds: DiagnosticsThresholds, rate_limit: RateLimiterConfig) -> Self;
-        fn with_thresholds_rate_limit_and_handler(thresholds: DiagnosticsThresholds, rate_limit: RateLimiterConfig, inner: Arc<dyn DiagnosticsHandler>) -> Self;
+        pub fn new() -> Self;
+        pub fn should_log(&self, diagnostics: &DiagnosticsContext) -> bool;
+        pub fn thresholds(&self) -> &DiagnosticsThresholds;
+        pub fn with_handler(inner: Arc<dyn DiagnosticsHandler>) -> Self;
+        pub fn with_thresholds(thresholds: DiagnosticsThresholds) -> Self;
+        pub fn with_thresholds_and_handler(thresholds: DiagnosticsThresholds, inner: Arc<dyn DiagnosticsHandler>) -> Self;
+        pub fn with_thresholds_and_rate_limit(thresholds: DiagnosticsThresholds, rate_limit: RateLimiterConfig) -> Self;
+        pub fn with_thresholds_rate_limit_and_handler(thresholds: DiagnosticsThresholds, rate_limit: RateLimiterConfig, inner: Arc<dyn DiagnosticsHandler>) -> Self;
     }
     impl Default for SamplingLogHandler {
         fn default() -> Self;
@@ -571,7 +571,7 @@ pub mod diagnostics {
     #[derive(Clone, Copy, Debug, Default)]
     pub struct TracingLogHandler;
     impl TracingLogHandler {
-        fn new() -> Self;
+        pub fn new() -> Self;
     }
     impl DiagnosticsHandler for TracingLogHandler {
         fn handle(&self, diagnostics: &DiagnosticsContext, cx: &Context<'_>);
@@ -608,9 +608,9 @@ pub mod diagnostics {
     }
     #[doc(inline)]
     impl TransportKind {
-        fn as_str(self) -> &'static str;
-        fn is_gateway(self) -> bool;
-        fn is_gateway_v2(self) -> bool;
+        pub fn as_str(self) -> &'static str;
+        pub fn is_gateway(self) -> bool;
+        pub fn is_gateway_v2(self) -> bool;
     }
     #[doc(inline)]
     impl AsRef<str> for TransportKind {
@@ -629,10 +629,10 @@ pub mod diagnostics {
         pub struct CosmosMetricsHandler {
         }
         impl CosmosMetricsHandler {
-            fn new() -> Self;
-            fn with_meter(meter: Meter) -> Self;
-            fn with_meter_and_options(meter: Meter, options: MetricsOptions) -> Self;
-            fn with_options(options: MetricsOptions) -> Self;
+            pub fn new() -> Self;
+            pub fn with_meter(meter: Meter) -> Self;
+            pub fn with_meter_and_options(meter: Meter, options: MetricsOptions) -> Self;
+            pub fn with_options(options: MetricsOptions) -> Self;
         }
         impl Debug for CosmosMetricsHandler {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
@@ -648,22 +648,22 @@ pub mod diagnostics {
         pub struct MetricsOptions {
         }
         impl MetricsOptions {
-            fn active_instance_metric_enabled(&self) -> bool;
-            fn extended_attributes_enabled(&self) -> bool;
-            fn hedged_metric_enabled(&self) -> bool;
-            fn new() -> Self;
-            fn request_charge_metric_enabled(&self) -> bool;
-            fn returned_rows_metric_enabled(&self) -> bool;
+            pub fn active_instance_metric_enabled(&self) -> bool;
+            pub fn extended_attributes_enabled(&self) -> bool;
+            pub fn hedged_metric_enabled(&self) -> bool;
+            pub fn new() -> Self;
+            pub fn request_charge_metric_enabled(&self) -> bool;
+            pub fn returned_rows_metric_enabled(&self) -> bool;
             #[must_use]
-            fn with_active_instance_metric(self, enabled: bool) -> Self;
+            pub fn with_active_instance_metric(self, enabled: bool) -> Self;
             #[must_use]
-            fn with_extended_attributes(self, enabled: bool) -> Self;
+            pub fn with_extended_attributes(self, enabled: bool) -> Self;
             #[must_use]
-            fn with_hedged_metric(self, enabled: bool) -> Self;
+            pub fn with_hedged_metric(self, enabled: bool) -> Self;
             #[must_use]
-            fn with_request_charge_metric(self, enabled: bool) -> Self;
+            pub fn with_request_charge_metric(self, enabled: bool) -> Self;
             #[must_use]
-            fn with_returned_rows_metric(self, enabled: bool) -> Self;
+            pub fn with_returned_rows_metric(self, enabled: bool) -> Self;
         }
         pub mod attributes {
             pub const ATTR_CONNECTION_MODE: &str = attributes::CONNECTION_MODE;
@@ -703,11 +703,11 @@ pub mod error {
     #[repr(transparent)]
     pub struct CosmosError(/* private fields */);
     impl CosmosError {
-        fn diagnostics(&self) -> Option<Arc<DiagnosticsContext>>;
+        pub fn diagnostics(&self) -> Option<Arc<DiagnosticsContext>>;
         #[cfg(feature = "preview_patch")]
-        fn patch_tracking_id(&self) -> Option<PatchTrackingId>;
-        fn response(&self) -> Option<&CosmosResponse>;
-        fn status(&self) -> CosmosStatus;
+        pub fn patch_tracking_id(&self) -> Option<PatchTrackingId>;
+        pub fn response(&self) -> Option<&CosmosResponse>;
+        pub fn status(&self) -> CosmosStatus;
     }
     impl Debug for CosmosError {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -743,9 +743,9 @@ pub mod fault_injection {
     }
     #[doc(inline)]
     impl CustomResponse {
-        fn body(&self) -> &[u8];
-        fn headers(&self) -> &Headers;
-        fn status_code(&self) -> StatusCode;
+        pub fn body(&self) -> &[u8];
+        pub fn headers(&self) -> &Headers;
+        pub fn status_code(&self) -> StatusCode;
     }
     #[doc(inline)]
     #[non_exhaustive]
@@ -753,11 +753,11 @@ pub mod fault_injection {
     }
     #[doc(inline)]
     impl CustomResponseBuilder {
-        fn build(self) -> CustomResponse;
-        fn new(status_code: StatusCode) -> Self;
-        fn with_body<impl Into<Vec<u8>>: Into<Vec<u8>>>(self, body: impl Into<Vec<u8>>) -> Self;
-        fn with_header<impl Into<HeaderName>: Into<HeaderName>, impl Into<HeaderValue>: Into<HeaderValue>>(self, name: impl Into<HeaderName>, value: impl Into<HeaderValue>) -> Self;
-        fn with_sub_status(self, code: u16) -> Self;
+        pub fn build(self) -> CustomResponse;
+        pub fn new(status_code: StatusCode) -> Self;
+        pub fn with_body<impl Into<Vec<u8>>: Into<Vec<u8>>>(self, body: impl Into<Vec<u8>>) -> Self;
+        pub fn with_header<impl Into<HeaderName>: Into<HeaderName>, impl Into<HeaderValue>: Into<HeaderValue>>(self, name: impl Into<HeaderName>, value: impl Into<HeaderValue>) -> Self;
+        pub fn with_sub_status(self, code: u16) -> Self;
     }
     #[doc(inline)]
     #[derive(Clone, Debug, Default)]
@@ -766,10 +766,10 @@ pub mod fault_injection {
     }
     #[doc(inline)]
     impl FaultInjectionCondition {
-        fn container_id(&self) -> Option<&str>;
-        fn operation_type(&self) -> Option<FaultOperationType>;
-        fn region(&self) -> Option<&Region>;
-        fn transport_kind(&self) -> Option<TransportKind>;
+        pub fn container_id(&self) -> Option<&str>;
+        pub fn operation_type(&self) -> Option<FaultOperationType>;
+        pub fn region(&self) -> Option<&Region>;
+        pub fn transport_kind(&self) -> Option<TransportKind>;
     }
     #[doc(inline)]
     #[derive(Default)]
@@ -778,12 +778,12 @@ pub mod fault_injection {
     }
     #[doc(inline)]
     impl FaultInjectionConditionBuilder {
-        fn build(self) -> FaultInjectionCondition;
-        fn new() -> Self;
-        fn with_container_id<impl Into<String>: Into<String>>(self, container_id: impl Into<String>) -> Self;
-        fn with_operation_type(self, operation_type: FaultOperationType) -> Self;
-        fn with_region(self, region: Region) -> Self;
-        fn with_transport_kind(self, transport_kind: TransportKind) -> Self;
+        pub fn build(self) -> FaultInjectionCondition;
+        pub fn new() -> Self;
+        pub fn with_container_id<impl Into<String>: Into<String>>(self, container_id: impl Into<String>) -> Self;
+        pub fn with_operation_type(self, operation_type: FaultOperationType) -> Self;
+        pub fn with_region(self, region: Region) -> Self;
+        pub fn with_transport_kind(self, transport_kind: TransportKind) -> Self;
     }
     #[doc(inline)]
     #[derive(Clone, Debug)]
@@ -792,10 +792,10 @@ pub mod fault_injection {
     }
     #[doc(inline)]
     impl FaultInjectionResult {
-        fn custom_response(&self) -> Option<&CustomResponse>;
-        fn delay(&self) -> Option<Duration>;
-        fn error_type(&self) -> Option<FaultInjectionErrorType>;
-        fn probability(&self) -> f32;
+        pub fn custom_response(&self) -> Option<&CustomResponse>;
+        pub fn delay(&self) -> Option<Duration>;
+        pub fn error_type(&self) -> Option<FaultInjectionErrorType>;
+        pub fn probability(&self) -> f32;
     }
     #[doc(inline)]
     #[non_exhaustive]
@@ -803,12 +803,12 @@ pub mod fault_injection {
     }
     #[doc(inline)]
     impl FaultInjectionResultBuilder {
-        fn build(self) -> FaultInjectionResult;
-        fn new() -> Self;
-        fn with_custom_response(self, response: CustomResponse) -> Self;
-        fn with_delay(self, delay: Duration) -> Self;
-        fn with_error(self, error_type: FaultInjectionErrorType) -> Self;
-        fn with_probability(self, probability: f32) -> Self;
+        pub fn build(self) -> FaultInjectionResult;
+        pub fn new() -> Self;
+        pub fn with_custom_response(self, response: CustomResponse) -> Self;
+        pub fn with_delay(self, delay: Duration) -> Self;
+        pub fn with_error(self, error_type: FaultInjectionErrorType) -> Self;
+        pub fn with_probability(self, probability: f32) -> Self;
     }
     #[doc(inline)]
     impl Default for FaultInjectionResultBuilder {
@@ -821,16 +821,16 @@ pub mod fault_injection {
     }
     #[doc(inline)]
     impl FaultInjectionRule {
-        fn condition(&self) -> &FaultInjectionCondition;
-        fn disable(&self);
-        fn enable(&self);
-        fn end_time(&self) -> Option<Instant>;
-        fn hit_count(&self) -> u32;
-        fn hit_limit(&self) -> Option<u32>;
-        fn id(&self) -> &str;
-        fn is_enabled(&self) -> bool;
-        fn result(&self) -> &FaultInjectionResult;
-        fn start_time(&self) -> Option<Instant>;
+        pub fn condition(&self) -> &FaultInjectionCondition;
+        pub fn disable(&self);
+        pub fn enable(&self);
+        pub fn end_time(&self) -> Option<Instant>;
+        pub fn hit_count(&self) -> u32;
+        pub fn hit_limit(&self) -> Option<u32>;
+        pub fn id(&self) -> &str;
+        pub fn is_enabled(&self) -> bool;
+        pub fn result(&self) -> &FaultInjectionResult;
+        pub fn start_time(&self) -> Option<Instant>;
     }
     #[doc(inline)]
     #[non_exhaustive]
@@ -838,14 +838,14 @@ pub mod fault_injection {
     }
     #[doc(inline)]
     impl FaultInjectionRuleBuilder {
-        fn build(self) -> FaultInjectionRule;
-        fn new<impl Into<String>: Into<String>>(id: impl Into<String>, result: FaultInjectionResult) -> Self;
-        fn with_condition(self, condition: FaultInjectionCondition) -> Self;
-        fn with_end_time(self, end_time: Instant) -> Self;
-        fn with_hit_limit(self, hit_limit: u32) -> Self;
-        fn with_result(self, result: FaultInjectionResult) -> Self;
-        fn with_shared_state(self, enabled: Arc<AtomicBool>, hit_count: Arc<AtomicU32>) -> Self;
-        fn with_start_time(self, start_time: Instant) -> Self;
+        pub fn build(self) -> FaultInjectionRule;
+        pub fn new<impl Into<String>: Into<String>>(id: impl Into<String>, result: FaultInjectionResult) -> Self;
+        pub fn with_condition(self, condition: FaultInjectionCondition) -> Self;
+        pub fn with_end_time(self, end_time: Instant) -> Self;
+        pub fn with_hit_limit(self, hit_limit: u32) -> Self;
+        pub fn with_result(self, result: FaultInjectionResult) -> Self;
+        pub fn with_shared_state(self, enabled: Arc<AtomicBool>, hit_count: Arc<AtomicU32>) -> Self;
+        pub fn with_start_time(self, start_time: Instant) -> Self;
     }
     #[doc(inline)]
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -893,8 +893,8 @@ pub mod fault_injection {
     }
     #[doc(inline)]
     impl FaultOperationType {
-        fn as_str(&self) -> &'static str;
-        fn from_operation_and_resource(operation_type: &OperationType, resource_type: &ResourceType) -> Option<Self>;
+        pub fn as_str(&self) -> &'static str;
+        pub fn from_operation_and_resource(operation_type: &OperationType, resource_type: &ResourceType) -> Option<Self>;
     }
     #[doc(inline)]
     impl Display for FaultOperationType {
@@ -914,9 +914,9 @@ pub mod fault_injection {
         GatewayV2,
     }
     impl TransportKind {
-        fn as_str(self) -> &'static str;
-        fn is_gateway(self) -> bool;
-        fn is_gateway_v2(self) -> bool;
+        pub fn as_str(self) -> &'static str;
+        pub fn is_gateway(self) -> bool;
+        pub fn is_gateway_v2(self) -> bool;
     }
     impl AsRef<str> for TransportKind {
         fn as_ref(&self) -> &str;
@@ -930,7 +930,7 @@ pub mod feed {
     pub struct ChangeFeedPageIterator<T: Send> {
     }
     impl<T: Send + DeserializeOwned + 'static> ChangeFeedPageIterator<T> {
-        fn to_continuation_token(&self) -> crate::Result<ContinuationToken>;
+        pub fn to_continuation_token(&self) -> crate::Result<ContinuationToken>;
     }
     impl<T: Send + DeserializeOwned + 'static> Stream for ChangeFeedPageIterator<T> {
         type Item = Result<FeedPage<T>, CosmosError>;
@@ -941,8 +941,8 @@ pub mod feed {
     pub struct ContinuationToken(/* private fields */);
     #[doc(inline)]
     impl ContinuationToken {
-        fn as_str(&self) -> &str;
-        fn from_string(token: String) -> Self;
+        pub fn as_str(&self) -> &str;
+        pub fn from_string(token: String) -> Self;
     }
     #[doc(inline)]
     impl Serialize for ContinuationToken {
@@ -956,24 +956,24 @@ pub mod feed {
     pub struct FeedPage<T> {
     }
     impl<T> FeedPage<T> {
-        fn diagnostics(&self) -> Arc<DiagnosticsContext>;
-        fn headers(&self) -> &ResponseHeaders;
-        fn into_items(self) -> Vec<T>;
-        fn items(&self) -> &[T];
+        pub fn diagnostics(&self) -> Arc<DiagnosticsContext>;
+        pub fn headers(&self) -> &ResponseHeaders;
+        pub fn into_items(self) -> Vec<T>;
+        pub fn items(&self) -> &[T];
     }
     #[doc(inline)]
     #[derive(Clone, Debug, Eq, Hash, PartialEq)]
     pub struct FeedRange(/* private fields */);
     #[doc(inline)]
     impl FeedRange {
-        fn for_partition(partition_key: PartitionKey, definition: &PartitionKeyDefinition) -> Self;
-        fn full() -> Self;
-        fn is_logical_partition(&self) -> bool;
-        fn is_subset_of(&self, other: &FeedRange) -> bool;
-        fn max_exclusive(&self) -> &EffectivePartitionKey;
-        fn min_inclusive(&self) -> &EffectivePartitionKey;
-        fn new(min_inclusive: EffectivePartitionKey, max_exclusive: EffectivePartitionKey) -> crate::error::Result<Self>;
-        fn overlaps(&self, other: &FeedRange) -> bool;
+        pub fn for_partition(partition_key: PartitionKey, definition: &PartitionKeyDefinition) -> Self;
+        pub fn full() -> Self;
+        pub fn is_logical_partition(&self) -> bool;
+        pub fn is_subset_of(&self, other: &FeedRange) -> bool;
+        pub fn max_exclusive(&self) -> &EffectivePartitionKey;
+        pub fn min_inclusive(&self) -> &EffectivePartitionKey;
+        pub fn new(min_inclusive: EffectivePartitionKey, max_exclusive: EffectivePartitionKey) -> crate::error::Result<Self>;
+        pub fn overlaps(&self, other: &FeedRange) -> bool;
     }
     #[doc(inline)]
     impl Display for FeedRange {
@@ -1001,9 +1001,9 @@ pub mod feed {
     pub struct Query {
     }
     impl Query {
-        fn append_text(self, text: &str) -> Self;
-        fn with_parameter<impl Into<String>: Into<String>, impl Serialize: Serialize>(self, name: impl Into<String>, value: impl Serialize) -> crate::Result<Self>;
-        fn with_text<impl Into<String>: Into<String>>(self, text: impl Into<String>) -> Self;
+        pub fn append_text(self, text: &str) -> Self;
+        pub fn with_parameter<impl Into<String>: Into<String>, impl Serialize: Serialize>(self, name: impl Into<String>, value: impl Serialize) -> crate::Result<Self>;
+        pub fn with_text<impl Into<String>: Into<String>>(self, text: impl Into<String>) -> Self;
     }
     impl<T: Into<String>> From<T> for Query {
         fn from(value: T) -> Self;
@@ -1012,19 +1012,19 @@ pub mod feed {
     pub struct QueryFeedPage<T> {
     }
     impl<T> QueryFeedPage<T> {
-        fn as_feed_page(&self) -> &FeedPage<T>;
-        fn diagnostics(&self) -> Arc<DiagnosticsContext>;
-        fn headers(&self) -> &ResponseHeaders;
-        fn index_metrics(&self) -> Option<&str>;
-        fn into_items(self) -> Vec<T>;
-        fn items(&self) -> &[T];
-        fn query_metrics(&self) -> Option<&str>;
+        pub fn as_feed_page(&self) -> &FeedPage<T>;
+        pub fn diagnostics(&self) -> Arc<DiagnosticsContext>;
+        pub fn headers(&self) -> &ResponseHeaders;
+        pub fn index_metrics(&self) -> Option<&str>;
+        pub fn into_items(self) -> Vec<T>;
+        pub fn items(&self) -> &[T];
+        pub fn query_metrics(&self) -> Option<&str>;
     }
     #[pin_project]
     pub struct QueryItemIterator<T: Send> {
     }
     impl<T: Send + DeserializeOwned + 'static> QueryItemIterator<T> {
-        fn into_pages(self) -> QueryPageIterator<T>;
+        pub fn into_pages(self) -> QueryPageIterator<T>;
     }
     impl<T: Send + DeserializeOwned + 'static> Stream for QueryItemIterator<T> {
         type Item = Result<T, CosmosError>;
@@ -1034,7 +1034,7 @@ pub mod feed {
     pub struct QueryPageIterator<T: Send> {
     }
     impl<T: Send + DeserializeOwned + 'static> QueryPageIterator<T> {
-        fn to_continuation_token(&self) -> crate::Result<ContinuationToken>;
+        pub fn to_continuation_token(&self) -> crate::Result<ContinuationToken>;
     }
     impl<T: Send + DeserializeOwned + 'static> Stream for QueryPageIterator<T> {
         type Item = Result<QueryFeedPage<T>, CosmosError>;
@@ -1047,9 +1047,9 @@ pub mod feed {
         Range(azure_data_cosmos_driver::models::FeedRange),
     }
     impl FeedScope {
-        fn full_container() -> Self;
-        fn partition<impl Into<PartitionKey>: Into<PartitionKey>>(pk: impl Into<PartitionKey>) -> Self;
-        fn range<impl Into<FeedRange>: Into<FeedRange>>(fr: impl Into<FeedRange>) -> Self;
+        pub fn full_container() -> Self;
+        pub fn partition<impl Into<PartitionKey>: Into<PartitionKey>>(pk: impl Into<PartitionKey>) -> Self;
+        pub fn range<impl Into<FeedRange>: Into<FeedRange>>(fr: impl Into<FeedRange>) -> Self;
     }
 }
 pub mod models {
@@ -1058,21 +1058,21 @@ pub mod models {
     pub struct BatchResponse {
     }
     impl BatchResponse {
-        fn diagnostics(&self) -> Arc<DiagnosticsContext>;
-        fn headers(&self) -> &ResponseHeaders;
-        fn into_body(self) -> ResponseBody;
-        fn into_model(self) -> crate::Result<TransactionalBatchResponse>;
-        fn status(&self) -> CosmosStatus;
+        pub fn diagnostics(&self) -> Arc<DiagnosticsContext>;
+        pub fn headers(&self) -> &ResponseHeaders;
+        pub fn into_body(self) -> ResponseBody;
+        pub fn into_model(self) -> crate::Result<TransactionalBatchResponse>;
+        pub fn status(&self) -> CosmosStatus;
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct ChangeFeedItem<T> {
     }
     impl<T> ChangeFeedItem<T> {
-        fn current(&self) -> Option<&T>;
-        fn metadata(&self) -> Option<&ChangeFeedMetadata>;
-        fn operation_type(&self) -> Option<ChangeFeedOperationType>;
-        fn previous(&self) -> Option<&T>;
+        pub fn current(&self) -> Option<&T>;
+        pub fn metadata(&self) -> Option<&ChangeFeedMetadata>;
+        pub fn operation_type(&self) -> Option<ChangeFeedOperationType>;
+        pub fn previous(&self) -> Option<&T>;
     }
     impl<'de, T> Deserialize<'de> for ChangeFeedItem<T> where T: DeserializeOwned {
         fn deserialize<D>(deserializer: D) -> Result<Self, <D as >::Error> where D: Deserializer<'de>;
@@ -1082,21 +1082,21 @@ pub mod models {
     pub struct ChangeFeedMetadata {
     }
     impl ChangeFeedMetadata {
-        fn conflict_resolution_timestamp(&self) -> Option<Duration>;
-        fn id(&self) -> Option<&str>;
-        fn lsn(&self) -> Option<LogicalSequenceNumber>;
-        fn operation_type(&self) -> Option<ChangeFeedOperationType>;
-        fn partition_key(&self) -> Option<&serde_json::Value>;
-        fn previous_image_lsn(&self) -> Option<LogicalSequenceNumber>;
-        fn time_to_live_expired(&self) -> Option<bool>;
+        pub fn conflict_resolution_timestamp(&self) -> Option<Duration>;
+        pub fn id(&self) -> Option<&str>;
+        pub fn lsn(&self) -> Option<LogicalSequenceNumber>;
+        pub fn operation_type(&self) -> Option<ChangeFeedOperationType>;
+        pub fn partition_key(&self) -> Option<&serde_json::Value>;
+        pub fn previous_image_lsn(&self) -> Option<LogicalSequenceNumber>;
+        pub fn time_to_live_expired(&self) -> Option<bool>;
     }
     #[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[non_exhaustive]
     pub struct ChangeFeedPolicy {
     }
     impl ChangeFeedPolicy {
-        fn retention_duration(&self) -> Option<Duration>;
-        fn with_retention_duration(self, retention: Duration) -> Self;
+        pub fn retention_duration(&self) -> Option<Duration>;
+        pub fn with_retention_duration(self, retention: Duration) -> Self;
     }
     #[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[non_exhaustive]
@@ -1105,7 +1105,7 @@ pub mod models {
         pub properties: Vec<CompositeIndexProperty>,
     }
     impl CompositeIndex {
-        fn with_property(self, property: CompositeIndexProperty) -> Self;
+        pub fn with_property(self, property: CompositeIndexProperty) -> Self;
     }
     #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[non_exhaustive]
@@ -1115,9 +1115,9 @@ pub mod models {
         pub order: CompositeIndexOrder,
     }
     impl CompositeIndexProperty {
-        fn new<impl Into<String>: Into<String>>(path: impl Into<String>, order: CompositeIndexOrder) -> Self;
-        fn with_order(self, order: CompositeIndexOrder) -> Self;
-        fn with_path<impl Into<String>: Into<String>>(self, path: impl Into<String>) -> Self;
+        pub fn new<impl Into<String>: Into<String>>(path: impl Into<String>, order: CompositeIndexOrder) -> Self;
+        pub fn with_order(self, order: CompositeIndexOrder) -> Self;
+        pub fn with_path<impl Into<String>: Into<String>>(self, path: impl Into<String>) -> Self;
     }
     #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[non_exhaustive]
@@ -1130,9 +1130,9 @@ pub mod models {
         pub resolution_procedure: String,
     }
     impl ConflictResolutionPolicy {
-        fn new(mode: ConflictResolutionMode) -> Self;
-        fn with_resolution_path<impl Into<String>: Into<String>>(self, resolution_path: impl Into<String>) -> Self;
-        fn with_resolution_procedure<impl Into<String>: Into<String>>(self, resolution_procedure: impl Into<String>) -> Self;
+        pub fn new(mode: ConflictResolutionMode) -> Self;
+        pub fn with_resolution_path<impl Into<String>: Into<String>>(self, resolution_path: impl Into<String>) -> Self;
+        pub fn with_resolution_procedure<impl Into<String>: Into<String>>(self, resolution_procedure: impl Into<String>) -> Self;
     }
     #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[non_exhaustive]
@@ -1162,15 +1162,15 @@ pub mod models {
         pub system_properties: crate::models::SystemProperties,
     }
     impl ContainerProperties {
-        fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(id: impl Into<Cow<'static, str>>, partition_key: PartitionKeyDefinition) -> Self;
-        fn with_analytical_storage_ttl<impl Into<TimeToLive>: Into<TimeToLive>>(self, analytical_storage_ttl: impl Into<TimeToLive>) -> Self;
-        fn with_change_feed_policy(self, change_feed_policy: ChangeFeedPolicy) -> Self;
-        fn with_conflict_resolution_policy(self, conflict_resolution_policy: ConflictResolutionPolicy) -> Self;
-        fn with_default_ttl<impl Into<TimeToLive>: Into<TimeToLive>>(self, default_ttl: impl Into<TimeToLive>) -> Self;
-        fn with_full_text_policy(self, full_text_policy: FullTextPolicy) -> Self;
-        fn with_indexing_policy(self, indexing_policy: IndexingPolicy) -> Self;
-        fn with_unique_key_policy(self, unique_key_policy: UniqueKeyPolicy) -> Self;
-        fn with_vector_embedding_policy(self, vector_embedding_policy: VectorEmbeddingPolicy) -> Self;
+        pub fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(id: impl Into<Cow<'static, str>>, partition_key: PartitionKeyDefinition) -> Self;
+        pub fn with_analytical_storage_ttl<impl Into<TimeToLive>: Into<TimeToLive>>(self, analytical_storage_ttl: impl Into<TimeToLive>) -> Self;
+        pub fn with_change_feed_policy(self, change_feed_policy: ChangeFeedPolicy) -> Self;
+        pub fn with_conflict_resolution_policy(self, conflict_resolution_policy: ConflictResolutionPolicy) -> Self;
+        pub fn with_default_ttl<impl Into<TimeToLive>: Into<TimeToLive>>(self, default_ttl: impl Into<TimeToLive>) -> Self;
+        pub fn with_full_text_policy(self, full_text_policy: FullTextPolicy) -> Self;
+        pub fn with_indexing_policy(self, indexing_policy: IndexingPolicy) -> Self;
+        pub fn with_unique_key_policy(self, unique_key_policy: UniqueKeyPolicy) -> Self;
+        pub fn with_vector_embedding_policy(self, vector_embedding_policy: VectorEmbeddingPolicy) -> Self;
     }
     #[doc(inline)]
     #[derive(Clone, Debug)]
@@ -1178,16 +1178,16 @@ pub mod models {
     pub struct ContainerReference(/* private fields */);
     #[doc(inline)]
     impl ContainerReference {
-        fn account(&self) -> &AccountReference;
-        fn base_path(&self) -> &str;
-        fn database_name(&self) -> Option<&str>;
-        fn database_rid(&self) -> &str;
-        fn is_by_rid(&self) -> bool;
-        fn name(&self) -> &str;
-        fn name_based_path(&self) -> Option<&str>;
-        fn partition_key_definition(&self) -> &crate::models::PartitionKeyDefinition;
-        fn rid(&self) -> &str;
-        fn rid_based_path(&self) -> &str;
+        pub fn account(&self) -> &AccountReference;
+        pub fn base_path(&self) -> &str;
+        pub fn database_name(&self) -> Option<&str>;
+        pub fn database_rid(&self) -> &str;
+        pub fn is_by_rid(&self) -> bool;
+        pub fn name(&self) -> &str;
+        pub fn name_based_path(&self) -> Option<&str>;
+        pub fn partition_key_definition(&self) -> &crate::models::PartitionKeyDefinition;
+        pub fn rid(&self) -> &str;
+        pub fn rid_based_path(&self) -> &str;
     }
     #[doc(inline)]
     impl Eq for ContainerReference {
@@ -1292,29 +1292,29 @@ pub mod models {
         const TRANSPORT_HTTP2_INCOMPATIBLE: CosmosStatus = _;
         const TRANSPORT_IO_FAILED: CosmosStatus = _;
         const WRITE_FORBIDDEN: CosmosStatus = _;
-        fn is_bad_request(&self) -> bool;
-        fn is_conflict(&self) -> bool;
-        fn is_database_account_not_found(&self) -> bool;
-        fn is_forbidden(&self) -> bool;
-        fn is_gone(&self) -> bool;
-        fn is_not_found(&self) -> bool;
-        fn is_partition_key_range_gone(&self) -> bool;
-        fn is_precondition_failed(&self) -> bool;
-        fn is_read_session_not_available(&self) -> bool;
-        fn is_retry_with(&self) -> bool;
-        fn is_service_unavailable(&self) -> bool;
-        fn is_success(&self) -> bool;
-        fn is_throttled(&self) -> bool;
-        fn is_timeout(&self) -> bool;
-        fn is_transient(&self) -> bool;
-        fn is_transport_generated_503(&self) -> bool;
-        fn is_unauthorized(&self) -> bool;
-        fn is_write_forbidden(&self) -> bool;
-        fn name(&self) -> Option<&'static str>;
-        fn new(status_code: StatusCode) -> Self;
-        fn status_code(&self) -> StatusCode;
-        fn sub_status(&self) -> Option<SubStatusCode>;
-        fn with_sub_status(self, sub_status_code: u16) -> Self;
+        pub fn is_bad_request(&self) -> bool;
+        pub fn is_conflict(&self) -> bool;
+        pub fn is_database_account_not_found(&self) -> bool;
+        pub fn is_forbidden(&self) -> bool;
+        pub fn is_gone(&self) -> bool;
+        pub fn is_not_found(&self) -> bool;
+        pub fn is_partition_key_range_gone(&self) -> bool;
+        pub fn is_precondition_failed(&self) -> bool;
+        pub fn is_read_session_not_available(&self) -> bool;
+        pub fn is_retry_with(&self) -> bool;
+        pub fn is_service_unavailable(&self) -> bool;
+        pub fn is_success(&self) -> bool;
+        pub fn is_throttled(&self) -> bool;
+        pub fn is_timeout(&self) -> bool;
+        pub fn is_transient(&self) -> bool;
+        pub fn is_transport_generated_503(&self) -> bool;
+        pub fn is_unauthorized(&self) -> bool;
+        pub fn is_write_forbidden(&self) -> bool;
+        pub fn name(&self) -> Option<&'static str>;
+        pub fn new(status_code: StatusCode) -> Self;
+        pub fn status_code(&self) -> StatusCode;
+        pub fn sub_status(&self) -> Option<SubStatusCode>;
+        pub fn with_sub_status(self, sub_status_code: u16) -> Self;
     }
     #[doc(inline)]
     impl Debug for CosmosStatus {
@@ -1361,7 +1361,7 @@ pub mod models {
     impl EffectivePartitionKey {
         const MAX: Self = _;
         const MIN: Self = _;
-        fn to_hex(&self) -> String;
+        pub fn to_hex(&self) -> String;
     }
     #[doc(inline)]
     impl Display for EffectivePartitionKey {
@@ -1414,8 +1414,8 @@ pub mod models {
         pub path: String,
     }
     impl FullTextIndex {
-        fn new<impl Into<String>: Into<String>>(path: impl Into<String>) -> Self;
-        fn with_path<impl Into<String>: Into<String>>(self, path: impl Into<String>) -> Self;
+        pub fn new<impl Into<String>: Into<String>>(path: impl Into<String>) -> Self;
+        pub fn with_path<impl Into<String>: Into<String>>(self, path: impl Into<String>) -> Self;
     }
     impl<T: Into<String>> From<T> for FullTextIndex {
         fn from(value: T) -> Self;
@@ -1430,9 +1430,9 @@ pub mod models {
         pub language: Option<String>,
     }
     impl FullTextPath {
-        fn new<impl Into<String>: Into<String>>(path: impl Into<String>) -> Self;
-        fn with_language<impl Into<String>: Into<String>>(self, language: impl Into<String>) -> Self;
-        fn with_path<impl Into<String>: Into<String>>(self, path: impl Into<String>) -> Self;
+        pub fn new<impl Into<String>: Into<String>>(path: impl Into<String>) -> Self;
+        pub fn with_language<impl Into<String>: Into<String>>(self, language: impl Into<String>) -> Self;
+        pub fn with_path<impl Into<String>: Into<String>>(self, path: impl Into<String>) -> Self;
     }
     impl<T: Into<String>> From<T> for FullTextPath {
         fn from(value: T) -> Self;
@@ -1449,9 +1449,9 @@ pub mod models {
         pub full_text_paths: Vec<FullTextPath>,
     }
     impl FullTextPolicy {
-        fn new<impl Into<String>: Into<String>>(default_language: impl Into<String>) -> Self;
-        fn with_default_language<impl Into<String>: Into<String>>(self, default_language: impl Into<String>) -> Self;
-        fn with_full_text_path<impl Into<FullTextPath>: Into<FullTextPath>>(self, full_text_path: impl Into<FullTextPath>) -> Self;
+        pub fn new<impl Into<String>: Into<String>>(default_language: impl Into<String>) -> Self;
+        pub fn with_default_language<impl Into<String>: Into<String>>(self, default_language: impl Into<String>) -> Self;
+        pub fn with_full_text_path<impl Into<FullTextPath>: Into<FullTextPath>>(self, full_text_path: impl Into<FullTextPath>) -> Self;
     }
     #[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[non_exhaustive]
@@ -1482,32 +1482,32 @@ pub mod models {
         pub full_text_indexes: Vec<FullTextIndex>,
     }
     impl IndexingPolicy {
-        fn with_composite_index(self, composite_index: CompositeIndex) -> Self;
-        fn with_excluded_path<impl Into<PropertyPath>: Into<PropertyPath>>(self, excluded_path: impl Into<PropertyPath>) -> Self;
-        fn with_full_text_index<impl Into<FullTextIndex>: Into<FullTextIndex>>(self, full_text_index: impl Into<FullTextIndex>) -> Self;
-        fn with_included_path<impl Into<PropertyPath>: Into<PropertyPath>>(self, included_path: impl Into<PropertyPath>) -> Self;
-        fn with_indexing_mode(self, indexing_mode: IndexingMode) -> Self;
-        fn with_spatial_index(self, spatial_index: SpatialIndex) -> Self;
-        fn with_vector_index(self, vector_index: VectorIndex) -> Self;
+        pub fn with_composite_index(self, composite_index: CompositeIndex) -> Self;
+        pub fn with_excluded_path<impl Into<PropertyPath>: Into<PropertyPath>>(self, excluded_path: impl Into<PropertyPath>) -> Self;
+        pub fn with_full_text_index<impl Into<FullTextIndex>: Into<FullTextIndex>>(self, full_text_index: impl Into<FullTextIndex>) -> Self;
+        pub fn with_included_path<impl Into<PropertyPath>: Into<PropertyPath>>(self, included_path: impl Into<PropertyPath>) -> Self;
+        pub fn with_indexing_mode(self, indexing_mode: IndexingMode) -> Self;
+        pub fn with_spatial_index(self, spatial_index: SpatialIndex) -> Self;
+        pub fn with_vector_index(self, vector_index: VectorIndex) -> Self;
     }
     #[derive(Debug)]
     #[non_exhaustive]
     pub struct ItemResponse {
     }
     impl ItemResponse {
-        fn diagnostics(&self) -> Arc<DiagnosticsContext>;
-        fn headers(&self) -> &ResponseHeaders;
-        fn into_body(self) -> ResponseBody;
-        fn into_model<T: DeserializeOwned>(self) -> crate::Result<T>;
+        pub fn diagnostics(&self) -> Arc<DiagnosticsContext>;
+        pub fn headers(&self) -> &ResponseHeaders;
+        pub fn into_body(self) -> ResponseBody;
+        pub fn into_model<T: DeserializeOwned>(self) -> crate::Result<T>;
         #[cfg(feature = "preview_patch")]
-        fn patch_tracking_id(&self) -> Option<PatchTrackingId>;
-        fn status(&self) -> CosmosStatus;
+        pub fn patch_tracking_id(&self) -> Option<PatchTrackingId>;
+        pub fn status(&self) -> CosmosStatus;
     }
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde::Deserialize)]
     #[serde(transparent)]
     pub struct LogicalSequenceNumber(/* private fields */);
     impl LogicalSequenceNumber {
-        fn value(&self) -> i64;
+        pub fn value(&self) -> i64;
     }
     impl From<LogicalSequenceNumber> for i64 {
         fn from(value: LogicalSequenceNumber) -> Self;
@@ -1523,9 +1523,9 @@ pub mod models {
     impl PartitionKey {
         const NULL: PartitionKeyValue = PartitionKeyValue::NULL;
         const UNDEFINED: PartitionKeyValue = PartitionKeyValue::UNDEFINED;
-        fn is_empty(&self) -> bool;
-        fn len(&self) -> usize;
-        fn values(&self) -> &[PartitionKeyValue];
+        pub fn is_empty(&self) -> bool;
+        pub fn len(&self) -> usize;
+        pub fn values(&self) -> &[PartitionKeyValue];
     }
     #[doc(inline)]
     impl AsHeaders for PartitionKey {
@@ -1557,13 +1557,13 @@ pub mod models {
     }
     #[doc(inline)]
     impl PartitionKeyDefinition {
-        fn is_complete(&self, pk: &PartitionKey) -> bool;
-        fn kind(&self) -> PartitionKeyKind;
-        fn new(paths: Vec<Cow<'static, str>>) -> Self;
-        fn paths(&self) -> &[Cow<'static, str>];
-        fn version(&self) -> PartitionKeyVersion;
-        fn with_kind(self, kind: PartitionKeyKind) -> Self;
-        fn with_version(self, version: PartitionKeyVersion) -> Self;
+        pub fn is_complete(&self, pk: &PartitionKey) -> bool;
+        pub fn kind(&self) -> PartitionKeyKind;
+        pub fn new(paths: Vec<Cow<'static, str>>) -> Self;
+        pub fn paths(&self) -> &[Cow<'static, str>];
+        pub fn version(&self) -> PartitionKeyVersion;
+        pub fn with_kind(self, kind: PartitionKeyKind) -> Self;
+        pub fn with_version(self, version: PartitionKeyVersion) -> Self;
     }
     #[doc(inline)]
     impl From<&str> for PartitionKeyDefinition {
@@ -1675,9 +1675,9 @@ pub mod models {
     }
     #[doc(inline)]
     impl PatchInstructions {
-        fn is_retry_safe(&self) -> bool;
-        fn new() -> Self;
-        fn with_operation(self, operation: PatchOperation) -> Self;
+        pub fn is_retry_safe(&self) -> bool;
+        pub fn new() -> Self;
+        pub fn with_operation(self, operation: PatchOperation) -> Self;
     }
     #[doc(inline)]
     impl From<Vec<PatchOperation>> for PatchInstructions {
@@ -1688,8 +1688,8 @@ pub mod models {
     pub struct PatchTrackingId(/* private fields */);
     #[cfg(feature = "preview_patch")]
     impl PatchTrackingId {
-        fn as_uuid(&self) -> Uuid;
-        fn new() -> Self;
+        pub fn as_uuid(&self) -> Uuid;
+        pub fn new() -> Self;
     }
     #[cfg(feature = "preview_patch")]
     impl Default for PatchTrackingId {
@@ -1723,7 +1723,7 @@ pub mod models {
         pub path: String,
     }
     impl PropertyPath {
-        fn with_path<impl Into<String>: Into<String>>(self, path: impl Into<String>) -> Self;
+        pub fn with_path<impl Into<String>: Into<String>>(self, path: impl Into<String>) -> Self;
     }
     impl<T: Into<String>> From<T> for PropertyPath {
         fn from(value: T) -> Self;
@@ -1733,22 +1733,22 @@ pub mod models {
     pub struct ResourceResponse<T> {
     }
     impl<T: DeserializeOwned> ResourceResponse<T> {
-        fn into_model(self) -> crate::Result<T>;
+        pub fn into_model(self) -> crate::Result<T>;
     }
     impl<T> ResourceResponse<T> {
-        fn diagnostics(&self) -> Arc<DiagnosticsContext>;
-        fn headers(&self) -> &ResponseHeaders;
-        fn into_body(self) -> ResponseBody;
-        fn status(&self) -> CosmosStatus;
+        pub fn diagnostics(&self) -> Arc<DiagnosticsContext>;
+        pub fn headers(&self) -> &ResponseHeaders;
+        pub fn into_body(self) -> ResponseBody;
+        pub fn status(&self) -> CosmosStatus;
     }
     #[derive(Clone, Debug, Default)]
     #[non_exhaustive]
     pub struct ResponseBody(/* private fields */);
     impl ResponseBody {
-        fn into_single<T: DeserializeOwned>(self) -> crate::Result<T>;
-        fn is_empty(&self) -> bool;
-        fn items(self) -> crate::Result<Vec<Bytes>>;
-        fn single(self) -> crate::Result<Bytes>;
+        pub fn into_single<T: DeserializeOwned>(self) -> crate::Result<T>;
+        pub fn is_empty(&self) -> bool;
+        pub fn items(self) -> crate::Result<Vec<Bytes>>;
+        pub fn single(self) -> crate::Result<Bytes>;
     }
     impl From<ResponseBody> for ResponseBody {
         fn from(inner: DriverResponseBody) -> Self;
@@ -1757,32 +1757,32 @@ pub mod models {
     #[non_exhaustive]
     pub struct ResponseHeaders(/* private fields */);
     impl ResponseHeaders {
-        fn activity_id(&self) -> Option<&ActivityId>;
-        fn collection_index_transformation_progress(&self) -> Option<i64>;
-        fn collection_lazy_indexing_progress(&self) -> Option<i64>;
-        fn continuation(&self) -> Option<&str>;
-        fn correlated_activity_id(&self) -> Option<&str>;
-        fn etag(&self) -> Option<&Etag>;
-        fn gateway_version(&self) -> Option<&str>;
-        fn global_committed_lsn(&self) -> Option<i64>;
-        fn index_metrics(&self) -> Option<&str>;
-        fn internal_partition_id(&self) -> Option<&str>;
-        fn item_count(&self) -> Option<u32>;
-        fn item_local_lsn(&self) -> Option<u64>;
-        fn item_lsn(&self) -> Option<u64>;
-        fn local_lsn(&self) -> Option<u64>;
-        fn lsn(&self) -> Option<u64>;
-        fn offer_replace_pending(&self) -> Option<bool>;
-        fn partition_key_range_id(&self) -> Option<&str>;
-        fn query_metrics(&self) -> Option<&str>;
-        fn request_charge(&self) -> Option<&RequestCharge>;
-        fn resource_quota(&self) -> Option<&str>;
-        fn resource_usage(&self) -> Option<&str>;
-        fn retry_after_ms(&self) -> Option<u64>;
-        fn server_duration_ms(&self) -> Option<f64>;
-        fn session_token(&self) -> Option<&SessionToken>;
-        fn substatus(&self) -> Option<&SubStatusCode>;
-        fn transport_request_id(&self) -> Option<u32>;
+        pub fn activity_id(&self) -> Option<&ActivityId>;
+        pub fn collection_index_transformation_progress(&self) -> Option<i64>;
+        pub fn collection_lazy_indexing_progress(&self) -> Option<i64>;
+        pub fn continuation(&self) -> Option<&str>;
+        pub fn correlated_activity_id(&self) -> Option<&str>;
+        pub fn etag(&self) -> Option<&Etag>;
+        pub fn gateway_version(&self) -> Option<&str>;
+        pub fn global_committed_lsn(&self) -> Option<i64>;
+        pub fn index_metrics(&self) -> Option<&str>;
+        pub fn internal_partition_id(&self) -> Option<&str>;
+        pub fn item_count(&self) -> Option<u32>;
+        pub fn item_local_lsn(&self) -> Option<u64>;
+        pub fn item_lsn(&self) -> Option<u64>;
+        pub fn local_lsn(&self) -> Option<u64>;
+        pub fn lsn(&self) -> Option<u64>;
+        pub fn offer_replace_pending(&self) -> Option<bool>;
+        pub fn partition_key_range_id(&self) -> Option<&str>;
+        pub fn query_metrics(&self) -> Option<&str>;
+        pub fn request_charge(&self) -> Option<&RequestCharge>;
+        pub fn resource_quota(&self) -> Option<&str>;
+        pub fn resource_usage(&self) -> Option<&str>;
+        pub fn retry_after_ms(&self) -> Option<u64>;
+        pub fn server_duration_ms(&self) -> Option<f64>;
+        pub fn session_token(&self) -> Option<&SessionToken>;
+        pub fn substatus(&self) -> Option<&SubStatusCode>;
+        pub fn transport_request_id(&self) -> Option<u32>;
     }
     impl From<CosmosResponseHeaders> for ResponseHeaders {
         fn from(inner: DriverCosmosResponseHeaders) -> Self;
@@ -1795,8 +1795,8 @@ pub mod models {
         pub types: Vec<SpatialType>,
     }
     impl SpatialIndex {
-        fn new<impl Into<String>: Into<String>>(path: impl Into<String>) -> Self;
-        fn with_type(self, spatial_type: SpatialType) -> Self;
+        pub fn new<impl Into<String>: Into<String>>(path: impl Into<String>) -> Self;
+        pub fn with_type(self, spatial_type: SpatialType) -> Self;
     }
     #[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[non_exhaustive]
@@ -1826,23 +1826,23 @@ pub mod models {
     }
     #[cfg(feature = "control_plane")]
     impl ThroughputProperties {
-        fn autoscale(starting_maximum_throughput: usize, increment_percent: Option<usize>) -> ThroughputProperties;
-        fn autoscale_increment(&self) -> Option<usize>;
-        fn autoscale_maximum(&self) -> Option<usize>;
-        fn manual(throughput: usize) -> ThroughputProperties;
-        fn throughput(&self) -> Option<usize>;
+        pub fn autoscale(starting_maximum_throughput: usize, increment_percent: Option<usize>) -> ThroughputProperties;
+        pub fn autoscale_increment(&self) -> Option<usize>;
+        pub fn autoscale_maximum(&self) -> Option<usize>;
+        pub fn manual(throughput: usize) -> ThroughputProperties;
+        pub fn throughput(&self) -> Option<usize>;
     }
     #[derive(Clone, Debug)]
     pub struct TransactionalBatch {
     }
     impl TransactionalBatch {
-        fn create_item<T: Serialize>(self, item: T) -> crate::Result<Self>;
-        fn delete_item<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, item_id: impl Into<Cow<'static, str>>, options: Option<BatchDeleteOptions>) -> Self;
-        fn new<impl Into<PartitionKey>: Into<PartitionKey>>(partition_key: impl Into<PartitionKey>) -> Self;
-        fn partition_key(&self) -> &PartitionKey;
-        fn read_item<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, item_id: impl Into<Cow<'static, str>>, options: Option<BatchReadOptions>) -> Self;
-        fn replace_item<T: Serialize, impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, item_id: impl Into<Cow<'static, str>>, item: T, options: Option<BatchReplaceOptions>) -> crate::Result<Self>;
-        fn upsert_item<T: Serialize>(self, item: T, options: Option<BatchUpsertOptions>) -> crate::Result<Self>;
+        pub fn create_item<T: Serialize>(self, item: T) -> crate::Result<Self>;
+        pub fn delete_item<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, item_id: impl Into<Cow<'static, str>>, options: Option<BatchDeleteOptions>) -> Self;
+        pub fn new<impl Into<PartitionKey>: Into<PartitionKey>>(partition_key: impl Into<PartitionKey>) -> Self;
+        pub fn partition_key(&self) -> &PartitionKey;
+        pub fn read_item<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, item_id: impl Into<Cow<'static, str>>, options: Option<BatchReadOptions>) -> Self;
+        pub fn replace_item<T: Serialize, impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, item_id: impl Into<Cow<'static, str>>, item: T, options: Option<BatchReplaceOptions>) -> crate::Result<Self>;
+        pub fn upsert_item<T: Serialize>(self, item: T, options: Option<BatchUpsertOptions>) -> crate::Result<Self>;
     }
     #[derive(Clone, Debug, serde::Deserialize)]
     #[non_exhaustive]
@@ -1850,21 +1850,21 @@ pub mod models {
     pub struct TransactionalBatchOperationResult {
     }
     impl TransactionalBatchOperationResult {
-        fn etag(&self) -> Option<&str>;
-        fn into_model<T: serde::de::DeserializeOwned>(&self) -> crate::Result<Option<T>>;
-        fn is_success(&self) -> bool;
-        fn request_charge(&self) -> Option<f64>;
-        fn resource_body(&self) -> Option<&serde_json::value::RawValue>;
-        fn retry_after_milliseconds(&self) -> Option<u64>;
-        fn status_code(&self) -> u16;
-        fn substatus_code(&self) -> Option<u32>;
+        pub fn etag(&self) -> Option<&str>;
+        pub fn into_model<T: serde::de::DeserializeOwned>(&self) -> crate::Result<Option<T>>;
+        pub fn is_success(&self) -> bool;
+        pub fn request_charge(&self) -> Option<f64>;
+        pub fn resource_body(&self) -> Option<&serde_json::value::RawValue>;
+        pub fn retry_after_milliseconds(&self) -> Option<u64>;
+        pub fn status_code(&self) -> u16;
+        pub fn substatus_code(&self) -> Option<u32>;
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct TransactionalBatchResponse {
     }
     impl TransactionalBatchResponse {
-        fn results(&self) -> &[TransactionalBatchOperationResult];
+        pub fn results(&self) -> &[TransactionalBatchOperationResult];
     }
     impl<'de> Deserialize<'de> for TransactionalBatchResponse {
         fn deserialize<D>(deserializer: D) -> Result<Self, <D as >::Error> where D: serde::Deserializer<'de>;
@@ -1876,7 +1876,7 @@ pub mod models {
         pub paths: Vec<String>,
     }
     impl UniqueKey {
-        fn with_path<impl Into<String>: Into<String>>(self, path: impl Into<String>) -> Self;
+        pub fn with_path<impl Into<String>: Into<String>>(self, path: impl Into<String>) -> Self;
     }
     #[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[non_exhaustive]
@@ -1885,7 +1885,7 @@ pub mod models {
         pub unique_keys: Vec<UniqueKey>,
     }
     impl UniqueKeyPolicy {
-        fn with_unique_key(self, unique_key: UniqueKey) -> Self;
+        pub fn with_unique_key(self, unique_key: UniqueKey) -> Self;
     }
     #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[non_exhaustive]
@@ -1897,11 +1897,11 @@ pub mod models {
         pub distance_function: VectorDistanceFunction,
     }
     impl VectorEmbedding {
-        fn new<impl Into<String>: Into<String>>(path: impl Into<String>, data_type: VectorDataType, dimensions: u32, distance_function: VectorDistanceFunction) -> Self;
-        fn with_data_type(self, data_type: VectorDataType) -> Self;
-        fn with_dimensions(self, dimensions: u32) -> Self;
-        fn with_distance_function(self, distance_function: VectorDistanceFunction) -> Self;
-        fn with_path<impl Into<String>: Into<String>>(self, path: impl Into<String>) -> Self;
+        pub fn new<impl Into<String>: Into<String>>(path: impl Into<String>, data_type: VectorDataType, dimensions: u32, distance_function: VectorDistanceFunction) -> Self;
+        pub fn with_data_type(self, data_type: VectorDataType) -> Self;
+        pub fn with_dimensions(self, dimensions: u32) -> Self;
+        pub fn with_distance_function(self, distance_function: VectorDistanceFunction) -> Self;
+        pub fn with_path<impl Into<String>: Into<String>>(self, path: impl Into<String>) -> Self;
     }
     #[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[non_exhaustive]
@@ -1911,7 +1911,7 @@ pub mod models {
         pub embeddings: Vec<VectorEmbedding>,
     }
     impl VectorEmbeddingPolicy {
-        fn with_embedding(self, embedding: VectorEmbedding) -> Self;
+        pub fn with_embedding(self, embedding: VectorEmbedding) -> Self;
     }
     #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[non_exhaustive]
@@ -1934,13 +1934,13 @@ pub mod models {
         pub vector_index_shard_key: Vec<String>,
     }
     impl VectorIndex {
-        fn new<impl Into<String>: Into<String>>(path: impl Into<String>, index_type: VectorIndexType) -> Self;
-        fn with_index_type(self, index_type: VectorIndexType) -> Self;
-        fn with_indexing_search_list_size(self, indexing_search_list_size: u32) -> Self;
-        fn with_path<impl Into<String>: Into<String>>(self, path: impl Into<String>) -> Self;
-        fn with_quantization_byte_size(self, quantization_byte_size: u32) -> Self;
-        fn with_quantizer_type(self, quantizer_type: QuantizerType) -> Self;
-        fn with_shard_key_path<impl Into<String>: Into<String>>(self, path: impl Into<String>) -> Self;
+        pub fn new<impl Into<String>: Into<String>>(path: impl Into<String>, index_type: VectorIndexType) -> Self;
+        pub fn with_index_type(self, index_type: VectorIndexType) -> Self;
+        pub fn with_indexing_search_list_size(self, indexing_search_list_size: u32) -> Self;
+        pub fn with_path<impl Into<String>: Into<String>>(self, path: impl Into<String>) -> Self;
+        pub fn with_quantization_byte_size(self, quantization_byte_size: u32) -> Self;
+        pub fn with_quantizer_type(self, quantizer_type: QuantizerType) -> Self;
+        pub fn with_shard_key_path<impl Into<String>: Into<String>>(self, path: impl Into<String>) -> Self;
     }
     #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize)]
     #[non_exhaustive]
@@ -2015,7 +2015,7 @@ pub mod models {
     }
     #[doc(inline)]
     impl PartitionKeyVersion {
-        const fn value(self) -> u32;
+        pub const fn value(self) -> u32;
     }
     #[doc(inline)]
     impl From<PartitionKeyVersion> for u32 {
@@ -2041,13 +2041,13 @@ pub mod models {
     }
     #[doc(inline)]
     impl PatchOperation {
-        fn add<impl Into<String>: Into<String>>(path: impl Into<String>, value: Value) -> Self;
-        fn increment<impl Into<String>: Into<String>, impl Into<CosmosNumber>: Into<CosmosNumber>>(path: impl Into<String>, value: impl Into<CosmosNumber>) -> Self;
-        fn move_value<impl Into<String>: Into<String>, impl Into<String>: Into<String>>(from: impl Into<String>, path: impl Into<String>) -> Self;
-        fn path(&self) -> &str;
-        fn remove<impl Into<String>: Into<String>>(path: impl Into<String>) -> Self;
-        fn replace<impl Into<String>: Into<String>>(path: impl Into<String>, value: Value) -> Self;
-        fn set<impl Into<String>: Into<String>>(path: impl Into<String>, value: Value) -> Self;
+        pub fn add<impl Into<String>: Into<String>>(path: impl Into<String>, value: Value) -> Self;
+        pub fn increment<impl Into<String>: Into<String>, impl Into<CosmosNumber>: Into<CosmosNumber>>(path: impl Into<String>, value: impl Into<CosmosNumber>) -> Self;
+        pub fn move_value<impl Into<String>: Into<String>, impl Into<String>: Into<String>>(from: impl Into<String>, path: impl Into<String>) -> Self;
+        pub fn path(&self) -> &str;
+        pub fn remove<impl Into<String>: Into<String>>(path: impl Into<String>) -> Self;
+        pub fn replace<impl Into<String>: Into<String>>(path: impl Into<String>, value: Value) -> Self;
+        pub fn set<impl Into<String>: Into<String>>(path: impl Into<String>, value: Value) -> Self;
     }
     #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[non_exhaustive]
@@ -2074,7 +2074,7 @@ pub mod models {
         Seconds(u32),
     }
     impl TimeToLive {
-        fn is_forever(&self) -> bool;
+        pub fn is_forever(&self) -> bool;
     }
     impl From<u32> for TimeToLive {
         fn from(n: u32) -> Self;
@@ -2125,7 +2125,7 @@ pub mod options {
         pub precondition: Option<azure_data_cosmos_driver::models::Precondition>,
     }
     impl BatchDeleteOptions {
-        fn with_precondition(self, precondition: Precondition) -> Self;
+        pub fn with_precondition(self, precondition: Precondition) -> Self;
     }
     #[derive(Clone, Default)]
     #[non_exhaustive]
@@ -2134,8 +2134,8 @@ pub mod options {
         pub session_token: Option<azure_data_cosmos_driver::models::SessionToken>,
     }
     impl BatchOptions {
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
-        fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, session_token: impl Into<SessionToken>) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, session_token: impl Into<SessionToken>) -> Self;
     }
     #[derive(Clone, Debug, Default)]
     #[non_exhaustive]
@@ -2143,7 +2143,7 @@ pub mod options {
         pub precondition: Option<azure_data_cosmos_driver::models::Precondition>,
     }
     impl BatchReadOptions {
-        fn with_precondition(self, precondition: Precondition) -> Self;
+        pub fn with_precondition(self, precondition: Precondition) -> Self;
     }
     #[derive(Clone, Debug, Default)]
     #[non_exhaustive]
@@ -2151,7 +2151,7 @@ pub mod options {
         pub precondition: Option<azure_data_cosmos_driver::models::Precondition>,
     }
     impl BatchReplaceOptions {
-        fn with_precondition(self, precondition: Precondition) -> Self;
+        pub fn with_precondition(self, precondition: Precondition) -> Self;
     }
     #[derive(Clone, Debug, Default)]
     #[non_exhaustive]
@@ -2159,7 +2159,7 @@ pub mod options {
         pub precondition: Option<azure_data_cosmos_driver::models::Precondition>,
     }
     impl BatchUpsertOptions {
-        fn with_precondition(self, precondition: Precondition) -> Self;
+        pub fn with_precondition(self, precondition: Precondition) -> Self;
     }
     #[doc(inline)]
     #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2170,9 +2170,9 @@ pub mod options {
     }
     #[doc(inline)]
     impl BinaryEncodingOptions {
-        fn new() -> Self;
-        fn with_enabled(self, enabled: bool) -> Self;
-        fn with_request_text_response(self, request_text_response: bool) -> Self;
+        pub fn new() -> Self;
+        pub fn with_enabled(self, enabled: bool) -> Self;
+        pub fn with_request_text_response(self, request_text_response: bool) -> Self;
     }
     #[doc(inline)]
     impl Default for BinaryEncodingOptions {
@@ -2187,12 +2187,12 @@ pub mod options {
         pub mode: ChangeFeedMode,
     }
     impl ChangeFeedOptions {
-        fn with_continuation_token(self, token: ContinuationToken) -> Self;
-        fn with_feed_options(self, feed: FeedOptions) -> Self;
-        fn with_max_item_count(self, max_item_count: MaxItemCountHint) -> Self;
-        fn with_mode(self, mode: ChangeFeedMode) -> Self;
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
-        fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, token: impl Into<SessionToken>) -> Self;
+        pub fn with_continuation_token(self, token: ContinuationToken) -> Self;
+        pub fn with_feed_options(self, feed: FeedOptions) -> Self;
+        pub fn with_max_item_count(self, max_item_count: MaxItemCountHint) -> Self;
+        pub fn with_mode(self, mode: ChangeFeedMode) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, token: impl Into<SessionToken>) -> Self;
     }
     #[doc(inline)]
     #[derive(Clone, Debug)]
@@ -2201,35 +2201,35 @@ pub mod options {
     }
     #[doc(inline)]
     impl ConnectionPoolOptions {
-        fn builder() -> ConnectionPoolOptionsBuilder;
-        fn gateway_v2_disabled(&self) -> bool;
-        fn http2_consecutive_failure_threshold(&self) -> u32;
-        fn http2_eviction_grace_period(&self) -> Duration;
-        fn http2_fan_out_threshold_percent(&self) -> u8;
-        fn http2_health_check_interval(&self) -> Duration;
-        fn http2_keep_alive_interval(&self) -> Duration;
-        fn http2_keep_alive_timeout(&self) -> Duration;
-        fn idle_connection_timeout(&self) -> Option<Duration>;
-        fn idle_http2_client_timeout(&self) -> Duration;
-        fn is_http2_allowed(&self) -> bool;
-        fn local_address(&self) -> Option<IpAddr>;
-        fn max_connect_timeout(&self) -> Duration;
-        fn max_dataplane_request_timeout(&self) -> Duration;
-        fn max_http2_connections_per_endpoint(&self) -> usize;
-        fn max_http2_streams_per_client(&self) -> u32;
-        fn max_idle_connections_per_endpoint(&self) -> usize;
-        fn max_metadata_request_timeout(&self) -> Duration;
-        fn min_connect_timeout(&self) -> Duration;
-        fn min_dataplane_request_timeout(&self) -> Duration;
-        fn min_http2_connections_per_endpoint(&self) -> usize;
-        fn min_metadata_request_timeout(&self) -> Duration;
-        fn proxy_allowed(&self) -> bool;
-        fn server_certificate_validation(&self) -> ServerCertificateValidation;
-        fn tcp_keepalive_interval(&self) -> Option<Duration>;
-        fn tcp_keepalive_retries(&self) -> Option<u32>;
-        fn tcp_keepalive_time(&self) -> Option<Duration>;
+        pub fn builder() -> ConnectionPoolOptionsBuilder;
+        pub fn gateway_v2_disabled(&self) -> bool;
+        pub fn http2_consecutive_failure_threshold(&self) -> u32;
+        pub fn http2_eviction_grace_period(&self) -> Duration;
+        pub fn http2_fan_out_threshold_percent(&self) -> u8;
+        pub fn http2_health_check_interval(&self) -> Duration;
+        pub fn http2_keep_alive_interval(&self) -> Duration;
+        pub fn http2_keep_alive_timeout(&self) -> Duration;
+        pub fn idle_connection_timeout(&self) -> Option<Duration>;
+        pub fn idle_http2_client_timeout(&self) -> Duration;
+        pub fn is_http2_allowed(&self) -> bool;
+        pub fn local_address(&self) -> Option<IpAddr>;
+        pub fn max_connect_timeout(&self) -> Duration;
+        pub fn max_dataplane_request_timeout(&self) -> Duration;
+        pub fn max_http2_connections_per_endpoint(&self) -> usize;
+        pub fn max_http2_streams_per_client(&self) -> u32;
+        pub fn max_idle_connections_per_endpoint(&self) -> usize;
+        pub fn max_metadata_request_timeout(&self) -> Duration;
+        pub fn min_connect_timeout(&self) -> Duration;
+        pub fn min_dataplane_request_timeout(&self) -> Duration;
+        pub fn min_http2_connections_per_endpoint(&self) -> usize;
+        pub fn min_metadata_request_timeout(&self) -> Duration;
+        pub fn proxy_allowed(&self) -> bool;
+        pub fn server_certificate_validation(&self) -> ServerCertificateValidation;
+        pub fn tcp_keepalive_interval(&self) -> Option<Duration>;
+        pub fn tcp_keepalive_retries(&self) -> Option<u32>;
+        pub fn tcp_keepalive_time(&self) -> Option<Duration>;
         #[cfg(feature = "rustls")]
-        fn tls_backend(&self) -> TlsBackend;
+        pub fn tls_backend(&self) -> TlsBackend;
     }
     #[doc(inline)]
     impl Default for ConnectionPoolOptions {
@@ -2243,41 +2243,41 @@ pub mod options {
     #[doc(inline)]
     #[automatically_derived]
     impl ConnectionPoolOptionsBuilder {
-        fn from_env() -> Self;
-        fn from_env_override() -> Self;
+        pub fn from_env() -> Self;
+        pub fn from_env_override() -> Self;
     }
     #[doc(inline)]
     impl ConnectionPoolOptionsBuilder {
-        fn build(self) -> crate::error::Result<ConnectionPoolOptions>;
-        fn new() -> Self;
-        fn with_gateway_v2_disabled(self, value: bool) -> Self;
-        fn with_http2_consecutive_failure_threshold(self, value: u32) -> Self;
-        fn with_http2_eviction_grace_period(self, timeout: Duration) -> Self;
-        fn with_http2_fan_out_threshold_percent(self, value: u8) -> Self;
-        fn with_http2_health_check_interval(self, timeout: Duration) -> Self;
-        fn with_http2_keep_alive_interval(self, timeout: Duration) -> Self;
-        fn with_http2_keep_alive_timeout(self, timeout: Duration) -> Self;
-        fn with_idle_connection_timeout(self, timeout: Duration) -> Self;
-        fn with_idle_http2_client_timeout(self, timeout: Duration) -> Self;
-        fn with_is_http2_allowed(self, value: bool) -> Self;
-        fn with_local_address(self, addr: IpAddr) -> Self;
-        fn with_max_connect_timeout(self, timeout: Duration) -> Self;
-        fn with_max_dataplane_request_timeout(self, timeout: Duration) -> Self;
-        fn with_max_http2_connections_per_endpoint(self, value: usize) -> Self;
-        fn with_max_http2_streams_per_client(self, value: u32) -> Self;
-        fn with_max_idle_connections_per_endpoint(self, count: usize) -> Self;
-        fn with_max_metadata_request_timeout(self, timeout: Duration) -> Self;
-        fn with_min_connect_timeout(self, timeout: Duration) -> Self;
-        fn with_min_dataplane_request_timeout(self, timeout: Duration) -> Self;
-        fn with_min_http2_connections_per_endpoint(self, value: usize) -> Self;
-        fn with_min_metadata_request_timeout(self, timeout: Duration) -> Self;
-        fn with_proxy_allowed(self, value: bool) -> Self;
-        fn with_server_certificate_validation(self, value: ServerCertificateValidation) -> Self;
-        fn with_tcp_keepalive_interval(self, timeout: Duration) -> Self;
-        fn with_tcp_keepalive_retries(self, value: u32) -> Self;
-        fn with_tcp_keepalive_time(self, timeout: Duration) -> Self;
+        pub fn build(self) -> crate::error::Result<ConnectionPoolOptions>;
+        pub fn new() -> Self;
+        pub fn with_gateway_v2_disabled(self, value: bool) -> Self;
+        pub fn with_http2_consecutive_failure_threshold(self, value: u32) -> Self;
+        pub fn with_http2_eviction_grace_period(self, timeout: Duration) -> Self;
+        pub fn with_http2_fan_out_threshold_percent(self, value: u8) -> Self;
+        pub fn with_http2_health_check_interval(self, timeout: Duration) -> Self;
+        pub fn with_http2_keep_alive_interval(self, timeout: Duration) -> Self;
+        pub fn with_http2_keep_alive_timeout(self, timeout: Duration) -> Self;
+        pub fn with_idle_connection_timeout(self, timeout: Duration) -> Self;
+        pub fn with_idle_http2_client_timeout(self, timeout: Duration) -> Self;
+        pub fn with_is_http2_allowed(self, value: bool) -> Self;
+        pub fn with_local_address(self, addr: IpAddr) -> Self;
+        pub fn with_max_connect_timeout(self, timeout: Duration) -> Self;
+        pub fn with_max_dataplane_request_timeout(self, timeout: Duration) -> Self;
+        pub fn with_max_http2_connections_per_endpoint(self, value: usize) -> Self;
+        pub fn with_max_http2_streams_per_client(self, value: u32) -> Self;
+        pub fn with_max_idle_connections_per_endpoint(self, count: usize) -> Self;
+        pub fn with_max_metadata_request_timeout(self, timeout: Duration) -> Self;
+        pub fn with_min_connect_timeout(self, timeout: Duration) -> Self;
+        pub fn with_min_dataplane_request_timeout(self, timeout: Duration) -> Self;
+        pub fn with_min_http2_connections_per_endpoint(self, value: usize) -> Self;
+        pub fn with_min_metadata_request_timeout(self, timeout: Duration) -> Self;
+        pub fn with_proxy_allowed(self, value: bool) -> Self;
+        pub fn with_server_certificate_validation(self, value: ServerCertificateValidation) -> Self;
+        pub fn with_tcp_keepalive_interval(self, timeout: Duration) -> Self;
+        pub fn with_tcp_keepalive_retries(self, value: u32) -> Self;
+        pub fn with_tcp_keepalive_time(self, timeout: Duration) -> Self;
         #[cfg(feature = "rustls")]
-        fn with_tls_backend(self, value: TlsBackend) -> Self;
+        pub fn with_tls_backend(self, value: TlsBackend) -> Self;
     }
     #[derive(Clone, Default)]
     #[non_exhaustive]
@@ -2290,9 +2290,9 @@ pub mod options {
         pub operation: azure_data_cosmos_driver::options::OperationOptions,
     }
     impl CosmosClientOptions {
-        fn with_diagnostics_handler(self, handler: Arc<dyn DiagnosticsHandler>) -> Self;
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
-        fn with_user_agent_suffix(self, suffix: UserAgentSuffix) -> Self;
+        pub fn with_diagnostics_handler(self, handler: Arc<dyn DiagnosticsHandler>) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_user_agent_suffix(self, suffix: UserAgentSuffix) -> Self;
     }
     #[cfg(feature = "control_plane")]
     #[derive(Clone, Default)]
@@ -2302,8 +2302,8 @@ pub mod options {
     }
     #[cfg(feature = "control_plane")]
     impl CreateContainerOptions {
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
-        fn with_throughput(self, throughput: ThroughputProperties) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_throughput(self, throughput: ThroughputProperties) -> Self;
     }
     #[cfg(feature = "control_plane")]
     #[derive(Clone, Default)]
@@ -2313,7 +2313,7 @@ pub mod options {
     }
     #[cfg(feature = "control_plane")]
     impl CreateDatabaseOptions {
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
     }
     #[cfg(feature = "control_plane")]
     #[derive(Clone, Default)]
@@ -2323,7 +2323,7 @@ pub mod options {
     }
     #[cfg(feature = "control_plane")]
     impl DeleteContainerOptions {
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
     }
     #[cfg(feature = "control_plane")]
     #[derive(Clone, Default)]
@@ -2333,7 +2333,7 @@ pub mod options {
     }
     #[cfg(feature = "control_plane")]
     impl DeleteDatabaseOptions {
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
     }
     #[doc(inline)]
     #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2342,10 +2342,10 @@ pub mod options {
     }
     #[doc(inline)]
     impl DiagnosticsOptions {
-        fn builder() -> DiagnosticsOptionsBuilder;
-        fn default_verbosity(&self) -> DiagnosticsVerbosity;
-        fn max_request_diagnostics(&self) -> usize;
-        fn max_summary_size_bytes(&self) -> usize;
+        pub fn builder() -> DiagnosticsOptionsBuilder;
+        pub fn default_verbosity(&self) -> DiagnosticsVerbosity;
+        pub fn max_request_diagnostics(&self) -> usize;
+        pub fn max_summary_size_bytes(&self) -> usize;
     }
     #[doc(inline)]
     impl Default for DiagnosticsOptions {
@@ -2359,15 +2359,15 @@ pub mod options {
     #[doc(inline)]
     #[automatically_derived]
     impl DiagnosticsOptionsBuilder {
-        fn from_env() -> Self;
+        pub fn from_env() -> Self;
     }
     #[doc(inline)]
     impl DiagnosticsOptionsBuilder {
-        fn build(self) -> crate::error::Result<DiagnosticsOptions>;
-        fn new() -> Self;
-        fn with_default_verbosity(self, verbosity: DiagnosticsVerbosity) -> Self;
-        fn with_max_request_diagnostics(self, max: usize) -> Self;
-        fn with_max_summary_size_bytes(self, size: usize) -> Self;
+        pub fn build(self) -> crate::error::Result<DiagnosticsOptions>;
+        pub fn new() -> Self;
+        pub fn with_default_verbosity(self, verbosity: DiagnosticsVerbosity) -> Self;
+        pub fn with_max_request_diagnostics(self, max: usize) -> Self;
+        pub fn with_max_summary_size_bytes(self, size: usize) -> Self;
     }
     #[doc(inline)]
     #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2376,8 +2376,8 @@ pub mod options {
     }
     #[doc(inline)]
     impl EndToEndOperationLatencyPolicy {
-        fn new(timeout: Duration) -> Self;
-        fn timeout(&self) -> Duration;
+        pub fn new(timeout: Duration) -> Self;
+        pub fn timeout(&self) -> Duration;
     }
     #[doc(inline)]
     impl From<Duration> for EndToEndOperationLatencyPolicy {
@@ -2388,11 +2388,11 @@ pub mod options {
     pub struct ExcludedRegions(pub Vec<crate::options::Region>);
     #[doc(inline)]
     impl ExcludedRegions {
-        fn is_empty(&self) -> bool;
-        fn iter(&self) -> impl Iterator<Item = &Region>;
-        fn len(&self) -> usize;
-        fn new() -> Self;
-        fn with_region<impl Into<Region>: Into<Region>>(self, region: impl Into<Region>) -> Self;
+        pub fn is_empty(&self) -> bool;
+        pub fn iter(&self) -> impl Iterator<Item = &Region>;
+        pub fn len(&self) -> usize;
+        pub fn new() -> Self;
+        pub fn with_region<impl Into<Region>: Into<Region>>(self, region: impl Into<Region>) -> Self;
     }
     #[doc(inline)]
     impl<T: Into<crate::options::Region>> FromIterator<T> for ExcludedRegions {
@@ -2406,17 +2406,17 @@ pub mod options {
         pub max_fan_out: Option<u32>,
     }
     impl FeedOptions {
-        fn with_continuation_token(self, continuation_token: ContinuationToken) -> Self;
-        fn with_max_fan_out(self, max_fan_out: u32) -> Self;
-        fn with_max_item_count(self, max_item_count: MaxItemCountHint) -> Self;
+        pub fn with_continuation_token(self, continuation_token: ContinuationToken) -> Self;
+        pub fn with_max_fan_out(self, max_fan_out: u32) -> Self;
+        pub fn with_max_item_count(self, max_item_count: MaxItemCountHint) -> Self;
     }
     #[doc(inline)]
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     pub struct HedgeThreshold(/* private fields */);
     #[doc(inline)]
     impl HedgeThreshold {
-        const fn get(self) -> Duration;
-        const fn new(duration: Duration) -> Option<Self>;
+        pub const fn get(self) -> Duration;
+        pub const fn new(duration: Duration) -> Option<Self>;
     }
     #[doc(inline)]
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -2425,8 +2425,8 @@ pub mod options {
     }
     #[doc(inline)]
     impl HedgingStrategy {
-        const fn new(threshold: HedgeThreshold) -> Self;
-        const fn threshold(&self) -> HedgeThreshold;
+        pub const fn new(threshold: HedgeThreshold) -> Self;
+        pub const fn threshold(&self) -> HedgeThreshold;
     }
     #[derive(Clone, Default)]
     #[non_exhaustive]
@@ -2436,9 +2436,9 @@ pub mod options {
         pub precondition: Option<azure_data_cosmos_driver::models::Precondition>,
     }
     impl ItemReadOptions {
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
-        fn with_precondition(self, precondition: Precondition) -> Self;
-        fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, session_token: impl Into<SessionToken>) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_precondition(self, precondition: Precondition) -> Self;
+        pub fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, session_token: impl Into<SessionToken>) -> Self;
     }
     #[derive(Clone, Default)]
     #[non_exhaustive]
@@ -2448,9 +2448,9 @@ pub mod options {
         pub precondition: Option<azure_data_cosmos_driver::models::Precondition>,
     }
     impl ItemWriteOptions {
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
-        fn with_precondition(self, precondition: Precondition) -> Self;
-        fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, session_token: impl Into<SessionToken>) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_precondition(self, precondition: Precondition) -> Self;
+        pub fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, session_token: impl Into<SessionToken>) -> Self;
     }
     #[doc(inline)]
     #[derive(Clone, Debug, Default)]
@@ -2476,8 +2476,8 @@ pub mod options {
     #[doc(inline)]
     #[automatically_derived]
     impl OperationOptions {
-        fn from_env() -> Self;
-        fn from_env_override() -> Self;
+        pub fn from_env() -> Self;
+        pub fn from_env_override() -> Self;
     }
     #[doc(inline)]
     #[automatically_derived]
@@ -2487,24 +2487,24 @@ pub mod options {
     #[automatically_derived]
     impl OperationOptionsBuilder {
         #[must_use]
-        fn build(self) -> OperationOptions;
-        fn new() -> Self;
-        fn with_availability_strategy(self, value: AvailabilityStrategy) -> Self;
-        fn with_binary_encoding(self, value: BinaryEncodingOptions) -> Self;
-        fn with_content_response_on_write(self, value: ContentResponseOnWrite) -> Self;
-        fn with_custom_headers(self, value: HashMap<HeaderName, HeaderValue>) -> Self;
-        fn with_end_to_end_latency_policy(self, value: EndToEndOperationLatencyPolicy) -> Self;
-        fn with_endpoint_unavailability_ttl(self, value: Duration) -> Self;
-        fn with_excluded_regions(self, value: ExcludedRegions) -> Self;
-        fn with_hedging_enabled(self, value: bool) -> Self;
-        fn with_max_failover_retry_count(self, value: u32) -> Self;
-        fn with_max_session_retry_count(self, value: u32) -> Self;
-        fn with_patch_strategy(self, value: PatchStrategy) -> Self;
-        fn with_query_plan_mode(self, value: QueryPlanMode) -> Self;
-        fn with_read_consistency_strategy(self, value: ReadConsistencyStrategy) -> Self;
-        fn with_session_capturing_disabled(self, value: bool) -> Self;
-        fn with_throttling_retry_options(self, value: ThrottlingRetryOptions) -> Self;
-        fn with_throughput_control(self, value: ThroughputControlOptions) -> Self;
+        pub fn build(self) -> OperationOptions;
+        pub fn new() -> Self;
+        pub fn with_availability_strategy(self, value: AvailabilityStrategy) -> Self;
+        pub fn with_binary_encoding(self, value: BinaryEncodingOptions) -> Self;
+        pub fn with_content_response_on_write(self, value: ContentResponseOnWrite) -> Self;
+        pub fn with_custom_headers(self, value: HashMap<HeaderName, HeaderValue>) -> Self;
+        pub fn with_end_to_end_latency_policy(self, value: EndToEndOperationLatencyPolicy) -> Self;
+        pub fn with_endpoint_unavailability_ttl(self, value: Duration) -> Self;
+        pub fn with_excluded_regions(self, value: ExcludedRegions) -> Self;
+        pub fn with_hedging_enabled(self, value: bool) -> Self;
+        pub fn with_max_failover_retry_count(self, value: u32) -> Self;
+        pub fn with_max_session_retry_count(self, value: u32) -> Self;
+        pub fn with_patch_strategy(self, value: PatchStrategy) -> Self;
+        pub fn with_query_plan_mode(self, value: QueryPlanMode) -> Self;
+        pub fn with_read_consistency_strategy(self, value: ReadConsistencyStrategy) -> Self;
+        pub fn with_session_capturing_disabled(self, value: bool) -> Self;
+        pub fn with_throttling_retry_options(self, value: ThrottlingRetryOptions) -> Self;
+        pub fn with_throughput_control(self, value: ThroughputControlOptions) -> Self;
     }
     #[doc(inline)]
     #[automatically_derived]
@@ -2513,24 +2513,24 @@ pub mod options {
     #[doc(inline)]
     #[automatically_derived]
     impl<'a> OperationOptionsView<'a> {
-        fn availability_strategy(&self) -> Option<&AvailabilityStrategy>;
-        fn binary_encoding(&self) -> Option<&BinaryEncodingOptions>;
-        fn content_response_on_write(&self) -> Option<&ContentResponseOnWrite>;
-        fn custom_headers(&self) -> Option<&HashMap<HeaderName, HeaderValue>>;
-        fn end_to_end_latency_policy(&self) -> Option<&EndToEndOperationLatencyPolicy>;
-        fn endpoint_unavailability_ttl(&self) -> Option<&Duration>;
-        fn excluded_regions(&self) -> Option<&ExcludedRegions>;
-        fn hedging_enabled(&self) -> Option<&bool>;
-        fn max_failover_retry_count(&self) -> Option<&u32>;
-        fn max_session_retry_count(&self) -> Option<&u32>;
-        fn new(env: Option<::std::sync::Arc<OperationOptions>>, runtime: Option<::std::sync::Arc<OperationOptions>>, account: Option<::std::sync::Arc<OperationOptions>>, operation: Option<&'a OperationOptions>) -> Self;
-        fn new_with_override(env_override: Option<::std::sync::Arc<OperationOptions>>, env: Option<::std::sync::Arc<OperationOptions>>, runtime: Option<::std::sync::Arc<OperationOptions>>, account: Option<::std::sync::Arc<OperationOptions>>, operation: Option<&'a OperationOptions>) -> Self;
-        fn patch_strategy(&self) -> Option<&PatchStrategy>;
-        fn query_plan_mode(&self) -> Option<&QueryPlanMode>;
-        fn read_consistency_strategy(&self) -> Option<&ReadConsistencyStrategy>;
-        fn session_capturing_disabled(&self) -> Option<&bool>;
-        fn throttling_retry_options(&self) -> ThrottlingRetryOptionsView<'_>;
-        fn throughput_control(&self) -> ThroughputControlOptionsView<'_>;
+        pub fn availability_strategy(&self) -> Option<&AvailabilityStrategy>;
+        pub fn binary_encoding(&self) -> Option<&BinaryEncodingOptions>;
+        pub fn content_response_on_write(&self) -> Option<&ContentResponseOnWrite>;
+        pub fn custom_headers(&self) -> Option<&HashMap<HeaderName, HeaderValue>>;
+        pub fn end_to_end_latency_policy(&self) -> Option<&EndToEndOperationLatencyPolicy>;
+        pub fn endpoint_unavailability_ttl(&self) -> Option<&Duration>;
+        pub fn excluded_regions(&self) -> Option<&ExcludedRegions>;
+        pub fn hedging_enabled(&self) -> Option<&bool>;
+        pub fn max_failover_retry_count(&self) -> Option<&u32>;
+        pub fn max_session_retry_count(&self) -> Option<&u32>;
+        pub fn new(env: Option<::std::sync::Arc<OperationOptions>>, runtime: Option<::std::sync::Arc<OperationOptions>>, account: Option<::std::sync::Arc<OperationOptions>>, operation: Option<&'a OperationOptions>) -> Self;
+        pub fn new_with_override(env_override: Option<::std::sync::Arc<OperationOptions>>, env: Option<::std::sync::Arc<OperationOptions>>, runtime: Option<::std::sync::Arc<OperationOptions>>, account: Option<::std::sync::Arc<OperationOptions>>, operation: Option<&'a OperationOptions>) -> Self;
+        pub fn patch_strategy(&self) -> Option<&PatchStrategy>;
+        pub fn query_plan_mode(&self) -> Option<&QueryPlanMode>;
+        pub fn read_consistency_strategy(&self) -> Option<&ReadConsistencyStrategy>;
+        pub fn session_capturing_disabled(&self) -> Option<&bool>;
+        pub fn throttling_retry_options(&self) -> ThrottlingRetryOptionsView<'_>;
+        pub fn throughput_control(&self) -> ThroughputControlOptionsView<'_>;
     }
     #[doc(inline)]
     #[derive(Clone, Debug)]
@@ -2539,14 +2539,14 @@ pub mod options {
     }
     #[doc(inline)]
     impl PartitionFailoverOptions {
-        fn builder() -> PartitionFailoverOptionsBuilder;
-        fn circuit_breaker_enabled(&self) -> bool;
-        fn consecutive_hedge_win_threshold(&self) -> u32;
-        fn counter_reset_window(&self) -> Duration;
-        fn failback_sweep_interval(&self) -> Duration;
-        fn partition_unavailability_duration(&self) -> Duration;
-        fn read_failure_threshold(&self) -> u32;
-        fn write_failure_threshold(&self) -> u32;
+        pub fn builder() -> PartitionFailoverOptionsBuilder;
+        pub fn circuit_breaker_enabled(&self) -> bool;
+        pub fn consecutive_hedge_win_threshold(&self) -> u32;
+        pub fn counter_reset_window(&self) -> Duration;
+        pub fn failback_sweep_interval(&self) -> Duration;
+        pub fn partition_unavailability_duration(&self) -> Duration;
+        pub fn read_failure_threshold(&self) -> u32;
+        pub fn write_failure_threshold(&self) -> u32;
     }
     #[doc(inline)]
     impl Default for PartitionFailoverOptions {
@@ -2559,15 +2559,15 @@ pub mod options {
     }
     #[doc(inline)]
     impl PartitionFailoverOptionsBuilder {
-        fn build(self) -> crate::error::Result<PartitionFailoverOptions>;
-        fn new() -> Self;
-        fn with_circuit_breaker_enabled(self, value: bool) -> Self;
-        fn with_consecutive_hedge_win_threshold(self, value: u32) -> Self;
-        fn with_counter_reset_window(self, value: Duration) -> Self;
-        fn with_failback_sweep_interval(self, value: Duration) -> Self;
-        fn with_partition_unavailability_duration(self, value: Duration) -> Self;
-        fn with_read_failure_threshold(self, value: u32) -> Self;
-        fn with_write_failure_threshold(self, value: u32) -> Self;
+        pub fn build(self) -> crate::error::Result<PartitionFailoverOptions>;
+        pub fn new() -> Self;
+        pub fn with_circuit_breaker_enabled(self, value: bool) -> Self;
+        pub fn with_consecutive_hedge_win_threshold(self, value: u32) -> Self;
+        pub fn with_counter_reset_window(self, value: Duration) -> Self;
+        pub fn with_failback_sweep_interval(self, value: Duration) -> Self;
+        pub fn with_partition_unavailability_duration(self, value: Duration) -> Self;
+        pub fn with_read_failure_threshold(self, value: u32) -> Self;
+        pub fn with_write_failure_threshold(self, value: u32) -> Self;
     }
     #[cfg(feature = "preview_patch")]
     #[derive(Clone, Default)]
@@ -2584,14 +2584,14 @@ pub mod options {
     }
     #[cfg(feature = "preview_patch")]
     impl PatchItemOptions {
-        fn with_max_attempts(self, max_attempts: std::num::NonZeroU8) -> Self;
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
-        fn with_precondition(self, precondition: Precondition) -> Self;
-        fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, session_token: impl Into<SessionToken>) -> Self;
-        fn with_strategy(self, strategy: PatchStrategy) -> Self;
-        fn with_tracking_capacity(self, capacity: std::num::NonZeroU16) -> Self;
-        fn with_tracking_id(self, tracking_id: PatchTrackingId) -> Self;
-        fn with_tracking_retention_seconds(self, retention_seconds: std::num::NonZeroU32) -> Self;
+        pub fn with_max_attempts(self, max_attempts: std::num::NonZeroU8) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_precondition(self, precondition: Precondition) -> Self;
+        pub fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, session_token: impl Into<SessionToken>) -> Self;
+        pub fn with_strategy(self, strategy: PatchStrategy) -> Self;
+        pub fn with_tracking_capacity(self, capacity: std::num::NonZeroU16) -> Self;
+        pub fn with_tracking_id(self, tracking_id: PatchTrackingId) -> Self;
+        pub fn with_tracking_retention_seconds(self, retention_seconds: std::num::NonZeroU32) -> Self;
     }
     #[cfg(feature = "control_plane")]
     #[derive(Clone, Default)]
@@ -2601,7 +2601,7 @@ pub mod options {
     }
     #[cfg(feature = "control_plane")]
     impl QueryContainersOptions {
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
     }
     #[cfg(feature = "control_plane")]
     #[derive(Clone, Default)]
@@ -2611,7 +2611,7 @@ pub mod options {
     }
     #[cfg(feature = "control_plane")]
     impl QueryDatabasesOptions {
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
     }
     #[derive(Clone, Default)]
     #[non_exhaustive]
@@ -2623,13 +2623,13 @@ pub mod options {
         pub populate_query_metrics: Option<bool>,
     }
     impl QueryOptions {
-        fn with_continuation_token(self, continuation_token: ContinuationToken) -> Self;
-        fn with_feed_options(self, feed: FeedOptions) -> Self;
-        fn with_max_item_count(self, max_item_count: MaxItemCountHint) -> Self;
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
-        fn with_populate_index_metrics(self, enable: bool) -> Self;
-        fn with_populate_query_metrics(self, enable: bool) -> Self;
-        fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, session_token: impl Into<SessionToken>) -> Self;
+        pub fn with_continuation_token(self, continuation_token: ContinuationToken) -> Self;
+        pub fn with_feed_options(self, feed: FeedOptions) -> Self;
+        pub fn with_max_item_count(self, max_item_count: MaxItemCountHint) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_populate_index_metrics(self, enable: bool) -> Self;
+        pub fn with_populate_query_metrics(self, enable: bool) -> Self;
+        pub fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, session_token: impl Into<SessionToken>) -> Self;
     }
     #[derive(Clone, Default)]
     #[non_exhaustive]
@@ -2637,7 +2637,7 @@ pub mod options {
         pub operation: azure_data_cosmos_driver::options::OperationOptions,
     }
     impl ReadContainerOptions {
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
     }
     #[cfg(feature = "control_plane")]
     #[derive(Clone, Default)]
@@ -2647,7 +2647,7 @@ pub mod options {
     }
     #[cfg(feature = "control_plane")]
     impl ReadDatabaseOptions {
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
     }
     #[derive(Clone, Debug, Default)]
     #[non_exhaustive]
@@ -2655,8 +2655,8 @@ pub mod options {
         pub operation: azure_data_cosmos_driver::options::OperationOptions,
     }
     impl ReadFeedRangesOptions {
-        fn with_force_refresh(self, force_refresh: bool) -> Self;
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_force_refresh(self, force_refresh: bool) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
     }
     #[doc(inline)]
     #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde::Serialize)]
@@ -2778,9 +2778,9 @@ pub mod options {
         const WEST_US: Region = _;
         const WEST_US_2: Region = _;
         const WEST_US_3: Region = _;
-        fn as_str(&self) -> &str;
-        fn display_name(&self) -> &str;
-        fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(name: impl Into<Cow<'static, str>>) -> Self;
+        pub fn as_str(&self) -> &str;
+        pub fn display_name(&self) -> &str;
+        pub fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(name: impl Into<Cow<'static, str>>) -> Self;
     }
     #[doc(inline)]
     impl AsRef<str> for Region {
@@ -2810,16 +2810,16 @@ pub mod options {
     }
     #[cfg(feature = "control_plane")]
     impl ReplaceContainerOptions {
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
     }
     #[doc(inline)]
     #[derive(Clone, Debug, Eq, Hash, PartialEq)]
     pub struct SessionToken(pub std::borrow::Cow<'static, str>);
     #[doc(inline)]
     impl SessionToken {
-        fn as_str(&self) -> &str;
-        fn merge(&self, other: &Self) -> crate::error::Result<Self>;
-        fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(value: impl Into<Cow<'static, str>>) -> Self;
+        pub fn as_str(&self) -> &str;
+        pub fn merge(&self, other: &Self) -> crate::error::Result<Self>;
+        pub fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(value: impl Into<Cow<'static, str>>) -> Self;
     }
     #[doc(inline)]
     impl AsRef<str> for SessionToken {
@@ -2843,7 +2843,7 @@ pub mod options {
     #[doc(inline)]
     #[automatically_derived]
     impl ThrottlingRetryOptions {
-        fn from_env() -> Self;
+        pub fn from_env() -> Self;
     }
     #[doc(inline)]
     #[automatically_derived]
@@ -2853,10 +2853,10 @@ pub mod options {
     #[automatically_derived]
     impl ThrottlingRetryOptionsBuilder {
         #[must_use]
-        fn build(self) -> ThrottlingRetryOptions;
-        fn new() -> Self;
-        fn with_max_retry_count(self, value: u32) -> Self;
-        fn with_max_retry_wait_time(self, value: Duration) -> Self;
+        pub fn build(self) -> ThrottlingRetryOptions;
+        pub fn new() -> Self;
+        pub fn with_max_retry_count(self, value: u32) -> Self;
+        pub fn with_max_retry_wait_time(self, value: Duration) -> Self;
     }
     #[doc(inline)]
     #[automatically_derived]
@@ -2865,17 +2865,17 @@ pub mod options {
     #[doc(inline)]
     #[automatically_derived]
     impl<'a> ThrottlingRetryOptionsView<'a> {
-        fn max_retry_count(&self) -> Option<&u32>;
-        fn max_retry_wait_time(&self) -> Option<&Duration>;
-        fn new(env: Option<::std::sync::Arc<ThrottlingRetryOptions>>, runtime: Option<::std::sync::Arc<ThrottlingRetryOptions>>, account: Option<::std::sync::Arc<ThrottlingRetryOptions>>, operation: Option<&'a ThrottlingRetryOptions>) -> Self;
+        pub fn max_retry_count(&self) -> Option<&u32>;
+        pub fn max_retry_wait_time(&self) -> Option<&Duration>;
+        pub fn new(env: Option<::std::sync::Arc<ThrottlingRetryOptions>>, runtime: Option<::std::sync::Arc<ThrottlingRetryOptions>>, account: Option<::std::sync::Arc<ThrottlingRetryOptions>>, operation: Option<&'a ThrottlingRetryOptions>) -> Self;
     }
     #[doc(inline)]
     #[derive(Clone, Debug, Eq, Hash, PartialEq)]
     pub struct ThroughputControlGroupName(pub std::borrow::Cow<'static, str>);
     #[doc(inline)]
     impl ThroughputControlGroupName {
-        fn as_str(&self) -> &str;
-        fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(name: impl Into<Cow<'static, str>>) -> Self;
+        pub fn as_str(&self) -> &str;
+        pub fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(name: impl Into<Cow<'static, str>>) -> Self;
     }
     #[doc(inline)]
     impl AsRef<str> for ThroughputControlGroupName {
@@ -2904,16 +2904,16 @@ pub mod options {
     }
     #[doc(inline)]
     impl ThroughputControlGroupOptions {
-        fn container(&self) -> &ContainerReference;
-        fn is_default(&self) -> bool;
-        fn name(&self) -> &ThroughputControlGroupName;
-        fn new<impl Into<ThroughputControlGroupName>: Into<ThroughputControlGroupName>>(name: impl Into<ThroughputControlGroupName>, container: ContainerReference, is_default: bool) -> Self;
-        fn priority_level(&self) -> Option<PriorityLevel>;
-        fn set_priority_level(&self, level: PriorityLevel);
-        fn set_throughput_bucket(&self, bucket: u32);
-        fn throughput_bucket(&self) -> Option<u32>;
-        fn with_priority_level(self, level: PriorityLevel) -> Self;
-        fn with_throughput_bucket(self, bucket: u32) -> Self;
+        pub fn container(&self) -> &ContainerReference;
+        pub fn is_default(&self) -> bool;
+        pub fn name(&self) -> &ThroughputControlGroupName;
+        pub fn new<impl Into<ThroughputControlGroupName>: Into<ThroughputControlGroupName>>(name: impl Into<ThroughputControlGroupName>, container: ContainerReference, is_default: bool) -> Self;
+        pub fn priority_level(&self) -> Option<PriorityLevel>;
+        pub fn set_priority_level(&self, level: PriorityLevel);
+        pub fn set_throughput_bucket(&self, bucket: u32);
+        pub fn throughput_bucket(&self) -> Option<u32>;
+        pub fn with_priority_level(self, level: PriorityLevel) -> Self;
+        pub fn with_throughput_bucket(self, bucket: u32) -> Self;
     }
     #[doc(inline)]
     #[derive(Clone, Debug, Default)]
@@ -2931,11 +2931,11 @@ pub mod options {
     #[automatically_derived]
     impl ThroughputControlOptionsBuilder {
         #[must_use]
-        fn build(self) -> ThroughputControlOptions;
-        fn new() -> Self;
-        fn with_group_name(self, value: ThroughputControlGroupName) -> Self;
-        fn with_priority_level(self, value: PriorityLevel) -> Self;
-        fn with_throughput_bucket(self, value: u32) -> Self;
+        pub fn build(self) -> ThroughputControlOptions;
+        pub fn new() -> Self;
+        pub fn with_group_name(self, value: ThroughputControlGroupName) -> Self;
+        pub fn with_priority_level(self, value: PriorityLevel) -> Self;
+        pub fn with_throughput_bucket(self, value: u32) -> Self;
     }
     #[doc(inline)]
     #[automatically_derived]
@@ -2944,10 +2944,10 @@ pub mod options {
     #[doc(inline)]
     #[automatically_derived]
     impl<'a> ThroughputControlOptionsView<'a> {
-        fn group_name(&self) -> Option<&ThroughputControlGroupName>;
-        fn new(env: Option<::std::sync::Arc<ThroughputControlOptions>>, runtime: Option<::std::sync::Arc<ThroughputControlOptions>>, account: Option<::std::sync::Arc<ThroughputControlOptions>>, operation: Option<&'a ThroughputControlOptions>) -> Self;
-        fn priority_level(&self) -> Option<&PriorityLevel>;
-        fn throughput_bucket(&self) -> Option<&u32>;
+        pub fn group_name(&self) -> Option<&ThroughputControlGroupName>;
+        pub fn new(env: Option<::std::sync::Arc<ThroughputControlOptions>>, runtime: Option<::std::sync::Arc<ThroughputControlOptions>>, account: Option<::std::sync::Arc<ThroughputControlOptions>>, operation: Option<&'a ThroughputControlOptions>) -> Self;
+        pub fn priority_level(&self) -> Option<&PriorityLevel>;
+        pub fn throughput_bucket(&self) -> Option<&u32>;
     }
     #[cfg(feature = "control_plane")]
     #[derive(Clone, Default)]
@@ -2957,7 +2957,7 @@ pub mod options {
     }
     #[cfg(feature = "control_plane")]
     impl ThroughputOptions {
-        fn with_operation_options(self, operation: OperationOptions) -> Self;
+        pub fn with_operation_options(self, operation: OperationOptions) -> Self;
     }
     #[doc(inline)]
     #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2965,9 +2965,9 @@ pub mod options {
     #[doc(inline)]
     impl UserAgentSuffix {
         const MAX_LENGTH: usize = 25;
-        fn as_str(&self) -> &str;
-        fn new<impl Into<String>: Into<String>>(value: impl Into<String>) -> Self;
-        fn try_new<impl Into<String>: Into<String>>(value: impl Into<String>) -> Option<Self>;
+        pub fn as_str(&self) -> &str;
+        pub fn new<impl Into<String>: Into<String>>(value: impl Into<String>) -> Self;
+        pub fn try_new<impl Into<String>: Into<String>>(value: impl Into<String>) -> Option<Self>;
     }
     #[doc(inline)]
     impl AsRef<str> for UserAgentSuffix {
@@ -3045,7 +3045,7 @@ pub mod options {
     }
     #[doc(inline)]
     impl DiagnosticsVerbosity {
-        fn as_str(&self) -> &'static str;
+        pub fn as_str(&self) -> &'static str;
     }
     #[doc(inline)]
     impl AsRef<str> for DiagnosticsVerbosity {
@@ -3080,7 +3080,7 @@ pub mod options {
     #[cfg(feature = "preview_patch")]
     #[doc(inline)]
     impl PatchStrategy {
-        fn as_str(&self) -> &'static str;
+        pub fn as_str(&self) -> &'static str;
     }
     #[cfg(feature = "preview_patch")]
     #[doc(inline)]
@@ -3102,12 +3102,12 @@ pub mod options {
     }
     #[doc(inline)]
     impl Precondition {
-        fn as_if_match(&self) -> Option<&Etag>;
-        fn as_if_none_match(&self) -> Option<&Etag>;
-        fn if_match<impl Into<Etag>: Into<Etag>>(etag: impl Into<Etag>) -> Self;
-        fn if_none_match<impl Into<Etag>: Into<Etag>>(etag: impl Into<Etag>) -> Self;
-        fn is_if_match(&self) -> bool;
-        fn is_if_none_match(&self) -> bool;
+        pub fn as_if_match(&self) -> Option<&Etag>;
+        pub fn as_if_none_match(&self) -> Option<&Etag>;
+        pub fn if_match<impl Into<Etag>: Into<Etag>>(etag: impl Into<Etag>) -> Self;
+        pub fn if_none_match<impl Into<Etag>: Into<Etag>>(etag: impl Into<Etag>) -> Self;
+        pub fn is_if_match(&self) -> bool;
+        pub fn is_if_none_match(&self) -> bool;
     }
     #[doc(inline)]
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
@@ -3119,7 +3119,7 @@ pub mod options {
     }
     #[doc(inline)]
     impl PriorityLevel {
-        fn as_str(&self) -> &'static str;
+        pub fn as_str(&self) -> &'static str;
     }
     #[doc(inline)]
     impl Display for PriorityLevel {
@@ -3140,7 +3140,7 @@ pub mod options {
     }
     #[doc(inline)]
     impl QueryPlanMode {
-        fn as_str(self) -> &'static str;
+        pub fn as_str(self) -> &'static str;
     }
     #[doc(inline)]
     impl Display for QueryPlanMode {
@@ -3163,7 +3163,7 @@ pub mod options {
     }
     #[doc(inline)]
     impl ReadConsistencyStrategy {
-        fn as_str(&self) -> &'static str;
+        pub fn as_str(&self) -> &'static str;
     }
     #[doc(inline)]
     impl Display for ReadConsistencyStrategy {

--- a/sdk/cosmos/azure_data_cosmos/api/API.metadata.yml
+++ b/sdk/cosmos/azure_data_cosmos/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: b4b18c17377dd7ee0ebddfa2a12c6319da074a34bb3b8d23dd6a6d971381a166
+apiMdSha256: 6453e0a6e4ed38330a4eac11fbb12b548b0cff6cb4b0166bd3c6374c84c85b6c
 packageVersion: 0.39.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/cosmos/azure_data_cosmos_benchmarks/api/API.md
+++ b/sdk/cosmos/azure_data_cosmos_benchmarks/api/API.md
@@ -15,7 +15,7 @@ pub async fn setup_live() -> (std::sync::Arc<azure_data_cosmos_driver::CosmosDri
 #[derive(Debug)]
 pub struct MockHttpClientFactory;
 impl MockHttpClientFactory {
-    fn new() -> Self;
+    pub fn new() -> Self;
 }
 impl Default for MockHttpClientFactory {
     fn default() -> Self;
@@ -28,8 +28,8 @@ pub struct MockTransportClient {
     pub latency: std::time::Duration,
 }
 impl MockTransportClient {
-    fn new() -> Self;
-    fn with_latency(latency: std::time::Duration) -> Self;
+    pub fn new() -> Self;
+    pub fn with_latency(latency: std::time::Duration) -> Self;
 }
 impl Default for MockTransportClient {
     fn default() -> Self;

--- a/sdk/cosmos/azure_data_cosmos_benchmarks/api/API.metadata.yml
+++ b/sdk/cosmos/azure_data_cosmos_benchmarks/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: e0cfc905860f9864f2ed34a602b6735cd7ef728ea8f700bc266b9d252388e513
+apiMdSha256: ecae8d63d04810eaed1840cbd37b9710f760b0f700534a552f0f93747423eca8
 packageVersion: 0.1.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/cosmos/azure_data_cosmos_driver/api/API.md
+++ b/sdk/cosmos/azure_data_cosmos_driver/api/API.md
@@ -203,32 +203,32 @@ pub mod diagnostics {
     pub struct DiagnosticsContext {
     }
     impl DiagnosticsContext {
-        fn activity_id(&self) -> &ActivityId;
-        fn compaction(&self) -> Option<&CompactionInfo>;
-        fn duration(&self) -> Duration;
-        fn effective_status(&self) -> Option<CosmosStatus>;
-        fn fault_injection_enabled(&self) -> bool;
-        fn hedge_diagnostics(&self) -> Option<&HedgeDiagnostics>;
-        fn hedging_started(&self) -> bool;
-        fn is_completed(&self) -> bool;
-        fn is_failure(&self) -> bool;
-        fn is_threshold_violated(&self, thresholds: &DiagnosticsThresholds) -> bool;
-        fn is_threshold_violated_for(&self, thresholds: &DiagnosticsThresholds, operation_name: Option<&str>) -> bool;
-        fn machine_id(&self) -> Option<&str>;
-        fn operation_name(&self) -> Option<&str>;
-        fn patch_tracking_id(&self) -> Option<PatchTrackingId>;
-        fn regions_contacted(&self) -> Vec<Region>;
-        fn request_count(&self) -> usize;
-        fn requested_regions(&self) -> Vec<RequestedRegion>;
-        fn requests(&self) -> Arc<Vec<RequestDiagnostics>>;
-        fn responded_regions(&self) -> Vec<&Region>;
-        fn retained_request_count(&self) -> usize;
-        fn status(&self) -> Option<&CosmosStatus>;
-        fn threshold_breach_for(&self, thresholds: &DiagnosticsThresholds, operation_name: Option<&str>) -> Option<ThresholdBreach>;
-        fn to_json_string(&self, verbosity: Option<DiagnosticsVerbosity>) -> &str;
-        fn total_request_charge(&self) -> RequestCharge;
-        fn total_requested_regions(&self) -> usize;
-        fn total_responded_regions(&self) -> usize;
+        pub fn activity_id(&self) -> &ActivityId;
+        pub fn compaction(&self) -> Option<&CompactionInfo>;
+        pub fn duration(&self) -> Duration;
+        pub fn effective_status(&self) -> Option<CosmosStatus>;
+        pub fn fault_injection_enabled(&self) -> bool;
+        pub fn hedge_diagnostics(&self) -> Option<&HedgeDiagnostics>;
+        pub fn hedging_started(&self) -> bool;
+        pub fn is_completed(&self) -> bool;
+        pub fn is_failure(&self) -> bool;
+        pub fn is_threshold_violated(&self, thresholds: &DiagnosticsThresholds) -> bool;
+        pub fn is_threshold_violated_for(&self, thresholds: &DiagnosticsThresholds, operation_name: Option<&str>) -> bool;
+        pub fn machine_id(&self) -> Option<&str>;
+        pub fn operation_name(&self) -> Option<&str>;
+        pub fn patch_tracking_id(&self) -> Option<PatchTrackingId>;
+        pub fn regions_contacted(&self) -> Vec<Region>;
+        pub fn request_count(&self) -> usize;
+        pub fn requested_regions(&self) -> Vec<RequestedRegion>;
+        pub fn requests(&self) -> Arc<Vec<RequestDiagnostics>>;
+        pub fn responded_regions(&self) -> Vec<&Region>;
+        pub fn retained_request_count(&self) -> usize;
+        pub fn status(&self) -> Option<&CosmosStatus>;
+        pub fn threshold_breach_for(&self, thresholds: &DiagnosticsThresholds, operation_name: Option<&str>) -> Option<ThresholdBreach>;
+        pub fn to_json_string(&self, verbosity: Option<DiagnosticsVerbosity>) -> &str;
+        pub fn total_request_charge(&self) -> RequestCharge;
+        pub fn total_requested_regions(&self) -> usize;
+        pub fn total_responded_regions(&self) -> usize;
     }
     impl Clone for DiagnosticsContext {
         fn clone(&self) -> Self;
@@ -249,80 +249,80 @@ pub mod diagnostics {
     pub struct FailedTransportShardDiagnostics {
     }
     impl FailedTransportShardDiagnostics {
-        fn error(&self) -> &str;
-        fn request_sent(&self) -> RequestSentStatus;
-        fn transport_shard(&self) -> &TransportShardDiagnostics;
+        pub fn error(&self) -> &str;
+        pub fn request_sent(&self) -> RequestSentStatus;
+        pub fn transport_shard(&self) -> &TransportShardDiagnostics;
     }
     #[derive(Clone, Debug, Eq, Hash, PartialEq)]
     #[non_exhaustive]
     pub struct HedgeDiagnostics {
     }
     impl HedgeDiagnostics {
-        fn alternate_region(&self) -> Option<&Region>;
-        fn primary_region(&self) -> &Region;
-        fn response_region(&self) -> Option<&Region>;
-        fn strategy_config(&self) -> HedgingStrategyConfig;
-        fn terminal_state(&self) -> HedgeTerminalState;
+        pub fn alternate_region(&self) -> Option<&Region>;
+        pub fn primary_region(&self) -> &Region;
+        pub fn response_region(&self) -> Option<&Region>;
+        pub fn strategy_config(&self) -> HedgingStrategyConfig;
+        pub fn terminal_state(&self) -> HedgeTerminalState;
     }
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     #[non_exhaustive]
     pub struct HedgingStrategyConfig {
     }
     impl HedgingStrategyConfig {
-        fn threshold(&self) -> HedgeThreshold;
+        pub fn threshold(&self) -> HedgeThreshold;
     }
     #[derive(Clone, Debug)]
-    pub struct ProxyConfiguration {
+    pub struct ProxyConfig {
         pub proxy_allowed: bool,
         pub https_proxy_set: bool,
         pub http_proxy_set: bool,
     }
-    impl ProxyConfiguration {
-        fn from_env(proxy_allowed: bool) -> Self;
+    impl ProxyConfig {
+        pub fn from_env(proxy_allowed: bool) -> Self;
     }
     #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
     #[non_exhaustive]
     pub struct RequestDiagnostics {
     }
     impl RequestDiagnostics {
-        fn activity_id(&self) -> Option<&ActivityId>;
-        fn completed_at(&self) -> Option<Instant>;
-        fn duration_ms(&self) -> u64;
-        fn endpoint(&self) -> &str;
-        fn error(&self) -> Option<&str>;
-        fn events(&self) -> &[RequestEvent];
-        fn execution_context(&self) -> ExecutionContext;
-        fn failed_transport_shards(&self) -> &[FailedTransportShardDiagnostics];
+        pub fn activity_id(&self) -> Option<&ActivityId>;
+        pub fn completed_at(&self) -> Option<Instant>;
+        pub fn duration_ms(&self) -> u64;
+        pub fn endpoint(&self) -> &str;
+        pub fn error(&self) -> Option<&str>;
+        pub fn events(&self) -> &[RequestEvent];
+        pub fn execution_context(&self) -> ExecutionContext;
+        pub fn failed_transport_shards(&self) -> &[FailedTransportShardDiagnostics];
         #[cfg(feature = "fault_injection")]
-        fn fault_injection_evaluations(&self) -> &[crate::fault_injection::FaultInjectionEvaluation];
-        fn local_shard_retry_count(&self) -> u32;
-        fn operation_name(&self) -> Option<&str>;
-        fn pipeline_type(&self) -> PipelineType;
-        fn region(&self) -> Option<&Region>;
-        fn request_charge(&self) -> RequestCharge;
-        fn request_sent(&self) -> RequestSentStatus;
-        fn server_duration_ms(&self) -> Option<f64>;
-        fn session_token(&self) -> Option<&str>;
-        fn started_at(&self) -> Instant;
-        fn status(&self) -> &CosmosStatus;
-        fn timed_out(&self) -> bool;
-        fn transport_http_version(&self) -> TransportHttpVersion;
-        fn transport_kind(&self) -> TransportKind;
-        fn transport_security(&self) -> TransportSecurity;
-        fn transport_shard(&self) -> Option<&TransportShardDiagnostics>;
+        pub fn fault_injection_evaluations(&self) -> &[crate::fault_injection::FaultInjectionEvaluation];
+        pub fn local_shard_retry_count(&self) -> u32;
+        pub fn operation_name(&self) -> Option<&str>;
+        pub fn pipeline_type(&self) -> PipelineKind;
+        pub fn region(&self) -> Option<&Region>;
+        pub fn request_charge(&self) -> RequestCharge;
+        pub fn request_sent(&self) -> RequestSentStatus;
+        pub fn server_duration_ms(&self) -> Option<f64>;
+        pub fn session_token(&self) -> Option<&str>;
+        pub fn started_at(&self) -> Instant;
+        pub fn status(&self) -> &CosmosStatus;
+        pub fn timed_out(&self) -> bool;
+        pub fn transport_http_version(&self) -> TransportHttpVersion;
+        pub fn transport_kind(&self) -> TransportKind;
+        pub fn transport_security(&self) -> TransportSecurity;
+        pub fn transport_shard(&self) -> Option<&TransportShardDiagnostics>;
     }
     #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
     #[non_exhaustive]
     pub struct RequestEvent {
     }
     impl RequestEvent {
-        fn details(&self) -> Option<&str>;
-        fn duration_ms(&self) -> Option<u64>;
-        fn event_type(&self) -> &RequestEventType;
-        fn new(event_type: RequestEventType) -> Self;
-        fn timestamp(&self) -> Instant;
-        fn with_details<impl Into<String>: Into<String>>(self, details: impl Into<String>) -> Self;
-        fn with_duration(event_type: RequestEventType, duration: Duration) -> Self;
+        pub fn details(&self) -> Option<&str>;
+        pub fn duration_ms(&self) -> Option<u64>;
+        pub fn event_type(&self) -> &RequestEventType;
+        pub fn new(event_type: RequestEventType) -> Self;
+        pub fn timestamp(&self) -> Instant;
+        pub fn with_details<impl Into<String>: Into<String>>(self, details: impl Into<String>) -> Self;
+        pub fn with_duration(event_type: RequestEventType, duration: Duration) -> Self;
     }
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct RequestHandle(/* private fields */);
@@ -337,13 +337,13 @@ pub mod diagnostics {
     pub struct TransportShardDiagnostics {
     }
     impl TransportShardDiagnostics {
-        fn consecutive_failures(&self) -> u32;
-        fn estimated_inflight(&self) -> u32;
-        fn marked_for_eviction(&self) -> bool;
-        fn shard_id(&self) -> u64;
-        fn total_cancellations(&self) -> u64;
-        fn total_failures(&self) -> u64;
-        fn total_requests(&self) -> u64;
+        pub fn consecutive_failures(&self) -> u32;
+        pub fn estimated_inflight(&self) -> u32;
+        pub fn marked_for_eviction(&self) -> bool;
+        pub fn shard_id(&self) -> u64;
+        pub fn total_cancellations(&self) -> u64;
+        pub fn total_failures(&self) -> u64;
+        pub fn total_requests(&self) -> u64;
     }
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, serde::Serialize)]
     #[non_exhaustive]
@@ -357,7 +357,7 @@ pub mod diagnostics {
         CircuitBreakerProbe,
     }
     impl ExecutionContext {
-        fn as_str(&self) -> &'static str;
+        pub fn as_str(&self) -> &'static str;
     }
     impl AsRef<str> for ExecutionContext {
         fn as_ref(&self) -> &str;
@@ -377,7 +377,7 @@ pub mod diagnostics {
         CancelledAwaitingPartner,
     }
     impl HedgeTerminalState {
-        fn as_str(&self) -> &'static str;
+        pub fn as_str(&self) -> &'static str;
     }
     impl Display for HedgeTerminalState {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
@@ -385,19 +385,19 @@ pub mod diagnostics {
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, serde::Serialize)]
     #[non_exhaustive]
     #[serde(rename_all = "snake_case")]
-    pub enum PipelineType {
+    pub enum PipelineKind {
         Metadata,
         DataPlane,
     }
-    impl PipelineType {
-        fn as_str(self) -> &'static str;
-        fn is_data_plane(self) -> bool;
-        fn is_metadata(self) -> bool;
+    impl PipelineKind {
+        pub fn as_str(self) -> &'static str;
+        pub fn is_data_plane(self) -> bool;
+        pub fn is_metadata(self) -> bool;
     }
-    impl AsRef<str> for PipelineType {
+    impl AsRef<str> for PipelineKind {
         fn as_ref(&self) -> &str;
     }
-    impl Display for PipelineType {
+    impl Display for PipelineKind {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
     }
     #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
@@ -411,8 +411,8 @@ pub mod diagnostics {
         TransportFailed,
     }
     impl RequestEventType {
-        fn as_str(&self) -> &str;
-        fn indicates_request_sent(&self) -> bool;
+        pub fn as_str(&self) -> &str;
+        pub fn indicates_request_sent(&self) -> bool;
     }
     impl AsRef<str> for RequestEventType {
         fn as_ref(&self) -> &str;
@@ -430,10 +430,10 @@ pub mod diagnostics {
         Unknown,
     }
     impl RequestSentStatus {
-        fn as_str(&self) -> &'static str;
-        fn definitely_not_sent(&self) -> bool;
-        fn definitely_sent(&self) -> bool;
-        fn may_have_been_sent(&self) -> bool;
+        pub fn as_str(&self) -> &'static str;
+        pub fn definitely_not_sent(&self) -> bool;
+        pub fn definitely_sent(&self) -> bool;
+        pub fn may_have_been_sent(&self) -> bool;
     }
     impl AsRef<str> for RequestSentStatus {
         fn as_ref(&self) -> &str;
@@ -456,9 +456,9 @@ pub mod diagnostics {
         Http2,
     }
     impl TransportHttpVersion {
-        fn as_str(self) -> &'static str;
-        fn is_http11(self) -> bool;
-        fn is_http2(self) -> bool;
+        pub fn as_str(self) -> &'static str;
+        pub fn is_http11(self) -> bool;
+        pub fn is_http2(self) -> bool;
     }
     impl AsRef<str> for TransportHttpVersion {
         fn as_ref(&self) -> &str;
@@ -475,9 +475,9 @@ pub mod diagnostics {
         GatewayV2,
     }
     impl TransportKind {
-        fn as_str(self) -> &'static str;
-        fn is_gateway(self) -> bool;
-        fn is_gateway_v2(self) -> bool;
+        pub fn as_str(self) -> &'static str;
+        pub fn is_gateway(self) -> bool;
+        pub fn is_gateway_v2(self) -> bool;
     }
     impl AsRef<str> for TransportKind {
         fn as_ref(&self) -> &str;
@@ -494,9 +494,9 @@ pub mod diagnostics {
         EmulatorWithInsecureCertificates,
     }
     impl TransportSecurity {
-        fn as_str(self) -> &'static str;
-        fn is_emulator(self) -> bool;
-        fn is_secure(self) -> bool;
+        pub fn as_str(self) -> &'static str;
+        pub fn is_emulator(self) -> bool;
+        pub fn is_secure(self) -> bool;
     }
     impl AsRef<str> for TransportSecurity {
         fn as_ref(&self) -> &str;
@@ -512,73 +512,73 @@ pub mod driver {
     }
     impl CosmosDriver {
         #[cfg(any(test, feature = "__internal_testing"))]
-        fn __test_only_force_ppaf_enabled(&self);
+        pub fn __test_only_force_ppaf_enabled(&self);
         #[cfg(any(test, feature = "__internal_testing"))]
-        fn __test_only_hub_region_cache_snapshot(&self) -> Vec<(String, String)>;
-        fn account(&self) -> &AccountReference;
+        pub fn __test_only_hub_region_cache_snapshot(&self) -> Vec<(String, String)>;
+        pub fn account(&self) -> &AccountReference;
         #[cfg(feature = "preview_dtx")]
-        async fn execute_distributed_transaction(&self, request: crate::models::DistributedTransactionRequest, options: OperationOptions) -> crate::error::Result<crate::models::DistributedTransactionResponse>;
-        async fn execute_operation(&self, operation: CosmosOperation, options: OperationOptions) -> crate::error::Result<Option<crate::models::CosmosResponse>>;
-        async fn execute_plan(&self, plan: &mut OperationPlan, container: Option<ContainerReference>, options: OperationOptions) -> crate::error::Result<Option<crate::models::CosmosResponse>>;
-        async fn execute_singleton_operation(&self, operation: CosmosOperation, options: OperationOptions) -> crate::error::Result<crate::models::CosmosResponse>;
-        async fn initialize(&self) -> crate::error::Result<()>;
-        fn operation_options_view<'a>(&self, operation_options: &'a OperationOptions) -> OperationOptionsView<'a>;
-        fn options(&self) -> &DriverOptions;
-        async fn plan_operation(&self, operation: CosmosOperation, options: &OperationOptions, continuation: Option<&ContinuationToken>, plan_options: &PlanOptions) -> crate::error::Result<OperationPlan>;
-        async fn prime_container(&self, db_name: &str, container_name: &str) -> crate::error::Result<()>;
-        async fn resolve_all_partition_key_ranges(&self, container: &ContainerReference, force_refresh: bool) -> crate::error::Result<Option<Vec<crate::models::partition_key_range::PartitionKeyRange>>>;
-        async fn resolve_container(&self, db_name: &str, container_name: &str, operation_options: OperationOptions) -> crate::error::Result<ContainerReference>;
-        async fn resolve_container_by_name(&self, db_name: &str, container_name: &str, operation_options: OperationOptions) -> crate::error::Result<ContainerReference>;
-        async fn resolve_container_by_rid(&self, container_rid: &str, operation_options: OperationOptions) -> crate::error::Result<ContainerReference>;
-        async fn resolve_partition_key_ranges_for_key(&self, container: &ContainerReference, partition_key: &PartitionKey, force_refresh: bool) -> crate::error::Result<Option<Vec<crate::models::partition_key_range::PartitionKeyRange>>>;
-        fn runtime(&self) -> &CosmosDriverRuntime;
-        fn user_agent(&self) -> &Arc<UserAgent>;
+        pub async fn execute_distributed_transaction(&self, request: crate::models::DistributedTransactionRequest, options: OperationOptions) -> crate::error::Result<crate::models::DistributedTransactionResponse>;
+        pub async fn execute_operation(&self, operation: CosmosOperation, options: OperationOptions) -> crate::error::Result<Option<crate::models::CosmosResponse>>;
+        pub async fn execute_plan(&self, plan: &mut OperationPlan, container: Option<ContainerReference>, options: OperationOptions) -> crate::error::Result<Option<crate::models::CosmosResponse>>;
+        pub async fn execute_singleton_operation(&self, operation: CosmosOperation, options: OperationOptions) -> crate::error::Result<crate::models::CosmosResponse>;
+        pub async fn initialize(&self) -> crate::error::Result<()>;
+        pub fn operation_options_view<'a>(&self, operation_options: &'a OperationOptions) -> OperationOptionsView<'a>;
+        pub fn options(&self) -> &DriverOptions;
+        pub async fn plan_operation(&self, operation: CosmosOperation, options: &OperationOptions, continuation: Option<&ContinuationToken>, plan_options: &PlanOptions) -> crate::error::Result<OperationPlan>;
+        pub async fn prime_container(&self, db_name: &str, container_name: &str) -> crate::error::Result<()>;
+        pub async fn resolve_all_partition_key_ranges(&self, container: &ContainerReference, force_refresh: bool) -> crate::error::Result<Option<Vec<crate::models::partition_key_range::PartitionKeyRange>>>;
+        pub async fn resolve_container(&self, db_name: &str, container_name: &str, operation_options: OperationOptions) -> crate::error::Result<ContainerReference>;
+        pub async fn resolve_container_by_name(&self, db_name: &str, container_name: &str, operation_options: OperationOptions) -> crate::error::Result<ContainerReference>;
+        pub async fn resolve_container_by_rid(&self, container_rid: &str, operation_options: OperationOptions) -> crate::error::Result<ContainerReference>;
+        pub async fn resolve_partition_key_ranges_for_key(&self, container: &ContainerReference, partition_key: &PartitionKey, force_refresh: bool) -> crate::error::Result<Option<Vec<crate::models::partition_key_range::PartitionKeyRange>>>;
+        pub fn runtime(&self) -> &CosmosDriverRuntime;
+        pub fn user_agent(&self) -> &Arc<UserAgent>;
     }
     #[derive(Debug)]
     #[non_exhaustive]
     pub struct CosmosDriverRuntime {
     }
     impl CosmosDriverRuntime {
-        fn builder() -> CosmosDriverRuntimeBuilder;
-        fn client_options(&self) -> &ClientOptions;
-        fn connection_pool(&self) -> &ConnectionPoolOptions;
-        fn correlation_id(&self) -> Option<&CorrelationId>;
-        async fn create_driver(self: &Arc<Self>, driver_options: DriverOptions) -> crate::error::Result<Arc<CosmosDriver>>;
-        fn default_operation_options(&self) -> Arc<OperationOptions>;
-        fn diagnostics_options(&self) -> &DiagnosticsOptions;
-        fn effective_correlation(&self) -> Option<&str>;
-        fn env_operation_options(&self) -> &Arc<OperationOptions>;
-        fn env_override_operation_options(&self) -> &Arc<OperationOptions>;
-        fn proxy_configuration(&self) -> &ProxyConfiguration;
-        fn set_default_operation_options(&self, options: OperationOptions);
-        fn user_agent(&self) -> &Arc<UserAgent>;
-        fn user_agent_suffix(&self) -> Option<&UserAgentSuffix>;
-        fn workload_id(&self) -> Option<WorkloadId>;
-        fn wrapping_sdk_identifier(&self) -> Option<&str>;
+        pub fn builder() -> CosmosDriverRuntimeBuilder;
+        pub fn client_options(&self) -> &ClientOptions;
+        pub fn connection_pool(&self) -> &ConnectionPoolOptions;
+        pub fn correlation_id(&self) -> Option<&CorrelationId>;
+        pub async fn create_driver(self: &Arc<Self>, driver_options: DriverOptions) -> crate::error::Result<Arc<CosmosDriver>>;
+        pub fn default_operation_options(&self) -> Arc<OperationOptions>;
+        pub fn diagnostics_options(&self) -> &DiagnosticsOptions;
+        pub fn effective_correlation(&self) -> Option<&str>;
+        pub fn env_operation_options(&self) -> &Arc<OperationOptions>;
+        pub fn env_override_operation_options(&self) -> &Arc<OperationOptions>;
+        pub fn proxy_configuration(&self) -> &ProxyConfig;
+        pub fn set_default_operation_options(&self, options: OperationOptions);
+        pub fn user_agent(&self) -> &Arc<UserAgent>;
+        pub fn user_agent_suffix(&self) -> Option<&UserAgentSuffix>;
+        pub fn workload_id(&self) -> Option<WorkloadId>;
+        pub fn wrapping_sdk_identifier(&self) -> Option<&str>;
     }
     #[derive(Clone, Debug, Default)]
     #[non_exhaustive]
     pub struct CosmosDriverRuntimeBuilder {
     }
     impl CosmosDriverRuntimeBuilder {
-        async fn build(self) -> crate::error::Result<Arc<CosmosDriverRuntime>>;
-        fn new() -> Self;
-        fn with_client_options(self, options: ClientOptions) -> Self;
-        fn with_connection_pool(self, options: ConnectionPoolOptions) -> Self;
-        fn with_correlation_id(self, correlation_id: CorrelationId) -> Self;
-        fn with_cpu_refresh_interval(self, interval: Duration) -> Self;
-        fn with_default_operation_options(self, options: OperationOptions) -> Self;
-        fn with_diagnostics_options(self, options: DiagnosticsOptions) -> Self;
+        pub async fn build(self) -> crate::error::Result<Arc<CosmosDriverRuntime>>;
+        pub fn new() -> Self;
+        pub fn with_client_options(self, options: ClientOptions) -> Self;
+        pub fn with_connection_pool(self, options: ConnectionPoolOptions) -> Self;
+        pub fn with_correlation_id(self, correlation_id: CorrelationId) -> Self;
+        pub fn with_cpu_refresh_interval(self, interval: Duration) -> Self;
+        pub fn with_default_operation_options(self, options: OperationOptions) -> Self;
+        pub fn with_diagnostics_options(self, options: DiagnosticsOptions) -> Self;
         #[cfg(feature = "__internal_mocking")]
-        fn with_mock_http_client_factory(self, factory: Arc<dyn HttpClientFactory>) -> Self;
-        fn with_user_agent_suffix(self, suffix: UserAgentSuffix) -> Self;
-        fn with_workload_id(self, workload_id: WorkloadId) -> Self;
-        fn with_wrapping_sdk_identifier<impl Into<String>: Into<String>>(self, identifier: impl Into<String>) -> Self;
+        pub fn with_mock_http_client_factory(self, factory: Arc<dyn HttpClientFactory>) -> Self;
+        pub fn with_user_agent_suffix(self, suffix: UserAgentSuffix) -> Self;
+        pub fn with_workload_id(self, workload_id: WorkloadId) -> Self;
+        pub fn with_wrapping_sdk_identifier<impl Into<String>: Into<String>>(self, identifier: impl Into<String>) -> Self;
     }
     pub struct OperationPlan {
     }
     impl OperationPlan {
-        fn to_continuation_token(&self) -> crate::error::Result<ContinuationToken>;
+        pub fn to_continuation_token(&self) -> crate::error::Result<ContinuationToken>;
     }
 }
 pub mod error {
@@ -596,15 +596,15 @@ pub mod error {
     pub struct CosmosError {
     }
     impl CosmosError {
-        fn backtrace(&self) -> Option<Arc<str>>;
-        fn diagnostics(&self) -> Option<Arc<DiagnosticsContext>>;
-        fn is_from_wire(&self) -> bool;
-        fn patch_tracking_id(&self) -> Option<PatchTrackingId>;
-        fn response(&self) -> Option<&CosmosResponse>;
-        fn status(&self) -> CosmosStatus;
+        pub fn backtrace(&self) -> Option<Arc<str>>;
+        pub fn diagnostics(&self) -> Option<Arc<DiagnosticsContext>>;
+        pub fn is_from_wire(&self) -> bool;
+        pub fn patch_tracking_id(&self) -> Option<PatchTrackingId>;
+        pub fn response(&self) -> Option<&CosmosResponse>;
+        pub fn status(&self) -> CosmosStatus;
     }
     impl CosmosError {
-        fn builder() -> CosmosErrorBuilder;
+        pub fn builder() -> CosmosErrorBuilder;
     }
     impl Debug for CosmosError {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -619,16 +619,16 @@ pub mod error {
     pub struct CosmosErrorBuilder {
     }
     impl CosmosErrorBuilder {
-        fn build(self) -> CosmosError;
-        fn from_error(err: CosmosError) -> Self;
-        fn with_arc_source(self, source: Arc<dyn StdError + Send + Sync + 'static>) -> Self;
-        fn with_context<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, context: impl Into<Cow<'static, str>>) -> Self;
-        fn with_diagnostics(self, diagnostics: Arc<DiagnosticsContext>) -> Self;
-        fn with_message<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, message: impl Into<Cow<'static, str>>) -> Self;
-        fn with_patch_tracking_id(self, id: PatchTrackingId) -> Self;
-        fn with_response(self, response: CosmosResponse) -> Self;
-        fn with_source<E>(self, source: E) -> Self where E: StdError + Send + Sync + 'static;
-        fn with_status(self, status: CosmosStatus) -> Self;
+        pub fn build(self) -> CosmosError;
+        pub fn from_error(err: CosmosError) -> Self;
+        pub fn with_arc_source(self, source: Arc<dyn StdError + Send + Sync + 'static>) -> Self;
+        pub fn with_context<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, context: impl Into<Cow<'static, str>>) -> Self;
+        pub fn with_diagnostics(self, diagnostics: Arc<DiagnosticsContext>) -> Self;
+        pub fn with_message<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, message: impl Into<Cow<'static, str>>) -> Self;
+        pub fn with_patch_tracking_id(self, id: PatchTrackingId) -> Self;
+        pub fn with_response(self, response: CosmosResponse) -> Self;
+        pub fn with_source<E>(self, source: E) -> Self where E: StdError + Send + Sync + 'static;
+        pub fn with_status(self, status: CosmosStatus) -> Self;
     }
     #[derive(Clone, Copy, Eq, Hash, PartialEq)]
     pub struct CosmosStatus {
@@ -720,29 +720,29 @@ pub mod error {
         const TRANSPORT_HTTP2_INCOMPATIBLE: CosmosStatus = _;
         const TRANSPORT_IO_FAILED: CosmosStatus = _;
         const WRITE_FORBIDDEN: CosmosStatus = _;
-        fn is_bad_request(&self) -> bool;
-        fn is_conflict(&self) -> bool;
-        fn is_database_account_not_found(&self) -> bool;
-        fn is_forbidden(&self) -> bool;
-        fn is_gone(&self) -> bool;
-        fn is_not_found(&self) -> bool;
-        fn is_partition_key_range_gone(&self) -> bool;
-        fn is_precondition_failed(&self) -> bool;
-        fn is_read_session_not_available(&self) -> bool;
-        fn is_retry_with(&self) -> bool;
-        fn is_service_unavailable(&self) -> bool;
-        fn is_success(&self) -> bool;
-        fn is_throttled(&self) -> bool;
-        fn is_timeout(&self) -> bool;
-        fn is_transient(&self) -> bool;
-        fn is_transport_generated_503(&self) -> bool;
-        fn is_unauthorized(&self) -> bool;
-        fn is_write_forbidden(&self) -> bool;
-        fn name(&self) -> Option<&'static str>;
-        fn new(status_code: StatusCode) -> Self;
-        fn status_code(&self) -> StatusCode;
-        fn sub_status(&self) -> Option<SubStatusCode>;
-        fn with_sub_status(self, sub_status_code: u16) -> Self;
+        pub fn is_bad_request(&self) -> bool;
+        pub fn is_conflict(&self) -> bool;
+        pub fn is_database_account_not_found(&self) -> bool;
+        pub fn is_forbidden(&self) -> bool;
+        pub fn is_gone(&self) -> bool;
+        pub fn is_not_found(&self) -> bool;
+        pub fn is_partition_key_range_gone(&self) -> bool;
+        pub fn is_precondition_failed(&self) -> bool;
+        pub fn is_read_session_not_available(&self) -> bool;
+        pub fn is_retry_with(&self) -> bool;
+        pub fn is_service_unavailable(&self) -> bool;
+        pub fn is_success(&self) -> bool;
+        pub fn is_throttled(&self) -> bool;
+        pub fn is_timeout(&self) -> bool;
+        pub fn is_transient(&self) -> bool;
+        pub fn is_transport_generated_503(&self) -> bool;
+        pub fn is_unauthorized(&self) -> bool;
+        pub fn is_write_forbidden(&self) -> bool;
+        pub fn name(&self) -> Option<&'static str>;
+        pub fn new(status_code: StatusCode) -> Self;
+        pub fn status_code(&self) -> StatusCode;
+        pub fn sub_status(&self) -> Option<SubStatusCode>;
+        pub fn with_sub_status(self, sub_status_code: u16) -> Self;
     }
     impl Debug for CosmosStatus {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1043,10 +1043,10 @@ pub mod error {
         const VALUE_DOES_NOT_MATCH_EXPECTED_BOUND: SubStatusCode = _;
         const WRITE_FORBIDDEN: SubStatusCode = _;
         const XP_COMPOSITE_REPLICATOR: SubStatusCode = _;
-        fn from_header_value(s: &str) -> Option<Self>;
-        fn name(&self, status_code: Option<StatusCode>) -> Option<&'static str>;
-        const fn new(code: u16) -> Self;
-        const fn value(&self) -> u16;
+        pub fn from_header_value(s: &str) -> Option<Self>;
+        pub fn name(&self, status_code: Option<StatusCode>) -> Option<&'static str>;
+        pub const fn new(code: u16) -> Self;
+        pub const fn value(&self) -> u16;
     }
     impl Debug for SubStatusCode {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1072,19 +1072,19 @@ pub mod fault_injection {
     pub struct CustomResponse {
     }
     impl CustomResponse {
-        fn body(&self) -> &[u8];
-        fn headers(&self) -> &Headers;
-        fn status_code(&self) -> StatusCode;
+        pub fn body(&self) -> &[u8];
+        pub fn headers(&self) -> &Headers;
+        pub fn status_code(&self) -> StatusCode;
     }
     #[non_exhaustive]
     pub struct CustomResponseBuilder {
     }
     impl CustomResponseBuilder {
-        fn build(self) -> CustomResponse;
-        fn new(status_code: StatusCode) -> Self;
-        fn with_body<impl Into<Vec<u8>>: Into<Vec<u8>>>(self, body: impl Into<Vec<u8>>) -> Self;
-        fn with_header<impl Into<HeaderName>: Into<HeaderName>, impl Into<HeaderValue>: Into<HeaderValue>>(self, name: impl Into<HeaderName>, value: impl Into<HeaderValue>) -> Self;
-        fn with_sub_status(self, code: u16) -> Self;
+        pub fn build(self) -> CustomResponse;
+        pub fn new(status_code: StatusCode) -> Self;
+        pub fn with_body<impl Into<Vec<u8>>: Into<Vec<u8>>>(self, body: impl Into<Vec<u8>>) -> Self;
+        pub fn with_header<impl Into<HeaderName>: Into<HeaderName>, impl Into<HeaderValue>: Into<HeaderValue>>(self, name: impl Into<HeaderName>, value: impl Into<HeaderValue>) -> Self;
+        pub fn with_sub_status(self, code: u16) -> Self;
     }
     #[derive(Debug)]
     #[non_exhaustive]
@@ -1099,43 +1099,43 @@ pub mod fault_injection {
     pub struct FaultInjectionCondition {
     }
     impl FaultInjectionCondition {
-        fn container_id(&self) -> Option<&str>;
-        fn operation_type(&self) -> Option<FaultOperationType>;
-        fn region(&self) -> Option<&Region>;
-        fn transport_kind(&self) -> Option<TransportKind>;
+        pub fn container_id(&self) -> Option<&str>;
+        pub fn operation_type(&self) -> Option<FaultOperationType>;
+        pub fn region(&self) -> Option<&Region>;
+        pub fn transport_kind(&self) -> Option<TransportKind>;
     }
     #[derive(Default)]
     #[non_exhaustive]
     pub struct FaultInjectionConditionBuilder {
     }
     impl FaultInjectionConditionBuilder {
-        fn build(self) -> FaultInjectionCondition;
-        fn new() -> Self;
-        fn with_container_id<impl Into<String>: Into<String>>(self, container_id: impl Into<String>) -> Self;
-        fn with_operation_type(self, operation_type: FaultOperationType) -> Self;
-        fn with_region(self, region: Region) -> Self;
-        fn with_transport_kind(self, transport_kind: TransportKind) -> Self;
+        pub fn build(self) -> FaultInjectionCondition;
+        pub fn new() -> Self;
+        pub fn with_container_id<impl Into<String>: Into<String>>(self, container_id: impl Into<String>) -> Self;
+        pub fn with_operation_type(self, operation_type: FaultOperationType) -> Self;
+        pub fn with_region(self, region: Region) -> Self;
+        pub fn with_transport_kind(self, transport_kind: TransportKind) -> Self;
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct FaultInjectionResult {
     }
     impl FaultInjectionResult {
-        fn custom_response(&self) -> Option<&CustomResponse>;
-        fn delay(&self) -> Option<Duration>;
-        fn error_type(&self) -> Option<FaultInjectionErrorType>;
-        fn probability(&self) -> f32;
+        pub fn custom_response(&self) -> Option<&CustomResponse>;
+        pub fn delay(&self) -> Option<Duration>;
+        pub fn error_type(&self) -> Option<FaultInjectionErrorType>;
+        pub fn probability(&self) -> f32;
     }
     #[non_exhaustive]
     pub struct FaultInjectionResultBuilder {
     }
     impl FaultInjectionResultBuilder {
-        fn build(self) -> FaultInjectionResult;
-        fn new() -> Self;
-        fn with_custom_response(self, response: CustomResponse) -> Self;
-        fn with_delay(self, delay: Duration) -> Self;
-        fn with_error(self, error_type: FaultInjectionErrorType) -> Self;
-        fn with_probability(self, probability: f32) -> Self;
+        pub fn build(self) -> FaultInjectionResult;
+        pub fn new() -> Self;
+        pub fn with_custom_response(self, response: CustomResponse) -> Self;
+        pub fn with_delay(self, delay: Duration) -> Self;
+        pub fn with_error(self, error_type: FaultInjectionErrorType) -> Self;
+        pub fn with_probability(self, probability: f32) -> Self;
     }
     impl Default for FaultInjectionResultBuilder {
         fn default() -> Self;
@@ -1145,29 +1145,29 @@ pub mod fault_injection {
     pub struct FaultInjectionRule {
     }
     impl FaultInjectionRule {
-        fn condition(&self) -> &FaultInjectionCondition;
-        fn disable(&self);
-        fn enable(&self);
-        fn end_time(&self) -> Option<Instant>;
-        fn hit_count(&self) -> u32;
-        fn hit_limit(&self) -> Option<u32>;
-        fn id(&self) -> &str;
-        fn is_enabled(&self) -> bool;
-        fn result(&self) -> &FaultInjectionResult;
-        fn start_time(&self) -> Option<Instant>;
+        pub fn condition(&self) -> &FaultInjectionCondition;
+        pub fn disable(&self);
+        pub fn enable(&self);
+        pub fn end_time(&self) -> Option<Instant>;
+        pub fn hit_count(&self) -> u32;
+        pub fn hit_limit(&self) -> Option<u32>;
+        pub fn id(&self) -> &str;
+        pub fn is_enabled(&self) -> bool;
+        pub fn result(&self) -> &FaultInjectionResult;
+        pub fn start_time(&self) -> Option<Instant>;
     }
     #[non_exhaustive]
     pub struct FaultInjectionRuleBuilder {
     }
     impl FaultInjectionRuleBuilder {
-        fn build(self) -> FaultInjectionRule;
-        fn new<impl Into<String>: Into<String>>(id: impl Into<String>, result: FaultInjectionResult) -> Self;
-        fn with_condition(self, condition: FaultInjectionCondition) -> Self;
-        fn with_end_time(self, end_time: Instant) -> Self;
-        fn with_hit_limit(self, hit_limit: u32) -> Self;
-        fn with_result(self, result: FaultInjectionResult) -> Self;
-        fn with_shared_state(self, enabled: Arc<AtomicBool>, hit_count: Arc<AtomicU32>) -> Self;
-        fn with_start_time(self, start_time: Instant) -> Self;
+        pub fn build(self) -> FaultInjectionRule;
+        pub fn new<impl Into<String>: Into<String>>(id: impl Into<String>, result: FaultInjectionResult) -> Self;
+        pub fn with_condition(self, condition: FaultInjectionCondition) -> Self;
+        pub fn with_end_time(self, end_time: Instant) -> Self;
+        pub fn with_hit_limit(self, hit_limit: u32) -> Self;
+        pub fn with_result(self, result: FaultInjectionResult) -> Self;
+        pub fn with_shared_state(self, enabled: Arc<AtomicBool>, hit_count: Arc<AtomicU32>) -> Self;
+        pub fn with_start_time(self, start_time: Instant) -> Self;
     }
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     #[non_exhaustive]
@@ -1208,8 +1208,8 @@ pub mod fault_injection {
         Superseded { rule_id: String },
     }
     impl FaultInjectionEvaluation {
-        fn rule_id(&self) -> &str;
-        fn was_applied(&self) -> bool;
+        pub fn rule_id(&self) -> &str;
+        pub fn was_applied(&self) -> bool;
     }
     impl Display for FaultInjectionEvaluation {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
@@ -1234,8 +1234,8 @@ pub mod fault_injection {
         MetadataPartitionKeyRanges,
     }
     impl FaultOperationType {
-        fn as_str(&self) -> &'static str;
-        fn from_operation_and_resource(operation_type: &OperationType, resource_type: &ResourceType) -> Option<Self>;
+        pub fn as_str(&self) -> &'static str;
+        pub fn from_operation_and_resource(operation_type: &OperationType, resource_type: &ResourceType) -> Option<Self>;
     }
     impl Display for FaultOperationType {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1251,14 +1251,14 @@ pub mod in_memory_emulator {
     pub struct ContainerConfig {
     }
     impl ContainerConfig {
-        fn build(self) -> crate::error::Result<Self>;
-        fn new() -> Self;
-        fn partition_count(&self) -> u32;
-        fn partition_key_range_page_size(&self) -> Option<u32>;
-        fn provisioned_throughput_ru(&self) -> Option<u32>;
-        fn with_partition_count(self, count: u32) -> Self;
-        fn with_partition_key_range_page_size(self, page_size: u32) -> Self;
-        fn with_throughput(self, ru_per_second: u32) -> Self;
+        pub fn build(self) -> crate::error::Result<Self>;
+        pub fn new() -> Self;
+        pub fn partition_count(&self) -> u32;
+        pub fn partition_key_range_page_size(&self) -> Option<u32>;
+        pub fn provisioned_throughput_ru(&self) -> Option<u32>;
+        pub fn with_partition_count(self, count: u32) -> Self;
+        pub fn with_partition_key_range_page_size(self, page_size: u32) -> Self;
+        pub fn with_throughput(self, ru_per_second: u32) -> Self;
     }
     impl Default for ContainerConfig {
         fn default() -> Self;
@@ -1268,7 +1268,7 @@ pub mod in_memory_emulator {
     impl EffectivePartitionKey {
         const MAX: Self = _;
         const MIN: Self = _;
-        fn to_hex(&self) -> String;
+        pub fn to_hex(&self) -> String;
     }
     impl Display for EffectivePartitionKey {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1306,20 +1306,20 @@ pub mod in_memory_emulator {
     pub struct EmulatorStore {
     }
     impl EmulatorStore {
-        fn add_region(&self, region: VirtualRegion, seeding: SeedingPolicy) -> crate::error::Result<()>;
-        fn announce_failover(&self, region_name: &str) -> crate::error::Result<()>;
-        fn begin_failover(&self, region_name: &str) -> crate::error::Result<()>;
-        fn begin_region_removal(&self, region_name: &str) -> crate::error::Result<()>;
-        fn cancel_region_removal(&self, region_name: &str) -> crate::error::Result<()>;
-        fn complete_failover(&self);
-        fn remove_region(&self, region_name: &str) -> crate::error::Result<()>;
-        fn restore_region_write(&self, region_name: &str) -> crate::error::Result<()>;
-        fn revoke_region_write(&self, region_name: &str) -> crate::error::Result<()>;
-        fn set_failover_priorities(&self, order: &[&str]) -> crate::error::Result<()>;
-        fn set_region_offline(&self, region_name: &str) -> crate::error::Result<()>;
-        fn set_region_online(&self, region_name: &str) -> crate::error::Result<()>;
-        fn set_write_mode(&self, mode: WriteMode);
-        fn set_write_region(&self, region_name: &str) -> crate::error::Result<()>;
+        pub fn add_region(&self, region: VirtualRegion, seeding: SeedingPolicy) -> crate::error::Result<()>;
+        pub fn announce_failover(&self, region_name: &str) -> crate::error::Result<()>;
+        pub fn begin_failover(&self, region_name: &str) -> crate::error::Result<()>;
+        pub fn begin_region_removal(&self, region_name: &str) -> crate::error::Result<()>;
+        pub fn cancel_region_removal(&self, region_name: &str) -> crate::error::Result<()>;
+        pub fn complete_failover(&self);
+        pub fn remove_region(&self, region_name: &str) -> crate::error::Result<()>;
+        pub fn restore_region_write(&self, region_name: &str) -> crate::error::Result<()>;
+        pub fn revoke_region_write(&self, region_name: &str) -> crate::error::Result<()>;
+        pub fn set_failover_priorities(&self, order: &[&str]) -> crate::error::Result<()>;
+        pub fn set_region_offline(&self, region_name: &str) -> crate::error::Result<()>;
+        pub fn set_region_online(&self, region_name: &str) -> crate::error::Result<()>;
+        pub fn set_write_mode(&self, mode: WriteMode);
+        pub fn set_write_region(&self, region_name: &str) -> crate::error::Result<()>;
     }
     impl Debug for EmulatorStore {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
@@ -1327,15 +1327,15 @@ pub mod in_memory_emulator {
     pub struct InMemoryEmulatorHttpClient {
     }
     impl InMemoryEmulatorHttpClient {
-        fn new(config: VirtualAccountConfig) -> Self;
-        fn runtime_builder(self: &Arc<Self>) -> crate::driver::CosmosDriverRuntimeBuilder;
+        pub fn new(config: VirtualAccountConfig) -> Self;
+        pub fn runtime_builder(self: &Arc<Self>) -> crate::driver::CosmosDriverRuntimeBuilder;
         #[cfg(feature = "fault_injection")]
-        fn runtime_builder_with_fault_rules(self: &Arc<Self>, rules: Vec<Arc<crate::fault_injection::FaultInjectionRule>>) -> crate::driver::CosmosDriverRuntimeBuilder;
-        fn store(&self) -> Arc<EmulatorStore>;
-        fn with_request_observer(self, observer: Arc<dyn RequestObserver>) -> Self;
+        pub fn runtime_builder_with_fault_rules(self: &Arc<Self>, rules: Vec<Arc<crate::fault_injection::FaultInjectionRule>>) -> crate::driver::CosmosDriverRuntimeBuilder;
+        pub fn store(&self) -> Arc<EmulatorStore>;
+        pub fn with_request_observer(self, observer: Arc<dyn RequestObserver>) -> Self;
     }
     impl InMemoryEmulatorHttpClient {
-        async fn execute_request(&self, request: &Request) -> crate::error::Result<AsyncRawResponse>;
+        pub async fn execute_request(&self, request: &Request) -> crate::error::Result<AsyncRawResponse>;
     }
     impl Debug for InMemoryEmulatorHttpClient {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
@@ -1344,17 +1344,17 @@ pub mod in_memory_emulator {
     pub struct ReplicationConfig {
     }
     impl ReplicationConfig {
-        fn fixed(delay: Duration) -> Self;
-        fn immediate() -> Self;
-        fn is_immediate(&self) -> bool;
-        fn max_buffered_replications(&self) -> usize;
-        fn max_delay(&self) -> Duration;
-        fn min_delay(&self) -> Duration;
-        fn range(min: Duration, max: Duration) -> crate::error::Result<Self>;
-        fn sample_delay(&self) -> Duration;
-        fn with_jitter_seed(self, seed: u64) -> Self;
-        fn with_max_buffered_replications(self, max: usize) -> Self;
-        fn with_replication_delay_fn(self, f: std::sync::Arc<dyn Fn() -> std::time::Duration + Send + Sync>) -> Self;
+        pub fn fixed(delay: Duration) -> Self;
+        pub fn immediate() -> Self;
+        pub fn is_immediate(&self) -> bool;
+        pub fn max_buffered_replications(&self) -> usize;
+        pub fn max_delay(&self) -> Duration;
+        pub fn min_delay(&self) -> Duration;
+        pub fn range(min: Duration, max: Duration) -> crate::error::Result<Self>;
+        pub fn sample_delay(&self) -> Duration;
+        pub fn with_jitter_seed(self, seed: u64) -> Self;
+        pub fn with_max_buffered_replications(self, max: usize) -> Self;
+        pub fn with_replication_delay_fn(self, f: std::sync::Arc<dyn Fn() -> std::time::Duration + Send + Sync>) -> Self;
     }
     impl Debug for ReplicationConfig {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
@@ -1362,26 +1362,26 @@ pub mod in_memory_emulator {
     impl Default for ReplicationConfig {
         fn default() -> Self;
     }
-    #[derive(Clone, Debug, Eq, PartialEq)]
-    pub struct ResolvedRegion {
-        pub name: String,
-        pub status: RegionStatus,
-    }
     #[derive(Clone, Debug)]
-    pub struct RuChargingModel {
+    pub struct RequestUnitChargingModel {
         pub read_base_ru: f64,
         pub create_base_ru: f64,
         pub write_multiplier: f64,
         pub indexing_ru_per_property: f64,
     }
-    impl RuChargingModel {
-        fn compute_create_ru(&self, doc_size: usize, num_properties: usize) -> f64;
-        fn compute_read_ru(&self, doc_size: usize) -> f64;
-        fn compute_replace_or_delete_ru(&self, doc_size: usize, num_properties: usize) -> f64;
-        fn count_properties(body: &serde_json::Value) -> usize;
+    impl RequestUnitChargingModel {
+        pub fn compute_create_ru(&self, doc_size: usize, num_properties: usize) -> f64;
+        pub fn compute_read_ru(&self, doc_size: usize) -> f64;
+        pub fn compute_replace_or_delete_ru(&self, doc_size: usize, num_properties: usize) -> f64;
+        pub fn count_properties(body: &serde_json::Value) -> usize;
     }
-    impl Default for RuChargingModel {
+    impl Default for RequestUnitChargingModel {
         fn default() -> Self;
+    }
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct ResolvedRegion {
+        pub name: String,
+        pub status: RegionStatus,
     }
     #[derive(Clone, Debug)]
     pub struct TopologySnapshot {
@@ -1394,46 +1394,46 @@ pub mod in_memory_emulator {
         pub next_write_region: Option<String>,
     }
     impl TopologySnapshot {
-        fn advertised(&self) -> Vec<&VirtualRegion>;
-        fn writable(&self, allow_multiple_write_locations: bool) -> Vec<&VirtualRegion>;
+        pub fn advertised(&self) -> Vec<&VirtualRegion>;
+        pub fn writable(&self, allow_multiple_write_locations: bool) -> Vec<&VirtualRegion>;
     }
     #[derive(Clone, Debug)]
     pub struct VirtualAccountConfig {
     }
     impl VirtualAccountConfig {
-        fn active_region_names(&self) -> Vec<String>;
-        fn active_regions(&self) -> Vec<VirtualRegion>;
-        fn consistency(&self) -> ConsistencyLevel;
-        fn is_write_region(&self, region_name: &str) -> bool;
-        fn new(regions: Vec<VirtualRegion>) -> crate::error::Result<Self>;
-        fn per_partition_failover_enabled(&self) -> bool;
-        fn region_for_url(&self, url: &Url) -> Option<ResolvedRegion>;
-        fn region_id_for(&self, region_name: &str) -> u64;
-        fn replication(&self) -> &ReplicationConfig;
-        fn replication_for(&self, source: &str, target: &str) -> &ReplicationConfig;
-        fn ru_model(&self) -> &RuChargingModel;
-        fn set_per_partition_failover(&self, enabled: bool);
-        fn throttling_enabled(&self) -> bool;
-        fn topology_snapshot(&self) -> TopologySnapshot;
-        fn with_consistency(self, level: ConsistencyLevel) -> Self;
-        fn with_per_partition_failover(self, enabled: bool) -> Self;
-        fn with_replication_config(self, config: ReplicationConfig) -> Self;
-        fn with_replication_override(self, source: &str, target: &str, config: ReplicationConfig) -> crate::error::Result<Self>;
-        fn with_ru_model(self, model: RuChargingModel) -> Self;
-        fn with_throttling_enabled(self, enabled: bool) -> Self;
-        fn with_write_mode(self, mode: WriteMode) -> Self;
-        fn write_mode(&self) -> WriteMode;
-        fn write_region_name(&self) -> String;
+        pub fn active_region_names(&self) -> Vec<String>;
+        pub fn active_regions(&self) -> Vec<VirtualRegion>;
+        pub fn consistency(&self) -> ConsistencyLevel;
+        pub fn is_write_region(&self, region_name: &str) -> bool;
+        pub fn new(regions: Vec<VirtualRegion>) -> crate::error::Result<Self>;
+        pub fn per_partition_failover_enabled(&self) -> bool;
+        pub fn region_for_url(&self, url: &Url) -> Option<ResolvedRegion>;
+        pub fn region_id_for(&self, region_name: &str) -> u64;
+        pub fn replication(&self) -> &ReplicationConfig;
+        pub fn replication_for(&self, source: &str, target: &str) -> &ReplicationConfig;
+        pub fn ru_model(&self) -> &RequestUnitChargingModel;
+        pub fn set_per_partition_failover(&self, enabled: bool);
+        pub fn throttling_enabled(&self) -> bool;
+        pub fn topology_snapshot(&self) -> TopologySnapshot;
+        pub fn with_consistency(self, level: ConsistencyLevel) -> Self;
+        pub fn with_per_partition_failover(self, enabled: bool) -> Self;
+        pub fn with_replication_config(self, config: ReplicationConfig) -> Self;
+        pub fn with_replication_override(self, source: &str, target: &str, config: ReplicationConfig) -> crate::error::Result<Self>;
+        pub fn with_ru_model(self, model: RequestUnitChargingModel) -> Self;
+        pub fn with_throttling_enabled(self, enabled: bool) -> Self;
+        pub fn with_write_mode(self, mode: WriteMode) -> Self;
+        pub fn write_mode(&self) -> WriteMode;
+        pub fn write_region_name(&self) -> String;
     }
     #[derive(Clone, Debug)]
     pub struct VirtualRegion {
     }
     impl VirtualRegion {
-        fn gateway_url(&self) -> &Url;
-        fn name(&self) -> &str;
-        fn new(name: &str, gateway_url: Url) -> Self;
-        fn region_id(&self) -> u64;
-        fn with_region_id(self, id: u64) -> Self;
+        pub fn gateway_url(&self) -> &Url;
+        pub fn name(&self) -> &str;
+        pub fn new(name: &str, gateway_url: Url) -> Self;
+        pub fn region_id(&self) -> u64;
+        pub fn with_region_id(self, id: u64) -> Self;
     }
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub enum ConsistencyLevel {
@@ -1444,8 +1444,8 @@ pub mod in_memory_emulator {
         Eventual,
     }
     impl ConsistencyLevel {
-        fn as_str(&self) -> &str;
-        fn is_session(&self) -> bool;
+        pub fn as_str(&self) -> &str;
+        pub fn is_session(&self) -> bool;
     }
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub enum RegionStatus {
@@ -1455,8 +1455,8 @@ pub mod in_memory_emulator {
         Retired,
     }
     impl RegionStatus {
-        fn is_unavailable(&self) -> bool;
-        fn is_unreachable(&self) -> bool;
+        pub fn is_unavailable(&self) -> bool;
+        pub fn is_unreachable(&self) -> bool;
     }
     #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
     pub enum SeedingPolicy {
@@ -1482,13 +1482,13 @@ pub mod models {
     #[non_exhaustive]
     pub struct AccountReference(/* private fields */);
     impl AccountReference {
-        fn auth(&self) -> &Credential;
-        fn backup_endpoints(&self) -> &[Url];
-        fn builder(endpoint: Url) -> AccountReferenceBuilder;
-        fn endpoint(&self) -> &Url;
-        fn with_backup_endpoints(self, endpoints: Vec<Url>) -> Self;
-        fn with_credential(endpoint: Url, credential: Arc<dyn TokenCredential>) -> Self;
-        fn with_master_key<impl Into<Secret>: Into<Secret>>(endpoint: Url, key: impl Into<Secret>) -> Self;
+        pub fn auth(&self) -> &Credential;
+        pub fn backup_endpoints(&self) -> &[Url];
+        pub fn builder(endpoint: Url) -> AccountReferenceBuilder;
+        pub fn endpoint(&self) -> &Url;
+        pub fn with_backup_endpoints(self, endpoints: Vec<Url>) -> Self;
+        pub fn with_credential(endpoint: Url, credential: Arc<dyn TokenCredential>) -> Self;
+        pub fn with_master_key<impl Into<Secret>: Into<Secret>>(endpoint: Url, key: impl Into<Secret>) -> Self;
     }
     impl Eq for AccountReference {
     }
@@ -1506,22 +1506,22 @@ pub mod models {
     pub struct AccountReferenceBuilder {
     }
     impl AccountReferenceBuilder {
-        fn auth(self, credential: Credential) -> Self;
-        fn build(self) -> crate::error::Result<AccountReference>;
-        fn credential(self, credential: Arc<dyn TokenCredential>) -> Self;
-        fn endpoint(self, endpoint: Url) -> Self;
-        fn master_key<impl Into<Secret>: Into<Secret>>(self, key: impl Into<Secret>) -> Self;
-        fn new(endpoint: Url) -> Self;
-        fn with_backup_endpoints(self, endpoints: Vec<Url>) -> Self;
+        pub fn auth(self, credential: Credential) -> Self;
+        pub fn build(self) -> crate::error::Result<AccountReference>;
+        pub fn credential(self, credential: Arc<dyn TokenCredential>) -> Self;
+        pub fn endpoint(self, endpoint: Url) -> Self;
+        pub fn master_key<impl Into<Secret>: Into<Secret>>(self, key: impl Into<Secret>) -> Self;
+        pub fn new(endpoint: Url) -> Self;
+        pub fn with_backup_endpoints(self, endpoints: Vec<Url>) -> Self;
     }
     #[derive(Clone, Debug, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(transparent)]
     pub struct ActivityId(/* private fields */);
     impl ActivityId {
-        fn as_str(&self) -> &str;
-        const fn from_static(value: &'static str) -> Self;
-        fn from_string(value: String) -> Self;
-        fn new_uuid() -> Self;
+        pub fn as_str(&self) -> &str;
+        pub const fn from_static(value: &'static str) -> Self;
+        pub fn from_string(value: String) -> Self;
+        pub fn new_uuid() -> Self;
     }
     impl AsRef<str> for ActivityId {
         fn as_ref(&self) -> &str;
@@ -1557,8 +1557,8 @@ pub mod models {
     pub struct ConnectionString {
     }
     impl ConnectionString {
-        fn account_endpoint(&self) -> &str;
-        fn account_key(&self) -> &Secret;
+        pub fn account_endpoint(&self) -> &str;
+        pub fn account_key(&self) -> &Secret;
     }
     impl FromStr for ConnectionString {
         type Err = CosmosError;
@@ -1572,16 +1572,16 @@ pub mod models {
     #[non_exhaustive]
     pub struct ContainerReference(/* private fields */);
     impl ContainerReference {
-        fn account(&self) -> &AccountReference;
-        fn base_path(&self) -> &str;
-        fn database_name(&self) -> Option<&str>;
-        fn database_rid(&self) -> &str;
-        fn is_by_rid(&self) -> bool;
-        fn name(&self) -> &str;
-        fn name_based_path(&self) -> Option<&str>;
-        fn partition_key_definition(&self) -> &crate::models::PartitionKeyDefinition;
-        fn rid(&self) -> &str;
-        fn rid_based_path(&self) -> &str;
+        pub fn account(&self) -> &AccountReference;
+        pub fn base_path(&self) -> &str;
+        pub fn database_name(&self) -> Option<&str>;
+        pub fn database_rid(&self) -> &str;
+        pub fn is_by_rid(&self) -> bool;
+        pub fn name(&self) -> &str;
+        pub fn name_based_path(&self) -> Option<&str>;
+        pub fn partition_key_definition(&self) -> &crate::models::PartitionKeyDefinition;
+        pub fn rid(&self) -> &str;
+        pub fn rid_based_path(&self) -> &str;
     }
     impl Eq for ContainerReference {
     }
@@ -1594,8 +1594,8 @@ pub mod models {
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct ContinuationToken(/* private fields */);
     impl ContinuationToken {
-        fn as_str(&self) -> &str;
-        fn from_string(token: String) -> Self;
+        pub fn as_str(&self) -> &str;
+        pub fn from_string(token: String) -> Self;
     }
     impl Serialize for ContinuationToken {
         fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<<S as >::Ok, <S as >::Error>;
@@ -1608,72 +1608,72 @@ pub mod models {
     pub struct CosmosOperation {
     }
     impl CosmosOperation {
-        fn allows_ambiguous_outcome_retry(&self) -> bool;
-        fn batch(container: ContainerReference, partition_key: PartitionKey) -> Self;
-        fn body(&self) -> Option<&[u8]>;
-        fn change_feed(container: ContainerReference, target: Option<FeedRange>) -> Self;
-        fn change_feed_all_versions_and_deletes(container: ContainerReference, target: Option<FeedRange>) -> Self;
-        fn change_feed_start(&self) -> Option<&ChangeFeedStartFrom>;
-        fn container(&self) -> Option<&ContainerReference>;
-        fn create_container(database: DatabaseReference) -> Self;
-        fn create_database(account: AccountReference) -> Self;
-        fn create_item(item: ItemReference) -> Self;
-        fn db_operation_name(&self) -> Option<&'static str>;
-        fn delete_container(container: ContainerReference) -> Self;
-        fn delete_database(database: DatabaseReference) -> Self;
-        fn delete_item(item: ItemReference) -> Self;
+        pub fn allows_ambiguous_outcome_retry(&self) -> bool;
+        pub fn batch(container: ContainerReference, partition_key: PartitionKey) -> Self;
+        pub fn body(&self) -> Option<&[u8]>;
+        pub fn change_feed(container: ContainerReference, target: Option<FeedRange>) -> Self;
+        pub fn change_feed_all_versions_and_deletes(container: ContainerReference, target: Option<FeedRange>) -> Self;
+        pub fn change_feed_start(&self) -> Option<&ChangeFeedStartFrom>;
+        pub fn container(&self) -> Option<&ContainerReference>;
+        pub fn create_container(database: DatabaseReference) -> Self;
+        pub fn create_database(account: AccountReference) -> Self;
+        pub fn create_item(item: ItemReference) -> Self;
+        pub fn db_operation_name(&self) -> Option<&'static str>;
+        pub fn delete_container(container: ContainerReference) -> Self;
+        pub fn delete_database(database: DatabaseReference) -> Self;
+        pub fn delete_item(item: ItemReference) -> Self;
         #[cfg(feature = "preview_dtx")]
-        fn distributed_transaction(account: AccountReference, transaction_type: crate::models::DistributedTransactionType) -> Self;
-        fn is_change_feed(&self) -> bool;
-        fn is_idempotent(&self) -> bool;
-        fn is_patch_sub_operation(&self) -> bool;
-        fn is_read_only(&self) -> bool;
-        fn is_trivial(&self) -> bool;
-        fn operation_type(&self) -> OperationType;
-        fn partition_key(&self) -> Option<&PartitionKey>;
-        fn patch_item(item: ItemReference) -> Self;
-        fn patch_max_attempts(&self) -> Option<std::num::NonZeroU8>;
-        fn patch_tracking_capacity(&self) -> Option<std::num::NonZeroU16>;
-        fn patch_tracking_id(&self) -> Option<crate::models::PatchTrackingId>;
-        fn patch_tracking_retention_seconds(&self) -> Option<std::num::NonZeroU32>;
-        fn precondition(&self) -> Option<&Precondition>;
-        fn query_containers(database: DatabaseReference) -> Self;
-        fn query_databases(account: AccountReference) -> Self;
-        fn query_items(container: ContainerReference, target: Option<FeedRange>) -> Self;
-        fn query_offers(account: AccountReference) -> Self;
-        fn query_plan(container: ContainerReference, supported_query_features: Cow<'static, str>) -> Self;
-        fn read_all_containers(database: DatabaseReference) -> Self;
-        fn read_all_databases(account: AccountReference) -> Self;
-        fn read_all_items(container: ContainerReference, partition_key: PartitionKey) -> Self;
-        fn read_all_items_cross_partition(container: ContainerReference) -> Self;
-        fn read_container(container: ContainerReference) -> Self;
-        fn read_container_by_name<impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>>(database: DatabaseReference, container_name: impl Into<std::borrow::Cow<'static, str>>) -> Self;
-        fn read_container_by_rid<impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>, impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>>(account: AccountReference, db_rid: impl Into<std::borrow::Cow<'static, str>>, container_rid: impl Into<std::borrow::Cow<'static, str>>) -> Self;
-        fn read_database(database: DatabaseReference) -> Self;
-        fn read_item(item: ItemReference) -> Self;
-        fn read_offer<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(account: AccountReference, offer_id: impl Into<Cow<'static, str>>) -> Self;
-        fn replace_container(container: ContainerReference) -> Self;
-        fn replace_item(item: ItemReference) -> Self;
-        fn replace_offer<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(account: AccountReference, offer_id: impl Into<Cow<'static, str>>) -> Self;
-        fn request_headers(&self) -> &CosmosRequestHeaders;
-        fn resource_type(&self) -> ResourceType;
-        fn target(&self) -> Option<&FeedRange>;
-        fn upsert_item(item: ItemReference) -> Self;
-        fn with_activity_id(self, activity_id: crate::models::ActivityId) -> Self;
-        fn with_body(self, body: Vec<u8>) -> Self;
-        fn with_change_feed_start(self, start_from: ChangeFeedStartFrom) -> Self;
-        fn with_if_modified_since(self, value: String) -> Self;
-        fn with_max_item_count(self, max_item_count: crate::models::MaxItemCountHint) -> Self;
-        fn with_patch_max_attempts(self, max_attempts: std::num::NonZeroU8) -> Self;
-        fn with_patch_tracking_capacity(self, capacity: std::num::NonZeroU16) -> Self;
-        fn with_patch_tracking_id(self, tracking_id: crate::models::PatchTrackingId) -> Self;
-        fn with_patch_tracking_retention_seconds(self, retention_seconds: std::num::NonZeroU32) -> Self;
-        fn with_populate_index_metrics(self, enabled: bool) -> Self;
-        fn with_populate_query_metrics(self, enabled: bool) -> Self;
-        fn with_precondition(self, precondition: Precondition) -> Self;
-        fn with_request_headers(self, headers: CosmosRequestHeaders) -> Self;
-        fn with_session_token<impl Into<crate::models::SessionToken>: Into<crate::models::SessionToken>>(self, session_token: impl Into<crate::models::SessionToken>) -> Self;
-        fn with_supported_serialization_formats<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, formats: impl Into<Cow<'static, str>>) -> Self;
+        pub fn distributed_transaction(account: AccountReference, transaction_type: crate::models::DistributedTransactionType) -> Self;
+        pub fn is_change_feed(&self) -> bool;
+        pub fn is_idempotent(&self) -> bool;
+        pub fn is_patch_sub_operation(&self) -> bool;
+        pub fn is_read_only(&self) -> bool;
+        pub fn is_trivial(&self) -> bool;
+        pub fn operation_type(&self) -> OperationType;
+        pub fn partition_key(&self) -> Option<&PartitionKey>;
+        pub fn patch_item(item: ItemReference) -> Self;
+        pub fn patch_max_attempts(&self) -> Option<std::num::NonZeroU8>;
+        pub fn patch_tracking_capacity(&self) -> Option<std::num::NonZeroU16>;
+        pub fn patch_tracking_id(&self) -> Option<crate::models::PatchTrackingId>;
+        pub fn patch_tracking_retention_seconds(&self) -> Option<std::num::NonZeroU32>;
+        pub fn precondition(&self) -> Option<&Precondition>;
+        pub fn query_containers(database: DatabaseReference) -> Self;
+        pub fn query_databases(account: AccountReference) -> Self;
+        pub fn query_items(container: ContainerReference, target: Option<FeedRange>) -> Self;
+        pub fn query_offers(account: AccountReference) -> Self;
+        pub fn query_plan(container: ContainerReference, supported_query_features: Cow<'static, str>) -> Self;
+        pub fn read_all_containers(database: DatabaseReference) -> Self;
+        pub fn read_all_databases(account: AccountReference) -> Self;
+        pub fn read_all_items(container: ContainerReference, partition_key: PartitionKey) -> Self;
+        pub fn read_all_items_cross_partition(container: ContainerReference) -> Self;
+        pub fn read_container(container: ContainerReference) -> Self;
+        pub fn read_container_by_name<impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>>(database: DatabaseReference, container_name: impl Into<std::borrow::Cow<'static, str>>) -> Self;
+        pub fn read_container_by_rid<impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>, impl Into<std::borrow::Cow<'static, str>>: Into<std::borrow::Cow<'static, str>>>(account: AccountReference, db_rid: impl Into<std::borrow::Cow<'static, str>>, container_rid: impl Into<std::borrow::Cow<'static, str>>) -> Self;
+        pub fn read_database(database: DatabaseReference) -> Self;
+        pub fn read_item(item: ItemReference) -> Self;
+        pub fn read_offer<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(account: AccountReference, offer_id: impl Into<Cow<'static, str>>) -> Self;
+        pub fn replace_container(container: ContainerReference) -> Self;
+        pub fn replace_item(item: ItemReference) -> Self;
+        pub fn replace_offer<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(account: AccountReference, offer_id: impl Into<Cow<'static, str>>) -> Self;
+        pub fn request_headers(&self) -> &CosmosRequestHeaders;
+        pub fn resource_type(&self) -> ResourceType;
+        pub fn target(&self) -> Option<&FeedRange>;
+        pub fn upsert_item(item: ItemReference) -> Self;
+        pub fn with_activity_id(self, activity_id: crate::models::ActivityId) -> Self;
+        pub fn with_body(self, body: Vec<u8>) -> Self;
+        pub fn with_change_feed_start(self, start_from: ChangeFeedStartFrom) -> Self;
+        pub fn with_if_modified_since(self, value: String) -> Self;
+        pub fn with_max_item_count(self, max_item_count: crate::models::MaxItemCountHint) -> Self;
+        pub fn with_patch_max_attempts(self, max_attempts: std::num::NonZeroU8) -> Self;
+        pub fn with_patch_tracking_capacity(self, capacity: std::num::NonZeroU16) -> Self;
+        pub fn with_patch_tracking_id(self, tracking_id: crate::models::PatchTrackingId) -> Self;
+        pub fn with_patch_tracking_retention_seconds(self, retention_seconds: std::num::NonZeroU32) -> Self;
+        pub fn with_populate_index_metrics(self, enabled: bool) -> Self;
+        pub fn with_populate_query_metrics(self, enabled: bool) -> Self;
+        pub fn with_precondition(self, precondition: Precondition) -> Self;
+        pub fn with_request_headers(self, headers: CosmosRequestHeaders) -> Self;
+        pub fn with_session_token<impl Into<crate::models::SessionToken>: Into<crate::models::SessionToken>>(self, session_token: impl Into<crate::models::SessionToken>) -> Self;
+        pub fn with_supported_serialization_formats<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, formats: impl Into<Cow<'static, str>>) -> Self;
     }
     #[derive(Clone, Debug, Default)]
     #[non_exhaustive]
@@ -1695,21 +1695,21 @@ pub mod models {
         pub supported_serialization_formats: Option<std::borrow::Cow<'static, str>>,
     }
     impl CosmosRequestHeaders {
-        fn new() -> Self;
+        pub fn new() -> Self;
     }
     #[derive(Clone, Debug)]
     pub struct CosmosResourceReference {
     }
     impl CosmosResourceReference {
-        fn account(&self) -> &AccountReference;
-        fn container(&self) -> Option<&ContainerReference>;
-        fn into_feed_reference(self) -> Self;
-        fn link_for_signing(&self) -> String;
-        fn request_path(&self) -> String;
-        fn resource_type(&self) -> ResourceType;
-        fn with_name(self, name: Cow<'static, str>) -> Self;
-        fn with_resource_type(self, resource_type: ResourceType) -> Self;
-        fn with_rid(self, rid: Cow<'static, str>) -> Self;
+        pub fn account(&self) -> &AccountReference;
+        pub fn container(&self) -> Option<&ContainerReference>;
+        pub fn into_feed_reference(self) -> Self;
+        pub fn link_for_signing(&self) -> String;
+        pub fn request_path(&self) -> String;
+        pub fn resource_type(&self) -> ResourceType;
+        pub fn with_name(self, name: Cow<'static, str>) -> Self;
+        pub fn with_resource_type(self, resource_type: ResourceType) -> Self;
+        pub fn with_rid(self, rid: Cow<'static, str>) -> Self;
     }
     impl Display for CosmosResourceReference {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
@@ -1737,14 +1737,14 @@ pub mod models {
     pub struct CosmosResponse {
     }
     impl CosmosResponse {
-        fn body(&self) -> &ResponseBody;
-        fn diagnostics(&self) -> Arc<DiagnosticsContext>;
-        fn diagnostics_ref(&self) -> &Arc<DiagnosticsContext>;
-        fn headers(&self) -> &CosmosResponseHeaders;
-        fn into_body(self) -> ResponseBody;
-        fn patch_tracking_id(&self) -> Option<PatchTrackingId>;
-        fn serving_region(&self) -> Option<Region>;
-        fn status(&self) -> CosmosStatus;
+        pub fn body(&self) -> &ResponseBody;
+        pub fn diagnostics(&self) -> Arc<DiagnosticsContext>;
+        pub fn diagnostics_ref(&self) -> &Arc<DiagnosticsContext>;
+        pub fn headers(&self) -> &CosmosResponseHeaders;
+        pub fn into_body(self) -> ResponseBody;
+        pub fn patch_tracking_id(&self) -> Option<PatchTrackingId>;
+        pub fn serving_region(&self) -> Option<Region>;
+        pub fn status(&self) -> CosmosStatus;
     }
     #[derive(Clone, Debug, Default)]
     #[non_exhaustive]
@@ -1786,9 +1786,9 @@ pub mod models {
         pub distributed_transaction_idempotency_token: Option<uuid::Uuid>,
     }
     impl CosmosResponseHeaders {
-        fn from_headers(headers: &Headers) -> Self;
-        fn new() -> Self;
-        fn to_raw_headers(&self) -> Headers;
+        pub fn from_headers(headers: &Headers) -> Self;
+        pub fn new() -> Self;
+        pub fn to_raw_headers(&self) -> Headers;
     }
     #[derive(Clone, Copy, Eq, Hash, PartialEq)]
     pub struct CosmosStatus {
@@ -1880,29 +1880,29 @@ pub mod models {
         const TRANSPORT_HTTP2_INCOMPATIBLE: CosmosStatus = _;
         const TRANSPORT_IO_FAILED: CosmosStatus = _;
         const WRITE_FORBIDDEN: CosmosStatus = _;
-        fn is_bad_request(&self) -> bool;
-        fn is_conflict(&self) -> bool;
-        fn is_database_account_not_found(&self) -> bool;
-        fn is_forbidden(&self) -> bool;
-        fn is_gone(&self) -> bool;
-        fn is_not_found(&self) -> bool;
-        fn is_partition_key_range_gone(&self) -> bool;
-        fn is_precondition_failed(&self) -> bool;
-        fn is_read_session_not_available(&self) -> bool;
-        fn is_retry_with(&self) -> bool;
-        fn is_service_unavailable(&self) -> bool;
-        fn is_success(&self) -> bool;
-        fn is_throttled(&self) -> bool;
-        fn is_timeout(&self) -> bool;
-        fn is_transient(&self) -> bool;
-        fn is_transport_generated_503(&self) -> bool;
-        fn is_unauthorized(&self) -> bool;
-        fn is_write_forbidden(&self) -> bool;
-        fn name(&self) -> Option<&'static str>;
-        fn new(status_code: StatusCode) -> Self;
-        fn status_code(&self) -> StatusCode;
-        fn sub_status(&self) -> Option<SubStatusCode>;
-        fn with_sub_status(self, sub_status_code: u16) -> Self;
+        pub fn is_bad_request(&self) -> bool;
+        pub fn is_conflict(&self) -> bool;
+        pub fn is_database_account_not_found(&self) -> bool;
+        pub fn is_forbidden(&self) -> bool;
+        pub fn is_gone(&self) -> bool;
+        pub fn is_not_found(&self) -> bool;
+        pub fn is_partition_key_range_gone(&self) -> bool;
+        pub fn is_precondition_failed(&self) -> bool;
+        pub fn is_read_session_not_available(&self) -> bool;
+        pub fn is_retry_with(&self) -> bool;
+        pub fn is_service_unavailable(&self) -> bool;
+        pub fn is_success(&self) -> bool;
+        pub fn is_throttled(&self) -> bool;
+        pub fn is_timeout(&self) -> bool;
+        pub fn is_transient(&self) -> bool;
+        pub fn is_transport_generated_503(&self) -> bool;
+        pub fn is_unauthorized(&self) -> bool;
+        pub fn is_write_forbidden(&self) -> bool;
+        pub fn name(&self) -> Option<&'static str>;
+        pub fn new(status_code: StatusCode) -> Self;
+        pub fn status_code(&self) -> StatusCode;
+        pub fn sub_status(&self) -> Option<SubStatusCode>;
+        pub fn with_sub_status(self, sub_status_code: u16) -> Self;
     }
     impl Debug for CosmosStatus {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1929,15 +1929,15 @@ pub mod models {
     #[non_exhaustive]
     pub struct DatabaseReference(/* private fields */);
     impl DatabaseReference {
-        fn account(&self) -> &AccountReference;
-        fn from_name<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(account: AccountReference, name: impl Into<Cow<'static, str>>) -> Self;
-        fn from_rid<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(account: AccountReference, rid: impl Into<Cow<'static, str>>) -> Self;
-        fn is_by_name(&self) -> bool;
-        fn is_by_rid(&self) -> bool;
-        fn name(&self) -> Option<&str>;
-        fn name_based_path(&self) -> Option<String>;
-        fn rid(&self) -> Option<&str>;
-        fn rid_based_path(&self) -> Option<String>;
+        pub fn account(&self) -> &AccountReference;
+        pub fn from_name<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(account: AccountReference, name: impl Into<Cow<'static, str>>) -> Self;
+        pub fn from_rid<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(account: AccountReference, rid: impl Into<Cow<'static, str>>) -> Self;
+        pub fn is_by_name(&self) -> bool;
+        pub fn is_by_rid(&self) -> bool;
+        pub fn name(&self) -> Option<&str>;
+        pub fn name_based_path(&self) -> Option<String>;
+        pub fn rid(&self) -> Option<&str>;
+        pub fn rid_based_path(&self) -> Option<String>;
     }
     #[cfg(feature = "preview_dtx")]
     #[derive(Clone, Debug)]
@@ -1952,11 +1952,11 @@ pub mod models {
     }
     #[cfg(feature = "preview_dtx")]
     impl DistributedTransactionOperation {
-        fn new(kind: DistributedTransactionOperationKind, target: DistributedTransactionTarget) -> Self;
-        fn with_patch_filter_predicate<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, predicate: impl Into<Cow<'static, str>>) -> Self;
-        fn with_precondition(self, precondition: Precondition) -> Self;
-        fn with_resource_body<impl Into<Bytes>: Into<Bytes>>(self, body: impl Into<Bytes>) -> Self;
-        fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, session_token: impl Into<SessionToken>) -> Self;
+        pub fn new(kind: DistributedTransactionOperationKind, target: DistributedTransactionTarget) -> Self;
+        pub fn with_patch_filter_predicate<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(self, predicate: impl Into<Cow<'static, str>>) -> Self;
+        pub fn with_precondition(self, precondition: Precondition) -> Self;
+        pub fn with_resource_body<impl Into<Bytes>: Into<Bytes>>(self, body: impl Into<Bytes>) -> Self;
+        pub fn with_session_token<impl Into<SessionToken>: Into<SessionToken>>(self, session_token: impl Into<SessionToken>) -> Self;
     }
     #[cfg(feature = "preview_dtx")]
     #[derive(Clone, Debug)]
@@ -1974,8 +1974,8 @@ pub mod models {
     }
     #[cfg(feature = "preview_dtx")]
     impl DistributedTransactionOperationResult {
-        fn is_completed_status_code(&self) -> bool;
-        fn is_success_status_code(&self) -> bool;
+        pub fn is_completed_status_code(&self) -> bool;
+        pub fn is_success_status_code(&self) -> bool;
     }
     #[cfg(feature = "preview_dtx")]
     #[derive(Clone, Debug)]
@@ -1987,8 +1987,8 @@ pub mod models {
     }
     #[cfg(feature = "preview_dtx")]
     impl DistributedTransactionRequest {
-        fn new(transaction_type: DistributedTransactionType, operations: Vec<DistributedTransactionOperation>) -> Self;
-        fn serialize_body(&self) -> crate::error::Result<Vec<u8>>;
+        pub fn new(transaction_type: DistributedTransactionType, operations: Vec<DistributedTransactionOperation>) -> Self;
+        pub fn serialize_body(&self) -> crate::error::Result<Vec<u8>>;
     }
     #[cfg(feature = "preview_dtx")]
     #[derive(Clone, Debug)]
@@ -2009,11 +2009,11 @@ pub mod models {
     }
     #[cfg(feature = "preview_dtx")]
     impl DistributedTransactionResponse {
-        fn from_body(status_code: azure_core::http::StatusCode, sub_status_code: Option<crate::models::SubStatusCode>, body: &[u8], operation_count: usize, idempotency_token: Uuid) -> Self;
-        fn is_completed_status_code(&self) -> bool;
-        fn is_empty(&self) -> bool;
-        fn is_success_status_code(&self) -> bool;
-        fn len(&self) -> usize;
+        pub fn from_body(status_code: azure_core::http::StatusCode, sub_status_code: Option<crate::models::SubStatusCode>, body: &[u8], operation_count: usize, idempotency_token: Uuid) -> Self;
+        pub fn is_completed_status_code(&self) -> bool;
+        pub fn is_empty(&self) -> bool;
+        pub fn is_success_status_code(&self) -> bool;
+        pub fn len(&self) -> usize;
     }
     #[cfg(feature = "preview_dtx")]
     #[derive(Clone, Debug)]
@@ -2025,19 +2025,19 @@ pub mod models {
     }
     #[cfg(feature = "preview_dtx")]
     impl DistributedTransactionTarget {
-        fn new<impl Into<PartitionKey>: Into<PartitionKey>, impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: ContainerReference, partition_key: impl Into<PartitionKey>, id: impl Into<Cow<'static, str>>) -> Self;
+        pub fn new<impl Into<PartitionKey>: Into<PartitionKey>, impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: ContainerReference, partition_key: impl Into<PartitionKey>, id: impl Into<Cow<'static, str>>) -> Self;
     }
     #[derive(Clone, Debug, Eq, Hash, PartialEq)]
     pub struct FeedRange(/* private fields */);
     impl FeedRange {
-        fn for_partition(partition_key: PartitionKey, definition: &PartitionKeyDefinition) -> Self;
-        fn full() -> Self;
-        fn is_logical_partition(&self) -> bool;
-        fn is_subset_of(&self, other: &FeedRange) -> bool;
-        fn max_exclusive(&self) -> &EffectivePartitionKey;
-        fn min_inclusive(&self) -> &EffectivePartitionKey;
-        fn new(min_inclusive: EffectivePartitionKey, max_exclusive: EffectivePartitionKey) -> crate::error::Result<Self>;
-        fn overlaps(&self, other: &FeedRange) -> bool;
+        pub fn for_partition(partition_key: PartitionKey, definition: &PartitionKeyDefinition) -> Self;
+        pub fn full() -> Self;
+        pub fn is_logical_partition(&self) -> bool;
+        pub fn is_subset_of(&self, other: &FeedRange) -> bool;
+        pub fn max_exclusive(&self) -> &EffectivePartitionKey;
+        pub fn min_inclusive(&self) -> &EffectivePartitionKey;
+        pub fn new(min_inclusive: EffectivePartitionKey, max_exclusive: EffectivePartitionKey) -> crate::error::Result<Self>;
+        pub fn overlaps(&self, other: &FeedRange) -> bool;
     }
     impl Display for FeedRange {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -2060,16 +2060,16 @@ pub mod models {
     #[non_exhaustive]
     pub struct ItemReference(/* private fields */);
     impl ItemReference {
-        fn account(&self) -> &AccountReference;
-        fn container(&self) -> &ContainerReference;
-        fn from_name<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, partition_key: PartitionKey, item_name: impl Into<Cow<'static, str>>) -> Self;
-        fn from_rid<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, partition_key: PartitionKey, item_rid: impl Into<Cow<'static, str>>) -> Self;
-        fn is_by_name(&self) -> bool;
-        fn is_by_rid(&self) -> bool;
-        fn name(&self) -> Option<&str>;
-        fn partition_key(&self) -> &PartitionKey;
-        fn resource_link(&self) -> &str;
-        fn rid(&self) -> Option<&str>;
+        pub fn account(&self) -> &AccountReference;
+        pub fn container(&self) -> &ContainerReference;
+        pub fn from_name<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, partition_key: PartitionKey, item_name: impl Into<Cow<'static, str>>) -> Self;
+        pub fn from_rid<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, partition_key: PartitionKey, item_rid: impl Into<Cow<'static, str>>) -> Self;
+        pub fn is_by_name(&self) -> bool;
+        pub fn is_by_rid(&self) -> bool;
+        pub fn name(&self) -> Option<&str>;
+        pub fn partition_key(&self) -> &PartitionKey;
+        pub fn resource_link(&self) -> &str;
+        pub fn rid(&self) -> Option<&str>;
     }
     #[derive(Clone, Debug, Default, serde::Serialize)]
     #[non_exhaustive]
@@ -2080,8 +2080,8 @@ pub mod models {
         pub auto_upgrade_policy: Option<AutoscaleAutoUpgradePolicy>,
     }
     impl OfferAutoscaleSettings {
-        fn new(max_throughput: usize) -> Self;
-        fn with_increment_percent(self, increment_percent: usize) -> Self;
+        pub fn new(max_throughput: usize) -> Self;
+        pub fn with_increment_percent(self, increment_percent: usize) -> Self;
     }
     #[derive(Clone, Debug, Eq, Hash, PartialEq)]
     #[non_exhaustive]
@@ -2089,9 +2089,9 @@ pub mod models {
     impl PartitionKey {
         const NULL: PartitionKeyValue = PartitionKeyValue::NULL;
         const UNDEFINED: PartitionKeyValue = PartitionKeyValue::UNDEFINED;
-        fn is_empty(&self) -> bool;
-        fn len(&self) -> usize;
-        fn values(&self) -> &[PartitionKeyValue];
+        pub fn is_empty(&self) -> bool;
+        pub fn len(&self) -> usize;
+        pub fn values(&self) -> &[PartitionKeyValue];
     }
     impl AsHeaders for PartitionKey {
         type Error = CosmosError;
@@ -2116,13 +2116,13 @@ pub mod models {
     pub struct PartitionKeyDefinition {
     }
     impl PartitionKeyDefinition {
-        fn is_complete(&self, pk: &PartitionKey) -> bool;
-        fn kind(&self) -> PartitionKeyKind;
-        fn new(paths: Vec<Cow<'static, str>>) -> Self;
-        fn paths(&self) -> &[Cow<'static, str>];
-        fn version(&self) -> PartitionKeyVersion;
-        fn with_kind(self, kind: PartitionKeyKind) -> Self;
-        fn with_version(self, version: PartitionKeyVersion) -> Self;
+        pub fn is_complete(&self, pk: &PartitionKey) -> bool;
+        pub fn kind(&self) -> PartitionKeyKind;
+        pub fn new(paths: Vec<Cow<'static, str>>) -> Self;
+        pub fn paths(&self) -> &[Cow<'static, str>];
+        pub fn version(&self) -> PartitionKeyVersion;
+        pub fn with_kind(self, kind: PartitionKeyKind) -> Self;
+        pub fn with_version(self, version: PartitionKeyVersion) -> Self;
     }
     impl From<&str> for PartitionKeyDefinition {
         fn from(value: &str) -> Self;
@@ -2143,10 +2143,10 @@ pub mod models {
     pub struct PartitionKeyRangeReference {
     }
     impl PartitionKeyRangeReference {
-        fn account(&self) -> &AccountReference;
-        fn container(&self) -> &ContainerReference;
-        fn from_range_id<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, range_id: impl Into<Cow<'static, str>>) -> Self;
-        fn range_id(&self) -> &str;
+        pub fn account(&self) -> &AccountReference;
+        pub fn container(&self) -> &ContainerReference;
+        pub fn from_range_id<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, range_id: impl Into<Cow<'static, str>>) -> Self;
+        pub fn range_id(&self) -> &str;
     }
     #[derive(Clone, Debug, Eq, Hash, PartialEq)]
     #[non_exhaustive]
@@ -2216,9 +2216,9 @@ pub mod models {
         pub operations: Vec<PatchOperation>,
     }
     impl PatchInstructions {
-        fn is_retry_safe(&self) -> bool;
-        fn new() -> Self;
-        fn with_operation(self, operation: PatchOperation) -> Self;
+        pub fn is_retry_safe(&self) -> bool;
+        pub fn new() -> Self;
+        pub fn with_operation(self, operation: PatchOperation) -> Self;
     }
     impl From<Vec<PatchOperation>> for PatchInstructions {
         fn from(operations: Vec<PatchOperation>) -> Self;
@@ -2226,8 +2226,8 @@ pub mod models {
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     pub struct PatchTrackingId(/* private fields */);
     impl PatchTrackingId {
-        fn as_uuid(&self) -> Uuid;
-        fn new() -> Self;
+        pub fn as_uuid(&self) -> Uuid;
+        pub fn new() -> Self;
     }
     impl Default for PatchTrackingId {
         fn default() -> Self;
@@ -2252,8 +2252,8 @@ pub mod models {
     #[serde(transparent)]
     pub struct RequestCharge(/* private fields */);
     impl RequestCharge {
-        fn new(value: f64) -> Self;
-        const fn value(self) -> f64;
+        pub fn new(value: f64) -> Self;
+        pub const fn value(self) -> f64;
     }
     impl Add for RequestCharge {
         type Output = RequestCharge;
@@ -2280,9 +2280,9 @@ pub mod models {
     #[derive(Clone, Debug, Eq, Hash, PartialEq)]
     pub struct SessionToken(pub std::borrow::Cow<'static, str>);
     impl SessionToken {
-        fn as_str(&self) -> &str;
-        fn merge(&self, other: &Self) -> crate::error::Result<Self>;
-        fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(value: impl Into<Cow<'static, str>>) -> Self;
+        pub fn as_str(&self) -> &str;
+        pub fn merge(&self, other: &Self) -> crate::error::Result<Self>;
+        pub fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(value: impl Into<Cow<'static, str>>) -> Self;
     }
     impl AsRef<str> for SessionToken {
         fn as_ref(&self) -> &str;
@@ -2298,11 +2298,11 @@ pub mod models {
     pub struct SessionTokenSegment {
     }
     impl SessionTokenSegment {
-        fn global_lsn(&self) -> u64;
-        fn is_as_recent_as(&self, other: &Self) -> bool;
-        fn merge_value(&mut self, other: &Self) -> bool;
-        fn pk_range_id(&self) -> &str;
-        fn set_pk_range_id<impl Into<String>: Into<String>>(&mut self, id: impl Into<String>);
+        pub fn global_lsn(&self) -> u64;
+        pub fn is_as_recent_as(&self, other: &Self) -> bool;
+        pub fn merge_value(&mut self, other: &Self) -> bool;
+        pub fn pk_range_id(&self) -> &str;
+        pub fn set_pk_range_id<impl Into<String>: Into<String>>(&mut self, id: impl Into<String>);
     }
     impl Display for SessionTokenSegment {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -2316,15 +2316,15 @@ pub mod models {
     pub struct StoredProcedureReference {
     }
     impl StoredProcedureReference {
-        fn account(&self) -> &AccountReference;
-        fn container(&self) -> &ContainerReference;
-        fn from_name<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, stored_procedure_name: impl Into<Cow<'static, str>>) -> Self;
-        fn from_rid<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, stored_procedure_rid: impl Into<Cow<'static, str>>) -> Self;
-        fn is_by_name(&self) -> bool;
-        fn is_by_rid(&self) -> bool;
-        fn name(&self) -> Option<&str>;
-        fn resource_link(&self) -> &str;
-        fn rid(&self) -> Option<&str>;
+        pub fn account(&self) -> &AccountReference;
+        pub fn container(&self) -> &ContainerReference;
+        pub fn from_name<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, stored_procedure_name: impl Into<Cow<'static, str>>) -> Self;
+        pub fn from_rid<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, stored_procedure_rid: impl Into<Cow<'static, str>>) -> Self;
+        pub fn is_by_name(&self) -> bool;
+        pub fn is_by_rid(&self) -> bool;
+        pub fn name(&self) -> Option<&str>;
+        pub fn resource_link(&self) -> &str;
+        pub fn rid(&self) -> Option<&str>;
     }
     #[derive(Clone, Copy, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(transparent)]
@@ -2604,10 +2604,10 @@ pub mod models {
         const VALUE_DOES_NOT_MATCH_EXPECTED_BOUND: SubStatusCode = _;
         const WRITE_FORBIDDEN: SubStatusCode = _;
         const XP_COMPOSITE_REPLICATOR: SubStatusCode = _;
-        fn from_header_value(s: &str) -> Option<Self>;
-        fn name(&self, status_code: Option<StatusCode>) -> Option<&'static str>;
-        const fn new(code: u16) -> Self;
-        const fn value(&self) -> u16;
+        pub fn from_header_value(s: &str) -> Option<Self>;
+        pub fn name(&self, status_code: Option<StatusCode>) -> Option<&'static str>;
+        pub const fn new(code: u16) -> Self;
+        pub const fn value(&self) -> u16;
     }
     impl Debug for SubStatusCode {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -2627,8 +2627,8 @@ pub mod models {
     #[derive(Clone, Debug, Eq, Hash, PartialEq)]
     pub struct ThroughputControlGroupName(pub std::borrow::Cow<'static, str>);
     impl ThroughputControlGroupName {
-        fn as_str(&self) -> &str;
-        fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(name: impl Into<Cow<'static, str>>) -> Self;
+        pub fn as_str(&self) -> &str;
+        pub fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(name: impl Into<Cow<'static, str>>) -> Self;
     }
     impl AsRef<str> for ThroughputControlGroupName {
         fn as_ref(&self) -> &str;
@@ -2650,38 +2650,38 @@ pub mod models {
     pub struct TriggerReference {
     }
     impl TriggerReference {
-        fn account(&self) -> &AccountReference;
-        fn container(&self) -> &ContainerReference;
-        fn from_name<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, trigger_name: impl Into<Cow<'static, str>>) -> Self;
-        fn from_rid<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, trigger_rid: impl Into<Cow<'static, str>>) -> Self;
-        fn is_by_name(&self) -> bool;
-        fn is_by_rid(&self) -> bool;
-        fn name(&self) -> Option<&str>;
-        fn resource_link(&self) -> &str;
-        fn rid(&self) -> Option<&str>;
+        pub fn account(&self) -> &AccountReference;
+        pub fn container(&self) -> &ContainerReference;
+        pub fn from_name<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, trigger_name: impl Into<Cow<'static, str>>) -> Self;
+        pub fn from_rid<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, trigger_rid: impl Into<Cow<'static, str>>) -> Self;
+        pub fn is_by_name(&self) -> bool;
+        pub fn is_by_rid(&self) -> bool;
+        pub fn name(&self) -> Option<&str>;
+        pub fn resource_link(&self) -> &str;
+        pub fn rid(&self) -> Option<&str>;
     }
     #[derive(Clone, Debug, Eq, Hash, PartialEq)]
     #[non_exhaustive]
     pub struct UdfReference {
     }
     impl UdfReference {
-        fn account(&self) -> &AccountReference;
-        fn container(&self) -> &ContainerReference;
-        fn from_name<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, udf_name: impl Into<Cow<'static, str>>) -> Self;
-        fn from_rid<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, udf_rid: impl Into<Cow<'static, str>>) -> Self;
-        fn is_by_name(&self) -> bool;
-        fn is_by_rid(&self) -> bool;
-        fn name(&self) -> Option<&str>;
-        fn resource_link(&self) -> &str;
-        fn rid(&self) -> Option<&str>;
+        pub fn account(&self) -> &AccountReference;
+        pub fn container(&self) -> &ContainerReference;
+        pub fn from_name<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, udf_name: impl Into<Cow<'static, str>>) -> Self;
+        pub fn from_rid<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(container: &ContainerReference, udf_rid: impl Into<Cow<'static, str>>) -> Self;
+        pub fn is_by_name(&self) -> bool;
+        pub fn is_by_rid(&self) -> bool;
+        pub fn name(&self) -> Option<&str>;
+        pub fn resource_link(&self) -> &str;
+        pub fn rid(&self) -> Option<&str>;
     }
     #[derive(Clone, Debug, Eq, PartialEq)]
     #[non_exhaustive]
     pub struct UserAgent {
     }
     impl UserAgent {
-        fn as_str(&self) -> &str;
-        fn suffix(&self) -> Option<&str>;
+        pub fn as_str(&self) -> &str;
+        pub fn suffix(&self) -> Option<&str>;
     }
     impl Default for UserAgent {
         fn default() -> Self;
@@ -2757,7 +2757,7 @@ pub mod models {
     }
     #[cfg(feature = "preview_dtx")]
     impl DistributedTransactionType {
-        fn as_str(self) -> &'static str;
+        pub fn as_str(self) -> &'static str;
     }
     #[cfg(feature = "preview_dtx")]
     impl AsRef<str> for DistributedTransactionType {
@@ -2796,12 +2796,12 @@ pub mod models {
         ReadDistributedTransaction,
     }
     impl OperationType {
-        fn as_str(self) -> &'static str;
-        fn http_method(self) -> azure_core::http::Method;
-        fn is_feed(self) -> bool;
-        fn is_idempotent(self) -> bool;
-        fn is_read_only(self) -> bool;
-        fn routes_to_write_endpoints(self) -> bool;
+        pub fn as_str(self) -> &'static str;
+        pub fn http_method(self) -> azure_core::http::Method;
+        pub fn is_feed(self) -> bool;
+        pub fn is_idempotent(self) -> bool;
+        pub fn is_read_only(self) -> bool;
+        pub fn routes_to_write_endpoints(self) -> bool;
     }
     impl AsRef<str> for OperationType {
         fn as_ref(&self) -> &str;
@@ -2825,7 +2825,7 @@ pub mod models {
         V2,
     }
     impl PartitionKeyVersion {
-        const fn value(self) -> u32;
+        pub const fn value(self) -> u32;
     }
     impl From<PartitionKeyVersion> for u32 {
         fn from(version: PartitionKeyVersion) -> Self;
@@ -2847,13 +2847,13 @@ pub mod models {
         Move { from: String, path: String },
     }
     impl PatchOperation {
-        fn add<impl Into<String>: Into<String>>(path: impl Into<String>, value: Value) -> Self;
-        fn increment<impl Into<String>: Into<String>, impl Into<CosmosNumber>: Into<CosmosNumber>>(path: impl Into<String>, value: impl Into<CosmosNumber>) -> Self;
-        fn move_value<impl Into<String>: Into<String>, impl Into<String>: Into<String>>(from: impl Into<String>, path: impl Into<String>) -> Self;
-        fn path(&self) -> &str;
-        fn remove<impl Into<String>: Into<String>>(path: impl Into<String>) -> Self;
-        fn replace<impl Into<String>: Into<String>>(path: impl Into<String>, value: Value) -> Self;
-        fn set<impl Into<String>: Into<String>>(path: impl Into<String>, value: Value) -> Self;
+        pub fn add<impl Into<String>: Into<String>>(path: impl Into<String>, value: Value) -> Self;
+        pub fn increment<impl Into<String>: Into<String>, impl Into<CosmosNumber>: Into<CosmosNumber>>(path: impl Into<String>, value: impl Into<CosmosNumber>) -> Self;
+        pub fn move_value<impl Into<String>: Into<String>, impl Into<String>: Into<String>>(from: impl Into<String>, path: impl Into<String>) -> Self;
+        pub fn path(&self) -> &str;
+        pub fn remove<impl Into<String>: Into<String>>(path: impl Into<String>) -> Self;
+        pub fn replace<impl Into<String>: Into<String>>(path: impl Into<String>, value: Value) -> Self;
+        pub fn set<impl Into<String>: Into<String>>(path: impl Into<String>, value: Value) -> Self;
     }
     #[derive(Clone, Debug, Eq, PartialEq)]
     #[non_exhaustive]
@@ -2862,12 +2862,12 @@ pub mod models {
         IfNoneMatch(azure_core::http::Etag),
     }
     impl Precondition {
-        fn as_if_match(&self) -> Option<&Etag>;
-        fn as_if_none_match(&self) -> Option<&Etag>;
-        fn if_match<impl Into<Etag>: Into<Etag>>(etag: impl Into<Etag>) -> Self;
-        fn if_none_match<impl Into<Etag>: Into<Etag>>(etag: impl Into<Etag>) -> Self;
-        fn is_if_match(&self) -> bool;
-        fn is_if_none_match(&self) -> bool;
+        pub fn as_if_match(&self) -> Option<&Etag>;
+        pub fn as_if_none_match(&self) -> Option<&Etag>;
+        pub fn if_match<impl Into<Etag>: Into<Etag>>(etag: impl Into<Etag>) -> Self;
+        pub fn if_none_match<impl Into<Etag>: Into<Etag>>(etag: impl Into<Etag>) -> Self;
+        pub fn is_if_match(&self) -> bool;
+        pub fn is_if_none_match(&self) -> bool;
     }
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     #[non_exhaustive]
@@ -2885,12 +2885,12 @@ pub mod models {
         DistributedTransactionBatch,
     }
     impl ResourceType {
-        fn as_str(self) -> &'static str;
-        fn is_metadata(self) -> bool;
-        fn is_partitioned(self, operation_type: OperationType) -> bool;
-        fn path_segment(self) -> &'static str;
-        fn requires_container(self) -> bool;
-        fn requires_database(self) -> bool;
+        pub fn as_str(self) -> &'static str;
+        pub fn is_metadata(self) -> bool;
+        pub fn is_partitioned(self, operation_type: OperationType) -> bool;
+        pub fn path_segment(self) -> &'static str;
+        pub fn requires_container(self) -> bool;
+        pub fn requires_database(self) -> bool;
     }
     impl AsRef<str> for ResourceType {
         fn as_ref(&self) -> &str;
@@ -2910,14 +2910,14 @@ pub mod models {
         Items(Vec<azure_core::Bytes>),
     }
     impl ResponseBody {
-        fn empty() -> Self;
-        fn from_bytes<impl Into<Bytes>: Into<Bytes>>(bytes: impl Into<Bytes>) -> Self;
-        fn from_items(items: Vec<Bytes>) -> Self;
-        fn into_items<T: DeserializeOwned>(self) -> crate::error::Result<Vec<T>>;
-        fn into_single<T: DeserializeOwned>(self) -> crate::error::Result<T>;
-        fn is_empty(&self) -> bool;
-        fn items(self) -> crate::error::Result<Vec<Bytes>>;
-        fn single(self) -> crate::error::Result<Bytes>;
+        pub fn empty() -> Self;
+        pub fn from_bytes<impl Into<Bytes>: Into<Bytes>>(bytes: impl Into<Bytes>) -> Self;
+        pub fn from_items(items: Vec<Bytes>) -> Self;
+        pub fn into_items<T: DeserializeOwned>(self) -> crate::error::Result<Vec<T>>;
+        pub fn into_single<T: DeserializeOwned>(self) -> crate::error::Result<T>;
+        pub fn is_empty(&self) -> bool;
+        pub fn items(self) -> crate::error::Result<Vec<Bytes>>;
+        pub fn single(self) -> crate::error::Result<Bytes>;
     }
     impl From<Bytes> for ResponseBody {
         fn from(bytes: Bytes) -> Self;
@@ -2935,7 +2935,7 @@ pub mod models {
         impl EffectivePartitionKey {
             const MAX: Self = _;
             const MIN: Self = _;
-            fn to_hex(&self) -> String;
+            pub fn to_hex(&self) -> String;
         }
         impl Display for EffectivePartitionKey {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -2987,8 +2987,8 @@ pub mod models {
             pub parents: Option<Vec<String>>,
         }
         impl PartitionKeyRange {
-            fn get_parent_ids(&self) -> HashSet<String>;
-            fn new<impl Into<EffectivePartitionKey>: Into<EffectivePartitionKey>, impl Into<EffectivePartitionKey>: Into<EffectivePartitionKey>>(id: String, min_inclusive: impl Into<EffectivePartitionKey>, max_exclusive: impl Into<EffectivePartitionKey>) -> Self;
+            pub fn get_parent_ids(&self) -> HashSet<String>;
+            pub fn new<impl Into<EffectivePartitionKey>: Into<EffectivePartitionKey>, impl Into<EffectivePartitionKey>: Into<EffectivePartitionKey>>(id: String, min_inclusive: impl Into<EffectivePartitionKey>, max_exclusive: impl Into<EffectivePartitionKey>) -> Self;
         }
         impl Eq for PartitionKeyRange {
         }
@@ -3018,9 +3018,9 @@ pub mod options {
         pub request_text_response: bool,
     }
     impl BinaryEncodingOptions {
-        fn new() -> Self;
-        fn with_enabled(self, enabled: bool) -> Self;
-        fn with_request_text_response(self, request_text_response: bool) -> Self;
+        pub fn new() -> Self;
+        pub fn with_enabled(self, enabled: bool) -> Self;
+        pub fn with_request_text_response(self, request_text_response: bool) -> Self;
     }
     impl Default for BinaryEncodingOptions {
         fn default() -> Self;
@@ -3030,35 +3030,35 @@ pub mod options {
     pub struct ConnectionPoolOptions {
     }
     impl ConnectionPoolOptions {
-        fn builder() -> ConnectionPoolOptionsBuilder;
-        fn gateway_v2_disabled(&self) -> bool;
-        fn http2_consecutive_failure_threshold(&self) -> u32;
-        fn http2_eviction_grace_period(&self) -> Duration;
-        fn http2_fan_out_threshold_percent(&self) -> u8;
-        fn http2_health_check_interval(&self) -> Duration;
-        fn http2_keep_alive_interval(&self) -> Duration;
-        fn http2_keep_alive_timeout(&self) -> Duration;
-        fn idle_connection_timeout(&self) -> Option<Duration>;
-        fn idle_http2_client_timeout(&self) -> Duration;
-        fn is_http2_allowed(&self) -> bool;
-        fn local_address(&self) -> Option<IpAddr>;
-        fn max_connect_timeout(&self) -> Duration;
-        fn max_dataplane_request_timeout(&self) -> Duration;
-        fn max_http2_connections_per_endpoint(&self) -> usize;
-        fn max_http2_streams_per_client(&self) -> u32;
-        fn max_idle_connections_per_endpoint(&self) -> usize;
-        fn max_metadata_request_timeout(&self) -> Duration;
-        fn min_connect_timeout(&self) -> Duration;
-        fn min_dataplane_request_timeout(&self) -> Duration;
-        fn min_http2_connections_per_endpoint(&self) -> usize;
-        fn min_metadata_request_timeout(&self) -> Duration;
-        fn proxy_allowed(&self) -> bool;
-        fn server_certificate_validation(&self) -> ServerCertificateValidation;
-        fn tcp_keepalive_interval(&self) -> Option<Duration>;
-        fn tcp_keepalive_retries(&self) -> Option<u32>;
-        fn tcp_keepalive_time(&self) -> Option<Duration>;
+        pub fn builder() -> ConnectionPoolOptionsBuilder;
+        pub fn gateway_v2_disabled(&self) -> bool;
+        pub fn http2_consecutive_failure_threshold(&self) -> u32;
+        pub fn http2_eviction_grace_period(&self) -> Duration;
+        pub fn http2_fan_out_threshold_percent(&self) -> u8;
+        pub fn http2_health_check_interval(&self) -> Duration;
+        pub fn http2_keep_alive_interval(&self) -> Duration;
+        pub fn http2_keep_alive_timeout(&self) -> Duration;
+        pub fn idle_connection_timeout(&self) -> Option<Duration>;
+        pub fn idle_http2_client_timeout(&self) -> Duration;
+        pub fn is_http2_allowed(&self) -> bool;
+        pub fn local_address(&self) -> Option<IpAddr>;
+        pub fn max_connect_timeout(&self) -> Duration;
+        pub fn max_dataplane_request_timeout(&self) -> Duration;
+        pub fn max_http2_connections_per_endpoint(&self) -> usize;
+        pub fn max_http2_streams_per_client(&self) -> u32;
+        pub fn max_idle_connections_per_endpoint(&self) -> usize;
+        pub fn max_metadata_request_timeout(&self) -> Duration;
+        pub fn min_connect_timeout(&self) -> Duration;
+        pub fn min_dataplane_request_timeout(&self) -> Duration;
+        pub fn min_http2_connections_per_endpoint(&self) -> usize;
+        pub fn min_metadata_request_timeout(&self) -> Duration;
+        pub fn proxy_allowed(&self) -> bool;
+        pub fn server_certificate_validation(&self) -> ServerCertificateValidation;
+        pub fn tcp_keepalive_interval(&self) -> Option<Duration>;
+        pub fn tcp_keepalive_retries(&self) -> Option<u32>;
+        pub fn tcp_keepalive_time(&self) -> Option<Duration>;
         #[cfg(feature = "rustls")]
-        fn tls_backend(&self) -> TlsBackend;
+        pub fn tls_backend(&self) -> TlsBackend;
     }
     impl Default for ConnectionPoolOptions {
         fn default() -> Self;
@@ -3069,48 +3069,48 @@ pub mod options {
     }
     #[automatically_derived]
     impl ConnectionPoolOptionsBuilder {
-        fn from_env() -> Self;
-        fn from_env_override() -> Self;
+        pub fn from_env() -> Self;
+        pub fn from_env_override() -> Self;
     }
     impl ConnectionPoolOptionsBuilder {
-        fn build(self) -> crate::error::Result<ConnectionPoolOptions>;
-        fn new() -> Self;
-        fn with_gateway_v2_disabled(self, value: bool) -> Self;
-        fn with_http2_consecutive_failure_threshold(self, value: u32) -> Self;
-        fn with_http2_eviction_grace_period(self, timeout: Duration) -> Self;
-        fn with_http2_fan_out_threshold_percent(self, value: u8) -> Self;
-        fn with_http2_health_check_interval(self, timeout: Duration) -> Self;
-        fn with_http2_keep_alive_interval(self, timeout: Duration) -> Self;
-        fn with_http2_keep_alive_timeout(self, timeout: Duration) -> Self;
-        fn with_idle_connection_timeout(self, timeout: Duration) -> Self;
-        fn with_idle_http2_client_timeout(self, timeout: Duration) -> Self;
-        fn with_is_http2_allowed(self, value: bool) -> Self;
-        fn with_local_address(self, addr: IpAddr) -> Self;
-        fn with_max_connect_timeout(self, timeout: Duration) -> Self;
-        fn with_max_dataplane_request_timeout(self, timeout: Duration) -> Self;
-        fn with_max_http2_connections_per_endpoint(self, value: usize) -> Self;
-        fn with_max_http2_streams_per_client(self, value: u32) -> Self;
-        fn with_max_idle_connections_per_endpoint(self, count: usize) -> Self;
-        fn with_max_metadata_request_timeout(self, timeout: Duration) -> Self;
-        fn with_min_connect_timeout(self, timeout: Duration) -> Self;
-        fn with_min_dataplane_request_timeout(self, timeout: Duration) -> Self;
-        fn with_min_http2_connections_per_endpoint(self, value: usize) -> Self;
-        fn with_min_metadata_request_timeout(self, timeout: Duration) -> Self;
-        fn with_proxy_allowed(self, value: bool) -> Self;
-        fn with_server_certificate_validation(self, value: ServerCertificateValidation) -> Self;
-        fn with_tcp_keepalive_interval(self, timeout: Duration) -> Self;
-        fn with_tcp_keepalive_retries(self, value: u32) -> Self;
-        fn with_tcp_keepalive_time(self, timeout: Duration) -> Self;
+        pub fn build(self) -> crate::error::Result<ConnectionPoolOptions>;
+        pub fn new() -> Self;
+        pub fn with_gateway_v2_disabled(self, value: bool) -> Self;
+        pub fn with_http2_consecutive_failure_threshold(self, value: u32) -> Self;
+        pub fn with_http2_eviction_grace_period(self, timeout: Duration) -> Self;
+        pub fn with_http2_fan_out_threshold_percent(self, value: u8) -> Self;
+        pub fn with_http2_health_check_interval(self, timeout: Duration) -> Self;
+        pub fn with_http2_keep_alive_interval(self, timeout: Duration) -> Self;
+        pub fn with_http2_keep_alive_timeout(self, timeout: Duration) -> Self;
+        pub fn with_idle_connection_timeout(self, timeout: Duration) -> Self;
+        pub fn with_idle_http2_client_timeout(self, timeout: Duration) -> Self;
+        pub fn with_is_http2_allowed(self, value: bool) -> Self;
+        pub fn with_local_address(self, addr: IpAddr) -> Self;
+        pub fn with_max_connect_timeout(self, timeout: Duration) -> Self;
+        pub fn with_max_dataplane_request_timeout(self, timeout: Duration) -> Self;
+        pub fn with_max_http2_connections_per_endpoint(self, value: usize) -> Self;
+        pub fn with_max_http2_streams_per_client(self, value: u32) -> Self;
+        pub fn with_max_idle_connections_per_endpoint(self, count: usize) -> Self;
+        pub fn with_max_metadata_request_timeout(self, timeout: Duration) -> Self;
+        pub fn with_min_connect_timeout(self, timeout: Duration) -> Self;
+        pub fn with_min_dataplane_request_timeout(self, timeout: Duration) -> Self;
+        pub fn with_min_http2_connections_per_endpoint(self, value: usize) -> Self;
+        pub fn with_min_metadata_request_timeout(self, timeout: Duration) -> Self;
+        pub fn with_proxy_allowed(self, value: bool) -> Self;
+        pub fn with_server_certificate_validation(self, value: ServerCertificateValidation) -> Self;
+        pub fn with_tcp_keepalive_interval(self, timeout: Duration) -> Self;
+        pub fn with_tcp_keepalive_retries(self, value: u32) -> Self;
+        pub fn with_tcp_keepalive_time(self, timeout: Duration) -> Self;
         #[cfg(feature = "rustls")]
-        fn with_tls_backend(self, value: TlsBackend) -> Self;
+        pub fn with_tls_backend(self, value: TlsBackend) -> Self;
     }
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct CorrelationId(/* private fields */);
     impl CorrelationId {
         const MAX_LENGTH: usize = 50;
-        fn as_str(&self) -> &str;
-        fn new<impl Into<String>: Into<String>>(value: impl Into<String>) -> Self;
-        fn try_new<impl Into<String>: Into<String>>(value: impl Into<String>) -> Option<Self>;
+        pub fn as_str(&self) -> &str;
+        pub fn new<impl Into<String>: Into<String>>(value: impl Into<String>) -> Self;
+        pub fn try_new<impl Into<String>: Into<String>>(value: impl Into<String>) -> Option<Self>;
     }
     impl AsRef<str> for CorrelationId {
         fn as_ref(&self) -> &str;
@@ -3123,10 +3123,10 @@ pub mod options {
     pub struct DiagnosticsOptions {
     }
     impl DiagnosticsOptions {
-        fn builder() -> DiagnosticsOptionsBuilder;
-        fn default_verbosity(&self) -> DiagnosticsVerbosity;
-        fn max_request_diagnostics(&self) -> usize;
-        fn max_summary_size_bytes(&self) -> usize;
+        pub fn builder() -> DiagnosticsOptionsBuilder;
+        pub fn default_verbosity(&self) -> DiagnosticsVerbosity;
+        pub fn max_request_diagnostics(&self) -> usize;
+        pub fn max_summary_size_bytes(&self) -> usize;
     }
     impl Default for DiagnosticsOptions {
         fn default() -> Self;
@@ -3137,33 +3137,33 @@ pub mod options {
     }
     #[automatically_derived]
     impl DiagnosticsOptionsBuilder {
-        fn from_env() -> Self;
+        pub fn from_env() -> Self;
     }
     impl DiagnosticsOptionsBuilder {
-        fn build(self) -> crate::error::Result<DiagnosticsOptions>;
-        fn new() -> Self;
-        fn with_default_verbosity(self, verbosity: DiagnosticsVerbosity) -> Self;
-        fn with_max_request_diagnostics(self, max: usize) -> Self;
-        fn with_max_summary_size_bytes(self, size: usize) -> Self;
+        pub fn build(self) -> crate::error::Result<DiagnosticsOptions>;
+        pub fn new() -> Self;
+        pub fn with_default_verbosity(self, verbosity: DiagnosticsVerbosity) -> Self;
+        pub fn with_max_request_diagnostics(self, max: usize) -> Self;
+        pub fn with_max_summary_size_bytes(self, size: usize) -> Self;
     }
     #[derive(Clone, Copy, Debug, PartialEq)]
     #[non_exhaustive]
     pub struct DiagnosticsThresholds {
     }
     impl DiagnosticsThresholds {
-        fn new() -> Self;
-        fn non_point_operation_latency(&self) -> Duration;
-        fn payload_size(&self) -> u64;
-        fn point_operation_latency(&self) -> Duration;
-        fn request_charge(&self) -> f64;
+        pub fn new() -> Self;
+        pub fn non_point_operation_latency(&self) -> Duration;
+        pub fn payload_size(&self) -> u64;
+        pub fn point_operation_latency(&self) -> Duration;
+        pub fn request_charge(&self) -> f64;
         #[must_use]
-        fn with_non_point_operation_latency(self, latency: Duration) -> Self;
+        pub fn with_non_point_operation_latency(self, latency: Duration) -> Self;
         #[must_use]
-        fn with_payload_size(self, payload_size: u64) -> Self;
+        pub fn with_payload_size(self, payload_size: u64) -> Self;
         #[must_use]
-        fn with_point_operation_latency(self, latency: Duration) -> Self;
+        pub fn with_point_operation_latency(self, latency: Duration) -> Self;
         #[must_use]
-        fn with_request_charge(self, request_charge: f64) -> Self;
+        pub fn with_request_charge(self, request_charge: f64) -> Self;
     }
     impl Default for DiagnosticsThresholds {
         fn default() -> Self;
@@ -3173,41 +3173,41 @@ pub mod options {
     pub struct DriverOptions {
     }
     impl DriverOptions {
-        fn account(&self) -> &AccountReference;
-        fn builder(account: AccountReference) -> DriverOptionsBuilder;
+        pub fn account(&self) -> &AccountReference;
+        pub fn builder(account: AccountReference) -> DriverOptionsBuilder;
         #[cfg(feature = "fault_injection")]
-        fn fault_injection_rules(&self) -> Option<&[Arc<FaultInjectionRule>]>;
-        fn hedging_options(&self) -> &HedgingOptions;
-        fn operation_options(&self) -> &Arc<OperationOptions>;
-        fn partition_failover_options(&self) -> &PartitionFailoverOptions;
-        fn partition_key_range_cache_enabled(&self) -> bool;
-        fn preferred_regions(&self) -> &[Region];
-        fn user_agent_suffix(&self) -> Option<&UserAgentSuffix>;
+        pub fn fault_injection_rules(&self) -> Option<&[Arc<FaultInjectionRule>]>;
+        pub fn hedging_options(&self) -> &HedgingOptions;
+        pub fn operation_options(&self) -> &Arc<OperationOptions>;
+        pub fn partition_failover_options(&self) -> &PartitionFailoverOptions;
+        pub fn partition_key_range_cache_enabled(&self) -> bool;
+        pub fn preferred_regions(&self) -> &[Region];
+        pub fn user_agent_suffix(&self) -> Option<&UserAgentSuffix>;
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct DriverOptionsBuilder {
     }
     impl DriverOptionsBuilder {
-        fn build(self) -> DriverOptions;
-        fn new(account: AccountReference) -> Self;
-        fn register_throughput_control_group(self, group: ThroughputControlGroupOptions) -> crate::error::Result<Self>;
+        pub fn build(self) -> DriverOptions;
+        pub fn new(account: AccountReference) -> Self;
+        pub fn register_throughput_control_group(self, group: ThroughputControlGroupOptions) -> crate::error::Result<Self>;
         #[cfg(feature = "fault_injection")]
-        fn with_fault_injection_rules(self, rules: Vec<Arc<FaultInjectionRule>>) -> crate::error::Result<Self>;
-        fn with_hedging_options(self, options: HedgingOptions) -> Self;
-        fn with_operation_options(self, options: OperationOptions) -> Self;
-        fn with_partition_failover_options(self, options: PartitionFailoverOptions) -> Self;
-        fn with_partition_key_range_cache_enabled(self, enabled: bool) -> Self;
-        fn with_preferred_regions(self, regions: Vec<Region>) -> Self;
-        fn with_user_agent_suffix(self, suffix: UserAgentSuffix) -> Self;
+        pub fn with_fault_injection_rules(self, rules: Vec<Arc<FaultInjectionRule>>) -> crate::error::Result<Self>;
+        pub fn with_hedging_options(self, options: HedgingOptions) -> Self;
+        pub fn with_operation_options(self, options: OperationOptions) -> Self;
+        pub fn with_partition_failover_options(self, options: PartitionFailoverOptions) -> Self;
+        pub fn with_partition_key_range_cache_enabled(self, enabled: bool) -> Self;
+        pub fn with_preferred_regions(self, regions: Vec<Region>) -> Self;
+        pub fn with_user_agent_suffix(self, suffix: UserAgentSuffix) -> Self;
     }
     #[derive(Clone, Debug, Eq, PartialEq)]
     #[non_exhaustive]
     pub struct EndToEndOperationLatencyPolicy {
     }
     impl EndToEndOperationLatencyPolicy {
-        fn new(timeout: Duration) -> Self;
-        fn timeout(&self) -> Duration;
+        pub fn new(timeout: Duration) -> Self;
+        pub fn timeout(&self) -> Duration;
     }
     impl From<Duration> for EndToEndOperationLatencyPolicy {
         fn from(timeout: Duration) -> Self;
@@ -3215,11 +3215,11 @@ pub mod options {
     #[derive(Clone, Debug, Default, Eq, PartialEq)]
     pub struct ExcludedRegions(pub Vec<crate::options::Region>);
     impl ExcludedRegions {
-        fn is_empty(&self) -> bool;
-        fn iter(&self) -> impl Iterator<Item = &Region>;
-        fn len(&self) -> usize;
-        fn new() -> Self;
-        fn with_region<impl Into<Region>: Into<Region>>(self, region: impl Into<Region>) -> Self;
+        pub fn is_empty(&self) -> bool;
+        pub fn iter(&self) -> impl Iterator<Item = &Region>;
+        pub fn len(&self) -> usize;
+        pub fn new() -> Self;
+        pub fn with_region<impl Into<Region>: Into<Region>>(self, region: impl Into<Region>) -> Self;
     }
     impl<T: Into<crate::options::Region>> FromIterator<T> for ExcludedRegions {
         fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self;
@@ -3227,16 +3227,16 @@ pub mod options {
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     pub struct HedgeThreshold(/* private fields */);
     impl HedgeThreshold {
-        const fn get(self) -> Duration;
-        const fn new(duration: Duration) -> Option<Self>;
+        pub const fn get(self) -> Duration;
+        pub const fn new(duration: Duration) -> Option<Self>;
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct HedgingOptions {
     }
     impl HedgingOptions {
-        fn builder() -> HedgingOptionsBuilder;
-        fn max_concurrent_metadata_attempts(&self) -> usize;
+        pub fn builder() -> HedgingOptionsBuilder;
+        pub fn max_concurrent_metadata_attempts(&self) -> usize;
     }
     impl Default for HedgingOptions {
         fn default() -> Self;
@@ -3246,17 +3246,17 @@ pub mod options {
     pub struct HedgingOptionsBuilder {
     }
     impl HedgingOptionsBuilder {
-        fn build(self) -> HedgingOptions;
-        fn new() -> Self;
-        fn with_max_concurrent_metadata_attempts(self, value: usize) -> Self;
+        pub fn build(self) -> HedgingOptions;
+        pub fn new() -> Self;
+        pub fn with_max_concurrent_metadata_attempts(self, value: usize) -> Self;
     }
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     #[non_exhaustive]
     pub struct HedgingStrategy {
     }
     impl HedgingStrategy {
-        const fn new(threshold: HedgeThreshold) -> Self;
-        const fn threshold(&self) -> HedgeThreshold;
+        pub const fn new(threshold: HedgeThreshold) -> Self;
+        pub const fn threshold(&self) -> HedgeThreshold;
     }
     #[derive(Clone, Debug, Default)]
     #[non_exhaustive]
@@ -3280,8 +3280,8 @@ pub mod options {
     }
     #[automatically_derived]
     impl OperationOptions {
-        fn from_env() -> Self;
-        fn from_env_override() -> Self;
+        pub fn from_env() -> Self;
+        pub fn from_env_override() -> Self;
     }
     #[automatically_derived]
     pub struct OperationOptionsBuilder {
@@ -3289,62 +3289,62 @@ pub mod options {
     #[automatically_derived]
     impl OperationOptionsBuilder {
         #[must_use]
-        fn build(self) -> OperationOptions;
-        fn new() -> Self;
-        fn with_availability_strategy(self, value: AvailabilityStrategy) -> Self;
-        fn with_binary_encoding(self, value: BinaryEncodingOptions) -> Self;
-        fn with_content_response_on_write(self, value: ContentResponseOnWrite) -> Self;
-        fn with_custom_headers(self, value: HashMap<HeaderName, HeaderValue>) -> Self;
-        fn with_end_to_end_latency_policy(self, value: EndToEndOperationLatencyPolicy) -> Self;
-        fn with_endpoint_unavailability_ttl(self, value: Duration) -> Self;
-        fn with_excluded_regions(self, value: ExcludedRegions) -> Self;
-        fn with_hedging_enabled(self, value: bool) -> Self;
-        fn with_max_failover_retry_count(self, value: u32) -> Self;
-        fn with_max_session_retry_count(self, value: u32) -> Self;
-        fn with_patch_strategy(self, value: PatchStrategy) -> Self;
-        fn with_query_plan_mode(self, value: QueryPlanMode) -> Self;
-        fn with_read_consistency_strategy(self, value: ReadConsistencyStrategy) -> Self;
-        fn with_session_capturing_disabled(self, value: bool) -> Self;
-        fn with_throttling_retry_options(self, value: ThrottlingRetryOptions) -> Self;
-        fn with_throughput_control(self, value: ThroughputControlOptions) -> Self;
+        pub fn build(self) -> OperationOptions;
+        pub fn new() -> Self;
+        pub fn with_availability_strategy(self, value: AvailabilityStrategy) -> Self;
+        pub fn with_binary_encoding(self, value: BinaryEncodingOptions) -> Self;
+        pub fn with_content_response_on_write(self, value: ContentResponseOnWrite) -> Self;
+        pub fn with_custom_headers(self, value: HashMap<HeaderName, HeaderValue>) -> Self;
+        pub fn with_end_to_end_latency_policy(self, value: EndToEndOperationLatencyPolicy) -> Self;
+        pub fn with_endpoint_unavailability_ttl(self, value: Duration) -> Self;
+        pub fn with_excluded_regions(self, value: ExcludedRegions) -> Self;
+        pub fn with_hedging_enabled(self, value: bool) -> Self;
+        pub fn with_max_failover_retry_count(self, value: u32) -> Self;
+        pub fn with_max_session_retry_count(self, value: u32) -> Self;
+        pub fn with_patch_strategy(self, value: PatchStrategy) -> Self;
+        pub fn with_query_plan_mode(self, value: QueryPlanMode) -> Self;
+        pub fn with_read_consistency_strategy(self, value: ReadConsistencyStrategy) -> Self;
+        pub fn with_session_capturing_disabled(self, value: bool) -> Self;
+        pub fn with_throttling_retry_options(self, value: ThrottlingRetryOptions) -> Self;
+        pub fn with_throughput_control(self, value: ThroughputControlOptions) -> Self;
     }
     #[automatically_derived]
     pub struct OperationOptionsView<'a> {
     }
     #[automatically_derived]
     impl<'a> OperationOptionsView<'a> {
-        fn availability_strategy(&self) -> Option<&AvailabilityStrategy>;
-        fn binary_encoding(&self) -> Option<&BinaryEncodingOptions>;
-        fn content_response_on_write(&self) -> Option<&ContentResponseOnWrite>;
-        fn custom_headers(&self) -> Option<&HashMap<HeaderName, HeaderValue>>;
-        fn end_to_end_latency_policy(&self) -> Option<&EndToEndOperationLatencyPolicy>;
-        fn endpoint_unavailability_ttl(&self) -> Option<&Duration>;
-        fn excluded_regions(&self) -> Option<&ExcludedRegions>;
-        fn hedging_enabled(&self) -> Option<&bool>;
-        fn max_failover_retry_count(&self) -> Option<&u32>;
-        fn max_session_retry_count(&self) -> Option<&u32>;
-        fn new(env: Option<::std::sync::Arc<OperationOptions>>, runtime: Option<::std::sync::Arc<OperationOptions>>, account: Option<::std::sync::Arc<OperationOptions>>, operation: Option<&'a OperationOptions>) -> Self;
-        fn new_with_override(env_override: Option<::std::sync::Arc<OperationOptions>>, env: Option<::std::sync::Arc<OperationOptions>>, runtime: Option<::std::sync::Arc<OperationOptions>>, account: Option<::std::sync::Arc<OperationOptions>>, operation: Option<&'a OperationOptions>) -> Self;
-        fn patch_strategy(&self) -> Option<&PatchStrategy>;
-        fn query_plan_mode(&self) -> Option<&QueryPlanMode>;
-        fn read_consistency_strategy(&self) -> Option<&ReadConsistencyStrategy>;
-        fn session_capturing_disabled(&self) -> Option<&bool>;
-        fn throttling_retry_options(&self) -> ThrottlingRetryOptionsView<'_>;
-        fn throughput_control(&self) -> ThroughputControlOptionsView<'_>;
+        pub fn availability_strategy(&self) -> Option<&AvailabilityStrategy>;
+        pub fn binary_encoding(&self) -> Option<&BinaryEncodingOptions>;
+        pub fn content_response_on_write(&self) -> Option<&ContentResponseOnWrite>;
+        pub fn custom_headers(&self) -> Option<&HashMap<HeaderName, HeaderValue>>;
+        pub fn end_to_end_latency_policy(&self) -> Option<&EndToEndOperationLatencyPolicy>;
+        pub fn endpoint_unavailability_ttl(&self) -> Option<&Duration>;
+        pub fn excluded_regions(&self) -> Option<&ExcludedRegions>;
+        pub fn hedging_enabled(&self) -> Option<&bool>;
+        pub fn max_failover_retry_count(&self) -> Option<&u32>;
+        pub fn max_session_retry_count(&self) -> Option<&u32>;
+        pub fn new(env: Option<::std::sync::Arc<OperationOptions>>, runtime: Option<::std::sync::Arc<OperationOptions>>, account: Option<::std::sync::Arc<OperationOptions>>, operation: Option<&'a OperationOptions>) -> Self;
+        pub fn new_with_override(env_override: Option<::std::sync::Arc<OperationOptions>>, env: Option<::std::sync::Arc<OperationOptions>>, runtime: Option<::std::sync::Arc<OperationOptions>>, account: Option<::std::sync::Arc<OperationOptions>>, operation: Option<&'a OperationOptions>) -> Self;
+        pub fn patch_strategy(&self) -> Option<&PatchStrategy>;
+        pub fn query_plan_mode(&self) -> Option<&QueryPlanMode>;
+        pub fn read_consistency_strategy(&self) -> Option<&ReadConsistencyStrategy>;
+        pub fn session_capturing_disabled(&self) -> Option<&bool>;
+        pub fn throttling_retry_options(&self) -> ThrottlingRetryOptionsView<'_>;
+        pub fn throughput_control(&self) -> ThroughputControlOptionsView<'_>;
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct PartitionFailoverOptions {
     }
     impl PartitionFailoverOptions {
-        fn builder() -> PartitionFailoverOptionsBuilder;
-        fn circuit_breaker_enabled(&self) -> bool;
-        fn consecutive_hedge_win_threshold(&self) -> u32;
-        fn counter_reset_window(&self) -> Duration;
-        fn failback_sweep_interval(&self) -> Duration;
-        fn partition_unavailability_duration(&self) -> Duration;
-        fn read_failure_threshold(&self) -> u32;
-        fn write_failure_threshold(&self) -> u32;
+        pub fn builder() -> PartitionFailoverOptionsBuilder;
+        pub fn circuit_breaker_enabled(&self) -> bool;
+        pub fn consecutive_hedge_win_threshold(&self) -> u32;
+        pub fn counter_reset_window(&self) -> Duration;
+        pub fn failback_sweep_interval(&self) -> Duration;
+        pub fn partition_unavailability_duration(&self) -> Duration;
+        pub fn read_failure_threshold(&self) -> u32;
+        pub fn write_failure_threshold(&self) -> u32;
     }
     impl Default for PartitionFailoverOptions {
         fn default() -> Self;
@@ -3354,15 +3354,15 @@ pub mod options {
     pub struct PartitionFailoverOptionsBuilder {
     }
     impl PartitionFailoverOptionsBuilder {
-        fn build(self) -> crate::error::Result<PartitionFailoverOptions>;
-        fn new() -> Self;
-        fn with_circuit_breaker_enabled(self, value: bool) -> Self;
-        fn with_consecutive_hedge_win_threshold(self, value: u32) -> Self;
-        fn with_counter_reset_window(self, value: Duration) -> Self;
-        fn with_failback_sweep_interval(self, value: Duration) -> Self;
-        fn with_partition_unavailability_duration(self, value: Duration) -> Self;
-        fn with_read_failure_threshold(self, value: u32) -> Self;
-        fn with_write_failure_threshold(self, value: u32) -> Self;
+        pub fn build(self) -> crate::error::Result<PartitionFailoverOptions>;
+        pub fn new() -> Self;
+        pub fn with_circuit_breaker_enabled(self, value: bool) -> Self;
+        pub fn with_consecutive_hedge_win_threshold(self, value: u32) -> Self;
+        pub fn with_counter_reset_window(self, value: Duration) -> Self;
+        pub fn with_failback_sweep_interval(self, value: Duration) -> Self;
+        pub fn with_partition_unavailability_duration(self, value: Duration) -> Self;
+        pub fn with_read_failure_threshold(self, value: u32) -> Self;
+        pub fn with_write_failure_threshold(self, value: u32) -> Self;
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
@@ -3370,7 +3370,7 @@ pub mod options {
         pub max_fan_out: u32,
     }
     impl PlanOptions {
-        fn with_max_fan_out(self, max_fan_out: u32) -> Self;
+        pub fn with_max_fan_out(self, max_fan_out: u32) -> Self;
     }
     impl Default for PlanOptions {
         fn default() -> Self;
@@ -3493,9 +3493,9 @@ pub mod options {
         const WEST_US: Region = _;
         const WEST_US_2: Region = _;
         const WEST_US_3: Region = _;
-        fn as_str(&self) -> &str;
-        fn display_name(&self) -> &str;
-        fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(name: impl Into<Cow<'static, str>>) -> Self;
+        pub fn as_str(&self) -> &str;
+        pub fn display_name(&self) -> &str;
+        pub fn new<impl Into<Cow<'static, str>>: Into<Cow<'static, str>>>(name: impl Into<Cow<'static, str>>) -> Self;
     }
     impl AsRef<str> for Region {
         fn as_ref(&self) -> &str;
@@ -3520,7 +3520,7 @@ pub mod options {
     }
     #[automatically_derived]
     impl ThrottlingRetryOptions {
-        fn from_env() -> Self;
+        pub fn from_env() -> Self;
     }
     #[automatically_derived]
     pub struct ThrottlingRetryOptionsBuilder {
@@ -3528,35 +3528,35 @@ pub mod options {
     #[automatically_derived]
     impl ThrottlingRetryOptionsBuilder {
         #[must_use]
-        fn build(self) -> ThrottlingRetryOptions;
-        fn new() -> Self;
-        fn with_max_retry_count(self, value: u32) -> Self;
-        fn with_max_retry_wait_time(self, value: Duration) -> Self;
+        pub fn build(self) -> ThrottlingRetryOptions;
+        pub fn new() -> Self;
+        pub fn with_max_retry_count(self, value: u32) -> Self;
+        pub fn with_max_retry_wait_time(self, value: Duration) -> Self;
     }
     #[automatically_derived]
     pub struct ThrottlingRetryOptionsView<'a> {
     }
     #[automatically_derived]
     impl<'a> ThrottlingRetryOptionsView<'a> {
-        fn max_retry_count(&self) -> Option<&u32>;
-        fn max_retry_wait_time(&self) -> Option<&Duration>;
-        fn new(env: Option<::std::sync::Arc<ThrottlingRetryOptions>>, runtime: Option<::std::sync::Arc<ThrottlingRetryOptions>>, account: Option<::std::sync::Arc<ThrottlingRetryOptions>>, operation: Option<&'a ThrottlingRetryOptions>) -> Self;
+        pub fn max_retry_count(&self) -> Option<&u32>;
+        pub fn max_retry_wait_time(&self) -> Option<&Duration>;
+        pub fn new(env: Option<::std::sync::Arc<ThrottlingRetryOptions>>, runtime: Option<::std::sync::Arc<ThrottlingRetryOptions>>, account: Option<::std::sync::Arc<ThrottlingRetryOptions>>, operation: Option<&'a ThrottlingRetryOptions>) -> Self;
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct ThroughputControlGroupOptions {
     }
     impl ThroughputControlGroupOptions {
-        fn container(&self) -> &ContainerReference;
-        fn is_default(&self) -> bool;
-        fn name(&self) -> &ThroughputControlGroupName;
-        fn new<impl Into<ThroughputControlGroupName>: Into<ThroughputControlGroupName>>(name: impl Into<ThroughputControlGroupName>, container: ContainerReference, is_default: bool) -> Self;
-        fn priority_level(&self) -> Option<PriorityLevel>;
-        fn set_priority_level(&self, level: PriorityLevel);
-        fn set_throughput_bucket(&self, bucket: u32);
-        fn throughput_bucket(&self) -> Option<u32>;
-        fn with_priority_level(self, level: PriorityLevel) -> Self;
-        fn with_throughput_bucket(self, bucket: u32) -> Self;
+        pub fn container(&self) -> &ContainerReference;
+        pub fn is_default(&self) -> bool;
+        pub fn name(&self) -> &ThroughputControlGroupName;
+        pub fn new<impl Into<ThroughputControlGroupName>: Into<ThroughputControlGroupName>>(name: impl Into<ThroughputControlGroupName>, container: ContainerReference, is_default: bool) -> Self;
+        pub fn priority_level(&self) -> Option<PriorityLevel>;
+        pub fn set_priority_level(&self, level: PriorityLevel);
+        pub fn set_throughput_bucket(&self, bucket: u32);
+        pub fn throughput_bucket(&self) -> Option<u32>;
+        pub fn with_priority_level(self, level: PriorityLevel) -> Self;
+        pub fn with_throughput_bucket(self, bucket: u32) -> Self;
     }
     #[derive(Clone, Debug, Default)]
     #[non_exhaustive]
@@ -3571,29 +3571,29 @@ pub mod options {
     #[automatically_derived]
     impl ThroughputControlOptionsBuilder {
         #[must_use]
-        fn build(self) -> ThroughputControlOptions;
-        fn new() -> Self;
-        fn with_group_name(self, value: ThroughputControlGroupName) -> Self;
-        fn with_priority_level(self, value: PriorityLevel) -> Self;
-        fn with_throughput_bucket(self, value: u32) -> Self;
+        pub fn build(self) -> ThroughputControlOptions;
+        pub fn new() -> Self;
+        pub fn with_group_name(self, value: ThroughputControlGroupName) -> Self;
+        pub fn with_priority_level(self, value: PriorityLevel) -> Self;
+        pub fn with_throughput_bucket(self, value: u32) -> Self;
     }
     #[automatically_derived]
     pub struct ThroughputControlOptionsView<'a> {
     }
     #[automatically_derived]
     impl<'a> ThroughputControlOptionsView<'a> {
-        fn group_name(&self) -> Option<&ThroughputControlGroupName>;
-        fn new(env: Option<::std::sync::Arc<ThroughputControlOptions>>, runtime: Option<::std::sync::Arc<ThroughputControlOptions>>, account: Option<::std::sync::Arc<ThroughputControlOptions>>, operation: Option<&'a ThroughputControlOptions>) -> Self;
-        fn priority_level(&self) -> Option<&PriorityLevel>;
-        fn throughput_bucket(&self) -> Option<&u32>;
+        pub fn group_name(&self) -> Option<&ThroughputControlGroupName>;
+        pub fn new(env: Option<::std::sync::Arc<ThroughputControlOptions>>, runtime: Option<::std::sync::Arc<ThroughputControlOptions>>, account: Option<::std::sync::Arc<ThroughputControlOptions>>, operation: Option<&'a ThroughputControlOptions>) -> Self;
+        pub fn priority_level(&self) -> Option<&PriorityLevel>;
+        pub fn throughput_bucket(&self) -> Option<&u32>;
     }
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct UserAgentSuffix(/* private fields */);
     impl UserAgentSuffix {
         const MAX_LENGTH: usize = 25;
-        fn as_str(&self) -> &str;
-        fn new<impl Into<String>: Into<String>>(value: impl Into<String>) -> Self;
-        fn try_new<impl Into<String>: Into<String>>(value: impl Into<String>) -> Option<Self>;
+        pub fn as_str(&self) -> &str;
+        pub fn new<impl Into<String>: Into<String>>(value: impl Into<String>) -> Self;
+        pub fn try_new<impl Into<String>: Into<String>>(value: impl Into<String>) -> Option<Self>;
     }
     impl AsRef<str> for UserAgentSuffix {
         fn as_ref(&self) -> &str;
@@ -3606,9 +3606,9 @@ pub mod options {
     impl WorkloadId {
         const MAX: u8 = 50;
         const MIN: u8 = 1;
-        fn new(value: u8) -> Self;
-        fn try_new(value: u8) -> Option<Self>;
-        fn value(&self) -> u8;
+        pub fn new(value: u8) -> Self;
+        pub fn try_new(value: u8) -> Option<Self>;
+        pub fn value(&self) -> u8;
     }
     impl Display for WorkloadId {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -3651,7 +3651,7 @@ pub mod options {
         Detailed,
     }
     impl DiagnosticsVerbosity {
-        fn as_str(&self) -> &'static str;
+        pub fn as_str(&self) -> &'static str;
     }
     impl AsRef<str> for DiagnosticsVerbosity {
         fn as_ref(&self) -> &str;
@@ -3672,7 +3672,7 @@ pub mod options {
         ServerSide,
     }
     impl PatchStrategy {
-        fn as_str(&self) -> &'static str;
+        pub fn as_str(&self) -> &'static str;
     }
     impl Display for PatchStrategy {
         fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
@@ -3689,7 +3689,7 @@ pub mod options {
         Low,
     }
     impl PriorityLevel {
-        fn as_str(&self) -> &'static str;
+        pub fn as_str(&self) -> &'static str;
     }
     impl Display for PriorityLevel {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -3706,7 +3706,7 @@ pub mod options {
         GatewayOnly,
     }
     impl QueryPlanMode {
-        fn as_str(self) -> &'static str;
+        pub fn as_str(self) -> &'static str;
     }
     impl Display for QueryPlanMode {
         fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
@@ -3725,7 +3725,7 @@ pub mod options {
         GlobalStrong,
     }
     impl ReadConsistencyStrategy {
-        fn as_str(&self) -> &'static str;
+        pub fn as_str(&self) -> &'static str;
     }
     impl Display for ReadConsistencyStrategy {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
@@ -3751,7 +3751,7 @@ pub mod options {
     pub const DEFAULT_MAX_FAN_OUT: u32 = 100;
 }
 #[cfg(feature = "__internal_mocking")]
-pub mod testing {
+pub mod test {
     pub use azure_data_cosmos_driver::options::connection_pool::ConnectionPoolOptions;
     #[derive(Clone, Copy, Debug)]
     pub struct HttpClientConfig {
@@ -3775,7 +3775,7 @@ pub mod testing {
         pub request_sent: crate::diagnostics::RequestSentStatus,
     }
     impl TransportError {
-        fn new<impl Into<crate::error::CosmosError>: Into<crate::error::CosmosError>>(error: impl Into<crate::error::CosmosError>, request_sent: RequestSentStatus) -> Self;
+        pub fn new<impl Into<crate::error::CosmosError>: Into<crate::error::CosmosError>>(error: impl Into<crate::error::CosmosError>, request_sent: RequestSentStatus) -> Self;
     }
     impl Debug for TransportError {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;

--- a/sdk/cosmos/azure_data_cosmos_driver/api/API.metadata.yml
+++ b/sdk/cosmos/azure_data_cosmos_driver/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: 91c979e114416e320babcb9f8ac6d660448c660c134e62583d735a140f98b757
+apiMdSha256: 7f38d61f56ac0371e50768ac51e400837aa9875bb359c43822f8a25bf1d113f7
 packageVersion: 0.8.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/cosmos/azure_data_cosmos_driver_native/api/API.metadata.yml
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/api/API.metadata.yml
@@ -1,4 +1,4 @@
 apiMdSha256: dfcbe439713a589189f20b0a5fc26facccb652520c29ac4b54c704b085250018
 packageVersion: 0.1.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/cosmos/azure_data_cosmos_emulator/api/API.metadata.yml
+++ b/sdk/cosmos/azure_data_cosmos_emulator/api/API.metadata.yml
@@ -1,4 +1,4 @@
 apiMdSha256: 8a1d23cf6228669723b5e996a0a1c630d33696821392958d1c05324086ebc61e
 packageVersion: 0.1.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/cosmos/azure_data_cosmos_macros/api/API.metadata.yml
+++ b/sdk/cosmos/azure_data_cosmos_macros/api/API.metadata.yml
@@ -1,4 +1,4 @@
 apiMdSha256: a324c03bc88bca0d66a09d946c785efddde62011cb172d096fc934a4d7cedd3d
 packageVersion: 0.3.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/cosmos/azure_data_cosmos_observability_harness/api/API.metadata.yml
+++ b/sdk/cosmos/azure_data_cosmos_observability_harness/api/API.metadata.yml
@@ -1,4 +1,4 @@
 apiMdSha256: 49b50d601a6e4ff6f813a53707a8b0ec3adf5cb3c204225769e3faa89c4be9f4
 packageVersion: 0.1.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/cosmos/azure_data_cosmos_perf/api/API.metadata.yml
+++ b/sdk/cosmos/azure_data_cosmos_perf/api/API.metadata.yml
@@ -1,4 +1,4 @@
 apiMdSha256: 188165f2fc3838d6be4bbbf5db3f01ef2015d2f8938438f1a681013fd371d0af
 packageVersion: 0.1.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/eventhubs/azure_messaging_eventhubs/api/API.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/api/API.md
@@ -24,14 +24,14 @@ pub use azure_messaging_eventhubs::error::Result;
 pub struct BufferedProducerClient {
 }
 impl BufferedProducerClient {
-    async fn abort(&self) -> Result<()>;
-    fn buffered_event_count(&self, partition_id: &str) -> usize;
-    fn builder() -> builders::BufferedProducerClientBuilder;
-    async fn close(&self) -> Result<()>;
-    async fn enqueue_event<impl Into<EventData>: Into<EventData>>(&self, event: impl Into<EventData>, options: Option<EnqueueEventOptions>) -> Result<()>;
-    async fn enqueue_events<E, impl IntoIterator<Item = E>: IntoIterator<Item = E>>(&self, events: impl IntoIterator<Item = E>, options: Option<EnqueueEventOptions>) -> Result<()> where E: Into<EventData>;
-    async fn flush(&self) -> Result<()>;
-    fn total_buffered_event_count(&self) -> usize;
+    pub async fn abort(&self) -> Result<()>;
+    pub fn buffered_event_count(&self, partition_id: &str) -> usize;
+    pub fn builder() -> builders::BufferedProducerClientBuilder;
+    pub async fn close(&self) -> Result<()>;
+    pub async fn enqueue_event<impl Into<EventData>: Into<EventData>>(&self, event: impl Into<EventData>, options: Option<EnqueueEventOptions>) -> Result<()>;
+    pub async fn enqueue_events<E, impl IntoIterator<Item = E>: IntoIterator<Item = E>>(&self, events: impl IntoIterator<Item = E>, options: Option<EnqueueEventOptions>) -> Result<()> where E: Into<EventData>;
+    pub async fn flush(&self) -> Result<()>;
+    pub fn total_buffered_event_count(&self) -> usize;
 }
 impl Debug for BufferedProducerClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
@@ -60,11 +60,11 @@ impl TryFrom<&Secret> for ConnectionString {
 pub struct ConsumerClient {
 }
 impl ConsumerClient {
-    fn builder() -> builders::ConsumerClientBuilder;
-    async fn close(self) -> Result<()>;
-    async fn get_eventhub_properties(&self) -> Result<EventHubProperties>;
-    async fn get_partition_properties(&self, partition_id: &str) -> Result<EventHubPartitionProperties>;
-    async fn open_receiver_on_partition(&self, partition_id: String, options: Option<OpenReceiverOptions>) -> Result<EventReceiver>;
+    pub fn builder() -> builders::ConsumerClientBuilder;
+    pub async fn close(self) -> Result<()>;
+    pub async fn get_eventhub_properties(&self) -> Result<EventHubProperties>;
+    pub async fn get_partition_properties(&self, partition_id: &str) -> Result<EventHubPartitionProperties>;
+    pub async fn open_receiver_on_partition(&self, partition_id: String, options: Option<OpenReceiverOptions>) -> Result<EventReceiver>;
 }
 #[derive(Clone, Debug, Default)]
 pub struct EnqueueEventOptions {
@@ -74,11 +74,11 @@ pub struct EnqueueEventOptions {
 pub struct EventDataBatch<'a> {
 }
 impl<'a> EventDataBatch<'a> {
-    fn is_empty(&self) -> bool;
-    fn len(&self) -> usize;
-    fn size(&self) -> u64;
-    fn try_add_amqp_message<impl Into<AmqpMessage>: Into<AmqpMessage>>(&self, message: impl Into<AmqpMessage>, options: Option<AddEventDataOptions>) -> Result<bool>;
-    fn try_add_event_data<impl Into<EventData>: Into<EventData>>(&self, event_data: impl Into<EventData>, options: Option<AddEventDataOptions>) -> Result<bool>;
+    pub fn is_empty(&self) -> bool;
+    pub fn len(&self) -> usize;
+    pub fn size(&self) -> u64;
+    pub fn try_add_amqp_message<impl Into<AmqpMessage>: Into<AmqpMessage>>(&self, message: impl Into<AmqpMessage>, options: Option<AddEventDataOptions>) -> Result<bool>;
+    pub fn try_add_event_data<impl Into<EventData>: Into<EventData>>(&self, event_data: impl Into<EventData>, options: Option<AddEventDataOptions>) -> Result<bool>;
 }
 #[derive(Default)]
 pub struct EventDataBatchOptions {
@@ -89,11 +89,11 @@ pub struct EventDataBatchOptions {
 pub struct EventProcessor {
 }
 impl EventProcessor {
-    fn builder() -> builders::EventProcessorBuilder;
-    async fn close(self) -> Result<()>;
-    async fn next_partition_client(&self) -> Result<Arc<PartitionClient>>;
-    async fn run(&self) -> Result<()>;
-    async fn shutdown(&self) -> Result<()>;
+    pub fn builder() -> builders::EventProcessorBuilder;
+    pub async fn close(self) -> Result<()>;
+    pub async fn next_partition_client(&self) -> Result<Arc<PartitionClient>>;
+    pub async fn run(&self) -> Result<()>;
+    pub async fn shutdown(&self) -> Result<()>;
 }
 impl Send for EventProcessor {
 }
@@ -102,9 +102,9 @@ impl Sync for EventProcessor {
 pub struct EventReceiver {
 }
 impl EventReceiver {
-    async fn close(self) -> Result<()>;
-    fn partition_id(&self) -> &str;
-    fn stream_events(&self) -> impl Stream<Item = Result<ReceivedEventData>> + '_;
+    pub async fn close(self) -> Result<()>;
+    pub fn partition_id(&self) -> &str;
+    pub fn stream_events(&self) -> impl Stream<Item = Result<ReceivedEventData>> + '_;
 }
 impl Drop for EventReceiver {
     fn drop(&mut self);
@@ -114,8 +114,8 @@ pub struct InMemoryCheckpointStore {
 }
 #[cfg(feature = "in_memory_checkpoint_store")]
 impl InMemoryCheckpointStore {
-    fn new() -> Self;
-    fn update_ownership(&self, ownership: &Ownership) -> Result<Ownership>;
+    pub fn new() -> Self;
+    pub fn update_ownership(&self, ownership: &Ownership) -> Result<Ownership>;
 }
 #[cfg(feature = "in_memory_checkpoint_store")]
 impl CheckpointStore for InMemoryCheckpointStore {
@@ -142,14 +142,14 @@ pub struct OpenReceiverOptions {
 pub struct ProducerClient {
 }
 impl ProducerClient {
-    fn builder() -> builders::ProducerClientBuilder;
-    async fn close(self) -> Result<()>;
-    async fn create_batch(&self, batch_options: Option<EventDataBatchOptions>) -> Result<EventDataBatch<'_>>;
-    async fn get_eventhub_properties(&self) -> Result<EventHubProperties>;
-    async fn get_partition_properties(&self, partition_id: &str) -> Result<EventHubPartitionProperties>;
-    async fn send_batch(&self, batch: EventDataBatch<'_>, options: Option<SendBatchOptions>) -> Result<()>;
-    async fn send_event<impl Into<EventData>: Into<EventData>>(&self, event: impl Into<EventData>, options: Option<SendEventOptions>) -> Result<()>;
-    async fn send_message<M>(&self, message: M, options: Option<SendMessageOptions>) -> Result<()> where M: Into<AmqpMessage> + Debug + Send;
+    pub fn builder() -> builders::ProducerClientBuilder;
+    pub async fn close(self) -> Result<()>;
+    pub async fn create_batch(&self, batch_options: Option<EventDataBatchOptions>) -> Result<EventDataBatch<'_>>;
+    pub async fn get_eventhub_properties(&self) -> Result<EventHubProperties>;
+    pub async fn get_partition_properties(&self, partition_id: &str) -> Result<EventHubPartitionProperties>;
+    pub async fn send_batch(&self, batch: EventDataBatch<'_>, options: Option<SendBatchOptions>) -> Result<()>;
+    pub async fn send_event<impl Into<EventData>: Into<EventData>>(&self, event: impl Into<EventData>, options: Option<SendEventOptions>) -> Result<()>;
+    pub async fn send_message<M>(&self, message: M, options: Option<SendMessageOptions>) -> Result<()> where M: Into<AmqpMessage> + Debug + Send;
 }
 #[derive(Clone, Debug)]
 pub struct RetryOptions {
@@ -222,15 +222,15 @@ pub mod builders {
     pub struct BufferedProducerClientBuilder {
     }
     impl BufferedProducerClientBuilder {
-        async fn open(self, fully_qualified_namespace: &str, eventhub: &str, credential: Arc<dyn azure_core::credentials::TokenCredential>) -> Result<BufferedProducerClient>;
-        async fn open_with_connection_string(self, connection_string: &str, eventhub: Option<&str>) -> Result<BufferedProducerClient>;
-        fn with_application_id(self, application_id: String) -> Self;
-        fn with_custom_endpoint(self, endpoint: String) -> Self;
-        fn with_max_buffered_event_count_per_partition(self, count: usize) -> Self;
-        fn with_max_wait_time(self, max_wait_time: Duration) -> Self;
-        fn with_on_send_failed<F, Fut>(self, handler: F) -> Self where F: Fn(SendBatchFailedContext) -> Fut + Send + Sync + 'static, Fut: Future<Output = ()> + Send + 'static;
-        fn with_on_send_succeeded<F, Fut>(self, handler: F) -> Self where F: Fn(SendBatchSucceededContext) -> Fut + Send + Sync + 'static, Fut: Future<Output = ()> + Send + 'static;
-        fn with_retry_options(self, retry_options: RetryOptions) -> Self;
+        pub async fn open(self, fully_qualified_namespace: &str, eventhub: &str, credential: Arc<dyn azure_core::credentials::TokenCredential>) -> Result<BufferedProducerClient>;
+        pub async fn open_with_connection_string(self, connection_string: &str, eventhub: Option<&str>) -> Result<BufferedProducerClient>;
+        pub fn with_application_id(self, application_id: String) -> Self;
+        pub fn with_custom_endpoint(self, endpoint: String) -> Self;
+        pub fn with_max_buffered_event_count_per_partition(self, count: usize) -> Self;
+        pub fn with_max_wait_time(self, max_wait_time: Duration) -> Self;
+        pub fn with_on_send_failed<F, Fut>(self, handler: F) -> Self where F: Fn(SendBatchFailedContext) -> Fut + Send + Sync + 'static, Fut: Future<Output = ()> + Send + 'static;
+        pub fn with_on_send_succeeded<F, Fut>(self, handler: F) -> Self where F: Fn(SendBatchSucceededContext) -> Fut + Send + Sync + 'static, Fut: Future<Output = ()> + Send + 'static;
+        pub fn with_retry_options(self, retry_options: RetryOptions) -> Self;
     }
     impl Default for BufferedProducerClientBuilder {
         fn default() -> Self;
@@ -239,37 +239,37 @@ pub mod builders {
     pub struct ConsumerClientBuilder {
     }
     impl ConsumerClientBuilder {
-        async fn open(self, fully_qualified_namespace: &str, eventhub_name: String, credential: Arc<dyn azure_core::credentials::TokenCredential>) -> Result<super::ConsumerClient>;
-        async fn open_with_connection_string(self, connection_string: &str, eventhub: Option<&str>) -> Result<super::ConsumerClient>;
-        fn with_application_id(self, application_id: String) -> Self;
-        fn with_consumer_group(self, consumer_group: String) -> Self;
-        fn with_custom_endpoint(self, endpoint: String) -> Self;
-        fn with_instance_id(self, instance_id: String) -> Self;
-        fn with_retry_options(self, retry_options: RetryOptions) -> Self;
-        fn with_transport(self, transport: AmqpTransport) -> Self;
+        pub async fn open(self, fully_qualified_namespace: &str, eventhub_name: String, credential: Arc<dyn azure_core::credentials::TokenCredential>) -> Result<super::ConsumerClient>;
+        pub async fn open_with_connection_string(self, connection_string: &str, eventhub: Option<&str>) -> Result<super::ConsumerClient>;
+        pub fn with_application_id(self, application_id: String) -> Self;
+        pub fn with_consumer_group(self, consumer_group: String) -> Self;
+        pub fn with_custom_endpoint(self, endpoint: String) -> Self;
+        pub fn with_instance_id(self, instance_id: String) -> Self;
+        pub fn with_retry_options(self, retry_options: RetryOptions) -> Self;
+        pub fn with_transport(self, transport: AmqpTransport) -> Self;
     }
     #[derive(Default)]
     pub struct EventProcessorBuilder {
     }
     impl EventProcessorBuilder {
-        async fn build(self, consumer_client: ConsumerClient, checkpoint_store: Arc<dyn CheckpointStore + Send + Sync>) -> Result<Arc<EventProcessor>>;
-        fn with_load_balancing_strategy(self, load_balancing_strategy: super::ProcessorStrategy) -> Self;
-        fn with_max_partition_count(self, max_partition_count: usize) -> Self;
-        fn with_partition_expiration_duration(self, partition_expiration_duration: Duration) -> Self;
-        fn with_prefetch(self, prefetch: u32) -> Self;
-        fn with_start_positions(self, start_positions: StartPositions) -> Self;
-        fn with_update_interval(self, update_interval: Duration) -> Self;
+        pub async fn build(self, consumer_client: ConsumerClient, checkpoint_store: Arc<dyn CheckpointStore + Send + Sync>) -> Result<Arc<EventProcessor>>;
+        pub fn with_load_balancing_strategy(self, load_balancing_strategy: super::ProcessorStrategy) -> Self;
+        pub fn with_max_partition_count(self, max_partition_count: usize) -> Self;
+        pub fn with_partition_expiration_duration(self, partition_expiration_duration: Duration) -> Self;
+        pub fn with_prefetch(self, prefetch: u32) -> Self;
+        pub fn with_start_positions(self, start_positions: StartPositions) -> Self;
+        pub fn with_update_interval(self, update_interval: Duration) -> Self;
     }
     #[derive(Default)]
     pub struct ProducerClientBuilder {
     }
     impl ProducerClientBuilder {
-        async fn open(self, fully_qualified_namespace: &str, eventhub: &str, credential: Arc<dyn azure_core::credentials::TokenCredential>) -> Result<ProducerClient>;
-        async fn open_with_connection_string(self, connection_string: &str, eventhub: Option<&str>) -> Result<ProducerClient>;
-        fn with_application_id(self, application_id: String) -> Self;
-        fn with_custom_endpoint(self, endpoint: String) -> Self;
-        fn with_retry_options(self, retry_options: RetryOptions) -> Self;
-        fn with_transport(self, transport: AmqpTransport) -> Self;
+        pub async fn open(self, fully_qualified_namespace: &str, eventhub: &str, credential: Arc<dyn azure_core::credentials::TokenCredential>) -> Result<ProducerClient>;
+        pub async fn open_with_connection_string(self, connection_string: &str, eventhub: Option<&str>) -> Result<ProducerClient>;
+        pub fn with_application_id(self, application_id: String) -> Self;
+        pub fn with_custom_endpoint(self, endpoint: String) -> Self;
+        pub fn with_retry_options(self, retry_options: RetryOptions) -> Self;
+        pub fn with_transport(self, transport: AmqpTransport) -> Self;
     }
 }
 pub mod error {
@@ -324,11 +324,11 @@ pub mod models {
         pub footer: Option<AmqpAnnotations>,
     }
     impl AmqpMessage {
-        fn add_message_annotation<impl Into<AmqpValue>: Into<AmqpValue>>(&mut self, name: AmqpSymbol, value: impl Into<AmqpValue>);
-        fn builder() -> builders::AmqpMessageBuilder;
-        fn serialize(message: &AmqpMessage) -> Result<Vec<u8>>;
-        fn set_message_body<impl Into<AmqpMessageBody>: Into<AmqpMessageBody>>(&mut self, body: impl Into<AmqpMessageBody>);
-        fn set_message_id<impl Into<AmqpMessageId>: Into<AmqpMessageId>>(&mut self, message_id: impl Into<AmqpMessageId>);
+        pub fn add_message_annotation<impl Into<AmqpValue>: Into<AmqpValue>>(&mut self, name: AmqpSymbol, value: impl Into<AmqpValue>);
+        pub fn builder() -> builders::AmqpMessageBuilder;
+        pub fn serialize(message: &AmqpMessage) -> Result<Vec<u8>>;
+        pub fn set_message_body<impl Into<AmqpMessageBody>: Into<AmqpMessageBody>>(&mut self, body: impl Into<AmqpMessageBody>);
+        pub fn set_message_id<impl Into<AmqpMessageId>: Into<AmqpMessageId>>(&mut self, message_id: impl Into<AmqpMessageId>);
     }
     impl AsRef<AmqpMessage> for AmqpMessage {
         fn as_ref(&self) -> &AmqpMessage;
@@ -383,19 +383,19 @@ pub mod models {
         pub sequence_number: Option<i64>,
     }
     impl Checkpoint {
-        fn get_checkpoint_blob_name(fully_qualified_namespace: &str, event_hub_name: &str, consumer_group: &str, partition_id: &str) -> Result<String>;
-        fn get_checkpoint_blob_prefix_name(fully_qualified_namespace: &str, event_hub_name: &str, consumer_group: &str) -> Result<String>;
+        pub fn get_checkpoint_blob_name(fully_qualified_namespace: &str, event_hub_name: &str, consumer_group: &str, partition_id: &str) -> Result<String>;
+        pub fn get_checkpoint_blob_prefix_name(fully_qualified_namespace: &str, event_hub_name: &str, consumer_group: &str) -> Result<String>;
     }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct EventData {
     }
     impl EventData {
-        fn body(&self) -> Option<&[u8]>;
-        fn builder() -> builders::EventDataBuilder;
-        fn content_type(&self) -> Option<&str>;
-        fn correlation_id(&self) -> Option<&MessageId>;
-        fn message_id(&self) -> Option<&MessageId>;
-        fn properties(&self) -> Option<&HashMap<String, AmqpSimpleValue>>;
+        pub fn body(&self) -> Option<&[u8]>;
+        pub fn builder() -> builders::EventDataBuilder;
+        pub fn content_type(&self) -> Option<&str>;
+        pub fn correlation_id(&self) -> Option<&MessageId>;
+        pub fn message_id(&self) -> Option<&MessageId>;
+        pub fn properties(&self) -> Option<&HashMap<String, AmqpSimpleValue>>;
     }
     impl From<EventData> for crate::models::AmqpMessage {
         fn from(event_data: EventData) -> Self;
@@ -430,19 +430,19 @@ pub mod models {
         pub last_modified_time: Option<azure_core::time::OffsetDateTime>,
     }
     impl Ownership {
-        fn get_ownership_name(fully_qualified_namespace: &str, event_hub_name: &str, consumer_group: &str, partition_id: &str) -> Result<String>;
-        fn get_ownership_prefix_name(fully_qualified_namespace: &str, event_hub_name: &str, consumer_group: &str) -> Result<String>;
+        pub fn get_ownership_name(fully_qualified_namespace: &str, event_hub_name: &str, consumer_group: &str, partition_id: &str) -> Result<String>;
+        pub fn get_ownership_prefix_name(fully_qualified_namespace: &str, event_hub_name: &str, consumer_group: &str) -> Result<String>;
     }
     pub struct ReceivedEventData {
     }
     impl ReceivedEventData {
-        fn enqueued_time(&self) -> Option<SystemTime>;
-        fn event_data(&self) -> &EventData;
-        fn offset(&self) -> &Option<String>;
-        fn partition_key(&self) -> &Option<String>;
-        fn raw_amqp_message(&self) -> &AmqpMessage;
-        fn sequence_number(&self) -> Option<i64>;
-        fn system_properties(&self) -> &HashMap<String, AmqpValue>;
+        pub fn enqueued_time(&self) -> Option<SystemTime>;
+        pub fn event_data(&self) -> &EventData;
+        pub fn offset(&self) -> &Option<String>;
+        pub fn partition_key(&self) -> &Option<String>;
+        pub fn raw_amqp_message(&self) -> &AmqpMessage;
+        pub fn sequence_number(&self) -> Option<i64>;
+        pub fn system_properties(&self) -> &HashMap<String, AmqpValue>;
     }
     impl Debug for ReceivedEventData {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result;
@@ -1199,12 +1199,12 @@ pub mod models {
         pub struct EventDataBuilder {
         }
         impl EventDataBuilder {
-            fn add_property<impl Into<AmqpSimpleValue>: Into<AmqpSimpleValue>>(self, key: String, value: impl Into<AmqpSimpleValue>) -> Self;
-            fn build(self) -> EventData;
-            fn with_body<T>(self, body: T) -> Self where T: Into<Vec<u8>>;
-            fn with_content_type(self, content_type: String) -> Self;
-            fn with_correlation_id<impl Into<MessageId>: Into<MessageId>>(self, correlation_id: impl Into<MessageId>) -> Self;
-            fn with_message_id<impl Into<MessageId>: Into<MessageId>>(self, message_id: impl Into<MessageId>) -> Self;
+            pub fn add_property<impl Into<AmqpSimpleValue>: Into<AmqpSimpleValue>>(self, key: String, value: impl Into<AmqpSimpleValue>) -> Self;
+            pub fn build(self) -> EventData;
+            pub fn with_body<T>(self, body: T) -> Self where T: Into<Vec<u8>>;
+            pub fn with_content_type(self, content_type: String) -> Self;
+            pub fn with_correlation_id<impl Into<MessageId>: Into<MessageId>>(self, correlation_id: impl Into<MessageId>) -> Self;
+            pub fn with_message_id<impl Into<MessageId>: Into<MessageId>>(self, message_id: impl Into<MessageId>) -> Self;
         }
     }
 }
@@ -1212,10 +1212,10 @@ pub mod processor {
     pub struct PartitionClient {
     }
     impl PartitionClient {
-        async fn close(self) -> Result<()>;
-        fn get_partition_id(&self) -> &str;
-        fn stream_events(&self) -> impl Stream<Item = Result<ReceivedEventData>> + '_;
-        async fn update_checkpoint(&self, event_data: &ReceivedEventData) -> Result<()>;
+        pub async fn close(self) -> Result<()>;
+        pub fn get_partition_id(&self) -> &str;
+        pub fn stream_events(&self) -> impl Stream<Item = Result<ReceivedEventData>> + '_;
+        pub async fn update_checkpoint(&self, event_data: &ReceivedEventData) -> Result<()>;
     }
     impl Drop for PartitionClient {
         fn drop(&mut self);

--- a/sdk/eventhubs/azure_messaging_eventhubs/api/API.metadata.yml
+++ b/sdk/eventhubs/azure_messaging_eventhubs/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: 813c7d76c3363c608da9d53f4952fdbd0a80b655519aafcad8730c2b48e10e95
+apiMdSha256: 3f3f5b94730ded0d81c38f42b65fa21ac864ca85b1de6dd6cad79bd2dbcd3279
 packageVersion: 0.16.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/api/API.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/api/API.md
@@ -20,7 +20,7 @@ pub mod checkpoint_store {
     pub struct BlobCheckpointStore {
     }
     impl BlobCheckpointStore {
-        fn new(blob_container_client: BlobContainerClient) -> Arc<Self>;
+        pub fn new(blob_container_client: BlobContainerClient) -> Arc<Self>;
     }
     impl CheckpointStore for BlobCheckpointStore {
         #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]

--- a/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/api/API.metadata.yml
+++ b/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: 4e028ec9d4042b1097c35bb72f83715b71e6de748134f5a73b45aa1ffe76adf8
+apiMdSha256: 7fe30732fa101d680cfbf2be4a4b7dc6907e89e170e68e7b0113e6294382ae25
 packageVersion: 0.10.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/identity/azure_identity/api/API.md
+++ b/sdk/identity/azure_identity/api/API.md
@@ -21,7 +21,7 @@ pub fn new_executor() -> std::sync::Arc<dyn Executor>;
 pub struct AzureCliCredential {
 }
 impl AzureCliCredential {
-    fn new(options: Option<AzureCliCredentialOptions>) -> azure_core::Result<Arc<Self>>;
+    pub fn new(options: Option<AzureCliCredentialOptions>) -> azure_core::Result<Arc<Self>>;
 }
 impl Debug for AzureCliCredential {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -42,7 +42,7 @@ impl Debug for AzureCliCredentialOptions {
 pub struct AzureDeveloperCliCredential {
 }
 impl AzureDeveloperCliCredential {
-    fn new(options: Option<AzureDeveloperCliCredentialOptions>) -> azure_core::Result<Arc<Self>>;
+    pub fn new(options: Option<AzureDeveloperCliCredentialOptions>) -> azure_core::Result<Arc<Self>>;
 }
 impl Debug for AzureDeveloperCliCredential {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -61,7 +61,7 @@ impl Debug for AzureDeveloperCliCredentialOptions {
 }
 pub struct AzurePipelinesCredential(/* private fields */);
 impl AzurePipelinesCredential {
-    fn new<T>(tenant_id: String, client_id: String, service_connection_id: &str, system_access_token: T, options: Option<AzurePipelinesCredentialOptions>) -> azure_core::Result<Arc<Self>> where T: Into<Secret>;
+    pub fn new<T>(tenant_id: String, client_id: String, service_connection_id: &str, system_access_token: T, options: Option<AzurePipelinesCredentialOptions>) -> azure_core::Result<Arc<Self>> where T: Into<Secret>;
 }
 impl Debug for AzurePipelinesCredential {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -80,7 +80,7 @@ impl Debug for AzurePipelinesCredentialOptions {
 pub struct ClientAssertionCredential<C> {
 }
 impl<C: ClientAssertion> ClientAssertionCredential<C> {
-    fn new(tenant_id: String, client_id: String, assertion: C, options: Option<ClientAssertionCredentialOptions>) -> azure_core::Result<Arc<Self>>;
+    pub fn new(tenant_id: String, client_id: String, assertion: C, options: Option<ClientAssertionCredentialOptions>) -> azure_core::Result<Arc<Self>>;
 }
 impl<C: ClientAssertion> TokenCredential for ClientAssertionCredential<C> {
     #[allow(elided_named_lifetimes, clippy::async_yields_async, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::needless_arbitrary_self_type, clippy::no_effect_underscore_binding, clippy::shadow_same, clippy::type_complexity, clippy::type_repetition_in_bounds, clippy::used_underscore_binding)]
@@ -101,7 +101,7 @@ pub struct ClientCertificateCredential {
 }
 #[cfg(feature = "client_certificate")]
 impl ClientCertificateCredential {
-    fn new(tenant_id: String, client_id: String, certificate: SecretBytes, options: Option<ClientCertificateCredentialOptions>) -> azure_core::Result<Arc<ClientCertificateCredential>>;
+    pub fn new(tenant_id: String, client_id: String, certificate: SecretBytes, options: Option<ClientCertificateCredentialOptions>) -> azure_core::Result<Arc<ClientCertificateCredential>>;
 }
 #[cfg(feature = "client_certificate")]
 impl Debug for ClientCertificateCredential {
@@ -125,7 +125,7 @@ impl Debug for ClientCertificateCredentialOptions {
 pub struct ClientSecretCredential {
 }
 impl ClientSecretCredential {
-    fn new(tenant_id: &str, client_id: String, secret: Secret, options: Option<ClientSecretCredentialOptions>) -> Result<Arc<Self>>;
+    pub fn new(tenant_id: &str, client_id: String, secret: Secret, options: Option<ClientSecretCredentialOptions>) -> Result<Arc<Self>>;
 }
 impl Debug for ClientSecretCredential {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -144,7 +144,7 @@ impl Debug for ClientSecretCredentialOptions {
 pub struct DeveloperToolsCredential {
 }
 impl DeveloperToolsCredential {
-    fn new(options: Option<DeveloperToolsCredentialOptions>) -> azure_core::Result<Arc<DeveloperToolsCredential>>;
+    pub fn new(options: Option<DeveloperToolsCredentialOptions>) -> azure_core::Result<Arc<DeveloperToolsCredential>>;
 }
 impl Debug for DeveloperToolsCredential {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -163,7 +163,7 @@ impl Debug for DeveloperToolsCredentialOptions {
 pub struct ManagedIdentityCredential {
 }
 impl ManagedIdentityCredential {
-    fn new(options: Option<ManagedIdentityCredentialOptions>) -> azure_core::Result<Arc<Self>>;
+    pub fn new(options: Option<ManagedIdentityCredentialOptions>) -> azure_core::Result<Arc<Self>>;
 }
 impl Debug for ManagedIdentityCredential {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -188,7 +188,7 @@ pub struct TokenProxyClientOptions<'a> {
 }
 pub struct WorkloadIdentityCredential(/* private fields */);
 impl WorkloadIdentityCredential {
-    fn new(options: Option<WorkloadIdentityCredentialOptions>) -> azure_core::Result<Arc<Self>>;
+    pub fn new(options: Option<WorkloadIdentityCredentialOptions>) -> azure_core::Result<Arc<Self>>;
 }
 impl Debug for WorkloadIdentityCredential {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;

--- a/sdk/identity/azure_identity/api/API.metadata.yml
+++ b/sdk/identity/azure_identity/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: 35807f39bbd93f8b61ecea494bd665b8de77fdbc7500ee814dfc1fa5e11d86c7
+apiMdSha256: d61550846fd728b35f58c635feeb3f6384c39a9722bed825665528be07cf2af5
 packageVersion: 1.1.0-beta.1
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/keyvault/azure_security_keyvault_certificates/api/API.md
+++ b/sdk/keyvault/azure_security_keyvault_certificates/api/API.md
@@ -39,37 +39,37 @@ pub mod clients {
     pub struct CertificateClient {
     }
     impl CertificateClient {
-        fn begin_create_certificate(&self, certificate_name: &str, parameters: RequestContent<CreateCertificateParameters>, options: Option<CertificateClientCreateCertificateOptions<'_>>) -> Result<Poller<CertificateOperation>>;
-        fn new(endpoint: &str, credential: Arc<dyn TokenCredential>, options: Option<CertificateClientOptions>) -> Result<Self>;
+        pub fn begin_create_certificate(&self, certificate_name: &str, parameters: RequestContent<CreateCertificateParameters>, options: Option<CertificateClientCreateCertificateOptions<'_>>) -> Result<Poller<CertificateOperation>>;
+        pub fn new(endpoint: &str, credential: Arc<dyn TokenCredential>, options: Option<CertificateClientOptions>) -> Result<Self>;
     }
     impl CertificateClient {
-        async fn backup_certificate(&self, certificate_name: &str, options: Option<CertificateClientBackupCertificateOptions<'_>>) -> Result<Response<BackupCertificateResult>>;
-        async fn delete_certificate(&self, certificate_name: &str, options: Option<CertificateClientDeleteCertificateOptions<'_>>) -> Result<Response<DeletedCertificate>>;
-        async fn delete_certificate_operation(&self, certificate_name: &str, options: Option<CertificateClientDeleteCertificateOperationOptions<'_>>) -> Result<Response<CertificateOperation>>;
-        async fn delete_contacts(&self, options: Option<CertificateClientDeleteContactsOptions<'_>>) -> Result<Response<Contacts>>;
-        async fn delete_issuer(&self, issuer_name: &str, options: Option<CertificateClientDeleteIssuerOptions<'_>>) -> Result<Response<Issuer>>;
-        fn endpoint(&self) -> &Url;
-        async fn get_certificate(&self, certificate_name: &str, options: Option<CertificateClientGetCertificateOptions<'_>>) -> Result<Response<Certificate>>;
-        async fn get_certificate_operation(&self, certificate_name: &str, options: Option<CertificateClientGetCertificateOperationOptions<'_>>) -> Result<Response<CertificateOperation>>;
-        async fn get_certificate_policy(&self, certificate_name: &str, options: Option<CertificateClientGetCertificatePolicyOptions<'_>>) -> Result<Response<CertificatePolicy>>;
-        async fn get_contacts(&self, options: Option<CertificateClientGetContactsOptions<'_>>) -> Result<Response<Contacts>>;
-        async fn get_deleted_certificate(&self, certificate_name: &str, options: Option<CertificateClientGetDeletedCertificateOptions<'_>>) -> Result<Response<DeletedCertificate>>;
-        async fn get_issuer(&self, issuer_name: &str, options: Option<CertificateClientGetIssuerOptions<'_>>) -> Result<Response<Issuer>>;
-        async fn import_certificate(&self, certificate_name: &str, parameters: RequestContent<ImportCertificateParameters>, options: Option<CertificateClientImportCertificateOptions<'_>>) -> Result<Response<Certificate>>;
-        fn list_certificate_properties(&self, options: Option<CertificateClientListCertificatePropertiesOptions<'_>>) -> Result<Pager<ListCertificatePropertiesResult>>;
-        fn list_certificate_properties_versions(&self, certificate_name: &str, options: Option<CertificateClientListCertificatePropertiesVersionsOptions<'_>>) -> Result<Pager<ListCertificatePropertiesResult>>;
-        fn list_deleted_certificate_properties(&self, options: Option<CertificateClientListDeletedCertificatePropertiesOptions<'_>>) -> Result<Pager<ListDeletedCertificatePropertiesResult>>;
-        fn list_issuer_properties(&self, options: Option<CertificateClientListIssuerPropertiesOptions<'_>>) -> Result<Pager<ListIssuerPropertiesResult>>;
-        async fn merge_certificate(&self, certificate_name: &str, parameters: RequestContent<MergeCertificateParameters>, options: Option<CertificateClientMergeCertificateOptions<'_>>) -> Result<Response<Certificate>>;
-        async fn purge_deleted_certificate(&self, certificate_name: &str, options: Option<CertificateClientPurgeDeletedCertificateOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn recover_deleted_certificate(&self, certificate_name: &str, options: Option<CertificateClientRecoverDeletedCertificateOptions<'_>>) -> Result<Response<Certificate>>;
-        async fn restore_certificate(&self, parameters: RequestContent<RestoreCertificateParameters>, options: Option<CertificateClientRestoreCertificateOptions<'_>>) -> Result<Response<Certificate>>;
-        async fn set_contacts(&self, contacts: RequestContent<Contacts>, options: Option<CertificateClientSetContactsOptions<'_>>) -> Result<Response<Contacts>>;
-        async fn set_issuer(&self, issuer_name: &str, parameter: RequestContent<SetIssuerParameters>, options: Option<CertificateClientSetIssuerOptions<'_>>) -> Result<Response<Issuer>>;
-        async fn update_certificate_operation(&self, certificate_name: &str, certificate_operation: RequestContent<UpdateCertificateOperationParameter>, options: Option<CertificateClientUpdateCertificateOperationOptions<'_>>) -> Result<Response<CertificateOperation>>;
-        async fn update_certificate_policy(&self, certificate_name: &str, certificate_policy: RequestContent<CertificatePolicy>, options: Option<CertificateClientUpdateCertificatePolicyOptions<'_>>) -> Result<Response<CertificatePolicy>>;
-        async fn update_certificate_properties(&self, certificate_name: &str, parameters: RequestContent<UpdateCertificatePropertiesParameters>, options: Option<CertificateClientUpdateCertificatePropertiesOptions<'_>>) -> Result<Response<Certificate>>;
-        async fn update_issuer(&self, issuer_name: &str, parameter: RequestContent<UpdateIssuerParameters>, options: Option<CertificateClientUpdateIssuerOptions<'_>>) -> Result<Response<Issuer>>;
+        pub async fn backup_certificate(&self, certificate_name: &str, options: Option<CertificateClientBackupCertificateOptions<'_>>) -> Result<Response<BackupCertificateResult>>;
+        pub async fn delete_certificate(&self, certificate_name: &str, options: Option<CertificateClientDeleteCertificateOptions<'_>>) -> Result<Response<DeletedCertificate>>;
+        pub async fn delete_certificate_operation(&self, certificate_name: &str, options: Option<CertificateClientDeleteCertificateOperationOptions<'_>>) -> Result<Response<CertificateOperation>>;
+        pub async fn delete_contacts(&self, options: Option<CertificateClientDeleteContactsOptions<'_>>) -> Result<Response<Contacts>>;
+        pub async fn delete_issuer(&self, issuer_name: &str, options: Option<CertificateClientDeleteIssuerOptions<'_>>) -> Result<Response<Issuer>>;
+        pub fn endpoint(&self) -> &Url;
+        pub async fn get_certificate(&self, certificate_name: &str, options: Option<CertificateClientGetCertificateOptions<'_>>) -> Result<Response<Certificate>>;
+        pub async fn get_certificate_operation(&self, certificate_name: &str, options: Option<CertificateClientGetCertificateOperationOptions<'_>>) -> Result<Response<CertificateOperation>>;
+        pub async fn get_certificate_policy(&self, certificate_name: &str, options: Option<CertificateClientGetCertificatePolicyOptions<'_>>) -> Result<Response<CertificatePolicy>>;
+        pub async fn get_contacts(&self, options: Option<CertificateClientGetContactsOptions<'_>>) -> Result<Response<Contacts>>;
+        pub async fn get_deleted_certificate(&self, certificate_name: &str, options: Option<CertificateClientGetDeletedCertificateOptions<'_>>) -> Result<Response<DeletedCertificate>>;
+        pub async fn get_issuer(&self, issuer_name: &str, options: Option<CertificateClientGetIssuerOptions<'_>>) -> Result<Response<Issuer>>;
+        pub async fn import_certificate(&self, certificate_name: &str, parameters: RequestContent<ImportCertificateParameters>, options: Option<CertificateClientImportCertificateOptions<'_>>) -> Result<Response<Certificate>>;
+        pub fn list_certificate_properties(&self, options: Option<CertificateClientListCertificatePropertiesOptions<'_>>) -> Result<Pager<ListCertificatePropertiesResult>>;
+        pub fn list_certificate_properties_versions(&self, certificate_name: &str, options: Option<CertificateClientListCertificatePropertiesVersionsOptions<'_>>) -> Result<Pager<ListCertificatePropertiesResult>>;
+        pub fn list_deleted_certificate_properties(&self, options: Option<CertificateClientListDeletedCertificatePropertiesOptions<'_>>) -> Result<Pager<ListDeletedCertificatePropertiesResult>>;
+        pub fn list_issuer_properties(&self, options: Option<CertificateClientListIssuerPropertiesOptions<'_>>) -> Result<Pager<ListIssuerPropertiesResult>>;
+        pub async fn merge_certificate(&self, certificate_name: &str, parameters: RequestContent<MergeCertificateParameters>, options: Option<CertificateClientMergeCertificateOptions<'_>>) -> Result<Response<Certificate>>;
+        pub async fn purge_deleted_certificate(&self, certificate_name: &str, options: Option<CertificateClientPurgeDeletedCertificateOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn recover_deleted_certificate(&self, certificate_name: &str, options: Option<CertificateClientRecoverDeletedCertificateOptions<'_>>) -> Result<Response<Certificate>>;
+        pub async fn restore_certificate(&self, parameters: RequestContent<RestoreCertificateParameters>, options: Option<CertificateClientRestoreCertificateOptions<'_>>) -> Result<Response<Certificate>>;
+        pub async fn set_contacts(&self, contacts: RequestContent<Contacts>, options: Option<CertificateClientSetContactsOptions<'_>>) -> Result<Response<Contacts>>;
+        pub async fn set_issuer(&self, issuer_name: &str, parameter: RequestContent<SetIssuerParameters>, options: Option<CertificateClientSetIssuerOptions<'_>>) -> Result<Response<Issuer>>;
+        pub async fn update_certificate_operation(&self, certificate_name: &str, certificate_operation: RequestContent<UpdateCertificateOperationParameter>, options: Option<CertificateClientUpdateCertificateOperationOptions<'_>>) -> Result<Response<CertificateOperation>>;
+        pub async fn update_certificate_policy(&self, certificate_name: &str, certificate_policy: RequestContent<CertificatePolicy>, options: Option<CertificateClientUpdateCertificatePolicyOptions<'_>>) -> Result<Response<CertificatePolicy>>;
+        pub async fn update_certificate_properties(&self, certificate_name: &str, parameters: RequestContent<UpdateCertificatePropertiesParameters>, options: Option<CertificateClientUpdateCertificatePropertiesOptions<'_>>) -> Result<Response<Certificate>>;
+        pub async fn update_issuer(&self, issuer_name: &str, parameter: RequestContent<UpdateIssuerParameters>, options: Option<CertificateClientUpdateIssuerOptions<'_>>) -> Result<Response<Issuer>>;
     }
     #[derive(Clone, Debug)]
     pub struct CertificateClientOptions {
@@ -150,7 +150,7 @@ pub mod models {
     }
     impl<'a> CertificateClientCreateCertificateOptions<'a> {
         #[must_use]
-        fn into_owned(self) -> CertificateClientCreateCertificateOptions<'static>;
+        pub fn into_owned(self) -> CertificateClientCreateCertificateOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct CertificateClientDeleteCertificateOperationOptions<'a> {
@@ -204,7 +204,7 @@ pub mod models {
         pub method_options: azure_core::http::pager::PagerOptions<'a>,
     }
     impl CertificateClientListCertificatePropertiesOptions<'_> {
-        fn into_owned(self) -> CertificateClientListCertificatePropertiesOptions<'static>;
+        pub fn into_owned(self) -> CertificateClientListCertificatePropertiesOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct CertificateClientListCertificatePropertiesVersionsOptions<'a> {
@@ -212,7 +212,7 @@ pub mod models {
         pub method_options: azure_core::http::pager::PagerOptions<'a>,
     }
     impl CertificateClientListCertificatePropertiesVersionsOptions<'_> {
-        fn into_owned(self) -> CertificateClientListCertificatePropertiesVersionsOptions<'static>;
+        pub fn into_owned(self) -> CertificateClientListCertificatePropertiesVersionsOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct CertificateClientListDeletedCertificatePropertiesOptions<'a> {
@@ -221,7 +221,7 @@ pub mod models {
         pub method_options: azure_core::http::pager::PagerOptions<'a>,
     }
     impl CertificateClientListDeletedCertificatePropertiesOptions<'_> {
-        fn into_owned(self) -> CertificateClientListDeletedCertificatePropertiesOptions<'static>;
+        pub fn into_owned(self) -> CertificateClientListDeletedCertificatePropertiesOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct CertificateClientListIssuerPropertiesOptions<'a> {
@@ -229,7 +229,7 @@ pub mod models {
         pub method_options: azure_core::http::pager::PagerOptions<'a>,
     }
     impl CertificateClientListIssuerPropertiesOptions<'_> {
-        fn into_owned(self) -> CertificateClientListIssuerPropertiesOptions<'static>;
+        pub fn into_owned(self) -> CertificateClientListIssuerPropertiesOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct CertificateClientMergeCertificateOptions<'a> {

--- a/sdk/keyvault/azure_security_keyvault_certificates/api/API.metadata.yml
+++ b/sdk/keyvault/azure_security_keyvault_certificates/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: 5363900601ea685b1fe289fb44afd06c32818b512fbe802b02a3d24c341f0679
+apiMdSha256: 62371df19f74541beb19709fb1d59636eb41af28c62ed2faea7338b307f474ec
 packageVersion: 1.1.0-beta.2
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/keyvault/azure_security_keyvault_keys/api/API.md
+++ b/sdk/keyvault/azure_security_keyvault_keys/api/API.md
@@ -39,37 +39,37 @@ pub mod clients {
     pub struct KeyClient {
     }
     impl KeyClient {
-        fn new(endpoint: &str, credential: Arc<dyn TokenCredential>, options: Option<KeyClientOptions>) -> Result<Self>;
+        pub fn new(endpoint: &str, credential: Arc<dyn TokenCredential>, options: Option<KeyClientOptions>) -> Result<Self>;
     }
     impl KeyClient {
-        async fn backup_key(&self, key_name: &str, options: Option<KeyClientBackupKeyOptions<'_>>) -> Result<Response<BackupKeyResult>>;
-        async fn create_key(&self, key_name: &str, parameters: RequestContent<CreateKeyParameters>, options: Option<KeyClientCreateKeyOptions<'_>>) -> Result<Response<Key>>;
-        async fn decrypt(&self, key_name: &str, key_version: &str, parameters: RequestContent<KeyOperationParameters>, options: Option<KeyClientDecryptOptions<'_>>) -> Result<Response<KeyOperationResult>>;
-        async fn delete_key(&self, key_name: &str, options: Option<KeyClientDeleteKeyOptions<'_>>) -> Result<Response<DeletedKey>>;
-        async fn encrypt(&self, key_name: &str, parameters: RequestContent<KeyOperationParameters>, options: Option<KeyClientEncryptOptions<'_>>) -> Result<Response<KeyOperationResult>>;
-        fn endpoint(&self) -> &Url;
-        async fn get_deleted_key(&self, key_name: &str, options: Option<KeyClientGetDeletedKeyOptions<'_>>) -> Result<Response<DeletedKey>>;
-        async fn get_key(&self, key_name: &str, options: Option<KeyClientGetKeyOptions<'_>>) -> Result<Response<Key>>;
-        async fn get_key_attestation(&self, key_name: &str, options: Option<KeyClientGetKeyAttestationOptions<'_>>) -> Result<Response<Key>>;
-        async fn get_key_rotation_policy(&self, key_name: &str, options: Option<KeyClientGetKeyRotationPolicyOptions<'_>>) -> Result<Response<KeyRotationPolicy>>;
-        async fn get_random_bytes(&self, parameters: RequestContent<GetRandomBytesParameters>, options: Option<KeyClientGetRandomBytesOptions<'_>>) -> Result<Response<RandomBytes>>;
-        async fn import_key(&self, key_name: &str, parameters: RequestContent<ImportKeyParameters>, options: Option<KeyClientImportKeyOptions<'_>>) -> Result<Response<Key>>;
-        fn list_deleted_key_properties(&self, options: Option<KeyClientListDeletedKeyPropertiesOptions<'_>>) -> Result<Pager<ListDeletedKeyPropertiesResult>>;
-        fn list_key_properties(&self, options: Option<KeyClientListKeyPropertiesOptions<'_>>) -> Result<Pager<ListKeyPropertiesResult>>;
-        fn list_key_properties_versions(&self, key_name: &str, options: Option<KeyClientListKeyPropertiesVersionsOptions<'_>>) -> Result<Pager<ListKeyPropertiesResult>>;
-        async fn purge_deleted_key(&self, key_name: &str, options: Option<KeyClientPurgeDeletedKeyOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn recover_deleted_key(&self, key_name: &str, options: Option<KeyClientRecoverDeletedKeyOptions<'_>>) -> Result<Response<Key>>;
-        async fn release(&self, key_name: &str, parameters: RequestContent<ReleaseParameters>, options: Option<KeyClientReleaseOptions<'_>>) -> Result<Response<KeyReleaseResult>>;
-        async fn restore_key(&self, parameters: RequestContent<RestoreKeyParameters>, options: Option<KeyClientRestoreKeyOptions<'_>>) -> Result<Response<Key>>;
-        async fn rotate_key(&self, key_name: &str, options: Option<KeyClientRotateKeyOptions<'_>>) -> Result<Response<Key>>;
-        async fn secure_unwrap_key(&self, key_name: &str, key_version: &str, parameters: RequestContent<SecureKeyUnWrapOperationParameters>, options: Option<KeyClientSecureUnwrapKeyOptions<'_>>) -> Result<Response<SecureKeyOperationResult>>;
-        async fn secure_wrap_key(&self, key_name: &str, parameters: RequestContent<SecureKeyWrapOperationParameters>, options: Option<KeyClientSecureWrapKeyOptions<'_>>) -> Result<Response<SecureKeyOperationResult>>;
-        async fn sign(&self, key_name: &str, parameters: RequestContent<SignParameters>, options: Option<KeyClientSignOptions<'_>>) -> Result<Response<KeyOperationResult>>;
-        async fn unwrap_key(&self, key_name: &str, key_version: &str, parameters: RequestContent<KeyOperationParameters>, options: Option<KeyClientUnwrapKeyOptions<'_>>) -> Result<Response<KeyOperationResult>>;
-        async fn update_key_properties(&self, key_name: &str, parameters: RequestContent<UpdateKeyPropertiesParameters>, options: Option<KeyClientUpdateKeyPropertiesOptions<'_>>) -> Result<Response<Key>>;
-        async fn update_key_rotation_policy(&self, key_name: &str, key_rotation_policy: RequestContent<KeyRotationPolicy>, options: Option<KeyClientUpdateKeyRotationPolicyOptions<'_>>) -> Result<Response<KeyRotationPolicy>>;
-        async fn verify(&self, key_name: &str, key_version: &str, parameters: RequestContent<VerifyParameters>, options: Option<KeyClientVerifyOptions<'_>>) -> Result<Response<KeyVerifyResult>>;
-        async fn wrap_key(&self, key_name: &str, parameters: RequestContent<KeyOperationParameters>, options: Option<KeyClientWrapKeyOptions<'_>>) -> Result<Response<KeyOperationResult>>;
+        pub async fn backup_key(&self, key_name: &str, options: Option<KeyClientBackupKeyOptions<'_>>) -> Result<Response<BackupKeyResult>>;
+        pub async fn create_key(&self, key_name: &str, parameters: RequestContent<CreateKeyParameters>, options: Option<KeyClientCreateKeyOptions<'_>>) -> Result<Response<Key>>;
+        pub async fn decrypt(&self, key_name: &str, key_version: &str, parameters: RequestContent<KeyOperationParameters>, options: Option<KeyClientDecryptOptions<'_>>) -> Result<Response<KeyOperationResult>>;
+        pub async fn delete_key(&self, key_name: &str, options: Option<KeyClientDeleteKeyOptions<'_>>) -> Result<Response<DeletedKey>>;
+        pub async fn encrypt(&self, key_name: &str, parameters: RequestContent<KeyOperationParameters>, options: Option<KeyClientEncryptOptions<'_>>) -> Result<Response<KeyOperationResult>>;
+        pub fn endpoint(&self) -> &Url;
+        pub async fn get_deleted_key(&self, key_name: &str, options: Option<KeyClientGetDeletedKeyOptions<'_>>) -> Result<Response<DeletedKey>>;
+        pub async fn get_key(&self, key_name: &str, options: Option<KeyClientGetKeyOptions<'_>>) -> Result<Response<Key>>;
+        pub async fn get_key_attestation(&self, key_name: &str, options: Option<KeyClientGetKeyAttestationOptions<'_>>) -> Result<Response<Key>>;
+        pub async fn get_key_rotation_policy(&self, key_name: &str, options: Option<KeyClientGetKeyRotationPolicyOptions<'_>>) -> Result<Response<KeyRotationPolicy>>;
+        pub async fn get_random_bytes(&self, parameters: RequestContent<GetRandomBytesParameters>, options: Option<KeyClientGetRandomBytesOptions<'_>>) -> Result<Response<RandomBytes>>;
+        pub async fn import_key(&self, key_name: &str, parameters: RequestContent<ImportKeyParameters>, options: Option<KeyClientImportKeyOptions<'_>>) -> Result<Response<Key>>;
+        pub fn list_deleted_key_properties(&self, options: Option<KeyClientListDeletedKeyPropertiesOptions<'_>>) -> Result<Pager<ListDeletedKeyPropertiesResult>>;
+        pub fn list_key_properties(&self, options: Option<KeyClientListKeyPropertiesOptions<'_>>) -> Result<Pager<ListKeyPropertiesResult>>;
+        pub fn list_key_properties_versions(&self, key_name: &str, options: Option<KeyClientListKeyPropertiesVersionsOptions<'_>>) -> Result<Pager<ListKeyPropertiesResult>>;
+        pub async fn purge_deleted_key(&self, key_name: &str, options: Option<KeyClientPurgeDeletedKeyOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn recover_deleted_key(&self, key_name: &str, options: Option<KeyClientRecoverDeletedKeyOptions<'_>>) -> Result<Response<Key>>;
+        pub async fn release(&self, key_name: &str, parameters: RequestContent<ReleaseParameters>, options: Option<KeyClientReleaseOptions<'_>>) -> Result<Response<KeyReleaseResult>>;
+        pub async fn restore_key(&self, parameters: RequestContent<RestoreKeyParameters>, options: Option<KeyClientRestoreKeyOptions<'_>>) -> Result<Response<Key>>;
+        pub async fn rotate_key(&self, key_name: &str, options: Option<KeyClientRotateKeyOptions<'_>>) -> Result<Response<Key>>;
+        pub async fn secure_unwrap_key(&self, key_name: &str, key_version: &str, parameters: RequestContent<SecureKeyUnWrapOperationParameters>, options: Option<KeyClientSecureUnwrapKeyOptions<'_>>) -> Result<Response<SecureKeyOperationResult>>;
+        pub async fn secure_wrap_key(&self, key_name: &str, parameters: RequestContent<SecureKeyWrapOperationParameters>, options: Option<KeyClientSecureWrapKeyOptions<'_>>) -> Result<Response<SecureKeyOperationResult>>;
+        pub async fn sign(&self, key_name: &str, parameters: RequestContent<SignParameters>, options: Option<KeyClientSignOptions<'_>>) -> Result<Response<KeyOperationResult>>;
+        pub async fn unwrap_key(&self, key_name: &str, key_version: &str, parameters: RequestContent<KeyOperationParameters>, options: Option<KeyClientUnwrapKeyOptions<'_>>) -> Result<Response<KeyOperationResult>>;
+        pub async fn update_key_properties(&self, key_name: &str, parameters: RequestContent<UpdateKeyPropertiesParameters>, options: Option<KeyClientUpdateKeyPropertiesOptions<'_>>) -> Result<Response<Key>>;
+        pub async fn update_key_rotation_policy(&self, key_name: &str, key_rotation_policy: RequestContent<KeyRotationPolicy>, options: Option<KeyClientUpdateKeyRotationPolicyOptions<'_>>) -> Result<Response<KeyRotationPolicy>>;
+        pub async fn verify(&self, key_name: &str, key_version: &str, parameters: RequestContent<VerifyParameters>, options: Option<KeyClientVerifyOptions<'_>>) -> Result<Response<KeyVerifyResult>>;
+        pub async fn wrap_key(&self, key_name: &str, parameters: RequestContent<KeyOperationParameters>, options: Option<KeyClientWrapKeyOptions<'_>>) -> Result<Response<KeyOperationResult>>;
     }
     #[derive(Clone, Debug)]
     pub struct KeyClientOptions {
@@ -321,7 +321,7 @@ pub mod models {
         pub method_options: azure_core::http::pager::PagerOptions<'a>,
     }
     impl KeyClientListDeletedKeyPropertiesOptions<'_> {
-        fn into_owned(self) -> KeyClientListDeletedKeyPropertiesOptions<'static>;
+        pub fn into_owned(self) -> KeyClientListDeletedKeyPropertiesOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct KeyClientListKeyPropertiesOptions<'a> {
@@ -329,7 +329,7 @@ pub mod models {
         pub method_options: azure_core::http::pager::PagerOptions<'a>,
     }
     impl KeyClientListKeyPropertiesOptions<'_> {
-        fn into_owned(self) -> KeyClientListKeyPropertiesOptions<'static>;
+        pub fn into_owned(self) -> KeyClientListKeyPropertiesOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct KeyClientListKeyPropertiesVersionsOptions<'a> {
@@ -337,7 +337,7 @@ pub mod models {
         pub method_options: azure_core::http::pager::PagerOptions<'a>,
     }
     impl KeyClientListKeyPropertiesVersionsOptions<'_> {
-        fn into_owned(self) -> KeyClientListKeyPropertiesVersionsOptions<'static>;
+        pub fn into_owned(self) -> KeyClientListKeyPropertiesVersionsOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct KeyClientPurgeDeletedKeyOptions<'a> {

--- a/sdk/keyvault/azure_security_keyvault_keys/api/API.metadata.yml
+++ b/sdk/keyvault/azure_security_keyvault_keys/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: b6e476c9e504d9d92156dc30da8cf98bcef465977a20c1ce929db25615558eb6
+apiMdSha256: 78b935ffa37de7ea0ef4686eb6505f557ed8a12a87a23c2b72c2f6bc775e3664
 packageVersion: 1.1.0-beta.1
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/keyvault/azure_security_keyvault_secrets/api/API.md
+++ b/sdk/keyvault/azure_security_keyvault_secrets/api/API.md
@@ -39,22 +39,22 @@ pub mod clients {
     pub struct SecretClient {
     }
     impl SecretClient {
-        fn new(endpoint: &str, credential: Arc<dyn TokenCredential>, options: Option<SecretClientOptions>) -> Result<Self>;
+        pub fn new(endpoint: &str, credential: Arc<dyn TokenCredential>, options: Option<SecretClientOptions>) -> Result<Self>;
     }
     impl SecretClient {
-        async fn backup_secret(&self, secret_name: &str, options: Option<SecretClientBackupSecretOptions<'_>>) -> Result<Response<BackupSecretResult>>;
-        async fn delete_secret(&self, secret_name: &str, options: Option<SecretClientDeleteSecretOptions<'_>>) -> Result<Response<DeletedSecret>>;
-        fn endpoint(&self) -> &Url;
-        async fn get_deleted_secret(&self, secret_name: &str, options: Option<SecretClientGetDeletedSecretOptions<'_>>) -> Result<Response<DeletedSecret>>;
-        async fn get_secret(&self, secret_name: &str, options: Option<SecretClientGetSecretOptions<'_>>) -> Result<Response<Secret>>;
-        fn list_deleted_secret_properties(&self, options: Option<SecretClientListDeletedSecretPropertiesOptions<'_>>) -> Result<Pager<ListDeletedSecretPropertiesResult>>;
-        fn list_secret_properties(&self, options: Option<SecretClientListSecretPropertiesOptions<'_>>) -> Result<Pager<ListSecretPropertiesResult>>;
-        fn list_secret_properties_versions(&self, secret_name: &str, options: Option<SecretClientListSecretPropertiesVersionsOptions<'_>>) -> Result<Pager<ListSecretPropertiesResult>>;
-        async fn purge_deleted_secret(&self, secret_name: &str, options: Option<SecretClientPurgeDeletedSecretOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn recover_deleted_secret(&self, secret_name: &str, options: Option<SecretClientRecoverDeletedSecretOptions<'_>>) -> Result<Response<Secret>>;
-        async fn restore_secret(&self, parameters: RequestContent<RestoreSecretParameters>, options: Option<SecretClientRestoreSecretOptions<'_>>) -> Result<Response<Secret>>;
-        async fn set_secret(&self, secret_name: &str, parameters: RequestContent<SetSecretParameters>, options: Option<SecretClientSetSecretOptions<'_>>) -> Result<Response<Secret>>;
-        async fn update_secret_properties(&self, secret_name: &str, parameters: RequestContent<UpdateSecretPropertiesParameters>, options: Option<SecretClientUpdateSecretPropertiesOptions<'_>>) -> Result<Response<Secret>>;
+        pub async fn backup_secret(&self, secret_name: &str, options: Option<SecretClientBackupSecretOptions<'_>>) -> Result<Response<BackupSecretResult>>;
+        pub async fn delete_secret(&self, secret_name: &str, options: Option<SecretClientDeleteSecretOptions<'_>>) -> Result<Response<DeletedSecret>>;
+        pub fn endpoint(&self) -> &Url;
+        pub async fn get_deleted_secret(&self, secret_name: &str, options: Option<SecretClientGetDeletedSecretOptions<'_>>) -> Result<Response<DeletedSecret>>;
+        pub async fn get_secret(&self, secret_name: &str, options: Option<SecretClientGetSecretOptions<'_>>) -> Result<Response<Secret>>;
+        pub fn list_deleted_secret_properties(&self, options: Option<SecretClientListDeletedSecretPropertiesOptions<'_>>) -> Result<Pager<ListDeletedSecretPropertiesResult>>;
+        pub fn list_secret_properties(&self, options: Option<SecretClientListSecretPropertiesOptions<'_>>) -> Result<Pager<ListSecretPropertiesResult>>;
+        pub fn list_secret_properties_versions(&self, secret_name: &str, options: Option<SecretClientListSecretPropertiesVersionsOptions<'_>>) -> Result<Pager<ListSecretPropertiesResult>>;
+        pub async fn purge_deleted_secret(&self, secret_name: &str, options: Option<SecretClientPurgeDeletedSecretOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn recover_deleted_secret(&self, secret_name: &str, options: Option<SecretClientRecoverDeletedSecretOptions<'_>>) -> Result<Response<Secret>>;
+        pub async fn restore_secret(&self, parameters: RequestContent<RestoreSecretParameters>, options: Option<SecretClientRestoreSecretOptions<'_>>) -> Result<Response<Secret>>;
+        pub async fn set_secret(&self, secret_name: &str, parameters: RequestContent<SetSecretParameters>, options: Option<SecretClientSetSecretOptions<'_>>) -> Result<Response<Secret>>;
+        pub async fn update_secret_properties(&self, secret_name: &str, parameters: RequestContent<UpdateSecretPropertiesParameters>, options: Option<SecretClientUpdateSecretPropertiesOptions<'_>>) -> Result<Response<Secret>>;
     }
     #[derive(Clone, Debug)]
     pub struct SecretClientOptions {
@@ -231,7 +231,7 @@ pub mod models {
         pub method_options: azure_core::http::pager::PagerOptions<'a>,
     }
     impl SecretClientListDeletedSecretPropertiesOptions<'_> {
-        fn into_owned(self) -> SecretClientListDeletedSecretPropertiesOptions<'static>;
+        pub fn into_owned(self) -> SecretClientListDeletedSecretPropertiesOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct SecretClientListSecretPropertiesOptions<'a> {
@@ -239,7 +239,7 @@ pub mod models {
         pub method_options: azure_core::http::pager::PagerOptions<'a>,
     }
     impl SecretClientListSecretPropertiesOptions<'_> {
-        fn into_owned(self) -> SecretClientListSecretPropertiesOptions<'static>;
+        pub fn into_owned(self) -> SecretClientListSecretPropertiesOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct SecretClientListSecretPropertiesVersionsOptions<'a> {
@@ -247,7 +247,7 @@ pub mod models {
         pub method_options: azure_core::http::pager::PagerOptions<'a>,
     }
     impl SecretClientListSecretPropertiesVersionsOptions<'_> {
-        fn into_owned(self) -> SecretClientListSecretPropertiesVersionsOptions<'static>;
+        pub fn into_owned(self) -> SecretClientListSecretPropertiesVersionsOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct SecretClientPurgeDeletedSecretOptions<'a> {

--- a/sdk/keyvault/azure_security_keyvault_secrets/api/API.metadata.yml
+++ b/sdk/keyvault/azure_security_keyvault_secrets/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: 363083bc5a2fc87ebf7a2238de6049a808667622587a9ba3f74c310664536606
+apiMdSha256: 7fc2fc1e72960ac5bbef2bbd15806064230c83aeb58b1a5dfc3fdf3f47bbd731
 packageVersion: 1.1.0-beta.1
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/keyvault/azure_security_keyvault_test/api/API.md
+++ b/sdk/keyvault/azure_security_keyvault_test/api/API.md
@@ -12,10 +12,10 @@
 #[derive(Debug)]
 pub struct Retry(/* private fields */);
 impl Retry {
-    fn duration(&self) -> Option<Duration>;
-    fn immediate() -> Self;
-    async fn next(&mut self) -> Option<()>;
-    fn progressive(timeout: Option<Duration>) -> Self;
+    pub fn duration(&self) -> Option<Duration>;
+    pub fn immediate() -> Self;
+    pub async fn next(&mut self) -> Option<()>;
+    pub fn progressive(timeout: Option<Duration>) -> Self;
 }
 pub mod policies {
     #[derive(Debug)]

--- a/sdk/keyvault/azure_security_keyvault_test/api/API.metadata.yml
+++ b/sdk/keyvault/azure_security_keyvault_test/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: 06c7eb9493437e0988464d710a46a51c41602d77f0160b95c24111a33b23b235
+apiMdSha256: 4082ef3fa5c2711d3bdbe3263061084db4c6e29e9a8148ff55ae42ca8597a1f4
 packageVersion: 0.1.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/servicebus/azure_messaging_servicebus/api/API.md
+++ b/sdk/servicebus/azure_messaging_servicebus/api/API.md
@@ -41,30 +41,30 @@ pub use azure_messaging_servicebus::client::SubQueue;
 pub struct Message {
 }
 impl Message {
-    fn body(&self) -> &[u8];
-    fn body_as_string(&self) -> Result<String>;
-    fn content_type(&self) -> Option<&String>;
-    fn correlation_id(&self) -> Option<&String>;
-    fn message_id(&self) -> Option<&String>;
-    fn new<T: Into<Vec<u8>>>(body: T) -> Self;
-    fn properties(&self) -> &HashMap<String, String>;
-    fn property(&self, key: &str) -> Option<&String>;
-    fn reply_to(&self) -> Option<&String>;
-    fn reply_to_session_id(&self) -> Option<&String>;
-    fn scheduled_enqueue_time(&self) -> Option<OffsetDateTime>;
-    fn session_id(&self) -> Option<&String>;
-    fn set_content_type<impl Into<String>: Into<String>>(&mut self, content_type: impl Into<String>);
-    fn set_correlation_id<impl Into<String>: Into<String>>(&mut self, correlation_id: impl Into<String>);
-    fn set_message_id<impl Into<String>: Into<String>>(&mut self, message_id: impl Into<String>);
-    fn set_property<impl Into<String>: Into<String>, impl Into<String>: Into<String>>(&mut self, key: impl Into<String>, value: impl Into<String>);
-    fn set_reply_to<impl Into<String>: Into<String>>(&mut self, reply_to: impl Into<String>);
-    fn set_reply_to_session_id<impl Into<String>: Into<String>>(&mut self, reply_to_session_id: impl Into<String>);
-    fn set_scheduled_enqueue_time(&mut self, scheduled_enqueue_time: OffsetDateTime);
-    fn set_session_id<impl Into<String>: Into<String>>(&mut self, session_id: impl Into<String>);
-    fn set_subject<impl Into<String>: Into<String>>(&mut self, subject: impl Into<String>);
-    fn set_time_to_live(&mut self, time_to_live: Duration);
-    fn subject(&self) -> Option<&String>;
-    fn time_to_live(&self) -> Option<Duration>;
+    pub fn body(&self) -> &[u8];
+    pub fn body_as_string(&self) -> Result<String>;
+    pub fn content_type(&self) -> Option<&String>;
+    pub fn correlation_id(&self) -> Option<&String>;
+    pub fn message_id(&self) -> Option<&String>;
+    pub fn new<T: Into<Vec<u8>>>(body: T) -> Self;
+    pub fn properties(&self) -> &HashMap<String, String>;
+    pub fn property(&self, key: &str) -> Option<&String>;
+    pub fn reply_to(&self) -> Option<&String>;
+    pub fn reply_to_session_id(&self) -> Option<&String>;
+    pub fn scheduled_enqueue_time(&self) -> Option<OffsetDateTime>;
+    pub fn session_id(&self) -> Option<&String>;
+    pub fn set_content_type<impl Into<String>: Into<String>>(&mut self, content_type: impl Into<String>);
+    pub fn set_correlation_id<impl Into<String>: Into<String>>(&mut self, correlation_id: impl Into<String>);
+    pub fn set_message_id<impl Into<String>: Into<String>>(&mut self, message_id: impl Into<String>);
+    pub fn set_property<impl Into<String>: Into<String>, impl Into<String>: Into<String>>(&mut self, key: impl Into<String>, value: impl Into<String>);
+    pub fn set_reply_to<impl Into<String>: Into<String>>(&mut self, reply_to: impl Into<String>);
+    pub fn set_reply_to_session_id<impl Into<String>: Into<String>>(&mut self, reply_to_session_id: impl Into<String>);
+    pub fn set_scheduled_enqueue_time(&mut self, scheduled_enqueue_time: OffsetDateTime);
+    pub fn set_session_id<impl Into<String>: Into<String>>(&mut self, session_id: impl Into<String>);
+    pub fn set_subject<impl Into<String>: Into<String>>(&mut self, subject: impl Into<String>);
+    pub fn set_time_to_live(&mut self, time_to_live: Duration);
+    pub fn subject(&self) -> Option<&String>;
+    pub fn time_to_live(&self) -> Option<Duration>;
 }
 impl From<&str> for Message {
     fn from(body: &str) -> Self;
@@ -80,37 +80,37 @@ pub struct MessageBatch {
 }
 impl MessageBatch {
     const DEFAULT_MAX_SIZE_BYTES: usize = _;
-    fn count(&self) -> usize;
-    fn is_empty(&self) -> bool;
-    fn maximum_size_in_bytes(&self) -> usize;
-    fn size_in_bytes(&self) -> usize;
-    fn try_add_message(&mut self, message: Message) -> bool;
+    pub fn count(&self) -> usize;
+    pub fn is_empty(&self) -> bool;
+    pub fn maximum_size_in_bytes(&self) -> usize;
+    pub fn size_in_bytes(&self) -> usize;
+    pub fn try_add_message(&mut self, message: Message) -> bool;
 }
 #[derive(Clone, Debug)]
 pub struct ReceivedMessage {
 }
 impl ReceivedMessage {
-    fn body(&self) -> &[u8];
-    fn body_as_string(&self) -> Result<String>;
-    fn correlation_id(&self) -> Option<&String>;
-    fn delivery_count(&self) -> Option<u32>;
-    fn enqueued_time_utc(&self) -> Option<OffsetDateTime>;
-    fn lock_token(&self) -> Option<Uuid>;
-    fn message_id(&self) -> Option<&String>;
-    fn properties(&self) -> &HashMap<String, String>;
-    fn property(&self, key: &str) -> Option<&String>;
-    fn sequence_number(&self) -> Option<i64>;
-    fn session_id(&self) -> Option<&String>;
-    fn system_properties(&self) -> &SystemProperties;
+    pub fn body(&self) -> &[u8];
+    pub fn body_as_string(&self) -> Result<String>;
+    pub fn correlation_id(&self) -> Option<&String>;
+    pub fn delivery_count(&self) -> Option<u32>;
+    pub fn enqueued_time_utc(&self) -> Option<OffsetDateTime>;
+    pub fn lock_token(&self) -> Option<Uuid>;
+    pub fn message_id(&self) -> Option<&String>;
+    pub fn properties(&self) -> &HashMap<String, String>;
+    pub fn property(&self, key: &str) -> Option<&String>;
+    pub fn sequence_number(&self) -> Option<i64>;
+    pub fn session_id(&self) -> Option<&String>;
+    pub fn system_properties(&self) -> &SystemProperties;
 }
 #[derive(Debug)]
 pub struct ServiceBusError {
 }
 impl ServiceBusError {
-    fn kind(&self) -> &ErrorKind;
-    fn message(&self) -> &str;
-    fn new<impl Into<String>: Into<String>>(kind: ErrorKind, message: impl Into<String>) -> Self;
-    fn with_source<impl Into<String>: Into<String>>(kind: ErrorKind, message: impl Into<String>, source: Box<dyn std::error::Error + 'static>) -> Self;
+    pub fn kind(&self) -> &ErrorKind;
+    pub fn message(&self) -> &str;
+    pub fn new<impl Into<String>: Into<String>>(kind: ErrorKind, message: impl Into<String>) -> Self;
+    pub fn with_source<impl Into<String>: Into<String>>(kind: ErrorKind, message: impl Into<String>, source: Box<dyn std::error::Error + 'static>) -> Self;
 }
 impl Display for ServiceBusError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -157,20 +157,20 @@ pub mod client {
     pub struct ServiceBusClient {
     }
     impl ServiceBusClient {
-        fn builder() -> ServiceBusClientBuilder;
-        async fn close(&self) -> Result<()>;
-        async fn create_receiver(&self, queue_name: &str, options: Option<CreateReceiverOptions>) -> Result<Receiver>;
-        async fn create_receiver_for_subscription(&self, topic_name: &str, subscription_name: &str, options: Option<CreateReceiverOptions>) -> Result<Receiver>;
-        async fn create_sender(&self, queue_or_topic_name: &str, _options: Option<CreateSenderOptions>) -> Result<Sender>;
-        fn fully_qualified_namespace(&self) -> &str;
+        pub fn builder() -> ServiceBusClientBuilder;
+        pub async fn close(&self) -> Result<()>;
+        pub async fn create_receiver(&self, queue_name: &str, options: Option<CreateReceiverOptions>) -> Result<Receiver>;
+        pub async fn create_receiver_for_subscription(&self, topic_name: &str, subscription_name: &str, options: Option<CreateReceiverOptions>) -> Result<Receiver>;
+        pub async fn create_sender(&self, queue_or_topic_name: &str, _options: Option<CreateSenderOptions>) -> Result<Sender>;
+        pub fn fully_qualified_namespace(&self) -> &str;
     }
     #[derive(Default)]
     pub struct ServiceBusClientBuilder {
     }
     impl ServiceBusClientBuilder {
-        fn new() -> Self;
-        async fn open(self, fully_qualified_namespace: &str, credential: Arc<dyn TokenCredential>) -> Result<ServiceBusClient>;
-        fn with_application_id(self, application_id: String) -> Self;
+        pub fn new() -> Self;
+        pub async fn open(self, fully_qualified_namespace: &str, credential: Arc<dyn TokenCredential>) -> Result<ServiceBusClient>;
+        pub fn with_application_id(self, application_id: String) -> Self;
     }
     #[derive(Clone, Debug)]
     pub struct ServiceBusClientOptions {
@@ -359,20 +359,20 @@ pub mod receiver {
     pub struct Receiver {
     }
     impl Receiver {
-        async fn abandon_message(&self, message: &ReceivedMessage, _options: Option<AbandonMessageOptions>) -> Result<()>;
-        async fn close(&self) -> Result<()>;
-        async fn complete_message(&self, message: &ReceivedMessage, _options: Option<CompleteMessageOptions>) -> Result<()>;
-        async fn dead_letter_message(&self, message: &ReceivedMessage, options: Option<DeadLetterMessageOptions>) -> Result<()>;
-        async fn defer_message(&self, message: &ReceivedMessage, options: Option<DeferMessageOptions>) -> Result<()>;
-        fn entity_name(&self) -> &str;
-        async fn peek_messages(&self, max_count: u32, options: Option<PeekMessagesOptions>) -> Result<Vec<ReceivedMessage>>;
-        async fn receive_deferred_message(&self, sequence_number: i64, _options: Option<ReceiveDeferredMessagesOptions>) -> Result<Option<ReceivedMessage>>;
-        async fn receive_deferred_messages(&self, sequence_numbers: &[i64], _options: Option<ReceiveDeferredMessagesOptions>) -> Result<Vec<ReceivedMessage>>;
-        async fn receive_message(&self, options: Option<ReceiveMessageOptions>) -> Result<Option<ReceivedMessage>>;
-        async fn receive_messages(&self, max_message_count: usize, options: Option<ReceiveMessageOptions>) -> Result<Vec<ReceivedMessage>>;
-        fn receive_mode(&self) -> ReceiveMode;
-        async fn renew_message_lock(&self, message: &ReceivedMessage, _options: Option<RenewMessageLockOptions>) -> Result<OffsetDateTime>;
-        fn subscription_name(&self) -> Option<&str>;
+        pub async fn abandon_message(&self, message: &ReceivedMessage, _options: Option<AbandonMessageOptions>) -> Result<()>;
+        pub async fn close(&self) -> Result<()>;
+        pub async fn complete_message(&self, message: &ReceivedMessage, _options: Option<CompleteMessageOptions>) -> Result<()>;
+        pub async fn dead_letter_message(&self, message: &ReceivedMessage, options: Option<DeadLetterMessageOptions>) -> Result<()>;
+        pub async fn defer_message(&self, message: &ReceivedMessage, options: Option<DeferMessageOptions>) -> Result<()>;
+        pub fn entity_name(&self) -> &str;
+        pub async fn peek_messages(&self, max_count: u32, options: Option<PeekMessagesOptions>) -> Result<Vec<ReceivedMessage>>;
+        pub async fn receive_deferred_message(&self, sequence_number: i64, _options: Option<ReceiveDeferredMessagesOptions>) -> Result<Option<ReceivedMessage>>;
+        pub async fn receive_deferred_messages(&self, sequence_numbers: &[i64], _options: Option<ReceiveDeferredMessagesOptions>) -> Result<Vec<ReceivedMessage>>;
+        pub async fn receive_message(&self, options: Option<ReceiveMessageOptions>) -> Result<Option<ReceivedMessage>>;
+        pub async fn receive_messages(&self, max_message_count: usize, options: Option<ReceiveMessageOptions>) -> Result<Vec<ReceivedMessage>>;
+        pub fn receive_mode(&self) -> ReceiveMode;
+        pub async fn renew_message_lock(&self, message: &ReceivedMessage, _options: Option<RenewMessageLockOptions>) -> Result<OffsetDateTime>;
+        pub fn subscription_name(&self) -> Option<&str>;
     }
     impl Drop for Receiver {
         fn drop(&mut self);
@@ -405,14 +405,14 @@ pub mod sender {
     pub struct Sender {
     }
     impl Sender {
-        async fn cancel_scheduled_message(&self, sequence_number: i64, _options: Option<CancelScheduledMessagesOptions>) -> Result<()>;
-        async fn close(&self) -> Result<()>;
-        async fn create_message_batch(&self, options: Option<CreateMessageBatchOptions>) -> crate::Result<crate::MessageBatch>;
-        fn entity_name(&self) -> &str;
-        async fn schedule_message(&self, message: Message, scheduled_enqueue_time: time::OffsetDateTime, _options: Option<ScheduleMessageOptions>) -> Result<i64>;
-        async fn send_message(&self, message: Message, _options: Option<SendMessageOptions>) -> Result<()>;
-        async fn send_message_batch(&self, batch: crate::MessageBatch, _options: Option<SendMessageBatchOptions>) -> crate::Result<()>;
-        async fn send_messages(&self, messages: Vec<Message>, _options: Option<SendMessagesOptions>) -> Result<()>;
+        pub async fn cancel_scheduled_message(&self, sequence_number: i64, _options: Option<CancelScheduledMessagesOptions>) -> Result<()>;
+        pub async fn close(&self) -> Result<()>;
+        pub async fn create_message_batch(&self, options: Option<CreateMessageBatchOptions>) -> crate::Result<crate::MessageBatch>;
+        pub fn entity_name(&self) -> &str;
+        pub async fn schedule_message(&self, message: Message, scheduled_enqueue_time: time::OffsetDateTime, _options: Option<ScheduleMessageOptions>) -> Result<i64>;
+        pub async fn send_message(&self, message: Message, _options: Option<SendMessageOptions>) -> Result<()>;
+        pub async fn send_message_batch(&self, batch: crate::MessageBatch, _options: Option<SendMessageBatchOptions>) -> crate::Result<()>;
+        pub async fn send_messages(&self, messages: Vec<Message>, _options: Option<SendMessagesOptions>) -> Result<()>;
     }
     impl Drop for Sender {
         fn drop(&mut self);

--- a/sdk/servicebus/azure_messaging_servicebus/api/API.metadata.yml
+++ b/sdk/servicebus/azure_messaging_servicebus/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: 5b53448ba7e3c4082c6251d5312329f9f7774e93a18529c6ddb81ae17cec06e0
+apiMdSha256: d30e065c51d2ad1eb5a909f1b884b346f8d6ad062f3db4157b49e55fcda752f7
 packageVersion: 0.22.0
-parserVersion: 2.2.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/storage/azure_storage_blob/api/API.md
+++ b/sdk/storage/azure_storage_blob/api/API.md
@@ -43,14 +43,14 @@ pub mod clients {
     pub struct AppendBlobClient {
     }
     impl AppendBlobClient {
-        fn new(blob_url: Url, credential: Option<Arc<dyn TokenCredential>>, options: Option<AppendBlobClientOptions>) -> Result<Self>;
-        fn url(&self) -> &Url;
+        pub fn new(blob_url: Url, credential: Option<Arc<dyn TokenCredential>>, options: Option<AppendBlobClientOptions>) -> Result<Self>;
+        pub fn url(&self) -> &Url;
     }
     impl AppendBlobClient {
-        async fn append_block(&self, body: RequestContent<Bytes, NoFormat>, content_length: u64, options: Option<AppendBlobClientAppendBlockOptions<'_>>) -> Result<Response<AppendBlobClientAppendBlockResult, NoFormat>>;
-        async fn append_block_from_url(&self, source_url: String, content_length: u64, options: Option<AppendBlobClientAppendBlockFromUrlOptions<'_>>) -> Result<Response<AppendBlobClientAppendBlockFromUrlResult, NoFormat>>;
-        async fn create(&self, options: Option<AppendBlobClientCreateOptions<'_>>) -> Result<Response<AppendBlobClientCreateResult, NoFormat>>;
-        async fn seal(&self, options: Option<AppendBlobClientSealOptions<'_>>) -> Result<Response<AppendBlobClientSealResult, NoFormat>>;
+        pub async fn append_block(&self, body: RequestContent<Bytes, NoFormat>, content_length: u64, options: Option<AppendBlobClientAppendBlockOptions<'_>>) -> Result<Response<AppendBlobClientAppendBlockResult, NoFormat>>;
+        pub async fn append_block_from_url(&self, source_url: String, content_length: u64, options: Option<AppendBlobClientAppendBlockFromUrlOptions<'_>>) -> Result<Response<AppendBlobClientAppendBlockFromUrlResult, NoFormat>>;
+        pub async fn create(&self, options: Option<AppendBlobClientCreateOptions<'_>>) -> Result<Response<AppendBlobClientCreateResult, NoFormat>>;
+        pub async fn seal(&self, options: Option<AppendBlobClientSealOptions<'_>>) -> Result<Response<AppendBlobClientSealResult, NoFormat>>;
     }
     #[derive(Clone, Debug)]
     pub struct AppendBlobClientOptions {
@@ -63,39 +63,39 @@ pub mod clients {
     pub struct BlobClient {
     }
     impl BlobClient {
-        fn append_blob_client(&self) -> AppendBlobClient;
-        fn block_blob_client(&self) -> BlockBlobClient;
-        async fn download(&self, options: Option<BlobClientDownloadOptions<'_>>) -> Result<BlobClientDownloadResult>;
-        async fn download_into(&self, buffer: &mut [u8], options: Option<BlobClientDownloadOptions<'_>>) -> Result<BlobClientDownloadIntoResult>;
-        async fn exists(&self) -> Result<bool>;
-        fn new(blob_url: Url, credential: Option<Arc<dyn TokenCredential>>, options: Option<BlobClientOptions>) -> Result<Self>;
-        fn page_blob_client(&self) -> PageBlobClient;
-        async fn upload(&self, content: RequestContent<Bytes, NoFormat>, options: Option<BlobClientUploadOptions<'_>>) -> Result<BlobClientUploadResult>;
-        fn url(&self) -> &Url;
-        fn with_snapshot(&self, snapshot: &str) -> Result<Self>;
-        fn with_version(&self, version_id: &str) -> Result<Self>;
+        pub fn append_blob_client(&self) -> AppendBlobClient;
+        pub fn block_blob_client(&self) -> BlockBlobClient;
+        pub async fn download(&self, options: Option<BlobClientDownloadOptions<'_>>) -> Result<BlobClientDownloadResult>;
+        pub async fn download_into(&self, buffer: &mut [u8], options: Option<BlobClientDownloadOptions<'_>>) -> Result<BlobClientDownloadIntoResult>;
+        pub async fn exists(&self) -> Result<bool>;
+        pub fn new(blob_url: Url, credential: Option<Arc<dyn TokenCredential>>, options: Option<BlobClientOptions>) -> Result<Self>;
+        pub fn page_blob_client(&self) -> PageBlobClient;
+        pub async fn upload(&self, content: RequestContent<Bytes, NoFormat>, options: Option<BlobClientUploadOptions<'_>>) -> Result<BlobClientUploadResult>;
+        pub fn url(&self) -> &Url;
+        pub fn with_snapshot(&self, snapshot: &str) -> Result<Self>;
+        pub fn with_version(&self, version_id: &str) -> Result<Self>;
     }
     impl BlobClient {
-        async fn abort_copy(&self, copy_id: &str, options: Option<BlobClientAbortCopyOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn acquire_lease(&self, duration: i32, options: Option<BlobClientAcquireLeaseOptions<'_>>) -> Result<Response<BlobClientAcquireLeaseResult, NoFormat>>;
-        async fn break_lease(&self, options: Option<BlobClientBreakLeaseOptions<'_>>) -> Result<Response<BlobClientBreakLeaseResult, NoFormat>>;
-        async fn change_lease(&self, lease_id: String, proposed_lease_id: String, options: Option<BlobClientChangeLeaseOptions<'_>>) -> Result<Response<BlobClientChangeLeaseResult, NoFormat>>;
-        async fn create_snapshot(&self, options: Option<BlobClientCreateSnapshotOptions<'_>>) -> Result<Response<BlobClientCreateSnapshotResult, NoFormat>>;
-        async fn delete(&self, options: Option<BlobClientDeleteOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn delete_immutability_policy(&self, options: Option<BlobClientDeleteImmutabilityPolicyOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn get_account_info(&self, options: Option<BlobClientGetAccountInfoOptions<'_>>) -> Result<Response<BlobClientGetAccountInfoResult, NoFormat>>;
-        async fn get_properties(&self, options: Option<BlobClientGetPropertiesOptions<'_>>) -> Result<Response<BlobClientGetPropertiesResult, NoFormat>>;
-        async fn get_tags(&self, options: Option<BlobClientGetTagsOptions<'_>>) -> Result<Response<BlobTags, XmlFormat>>;
-        async fn release_lease(&self, lease_id: String, options: Option<BlobClientReleaseLeaseOptions<'_>>) -> Result<Response<BlobClientReleaseLeaseResult, NoFormat>>;
-        async fn renew_lease(&self, lease_id: String, options: Option<BlobClientRenewLeaseOptions<'_>>) -> Result<Response<BlobClientRenewLeaseResult, NoFormat>>;
-        async fn set_immutability_policy(&self, expiry: &OffsetDateTime, options: Option<BlobClientSetImmutabilityPolicyOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn set_legal_hold(&self, legal_hold: bool, options: Option<BlobClientSetLegalHoldOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn set_metadata(&self, metadata: &HashMap<String, String>, options: Option<BlobClientSetMetadataOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn set_properties(&self, options: Option<BlobClientSetPropertiesOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn set_tags(&self, tags: RequestContent<BlobTags, XmlFormat>, options: Option<BlobClientSetTagsOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn set_tier(&self, tier: AccessTier, options: Option<BlobClientSetTierOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn start_copy_from_url(&self, copy_source: String, options: Option<BlobClientStartCopyFromUrlOptions<'_>>) -> Result<Response<BlobClientStartCopyFromUrlResult, NoFormat>>;
-        async fn undelete(&self, options: Option<BlobClientUndeleteOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn abort_copy(&self, copy_id: &str, options: Option<BlobClientAbortCopyOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn acquire_lease(&self, duration: i32, options: Option<BlobClientAcquireLeaseOptions<'_>>) -> Result<Response<BlobClientAcquireLeaseResult, NoFormat>>;
+        pub async fn break_lease(&self, options: Option<BlobClientBreakLeaseOptions<'_>>) -> Result<Response<BlobClientBreakLeaseResult, NoFormat>>;
+        pub async fn change_lease(&self, lease_id: String, proposed_lease_id: String, options: Option<BlobClientChangeLeaseOptions<'_>>) -> Result<Response<BlobClientChangeLeaseResult, NoFormat>>;
+        pub async fn create_snapshot(&self, options: Option<BlobClientCreateSnapshotOptions<'_>>) -> Result<Response<BlobClientCreateSnapshotResult, NoFormat>>;
+        pub async fn delete(&self, options: Option<BlobClientDeleteOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn delete_immutability_policy(&self, options: Option<BlobClientDeleteImmutabilityPolicyOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn get_account_info(&self, options: Option<BlobClientGetAccountInfoOptions<'_>>) -> Result<Response<BlobClientGetAccountInfoResult, NoFormat>>;
+        pub async fn get_properties(&self, options: Option<BlobClientGetPropertiesOptions<'_>>) -> Result<Response<BlobClientGetPropertiesResult, NoFormat>>;
+        pub async fn get_tags(&self, options: Option<BlobClientGetTagsOptions<'_>>) -> Result<Response<BlobTags, XmlFormat>>;
+        pub async fn release_lease(&self, lease_id: String, options: Option<BlobClientReleaseLeaseOptions<'_>>) -> Result<Response<BlobClientReleaseLeaseResult, NoFormat>>;
+        pub async fn renew_lease(&self, lease_id: String, options: Option<BlobClientRenewLeaseOptions<'_>>) -> Result<Response<BlobClientRenewLeaseResult, NoFormat>>;
+        pub async fn set_immutability_policy(&self, expiry: &OffsetDateTime, options: Option<BlobClientSetImmutabilityPolicyOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn set_legal_hold(&self, legal_hold: bool, options: Option<BlobClientSetLegalHoldOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn set_metadata(&self, metadata: &HashMap<String, String>, options: Option<BlobClientSetMetadataOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn set_properties(&self, options: Option<BlobClientSetPropertiesOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn set_tags(&self, tags: RequestContent<BlobTags, XmlFormat>, options: Option<BlobClientSetTagsOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn set_tier(&self, tier: AccessTier, options: Option<BlobClientSetTierOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn start_copy_from_url(&self, copy_source: String, options: Option<BlobClientStartCopyFromUrlOptions<'_>>) -> Result<Response<BlobClientStartCopyFromUrlResult, NoFormat>>;
+        pub async fn undelete(&self, options: Option<BlobClientUndeleteOptions<'_>>) -> Result<Response<(), NoFormat>>;
     }
     #[derive(Clone, Debug)]
     pub struct BlobClientOptions {
@@ -108,26 +108,26 @@ pub mod clients {
     pub struct BlobContainerClient {
     }
     impl BlobContainerClient {
-        fn blob_client(&self, blob_name: &str) -> BlobClient;
-        async fn exists(&self) -> Result<bool>;
-        fn new(container_url: Url, credential: Option<Arc<dyn TokenCredential>>, options: Option<BlobContainerClientOptions>) -> Result<Self>;
-        fn url(&self) -> &Url;
+        pub fn blob_client(&self, blob_name: &str) -> BlobClient;
+        pub async fn exists(&self) -> Result<bool>;
+        pub fn new(container_url: Url, credential: Option<Arc<dyn TokenCredential>>, options: Option<BlobContainerClientOptions>) -> Result<Self>;
+        pub fn url(&self) -> &Url;
     }
     impl BlobContainerClient {
-        async fn acquire_lease(&self, duration: i32, options: Option<BlobContainerClientAcquireLeaseOptions<'_>>) -> Result<Response<BlobContainerClientAcquireLeaseResult, NoFormat>>;
-        async fn break_lease(&self, options: Option<BlobContainerClientBreakLeaseOptions<'_>>) -> Result<Response<BlobContainerClientBreakLeaseResult, NoFormat>>;
-        async fn change_lease(&self, lease_id: String, proposed_lease_id: String, options: Option<BlobContainerClientChangeLeaseOptions<'_>>) -> Result<Response<BlobContainerClientChangeLeaseResult, NoFormat>>;
-        async fn create(&self, options: Option<BlobContainerClientCreateOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn delete(&self, options: Option<BlobContainerClientDeleteOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        fn find_blobs_by_tags(&self, filter_expression: &str, options: Option<BlobContainerClientFindBlobsByTagsOptions<'_>>) -> Result<Pager<FilteredBlobResponse, XmlFormat>>;
-        async fn get_access_policy(&self, options: Option<BlobContainerClientGetAccessPolicyOptions<'_>>) -> Result<Response<SignedIdentifiers, XmlFormat>>;
-        async fn get_account_info(&self, options: Option<BlobContainerClientGetAccountInfoOptions<'_>>) -> Result<Response<BlobContainerClientGetAccountInfoResult, NoFormat>>;
-        async fn get_properties(&self, options: Option<BlobContainerClientGetPropertiesOptions<'_>>) -> Result<Response<BlobContainerClientGetPropertiesResult, NoFormat>>;
-        fn list_blobs(&self, options: Option<BlobContainerClientListBlobsOptions<'_>>) -> Result<Pager<ListBlobsResponse, XmlFormat>>;
-        async fn release_lease(&self, lease_id: String, options: Option<BlobContainerClientReleaseLeaseOptions<'_>>) -> Result<Response<BlobContainerClientReleaseLeaseResult, NoFormat>>;
-        async fn renew_lease(&self, lease_id: String, options: Option<BlobContainerClientRenewLeaseOptions<'_>>) -> Result<Response<BlobContainerClientRenewLeaseResult, NoFormat>>;
-        async fn set_access_policy(&self, container_acl: RequestContent<SignedIdentifiers, XmlFormat>, options: Option<BlobContainerClientSetAccessPolicyOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn set_metadata(&self, metadata: &HashMap<String, String>, options: Option<BlobContainerClientSetMetadataOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn acquire_lease(&self, duration: i32, options: Option<BlobContainerClientAcquireLeaseOptions<'_>>) -> Result<Response<BlobContainerClientAcquireLeaseResult, NoFormat>>;
+        pub async fn break_lease(&self, options: Option<BlobContainerClientBreakLeaseOptions<'_>>) -> Result<Response<BlobContainerClientBreakLeaseResult, NoFormat>>;
+        pub async fn change_lease(&self, lease_id: String, proposed_lease_id: String, options: Option<BlobContainerClientChangeLeaseOptions<'_>>) -> Result<Response<BlobContainerClientChangeLeaseResult, NoFormat>>;
+        pub async fn create(&self, options: Option<BlobContainerClientCreateOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn delete(&self, options: Option<BlobContainerClientDeleteOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub fn find_blobs_by_tags(&self, filter_expression: &str, options: Option<BlobContainerClientFindBlobsByTagsOptions<'_>>) -> Result<Pager<FilteredBlobResponse, XmlFormat>>;
+        pub async fn get_access_policy(&self, options: Option<BlobContainerClientGetAccessPolicyOptions<'_>>) -> Result<Response<SignedIdentifiers, XmlFormat>>;
+        pub async fn get_account_info(&self, options: Option<BlobContainerClientGetAccountInfoOptions<'_>>) -> Result<Response<BlobContainerClientGetAccountInfoResult, NoFormat>>;
+        pub async fn get_properties(&self, options: Option<BlobContainerClientGetPropertiesOptions<'_>>) -> Result<Response<BlobContainerClientGetPropertiesResult, NoFormat>>;
+        pub fn list_blobs(&self, options: Option<BlobContainerClientListBlobsOptions<'_>>) -> Result<Pager<ListBlobsResponse, XmlFormat>>;
+        pub async fn release_lease(&self, lease_id: String, options: Option<BlobContainerClientReleaseLeaseOptions<'_>>) -> Result<Response<BlobContainerClientReleaseLeaseResult, NoFormat>>;
+        pub async fn renew_lease(&self, lease_id: String, options: Option<BlobContainerClientRenewLeaseOptions<'_>>) -> Result<Response<BlobContainerClientRenewLeaseResult, NoFormat>>;
+        pub async fn set_access_policy(&self, container_acl: RequestContent<SignedIdentifiers, XmlFormat>, options: Option<BlobContainerClientSetAccessPolicyOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn set_metadata(&self, metadata: &HashMap<String, String>, options: Option<BlobContainerClientSetMetadataOptions<'_>>) -> Result<Response<(), NoFormat>>;
     }
     #[derive(Clone, Debug)]
     pub struct BlobContainerClientOptions {
@@ -140,19 +140,19 @@ pub mod clients {
     pub struct BlobServiceClient {
     }
     impl BlobServiceClient {
-        fn blob_client(&self, container_name: &str, blob_name: &str) -> BlobClient;
-        fn blob_container_client(&self, container_name: &str) -> BlobContainerClient;
-        fn new(service_url: Url, credential: Option<Arc<dyn TokenCredential>>, options: Option<BlobServiceClientOptions>) -> Result<Self>;
-        fn url(&self) -> &Url;
+        pub fn blob_client(&self, container_name: &str, blob_name: &str) -> BlobClient;
+        pub fn blob_container_client(&self, container_name: &str) -> BlobContainerClient;
+        pub fn new(service_url: Url, credential: Option<Arc<dyn TokenCredential>>, options: Option<BlobServiceClientOptions>) -> Result<Self>;
+        pub fn url(&self) -> &Url;
     }
     impl BlobServiceClient {
-        fn find_blobs_by_tags(&self, filter_expression: &str, options: Option<BlobServiceClientFindBlobsByTagsOptions<'_>>) -> Result<Pager<FilteredBlobResponse, XmlFormat>>;
-        async fn get_account_info(&self, options: Option<BlobServiceClientGetAccountInfoOptions<'_>>) -> Result<Response<BlobServiceClientGetAccountInfoResult, NoFormat>>;
-        async fn get_properties(&self, options: Option<BlobServiceClientGetPropertiesOptions<'_>>) -> Result<Response<BlobServiceProperties, XmlFormat>>;
-        async fn get_statistics(&self, options: Option<BlobServiceClientGetStatisticsOptions<'_>>) -> Result<Response<StorageServiceStats, XmlFormat>>;
-        async fn get_user_delegation_key(&self, key_info: RequestContent<KeyInfo, XmlFormat>, options: Option<BlobServiceClientGetUserDelegationKeyOptions<'_>>) -> Result<Response<UserDelegationKey, XmlFormat>>;
-        fn list_containers(&self, options: Option<BlobServiceClientListContainersOptions<'_>>) -> Result<Pager<ListContainersResponse, XmlFormat>>;
-        async fn set_properties(&self, storage_service_properties: RequestContent<BlobServiceProperties, XmlFormat>, options: Option<BlobServiceClientSetPropertiesOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub fn find_blobs_by_tags(&self, filter_expression: &str, options: Option<BlobServiceClientFindBlobsByTagsOptions<'_>>) -> Result<Pager<FilteredBlobResponse, XmlFormat>>;
+        pub async fn get_account_info(&self, options: Option<BlobServiceClientGetAccountInfoOptions<'_>>) -> Result<Response<BlobServiceClientGetAccountInfoResult, NoFormat>>;
+        pub async fn get_properties(&self, options: Option<BlobServiceClientGetPropertiesOptions<'_>>) -> Result<Response<BlobServiceProperties, XmlFormat>>;
+        pub async fn get_statistics(&self, options: Option<BlobServiceClientGetStatisticsOptions<'_>>) -> Result<Response<StorageServiceStats, XmlFormat>>;
+        pub async fn get_user_delegation_key(&self, key_info: RequestContent<KeyInfo, XmlFormat>, options: Option<BlobServiceClientGetUserDelegationKeyOptions<'_>>) -> Result<Response<UserDelegationKey, XmlFormat>>;
+        pub fn list_containers(&self, options: Option<BlobServiceClientListContainersOptions<'_>>) -> Result<Pager<ListContainersResponse, XmlFormat>>;
+        pub async fn set_properties(&self, storage_service_properties: RequestContent<BlobServiceProperties, XmlFormat>, options: Option<BlobServiceClientSetPropertiesOptions<'_>>) -> Result<Response<(), NoFormat>>;
     }
     #[derive(Clone, Debug)]
     pub struct BlobServiceClientOptions {
@@ -165,16 +165,16 @@ pub mod clients {
     pub struct BlockBlobClient {
     }
     impl BlockBlobClient {
-        fn new(blob_url: Url, credential: Option<Arc<dyn TokenCredential>>, options: Option<BlockBlobClientOptions>) -> Result<Self>;
-        async fn upload(&self, content: RequestContent<Bytes, NoFormat>, options: Option<BlockBlobClientUploadOptions<'_>>) -> Result<BlockBlobClientUploadResult>;
-        fn url(&self) -> &Url;
+        pub fn new(blob_url: Url, credential: Option<Arc<dyn TokenCredential>>, options: Option<BlockBlobClientOptions>) -> Result<Self>;
+        pub async fn upload(&self, content: RequestContent<Bytes, NoFormat>, options: Option<BlockBlobClientUploadOptions<'_>>) -> Result<BlockBlobClientUploadResult>;
+        pub fn url(&self) -> &Url;
     }
     impl BlockBlobClient {
-        async fn commit_block_list(&self, blocks: RequestContent<BlockLookupList, XmlFormat>, options: Option<BlockBlobClientCommitBlockListOptions<'_>>) -> Result<Response<BlockBlobClientCommitBlockListResult, NoFormat>>;
-        async fn get_block_list(&self, list_type: BlockListType, options: Option<BlockBlobClientGetBlockListOptions<'_>>) -> Result<Response<BlockList, XmlFormat>>;
-        async fn stage_block(&self, block_id: &[u8], content_length: u64, body: RequestContent<Bytes, NoFormat>, options: Option<BlockBlobClientStageBlockOptions<'_>>) -> Result<Response<BlockBlobClientStageBlockResult, NoFormat>>;
-        async fn stage_block_from_url(&self, block_id: &[u8], content_length: u64, source_url: String, options: Option<BlockBlobClientStageBlockFromUrlOptions<'_>>) -> Result<Response<BlockBlobClientStageBlockFromUrlResult, NoFormat>>;
-        async fn upload_blob_from_url(&self, copy_source: String, options: Option<BlockBlobClientUploadBlobFromUrlOptions<'_>>) -> Result<Response<BlockBlobClientUploadBlobFromUrlResult, NoFormat>>;
+        pub async fn commit_block_list(&self, blocks: RequestContent<BlockLookupList, XmlFormat>, options: Option<BlockBlobClientCommitBlockListOptions<'_>>) -> Result<Response<BlockBlobClientCommitBlockListResult, NoFormat>>;
+        pub async fn get_block_list(&self, list_type: BlockListType, options: Option<BlockBlobClientGetBlockListOptions<'_>>) -> Result<Response<BlockList, XmlFormat>>;
+        pub async fn stage_block(&self, block_id: &[u8], content_length: u64, body: RequestContent<Bytes, NoFormat>, options: Option<BlockBlobClientStageBlockOptions<'_>>) -> Result<Response<BlockBlobClientStageBlockResult, NoFormat>>;
+        pub async fn stage_block_from_url(&self, block_id: &[u8], content_length: u64, source_url: String, options: Option<BlockBlobClientStageBlockFromUrlOptions<'_>>) -> Result<Response<BlockBlobClientStageBlockFromUrlResult, NoFormat>>;
+        pub async fn upload_blob_from_url(&self, copy_source: String, options: Option<BlockBlobClientUploadBlobFromUrlOptions<'_>>) -> Result<Response<BlockBlobClientUploadBlobFromUrlResult, NoFormat>>;
     }
     #[derive(Clone, Debug)]
     pub struct BlockBlobClientOptions {
@@ -187,17 +187,17 @@ pub mod clients {
     pub struct PageBlobClient {
     }
     impl PageBlobClient {
-        fn new(blob_url: Url, credential: Option<Arc<dyn TokenCredential>>, options: Option<PageBlobClientOptions>) -> Result<Self>;
-        fn url(&self) -> &Url;
+        pub fn new(blob_url: Url, credential: Option<Arc<dyn TokenCredential>>, options: Option<PageBlobClientOptions>) -> Result<Self>;
+        pub fn url(&self) -> &Url;
     }
     impl PageBlobClient {
-        async fn clear_pages(&self, range: HttpRange, options: Option<PageBlobClientClearPagesOptions<'_>>) -> Result<Response<PageBlobClientClearPagesResult, NoFormat>>;
-        async fn create(&self, size: u64, options: Option<PageBlobClientCreateOptions<'_>>) -> Result<Response<PageBlobClientCreateResult, NoFormat>>;
-        fn list_page_ranges(&self, options: Option<PageBlobClientListPageRangesOptions<'_>>) -> Result<PageIterator<Response<PageList, XmlFormat>>>;
-        async fn resize(&self, size: u64, options: Option<PageBlobClientResizeOptions<'_>>) -> Result<Response<PageBlobClientResizeResult, NoFormat>>;
-        async fn set_sequence_number(&self, sequence_number_action: SequenceNumberActionType, options: Option<PageBlobClientSetSequenceNumberOptions<'_>>) -> Result<Response<PageBlobClientSetSequenceNumberResult, NoFormat>>;
-        async fn upload_pages(&self, body: RequestContent<Bytes, NoFormat>, content_length: u64, range: HttpRange, options: Option<PageBlobClientUploadPagesOptions<'_>>) -> Result<Response<PageBlobClientUploadPagesResult, NoFormat>>;
-        async fn upload_pages_from_url(&self, source_url: String, source_range: HttpRange, content_length: u64, range: HttpRange, options: Option<PageBlobClientUploadPagesFromUrlOptions<'_>>) -> Result<Response<PageBlobClientUploadPagesFromUrlResult, NoFormat>>;
+        pub async fn clear_pages(&self, range: HttpRange, options: Option<PageBlobClientClearPagesOptions<'_>>) -> Result<Response<PageBlobClientClearPagesResult, NoFormat>>;
+        pub async fn create(&self, size: u64, options: Option<PageBlobClientCreateOptions<'_>>) -> Result<Response<PageBlobClientCreateResult, NoFormat>>;
+        pub fn list_page_ranges(&self, options: Option<PageBlobClientListPageRangesOptions<'_>>) -> Result<PageIterator<Response<PageList, XmlFormat>>>;
+        pub async fn resize(&self, size: u64, options: Option<PageBlobClientResizeOptions<'_>>) -> Result<Response<PageBlobClientResizeResult, NoFormat>>;
+        pub async fn set_sequence_number(&self, sequence_number_action: SequenceNumberActionType, options: Option<PageBlobClientSetSequenceNumberOptions<'_>>) -> Result<Response<PageBlobClientSetSequenceNumberResult, NoFormat>>;
+        pub async fn upload_pages(&self, body: RequestContent<Bytes, NoFormat>, content_length: u64, range: HttpRange, options: Option<PageBlobClientUploadPagesOptions<'_>>) -> Result<Response<PageBlobClientUploadPagesResult, NoFormat>>;
+        pub async fn upload_pages_from_url(&self, source_url: String, source_range: HttpRange, content_length: u64, range: HttpRange, options: Option<PageBlobClientUploadPagesFromUrlOptions<'_>>) -> Result<Response<PageBlobClientUploadPagesFromUrlResult, NoFormat>>;
     }
     #[derive(Clone, Debug)]
     pub struct PageBlobClientOptions {
@@ -300,10 +300,10 @@ pub mod models {
         pub timeout: Option<i32>,
     }
     impl crate::models::AppendBlobClientCreateOptions<'_> {
-        fn if_not_exists(self) -> Self;
+        pub fn if_not_exists(self) -> Self;
     }
     impl crate::models::AppendBlobClientCreateOptions<'_> {
-        fn with_tags<impl Into<BlobTags>: Into<BlobTags>>(self, tags: impl Into<BlobTags>) -> Self;
+        pub fn with_tags<impl Into<BlobTags>: Into<BlobTags>>(self, tags: impl Into<BlobTags>) -> Self;
     }
     #[derive(Debug)]
     pub struct AppendBlobClientCreateResult;
@@ -659,7 +659,7 @@ pub mod models {
         pub timeout: Option<i32>,
     }
     impl BlobContainerClientFindBlobsByTagsOptions<'_> {
-        fn into_owned(self) -> BlobContainerClientFindBlobsByTagsOptions<'static>;
+        pub fn into_owned(self) -> BlobContainerClientFindBlobsByTagsOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct BlobContainerClientGetAccessPolicyOptions<'a> {
@@ -693,7 +693,7 @@ pub mod models {
         pub timeout: Option<i32>,
     }
     impl BlobContainerClientListBlobsOptions<'_> {
-        fn into_owned(self) -> BlobContainerClientListBlobsOptions<'static>;
+        pub fn into_owned(self) -> BlobContainerClientListBlobsOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct BlobContainerClientReleaseLeaseOptions<'a> {
@@ -907,7 +907,7 @@ pub mod models {
         pub timeout: Option<i32>,
     }
     impl BlobServiceClientFindBlobsByTagsOptions<'_> {
-        fn into_owned(self) -> BlobServiceClientFindBlobsByTagsOptions<'static>;
+        pub fn into_owned(self) -> BlobServiceClientFindBlobsByTagsOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct BlobServiceClientGetAccountInfoOptions<'a> {
@@ -941,7 +941,7 @@ pub mod models {
         pub timeout: Option<i32>,
     }
     impl BlobServiceClientListContainersOptions<'_> {
-        fn into_owned(self) -> BlobServiceClientListContainersOptions<'static>;
+        pub fn into_owned(self) -> BlobServiceClientListContainersOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct BlobServiceClientSetPropertiesOptions<'a> {
@@ -1032,7 +1032,7 @@ pub mod models {
         pub transactional_content_md5: Option<Vec<u8>>,
     }
     impl crate::models::BlockBlobClientCommitBlockListOptions<'_> {
-        fn with_tags<impl Into<BlobTags>: Into<BlobTags>>(self, tags: impl Into<BlobTags>) -> Self;
+        pub fn with_tags<impl Into<BlobTags>: Into<BlobTags>>(self, tags: impl Into<BlobTags>) -> Self;
     }
     #[derive(Debug)]
     pub struct BlockBlobClientCommitBlockListResult;
@@ -1121,10 +1121,10 @@ pub mod models {
         pub transactional_content_md5: Option<Vec<u8>>,
     }
     impl crate::models::BlockBlobClientUploadBlobFromUrlOptions<'_> {
-        fn if_not_exists(self) -> Self;
+        pub fn if_not_exists(self) -> Self;
     }
     impl crate::models::BlockBlobClientUploadBlobFromUrlOptions<'_> {
-        fn with_tags<impl Into<BlobTags>: Into<BlobTags>>(self, tags: impl Into<BlobTags>) -> Self;
+        pub fn with_tags<impl Into<BlobTags>: Into<BlobTags>>(self, tags: impl Into<BlobTags>) -> Self;
     }
     #[derive(Debug)]
     pub struct BlockBlobClientUploadBlobFromUrlResult;
@@ -1158,10 +1158,10 @@ pub mod models {
         pub tier: Option<crate::models::AccessTier>,
     }
     impl crate::models::BlockBlobClientUploadOptions<'_> {
-        fn if_not_exists(self) -> Self;
+        pub fn if_not_exists(self) -> Self;
     }
     impl crate::models::BlockBlobClientUploadOptions<'_> {
-        fn with_tags<impl Into<BlobTags>: Into<BlobTags>>(self, tags: impl Into<BlobTags>) -> Self;
+        pub fn with_tags<impl Into<BlobTags>: Into<BlobTags>>(self, tags: impl Into<BlobTags>) -> Self;
     }
     #[derive(Debug)]
     pub struct BlockBlobClientUploadResult {
@@ -1329,8 +1329,8 @@ pub mod models {
     pub struct HttpRange {
     }
     impl HttpRange {
-        fn from_offset(offset: u64) -> Self;
-        fn new(offset: u64, length: u64) -> Self;
+        pub fn from_offset(offset: u64) -> Self;
+        pub fn new(offset: u64, length: u64) -> Self;
     }
     impl Display for HttpRange {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -1513,10 +1513,10 @@ pub mod models {
         pub timeout: Option<i32>,
     }
     impl crate::models::PageBlobClientCreateOptions<'_> {
-        fn if_not_exists(self) -> Self;
+        pub fn if_not_exists(self) -> Self;
     }
     impl crate::models::PageBlobClientCreateOptions<'_> {
-        fn with_tags<impl Into<BlobTags>: Into<BlobTags>>(self, tags: impl Into<BlobTags>) -> Self;
+        pub fn with_tags<impl Into<BlobTags>: Into<BlobTags>>(self, tags: impl Into<BlobTags>) -> Self;
     }
     #[derive(Debug)]
     pub struct PageBlobClientCreateResult;
@@ -1536,7 +1536,7 @@ pub mod models {
         pub timeout: Option<i32>,
     }
     impl PageBlobClientListPageRangesOptions<'_> {
-        fn into_owned(self) -> PageBlobClientListPageRangesOptions<'static>;
+        pub fn into_owned(self) -> PageBlobClientListPageRangesOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct PageBlobClientResizeOptions<'a> {
@@ -2682,7 +2682,7 @@ pub mod stream {
         pub struct FileStream {
         }
         impl FileStream {
-            fn builder(file: File) -> FileStreamBuilder;
+            pub fn builder(file: File) -> FileStreamBuilder;
         }
         impl AsyncRead for FileStream {
             fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<std::io::Result<usize>>;
@@ -2700,8 +2700,8 @@ pub mod stream {
         pub struct FileStreamBuilder {
         }
         impl FileStreamBuilder {
-            async fn build(self) -> azure_core::Result<FileStream>;
-            fn with_buffer_size(self, buffer_size: usize) -> Self;
+            pub async fn build(self) -> azure_core::Result<FileStream>;
+            pub fn with_buffer_size(self, buffer_size: usize) -> Self;
         }
     }
 }

--- a/sdk/storage/azure_storage_blob/api/API.metadata.yml
+++ b/sdk/storage/azure_storage_blob/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: 6cb49600de8eb40628e1ae55cb6b69e6dac3440f39701ac1fb6c7466da18d5a2
-packageVersion: 1.1.0-beta.3
-parserVersion: 2.2.1
+apiMdSha256: 2fc2a100e208436bb67bdb97b43ca3b030e69d14a04a20f0b5344751a05a1617
+packageVersion: 1.2.0-beta.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/storage/azure_storage_common/api/API.metadata.yml
+++ b/sdk/storage/azure_storage_common/api/API.metadata.yml
@@ -1,4 +1,4 @@
 apiMdSha256: 47ef6d6866775d84abef945aa3e9d5979d0c1e970205545da34d3b7640ca7172
-packageVersion: 0.2.0
-parserVersion: 2.2.1
+packageVersion: 1.1.0-beta.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/storage/azure_storage_queue/api/API.md
+++ b/sdk/storage/azure_storage_queue/api/API.md
@@ -20,23 +20,23 @@ pub mod clients {
     pub struct QueueClient {
     }
     impl QueueClient {
-        async fn clear(&self, options: Option<QueueClientClearOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn create(&self, options: Option<QueueClientCreateOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn delete(&self, options: Option<QueueClientDeleteOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn delete_message(&self, message_id: &str, pop_receipt: &str, options: Option<QueueClientDeleteMessageOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn get_access_policy(&self, options: Option<QueueClientGetAccessPolicyOptions<'_>>) -> Result<Response<SignedIdentifiers, XmlFormat>>;
-        async fn get_properties(&self, options: Option<QueueClientGetPropertiesOptions<'_>>) -> Result<Response<QueueClientGetPropertiesResult, NoFormat>>;
-        async fn peek_messages(&self, options: Option<QueueClientPeekMessagesOptions<'_>>) -> Result<Response<PeekedMessages, XmlFormat>>;
-        async fn receive_messages(&self, options: Option<QueueClientReceiveMessagesOptions<'_>>) -> Result<Response<ReceivedMessages, XmlFormat>>;
-        async fn send_message(&self, queue_message: RequestContent<QueueMessage, XmlFormat>, options: Option<QueueClientSendMessageOptions<'_>>) -> Result<Response<ListOfSentMessage, XmlFormat>>;
-        async fn set_access_policy(&self, queue_acl: RequestContent<SignedIdentifiers, XmlFormat>, options: Option<QueueClientSetAccessPolicyOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn set_metadata(&self, metadata: &HashMap<String, String>, options: Option<QueueClientSetMetadataOptions<'_>>) -> Result<Response<(), NoFormat>>;
-        async fn update_message(&self, message_id: &str, pop_receipt: &str, visibility_timeout: i32, options: Option<QueueClientUpdateMessageOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn clear(&self, options: Option<QueueClientClearOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn create(&self, options: Option<QueueClientCreateOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn delete(&self, options: Option<QueueClientDeleteOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn delete_message(&self, message_id: &str, pop_receipt: &str, options: Option<QueueClientDeleteMessageOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn get_access_policy(&self, options: Option<QueueClientGetAccessPolicyOptions<'_>>) -> Result<Response<SignedIdentifiers, XmlFormat>>;
+        pub async fn get_properties(&self, options: Option<QueueClientGetPropertiesOptions<'_>>) -> Result<Response<QueueClientGetPropertiesResult, NoFormat>>;
+        pub async fn peek_messages(&self, options: Option<QueueClientPeekMessagesOptions<'_>>) -> Result<Response<PeekedMessages, XmlFormat>>;
+        pub async fn receive_messages(&self, options: Option<QueueClientReceiveMessagesOptions<'_>>) -> Result<Response<ReceivedMessages, XmlFormat>>;
+        pub async fn send_message(&self, queue_message: RequestContent<QueueMessage, XmlFormat>, options: Option<QueueClientSendMessageOptions<'_>>) -> Result<Response<ListOfSentMessage, XmlFormat>>;
+        pub async fn set_access_policy(&self, queue_acl: RequestContent<SignedIdentifiers, XmlFormat>, options: Option<QueueClientSetAccessPolicyOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn set_metadata(&self, metadata: &HashMap<String, String>, options: Option<QueueClientSetMetadataOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn update_message(&self, message_id: &str, pop_receipt: &str, visibility_timeout: i32, options: Option<QueueClientUpdateMessageOptions<'_>>) -> Result<Response<(), NoFormat>>;
     }
     impl QueueClient {
-        async fn exists(&self) -> Result<bool>;
-        fn new(queue_url: Url, credential: Option<Arc<dyn TokenCredential>>, options: Option<QueueClientOptions>) -> Result<Self>;
-        fn url(&self) -> &Url;
+        pub async fn exists(&self) -> Result<bool>;
+        pub fn new(queue_url: Url, credential: Option<Arc<dyn TokenCredential>>, options: Option<QueueClientOptions>) -> Result<Self>;
+        pub fn url(&self) -> &Url;
     }
     #[derive(Clone, Debug)]
     pub struct QueueClientOptions {
@@ -49,16 +49,16 @@ pub mod clients {
     pub struct QueueServiceClient {
     }
     impl QueueServiceClient {
-        async fn get_properties(&self, options: Option<QueueServiceClientGetPropertiesOptions<'_>>) -> Result<Response<QueueServiceProperties, XmlFormat>>;
-        async fn get_statistics(&self, options: Option<QueueServiceClientGetStatisticsOptions<'_>>) -> Result<Response<QueueServiceStats, XmlFormat>>;
-        async fn get_user_delegation_key(&self, key_info: RequestContent<KeyInfo, XmlFormat>, options: Option<QueueServiceClientGetUserDelegationKeyOptions<'_>>) -> Result<Response<UserDelegationKey, XmlFormat>>;
-        fn list_queues(&self, options: Option<QueueServiceClientListQueuesOptions<'_>>) -> Result<Pager<ListQueuesResponse, XmlFormat>>;
-        async fn set_properties(&self, queue_service_properties: RequestContent<QueueServiceProperties, XmlFormat>, options: Option<QueueServiceClientSetPropertiesOptions<'_>>) -> Result<Response<(), NoFormat>>;
+        pub async fn get_properties(&self, options: Option<QueueServiceClientGetPropertiesOptions<'_>>) -> Result<Response<QueueServiceProperties, XmlFormat>>;
+        pub async fn get_statistics(&self, options: Option<QueueServiceClientGetStatisticsOptions<'_>>) -> Result<Response<QueueServiceStats, XmlFormat>>;
+        pub async fn get_user_delegation_key(&self, key_info: RequestContent<KeyInfo, XmlFormat>, options: Option<QueueServiceClientGetUserDelegationKeyOptions<'_>>) -> Result<Response<UserDelegationKey, XmlFormat>>;
+        pub fn list_queues(&self, options: Option<QueueServiceClientListQueuesOptions<'_>>) -> Result<Pager<ListQueuesResponse, XmlFormat>>;
+        pub async fn set_properties(&self, queue_service_properties: RequestContent<QueueServiceProperties, XmlFormat>, options: Option<QueueServiceClientSetPropertiesOptions<'_>>) -> Result<Response<(), NoFormat>>;
     }
     impl QueueServiceClient {
-        fn new(service_url: Url, credential: Option<Arc<dyn TokenCredential>>, options: Option<QueueServiceClientOptions>) -> Result<Self>;
-        fn queue_client(&self, queue_name: &str) -> Result<QueueClient>;
-        fn url(&self) -> &Url;
+        pub fn new(service_url: Url, credential: Option<Arc<dyn TokenCredential>>, options: Option<QueueServiceClientOptions>) -> Result<Self>;
+        pub fn queue_client(&self, queue_name: &str) -> Result<QueueClient>;
+        pub fn url(&self) -> &Url;
     }
     #[derive(Clone, Debug)]
     pub struct QueueServiceClientOptions {
@@ -131,7 +131,7 @@ pub mod models {
         pub items: Option<Vec<SentMessage>>,
     }
     impl ListOfSentMessage {
-        fn into_message(self) -> Result<SentMessage>;
+        pub fn into_message(self) -> Result<SentMessage>;
     }
     #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
     #[non_exhaustive]
@@ -314,7 +314,7 @@ pub mod models {
         pub timeout: Option<i32>,
     }
     impl QueueServiceClientListQueuesOptions<'_> {
-        fn into_owned(self) -> QueueServiceClientListQueuesOptions<'static>;
+        pub fn into_owned(self) -> QueueServiceClientListQueuesOptions<'static>;
     }
     #[derive(Clone, Debug, Default)]
     pub struct QueueServiceClientSetPropertiesOptions<'a> {

--- a/sdk/storage/azure_storage_queue/api/API.metadata.yml
+++ b/sdk/storage/azure_storage_queue/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: 055f649752ddbd67649e0488f973f80b11e9dd64af940ff36dcd81d3d08b9fc7
-packageVersion: 1.1.0-beta.2
-parserVersion: 2.2.1
+apiMdSha256: 5dd7f2c9bd2100bf40565c6e9a6cdc5aa3ad05b46a4ef4a5f68bc8fda8db3496
+packageVersion: 1.2.0-beta.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly

--- a/sdk/storage/azure_storage_sas/api/API.md
+++ b/sdk/storage/azure_storage_sas/api/API.md
@@ -13,74 +13,74 @@ pub struct SasBuilder<'a, S = Untyped> {
 }
 #[allow(private_bounds)]
 impl<S: SasResource> SasBuilder<'_, S> {
-    fn build(&self) -> String;
+    pub fn build(&self) -> String;
 }
 impl<S> SasBuilder<'_, S> {
-    fn delegated_user_object_id<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
-    fn ip_range(self, ip: SasIpRange) -> Self;
-    fn protocol(self, protocol: SasProtocol) -> Self;
-    fn start(self, start: OffsetDateTime) -> Self;
+    pub fn delegated_user_object_id<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
+    pub fn ip_range(self, ip: SasIpRange) -> Self;
+    pub fn protocol(self, protocol: SasProtocol) -> Self;
+    pub fn start(self, start: OffsetDateTime) -> Self;
 }
 #[allow(private_bounds)]
 impl<S: BlobServiceState + BlobOptions> crate::builder::SasBuilder<'_, S> {
-    fn authorized_object_id<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
-    fn cache_control<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
-    fn content_disposition<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
-    fn content_encoding<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
-    fn content_language<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
-    fn content_type<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
-    fn correlation_id<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
-    fn encryption_scope<impl Into<String>: Into<String>>(self, scope: impl Into<String>) -> Self;
-    fn signed_request_header<impl Into<String>: Into<String>, impl Into<String>: Into<String>>(self, key: impl Into<String>, value: impl Into<String>) -> Self;
-    fn signed_request_query_parameter<impl Into<String>: Into<String>, impl Into<String>: Into<String>>(self, key: impl Into<String>, value: impl Into<String>) -> Self;
-    fn unauthorized_object_id<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
+    pub fn authorized_object_id<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
+    pub fn cache_control<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
+    pub fn content_disposition<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
+    pub fn content_encoding<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
+    pub fn content_language<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
+    pub fn content_type<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
+    pub fn correlation_id<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
+    pub fn encryption_scope<impl Into<String>: Into<String>>(self, scope: impl Into<String>) -> Self;
+    pub fn signed_request_header<impl Into<String>: Into<String>, impl Into<String>: Into<String>>(self, key: impl Into<String>, value: impl Into<String>) -> Self;
+    pub fn signed_request_query_parameter<impl Into<String>: Into<String>, impl Into<String>: Into<String>>(self, key: impl Into<String>, value: impl Into<String>) -> Self;
+    pub fn unauthorized_object_id<impl Into<String>: Into<String>>(self, value: impl Into<String>) -> Self;
 }
 #[allow(private_bounds)]
 impl<S: ContainerPermsAccess> crate::builder::SasBuilder<'_, S> {
-    fn add(self) -> Self;
-    fn create(self) -> Self;
-    fn delete(self) -> Self;
-    fn delete_version(self) -> Self;
-    fn execute(self) -> Self;
-    fn list(self) -> Self;
-    fn move_blob(self) -> Self;
-    fn ownership(self) -> Self;
-    fn permanent_delete(self) -> Self;
-    fn permissions(self) -> Self;
-    fn read(self) -> Self;
-    fn set_immutability_policy(self) -> Self;
-    fn tags(self) -> Self;
-    fn write(self) -> Self;
+    pub fn add(self) -> Self;
+    pub fn create(self) -> Self;
+    pub fn delete(self) -> Self;
+    pub fn delete_version(self) -> Self;
+    pub fn execute(self) -> Self;
+    pub fn list(self) -> Self;
+    pub fn move_blob(self) -> Self;
+    pub fn ownership(self) -> Self;
+    pub fn permanent_delete(self) -> Self;
+    pub fn permissions(self) -> Self;
+    pub fn read(self) -> Self;
+    pub fn set_immutability_policy(self) -> Self;
+    pub fn tags(self) -> Self;
+    pub fn write(self) -> Self;
 }
 impl<'a> SasBuilder<'a, Untyped> {
-    fn blob<impl Into<String>: Into<String>, impl Into<String>: Into<String>>(self, container: impl Into<String>, blob: impl Into<String>) -> SasBuilder<'a, BlobState>;
-    fn container<impl Into<String>: Into<String>>(self, container: impl Into<String>) -> SasBuilder<'a, ContainerState>;
-    fn directory<impl Into<String>: Into<String>, impl Into<String>: Into<String>>(self, container: impl Into<String>, directory: impl Into<String>) -> SasBuilder<'a, DirectoryState>;
-    fn new<impl Into<String>: Into<String>>(account: impl Into<String>, key: &'a UserDelegationKey, expiry: OffsetDateTime) -> azure_core::Result<Self>;
-    fn queue<impl Into<String>: Into<String>>(self, queue: impl Into<String>) -> SasBuilder<'a, QueueState>;
+    pub fn blob<impl Into<String>: Into<String>, impl Into<String>: Into<String>>(self, container: impl Into<String>, blob: impl Into<String>) -> SasBuilder<'a, BlobState>;
+    pub fn container<impl Into<String>: Into<String>>(self, container: impl Into<String>) -> SasBuilder<'a, ContainerState>;
+    pub fn directory<impl Into<String>: Into<String>, impl Into<String>: Into<String>>(self, container: impl Into<String>, directory: impl Into<String>) -> SasBuilder<'a, DirectoryState>;
+    pub fn new<impl Into<String>: Into<String>>(account: impl Into<String>, key: &'a UserDelegationKey, expiry: OffsetDateTime) -> azure_core::Result<Self>;
+    pub fn queue<impl Into<String>: Into<String>>(self, queue: impl Into<String>) -> SasBuilder<'a, QueueState>;
 }
 impl crate::builder::SasBuilder<'_, BlobState> {
-    fn add(self) -> Self;
-    fn create(self) -> Self;
-    fn delete(self) -> Self;
-    fn delete_version(self) -> Self;
-    fn execute(self) -> Self;
-    fn move_blob(self) -> Self;
-    fn ownership(self) -> Self;
-    fn permanent_delete(self) -> Self;
-    fn permissions(self) -> Self;
-    fn read(self) -> Self;
-    fn set_immutability_policy(self) -> Self;
-    fn snapshot<impl Into<String>: Into<String>>(self, snapshot: impl Into<String>) -> Self;
-    fn tags(self) -> Self;
-    fn version<impl Into<String>: Into<String>>(self, version_id: impl Into<String>) -> Self;
-    fn write(self) -> Self;
+    pub fn add(self) -> Self;
+    pub fn create(self) -> Self;
+    pub fn delete(self) -> Self;
+    pub fn delete_version(self) -> Self;
+    pub fn execute(self) -> Self;
+    pub fn move_blob(self) -> Self;
+    pub fn ownership(self) -> Self;
+    pub fn permanent_delete(self) -> Self;
+    pub fn permissions(self) -> Self;
+    pub fn read(self) -> Self;
+    pub fn set_immutability_policy(self) -> Self;
+    pub fn snapshot<impl Into<String>: Into<String>>(self, snapshot: impl Into<String>) -> Self;
+    pub fn tags(self) -> Self;
+    pub fn version<impl Into<String>: Into<String>>(self, version_id: impl Into<String>) -> Self;
+    pub fn write(self) -> Self;
 }
 impl crate::builder::SasBuilder<'_, QueueState> {
-    fn add(self) -> Self;
-    fn process(self) -> Self;
-    fn read(self) -> Self;
-    fn update(self) -> Self;
+    pub fn add(self) -> Self;
+    pub fn process(self) -> Self;
+    pub fn read(self) -> Self;
+    pub fn update(self) -> Self;
 }
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SasIpRange {

--- a/sdk/storage/azure_storage_sas/api/API.metadata.yml
+++ b/sdk/storage/azure_storage_sas/api/API.metadata.yml
@@ -1,4 +1,4 @@
-apiMdSha256: 71bf1c945d9a7225e6522ad1a8e4aab8ad10074d06faf499c51fb166545da717
-packageVersion: 0.2.0
-parserVersion: 2.2.1
+apiMdSha256: ab5cecf53432eedfb6d1c6aba309070deaf0bccc132ff2e1abd19ffa081e6ab8
+packageVersion: 1.1.0-beta.1
+parserVersion: 2.2.2
 rustVersion: 1.97.0-nightly


### PR DESCRIPTION
Render inherent impl methods as `pub fn` in generated API.md output while keeping trait and trait-impl members unchanged. Add regression coverage and document the visibility rule in the tool guidance.

Bump `generate_api` to 2.2.2 and regenerate checked-in API.md/API.metadata.yml artifacts across SDK crates so parserVersion and hashes match the new output.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: 2646ea82-468f-4b81-8497-6a3570e7f65d
