### PR TITLE
Build Cosmos native driver with MS Rust

### DIFF
--- a/eng/pipelines/templates/steps/use-ms-rust.yml
+++ b/eng/pipelines/templates/steps/use-ms-rust.yml
@@ -1,0 +1,40 @@
+parameters:
+  - name: ToolchainConfig
+    type: string
+    default: $(Build.SourcesDirectory)/eng/templates/ms-rust-toolchain.toml
+  - name: MaxAttempts
+    type: number
+    default: 3
+  - name: WorkingDirectory
+    type: string
+    default: $(System.DefaultWorkingDirectory)
+  - name: ConfigureRegistry
+    type: boolean
+    default: true
+
+steps:
+  - pwsh: |
+      $source = '${{ parameters.ToolchainConfig }}'
+      if (-not (Test-Path -Path $source -PathType Leaf)) {
+        throw "Microsoft Rust toolchain configuration was not found: $source"
+      }
+
+      Copy-Item `
+        -Path $source `
+        -Destination '$(Build.SourcesDirectory)/rust-toolchain.toml' `
+        -Force
+      Write-Host "##vso[task.setvariable variable=RUSTUP_EXE]msrustup"
+    displayName: Configure pinned Microsoft Rust toolchain
+
+  - task: RustInstaller@1
+    displayName: Install Microsoft Rust toolchain
+    inputs:
+      toolchainFeed: https://pkgs.dev.azure.com/azure-sdk/internal/_packaging/ms-rust-tools/nuget/v3/index.json
+
+  - template: /eng/pipelines/templates/steps/use-rust.yml@self
+    parameters:
+      Toolchain: active
+      MaxAttempts: ${{ parameters.MaxAttempts }}
+      WorkingDirectory: ${{ parameters.WorkingDirectory }}
+      ConfigureRegistry: ${{ parameters.ConfigureRegistry }}
+      InstallToolchain: false

--- a/eng/pipelines/templates/steps/use-ms-rust.yml
+++ b/eng/pipelines/templates/steps/use-ms-rust.yml
@@ -2,12 +2,6 @@ parameters:
   - name: ToolchainConfig
     type: string
     default: $(Build.SourcesDirectory)/eng/templates/ms-rust-toolchain.toml
-  - name: MaxAttempts
-    type: number
-    default: 3
-  - name: WorkingDirectory
-    type: string
-    default: $(System.DefaultWorkingDirectory)
   - name: ConfigureRegistry
     type: boolean
     default: true
@@ -23,7 +17,6 @@ steps:
         -Path $source `
         -Destination '$(Build.SourcesDirectory)/rust-toolchain.toml' `
         -Force
-      Write-Host "##vso[task.setvariable variable=RUSTUP_EXE]msrustup"
     displayName: Configure pinned Microsoft Rust toolchain
 
   - task: RustInstaller@1
@@ -33,8 +26,5 @@ steps:
 
   - template: /eng/pipelines/templates/steps/use-rust.yml@self
     parameters:
-      Toolchain: active
-      MaxAttempts: ${{ parameters.MaxAttempts }}
-      WorkingDirectory: ${{ parameters.WorkingDirectory }}
       ConfigureRegistry: ${{ parameters.ConfigureRegistry }}
       InstallToolchain: false

--- a/eng/pipelines/templates/steps/use-rust.yml
+++ b/eng/pipelines/templates/steps/use-rust.yml
@@ -19,6 +19,10 @@ parameters:
   - name: ConfigureRegistry
     type: boolean
     default: true
+  - name: InstallToolchain
+    type: boolean
+    # RustInstaller@1 handles installation for Microsoft Rust consumers.
+    default: true
 
 steps:
 # `variables/rust.yml` relocates CARGO_HOME off the OS volume. Cargo finds its own
@@ -72,14 +76,15 @@ steps:
     env:
       SYSTEM_ACCESSTOKEN: $(VSS_NUGET_ACCESSTOKEN)
 
-- task: PowerShell@2
-  displayName: "Use Rust ${{ parameters.Toolchain }}"
-  inputs:
-    pwsh: true
-    filePath: $(Build.SourcesDirectory)/eng/scripts/Use-Rust.ps1
-    arguments: >
-      -Toolchain '${{ parameters.Toolchain }}'
-      -MaxAttempts ${{ parameters.MaxAttempts }}
-      -SetDefault $${{ parameters.SetDefault }}
-      -OutsideDirectory '$(Pipeline.Workspace)'
-    workingDirectory: ${{ parameters.WorkingDirectory }}
+- ${{ if parameters.InstallToolchain }}:
+  - task: PowerShell@2
+    displayName: "Use Rust ${{ parameters.Toolchain }}"
+    inputs:
+      pwsh: true
+      filePath: $(Build.SourcesDirectory)/eng/scripts/Use-Rust.ps1
+      arguments: >
+        -Toolchain '${{ parameters.Toolchain }}'
+        -MaxAttempts ${{ parameters.MaxAttempts }}
+        -SetDefault $${{ parameters.SetDefault }}
+        -OutsideDirectory '$(Pipeline.Workspace)'
+      workingDirectory: ${{ parameters.WorkingDirectory }}

--- a/eng/scripts/Use-Rust.ps1
+++ b/eng/scripts/Use-Rust.ps1
@@ -23,18 +23,19 @@ Set-StrictMode -Version 2.0
 . ([System.IO.Path]::Combine($PSScriptRoot, '..', 'common', 'scripts', 'common.ps1'))
 . ([System.IO.Path]::Combine($PSScriptRoot, 'shared', 'Cargo.ps1'))
 
+$rustup = Get-RustupExecutable
 $toolchainArg = if ($Toolchain -eq 'active') {
   # Depending on the version of rustup currently installed, simply calling `rustup --version` will
   # install the active toolchain per rust-toolchain.toml if it's not already installed. We should
   # check the rust version outside of our repo's context to avoid any rustup-toolchain file influence.
-  $rustupVersion = Invoke-LoggedCommand "rustup --version" -ExecutePath $OutsideDirectory -GroupOutput
+  $rustupVersion = Invoke-LoggedCommand "$rustup --version" -ExecutePath $OutsideDirectory -GroupOutput
 
   if ($rustupVersion -match 'rustup (\d+)\.(\d+)\.\d+') {
     $major = [int] $matches[1]
     $minor = [int] $matches[2]
     # You can't call 'rustup install' without a toolchain before rustup 1.28.0.
     if ($major -lt 1 -or ($major -eq 1 -and $minor -lt 28)) {
-      Invoke-LoggedCommand "rustup self update" -GroupOutput
+      Invoke-LoggedCommand "$rustup self update" -GroupOutput
     }
   }
 
@@ -57,7 +58,7 @@ while ($true) {
     $installArgs += '--override'
   }
   $installArgs += $installToolchainArg
-  Invoke-LoggedCommand "rustup install $($installArgs -join ' ')" -GroupOutput -DoNotExitOnFailedExitCode
+  Invoke-LoggedCommand "$rustup install $($installArgs -join ' ')" -GroupOutput -DoNotExitOnFailedExitCode
 
   if ($LASTEXITCODE -eq 0) { break }
 
@@ -73,4 +74,4 @@ while ($true) {
   Start-Sleep -Seconds 3
 }
 
-Invoke-LoggedCommand "rustup show" -GroupOutput
+Invoke-LoggedCommand "$rustup show" -GroupOutput

--- a/eng/scripts/Use-Rust.ps1
+++ b/eng/scripts/Use-Rust.ps1
@@ -23,19 +23,18 @@ Set-StrictMode -Version 2.0
 . ([System.IO.Path]::Combine($PSScriptRoot, '..', 'common', 'scripts', 'common.ps1'))
 . ([System.IO.Path]::Combine($PSScriptRoot, 'shared', 'Cargo.ps1'))
 
-$rustup = Get-RustupExecutable
 $toolchainArg = if ($Toolchain -eq 'active') {
   # Depending on the version of rustup currently installed, simply calling `rustup --version` will
   # install the active toolchain per rust-toolchain.toml if it's not already installed. We should
   # check the rust version outside of our repo's context to avoid any rustup-toolchain file influence.
-  $rustupVersion = Invoke-LoggedCommand "$rustup --version" -ExecutePath $OutsideDirectory -GroupOutput
+  $rustupVersion = Invoke-LoggedCommand "rustup --version" -ExecutePath $OutsideDirectory -GroupOutput
 
   if ($rustupVersion -match 'rustup (\d+)\.(\d+)\.\d+') {
     $major = [int] $matches[1]
     $minor = [int] $matches[2]
     # You can't call 'rustup install' without a toolchain before rustup 1.28.0.
     if ($major -lt 1 -or ($major -eq 1 -and $minor -lt 28)) {
-      Invoke-LoggedCommand "$rustup self update" -GroupOutput
+      Invoke-LoggedCommand "rustup self update" -GroupOutput
     }
   }
 
@@ -58,7 +57,7 @@ while ($true) {
     $installArgs += '--override'
   }
   $installArgs += $installToolchainArg
-  Invoke-LoggedCommand "$rustup install $($installArgs -join ' ')" -GroupOutput -DoNotExitOnFailedExitCode
+  Invoke-LoggedCommand "rustup install $($installArgs -join ' ')" -GroupOutput -DoNotExitOnFailedExitCode
 
   if ($LASTEXITCODE -eq 0) { break }
 
@@ -74,4 +73,4 @@ while ($true) {
   Start-Sleep -Seconds 3
 }
 
-Invoke-LoggedCommand "$rustup show" -GroupOutput
+Invoke-LoggedCommand "rustup show" -GroupOutput

--- a/eng/scripts/shared/Cargo.ps1
+++ b/eng/scripts/shared/Cargo.ps1
@@ -2,27 +2,15 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-function Get-RustupExecutable() {
-  if ($env:RUSTUP_EXE) {
-    return $env:RUSTUP_EXE
-  }
-
-  return 'rustup'
-}
-
 function Get-ActiveRustToolchain(
   [string]$ExecutePath
 ) {
-  $rustup = Get-RustupExecutable
-  $output = Invoke-LoggedCommand "$rustup show active-toolchain" -ExecutePath $ExecutePath
-  $activeToolchain = $output |
-      Where-Object { $_ -match '\S' -and $_ -notmatch '^\s*(INFO|WARN)\b' } |
-      Select-Object -First 1
+  $activeToolchain = (Invoke-LoggedCommand "rustup show active-toolchain" -ExecutePath $ExecutePath | Select-Object -First 1).Trim()
   if (!$activeToolchain) {
     throw "Failed to determine the active Rust toolchain."
   }
 
-  return ($activeToolchain.Trim() -split '\s+')[0]
+  return ($activeToolchain -split '\s+')[0]
 }
 
 function Get-ResolvedRustToolchain(

--- a/eng/scripts/shared/Cargo.ps1
+++ b/eng/scripts/shared/Cargo.ps1
@@ -2,15 +2,27 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+function Get-RustupExecutable() {
+  if ($env:RUSTUP_EXE) {
+    return $env:RUSTUP_EXE
+  }
+
+  return 'rustup'
+}
+
 function Get-ActiveRustToolchain(
   [string]$ExecutePath
 ) {
-  $activeToolchain = (Invoke-LoggedCommand "rustup show active-toolchain" -ExecutePath $ExecutePath | Select-Object -First 1).Trim()
+  $rustup = Get-RustupExecutable
+  $output = Invoke-LoggedCommand "$rustup show active-toolchain" -ExecutePath $ExecutePath
+  $activeToolchain = $output |
+      Where-Object { $_ -match '\S' -and $_ -notmatch '^\s*(INFO|WARN)\b' } |
+      Select-Object -First 1
   if (!$activeToolchain) {
     throw "Failed to determine the active Rust toolchain."
   }
 
-  return ($activeToolchain -split '\s+')[0]
+  return ($activeToolchain.Trim() -split '\s+')[0]
 }
 
 function Get-ResolvedRustToolchain(

--- a/eng/scripts/shared/MicrosoftRust.ps1
+++ b/eng/scripts/shared/MicrosoftRust.ps1
@@ -44,16 +44,3 @@ function Get-MicrosoftRustToolchainConfiguration(
     Targets = $targets
   }
 }
-
-function Test-MicrosoftRustActiveToolchain(
-  [Parameter(Mandatory = $true)]
-  [string] $ActiveToolchain,
-
-  [Parameter(Mandatory = $true)]
-  [string] $Channel
-) {
-  return (
-    $ActiveToolchain -ceq $Channel -or
-    $ActiveToolchain.StartsWith("$Channel-", [StringComparison]::Ordinal)
-  )
-}

--- a/eng/scripts/shared/MicrosoftRust.ps1
+++ b/eng/scripts/shared/MicrosoftRust.ps1
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+function Get-MicrosoftRustToolchainConfiguration(
+  [Parameter(Mandatory = $true)]
+  [string] $Path
+) {
+  if (!(Test-Path -Path $Path -PathType Leaf)) {
+    throw "Microsoft Rust toolchain configuration was not found: $Path"
+  }
+
+  $content = Get-Content -Path $Path -Raw
+  $channelMatches = [regex]::Matches(
+    $content,
+    '(?m)^\s*channel\s*=\s*"([^"]+)"\s*$'
+  )
+  if ($channelMatches.Count -ne 1) {
+    throw "Microsoft Rust toolchain configuration must declare exactly one channel."
+  }
+
+  $channel = $channelMatches[0].Groups[1].Value
+  if ($channel -notmatch '^ms-prod-\d+(?:\.\d+)+$') {
+    throw "Microsoft Rust channel '$channel' is not an explicit pinned ms-prod channel."
+  }
+
+  $targetsMatch = [regex]::Match(
+    $content,
+    '(?ms)^\s*targets\s*=\s*\[(.*?)\]'
+  )
+  if (!$targetsMatch.Success) {
+    throw "Microsoft Rust toolchain configuration must declare targets."
+  }
+
+  $targets = @(
+    [regex]::Matches($targetsMatch.Groups[1].Value, '"([^"]+)"') |
+      ForEach-Object { $_.Groups[1].Value }
+  )
+  if ($targets.Count -eq 0) {
+    throw "Microsoft Rust toolchain configuration must declare at least one target."
+  }
+
+  return [pscustomobject]@{
+    Channel = $channel
+    Targets = $targets
+  }
+}
+
+function Test-MicrosoftRustActiveToolchain(
+  [Parameter(Mandatory = $true)]
+  [string] $ActiveToolchain,
+
+  [Parameter(Mandatory = $true)]
+  [string] $Channel
+) {
+  return (
+    $ActiveToolchain -ceq $Channel -or
+    $ActiveToolchain.StartsWith("$Channel-", [StringComparison]::Ordinal)
+  )
+}

--- a/eng/scripts/shared/common.ps1
+++ b/eng/scripts/shared/common.ps1
@@ -3,3 +3,4 @@
 
 . ([System.IO.Path]::Combine($PSScriptRoot, 'Process.ps1'))
 . ([System.IO.Path]::Combine($PSScriptRoot, 'Cargo.ps1'))
+. ([System.IO.Path]::Combine($PSScriptRoot, 'MicrosoftRust.ps1'))

--- a/eng/templates/ms-rust-toolchain.toml
+++ b/eng/templates/ms-rust-toolchain.toml
@@ -1,0 +1,20 @@
+# Microsoft Rust release pin for governed native artifact builds.
+# Update only after the full internal target matrix succeeds.
+[toolchain]
+channel = "ms-prod-1.95"
+components = [
+  "rustc",
+  "rustfmt",
+  "cargo",
+  "clippy",
+  "rust-analyzer",
+]
+targets = [
+  "x86_64-pc-windows-gnu",
+  "x86_64-unknown-linux-gnu",
+  "aarch64-unknown-linux-gnu",
+  "aarch64-apple-darwin",
+  "x86_64-unknown-linux-musl",
+  "aarch64-unknown-linux-musl",
+]
+profile = "default"

--- a/sdk/cosmos/.cspell.json
+++ b/sdk/cosmos/.cspell.json
@@ -255,6 +255,7 @@
     "lwinpthread",
     "MACVMIMAGEM",
     "MSYS",
+    "msrustup",
     "osxcross",
     "pipefail",
     "prependpath",

--- a/sdk/cosmos/azure_data_cosmos_driver_native/docs/NATIVE_SUPPLY_CHAIN.md
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/docs/NATIVE_SUPPLY_CHAIN.md
@@ -15,12 +15,18 @@ commands are documented in `pipeline/README.md`.
 
 ## Scope
 
-This pull request produces `libazurecosmosdriver.a` for:
+This pull request configures `libazurecosmosdriver.a` builds for the following
+intended release matrix:
 
 - Windows AMD64
 - Linux AMD64 and ARM64 using glibc
 - Linux AMD64 and ARM64 using musl
 - macOS ARM64
+
+Availability of all six target standard libraries in the private Microsoft Rust
+feed remains unverified until the pipeline completes a manual internal Azure
+DevOps run. A missing target fails the build rather than falling back to
+upstream Rust.
 
 The Go SDK links this static library into the customer's final executable.
 
@@ -51,8 +57,8 @@ The metadata records:
 - the Rust target;
 - the source repository commit;
 - the native-interface and driver versions;
-- the `msrustup` executable, manager version, and active pinned Microsoft Rust
-  channel;
+- the `msrustup` executable and manager version, plus the explicitly selected
+  pinned Microsoft Rust channel;
 - the complete `rustc -Vv` output and Cargo version;
 - the linker command, resolved executable path, and version output;
 - the operating-system libraries required by the Go linker; and
@@ -125,11 +131,14 @@ required by the release matrix. It does not list `rust-std` as a host component;
 cross-target standard libraries are installed through the toolchain target
 mechanism.
 
-`Build-NativeMatrix.ps1` requires `RUSTUP_EXE` to select `msrustup`, validates the
-active channel against the centralized pin, and checks each target with
-`msrustup target list --installed`. A missing target is installed only through
-`msrustup` and verified again. Any missing manager, upstream fallback, channel
-mismatch, or unsupported target stops the build before Cargo runs.
+`Build-NativeMatrix.ps1` uses `msrustup` only to manage the pinned toolchain and
+its targets. Every compiler and build command selects that toolchain explicitly
+with `+ms-prod-1.95`, using the repository's existing Cargo toolchain-selection
+model rather than redirecting Cargo or rustup through an environment variable.
+Each target is checked with `msrustup target list --installed --toolchain` and a
+missing target is installed only through `msrustup` and verified again. Any
+missing manager, upstream compiler fallback, unpinned channel, or unsupported
+target stops the build.
 
 The target list must still be exercised by a manual build in the internal Azure
 DevOps project. Local tests verify the fail-closed behavior but cannot prove that
@@ -278,7 +287,7 @@ repository then requires one approval and code-owner approval before merge.
 
 `Invoke-LocalSupplyChain.ps1` exercises the mechanics on a developer machine
 that already has the pinned Microsoft Rust toolchain installed through
-`msrustup` and selects it with `RUSTUP_EXE=msrustup`. It:
+`msrustup`. Build commands select the pinned channel explicitly. It:
 
 1. builds the native libraries;
 2. applies a disposable test signature to the Windows DLL;

--- a/sdk/cosmos/azure_data_cosmos_driver_native/docs/NATIVE_SUPPLY_CHAIN.md
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/docs/NATIVE_SUPPLY_CHAIN.md
@@ -2,7 +2,7 @@
 Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 -->
-<!-- cSpell:ignore Authenticode codesign dylib staticlib rustls mingw musl SPDX -->
+<!-- cSpell:ignore Authenticode codesign dylib staticlib rustls mingw musl msrustup SPDX -->
 
 # How the Go native driver is built and verified
 
@@ -51,15 +51,20 @@ The metadata records:
 - the Rust target;
 - the source repository commit;
 - the native-interface and driver versions;
-- the Rust and Cargo tool versions;
+- the `msrustup` executable, manager version, and active pinned Microsoft Rust
+  channel;
+- the complete `rustc -Vv` output and Cargo version;
+- the linker command, resolved executable path, and version output;
 - the operating-system libraries required by the Go linker; and
 - the SHA256 checksums of the built libraries and C header.
 
 Before generating output, `New-GoModules.ps1` verifies that every selected
 artifact matches its matrix identity and recorded file hashes, that all targets
-come from the same source commit and package versions, and that every target
-contains the same C header. After those checks pass, it creates the directory
-layout expected by `Azure/azure-cosmos-driver`:
+come from the same source commit, package versions, and Microsoft Rust release,
+and that every target contains the same C header. Missing provenance, upstream
+Rust, unpinned channels, and mixed toolchains fail the build. After those checks
+pass, it creates the directory layout expected by
+`Azure/azure-cosmos-driver`:
 
 ```text
 azure-cosmos-driver/
@@ -106,6 +111,29 @@ The Go release therefore uses this chain:
 
 No unsigned Microsoft shared library is loaded at runtime in this model. The
 `.a` becomes part of the customer's Go executable.
+
+## Pinned Microsoft Rust toolchain
+
+The production native-driver jobs opt into the shared
+`eng/pipelines/templates/steps/use-ms-rust.yml` template. That template copies
+`eng/templates/ms-rust-toolchain.toml` to the repository root and invokes
+`RustInstaller@1` against the private `ms-rust-tools` feed. Other pipeline
+consumers continue to use the standard upstream Rust path.
+
+The configuration pins `ms-prod-1.95` and declares the six Rust target triples
+required by the release matrix. It does not list `rust-std` as a host component;
+cross-target standard libraries are installed through the toolchain target
+mechanism.
+
+`Build-NativeMatrix.ps1` requires `RUSTUP_EXE` to select `msrustup`, validates the
+active channel against the centralized pin, and checks each target with
+`msrustup target list --installed`. A missing target is installed only through
+`msrustup` and verified again. Any missing manager, upstream fallback, channel
+mismatch, or unsupported target stops the build before Cargo runs.
+
+The target list must still be exercised by a manual build in the internal Azure
+DevOps project. Local tests verify the fail-closed behavior but cannot prove that
+the private feed currently supplies every target.
 
 ## Release evidence
 
@@ -158,8 +186,11 @@ binds the published static libraries back to their exact source:
   authoritative pin);
 - `native_interface_crate` / `native_interface_version` — the wrapper crate and
   the `AZURECOSMOSDRIVER_H_VERSION` header contract; and
+- `toolchain` — the Microsoft provider, `msrustup` manager identity, pinned
+  channel, Rust release, and Cargo version shared by every target; and
 - `targets[]` — one entry per built row with its `id`, `triple`, `module_path`,
-  and the SHA256 of the static library and C header.
+  full `rustc -Vv` output, linker identity, and the SHA256 of the static library
+  and C header.
 
 `New-GoModules.ps1` cross-validates that every selected target agrees on the
 identity fields before emitting the file, so a mismatched or tampered target
@@ -226,10 +257,11 @@ Open a draft pull request in Azure/azure-cosmos-driver
 Receive GitHub code-owner review and approval
 ```
 
-The checked-in pipeline extends the official 1ES wrapper and uses the standard
-managed pool definitions for Linux, Windows, and Apple Silicon macOS. It remains
-unregistered, so an owner must create its internal Azure DevOps definition
-before it can run.
+The checked-in pipeline extends the official 1ES wrapper, uses the standard
+managed pool definitions for Linux, Windows, and Apple Silicon macOS, and
+installs Microsoft Rust from an internal feed. It remains unregistered, so an
+owner must create its internal Azure DevOps definition and confirm all six
+toolchain targets with a manual run before release.
 
 The publication stage runs only for a successful non-pull-request build of
 `refs/heads/main`. It uses the existing Azure SDK Automation GitHub App to clone
@@ -244,7 +276,9 @@ repository then requires one approval and code-owner approval before merge.
 
 ## Local integration test
 
-`Invoke-LocalSupplyChain.ps1` exercises the mechanics on a developer machine. It:
+`Invoke-LocalSupplyChain.ps1` exercises the mechanics on a developer machine
+that already has the pinned Microsoft Rust toolchain installed through
+`msrustup` and selects it with `RUSTUP_EXE=msrustup`. It:
 
 1. builds the native libraries;
 2. applies a disposable test signature to the Windows DLL;

--- a/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/Build-NativeMatrix.ps1
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/Build-NativeMatrix.ps1
@@ -10,7 +10,7 @@
 
 .DESCRIPTION
     For each row in build-matrix.json this script:
-      1. Ensures the Rust target triple is installed (rustup).
+      1. Ensures the Rust target triple is installed with msrustup.
       2. Captures the exact rustc syslib link line PROGRAMMATICALLY via
          `cargo rustc ... -- --print native-static-libs`, then applies declared
          target-specific ABI-compatible compiler-library replacements.
@@ -140,7 +140,7 @@ function Invoke-RequiredToolOutput(
 function Get-NativeStaticLibs([string] $triple) {
     Push-Location $CrateDir
     try {
-        $out = & cargo rustc --release --quiet `
+        $out = & cargo $cargoToolchainArgument rustc --release --quiet `
             -p $matrix.native_interface_crate `
             --target $triple `
             -- --print native-static-libs 2>&1
@@ -210,52 +210,41 @@ function Resolve-ConsumerNativeStaticLibs(
 
 function Test-TripleInstalled([string] $triple) {
     $installedTargets = @(
-        (& $rustupExecutable target list --installed 2>&1) |
+        (& $msrustupExecutable target list --installed `
+            --toolchain $microsoftRustConfig.Channel 2>&1) |
             Where-Object { $_ -match '\S' -and $_ -notmatch '^\s*(INFO|WARN)\b' } |
             ForEach-Object { ([string]$_).Trim() }
     )
     if ($LASTEXITCODE -ne 0) {
-        throw "$rustupExecutable target list --installed failed with exit code $LASTEXITCODE."
+        throw "msrustup target list failed for '$($microsoftRustConfig.Channel)' with exit code $LASTEXITCODE."
     }
 
     return $installedTargets -contains $triple
 }
 
-$rustupExecutable = Get-RustupExecutable
-$rustupName = [System.IO.Path]::GetFileNameWithoutExtension($rustupExecutable)
-if ($rustupName -cne 'msrustup') {
-    throw "Microsoft Rust is required: RUSTUP_EXE must resolve to msrustup, found '$rustupExecutable'."
+$msrustupCommand = Get-Command 'msrustup' -ErrorAction SilentlyContinue
+if (-not $msrustupCommand) {
+    throw 'Microsoft Rust is required: msrustup is not installed or is not available on PATH.'
 }
+$msrustupExecutable = if ($msrustupCommand.Source) {
+    $msrustupCommand.Source
+}
+else {
+    $msrustupCommand.Name
+}
+$cargoToolchainArgument = "+$($microsoftRustConfig.Channel)"
 
 $managerVersion = Invoke-RequiredToolOutput `
-    -Executable $rustupExecutable `
+    -Executable $msrustupExecutable `
     -Arguments @('--version') `
     -Description 'Microsoft Rust toolchain manager'
-$activeToolchainOutput = Invoke-RequiredToolOutput `
-    -Executable $rustupExecutable `
-    -Arguments @('show', 'active-toolchain') `
-    -Description 'Microsoft Rust active toolchain query'
-$activeToolchain = (
-    $activeToolchainOutput -split "`r?`n" |
-        Where-Object { $_ -match '\S' -and $_ -notmatch '^\s*(INFO|WARN)\b' } |
-        Select-Object -First 1
-)
-if (
-    -not $activeToolchain -or
-    -not (Test-MicrosoftRustActiveToolchain `
-        -ActiveToolchain $activeToolchain.Trim() `
-        -Channel $microsoftRustConfig.Channel)
-) {
-    throw "Active Rust toolchain '$activeToolchain' does not match pinned Microsoft channel '$($microsoftRustConfig.Channel)'."
-}
-$activeToolchain = $activeToolchain.Trim()
 
 $rustcVerboseVersion = Invoke-RequiredToolOutput `
     -Executable 'rustc' `
-    -Arguments @('-Vv') `
-    -Description 'rustc -Vv'
+    -Arguments @($cargoToolchainArgument, '-Vv') `
+    -Description "rustc $cargoToolchainArgument -Vv"
 if ($rustcVerboseVersion -notmatch '(?im)^rustc\s+.*\bmicrosoft\b') {
-    throw "rustc -Vv does not identify a Microsoft Rust compiler; refusing a possible upstream fallback."
+    throw "rustc $cargoToolchainArgument -Vv does not identify a Microsoft Rust compiler; refusing a possible upstream fallback."
 }
 $rustcReleaseMatch = [regex]::Match(
     $rustcVerboseVersion,
@@ -265,15 +254,19 @@ if (-not $rustcReleaseMatch.Success) {
     throw "rustc -Vv did not report a release identity."
 }
 $rustcRelease = $rustcReleaseMatch.Groups[1].Value
+$channelRelease = $microsoftRustConfig.Channel.Substring('ms-prod-'.Length)
+if ($rustcRelease -notmatch "^$([regex]::Escape($channelRelease))(?:\.|$)") {
+    throw "Microsoft Rust release '$rustcRelease' does not match pinned channel '$($microsoftRustConfig.Channel)'."
+}
 $cargoVersion = Invoke-RequiredToolOutput `
     -Executable 'cargo' `
-    -Arguments @('--version') `
-    -Description 'cargo --version'
+    -Arguments @($cargoToolchainArgument, '--version') `
+    -Description "cargo $cargoToolchainArgument --version"
 
 $sourceCommit = (& git -C $RepoRoot rev-parse HEAD 2>$null)
 if ($LASTEXITCODE -ne 0) { throw 'Unable to resolve the source commit.' }
 
-$cargoMetadataJson = & cargo metadata --format-version 1 --no-deps `
+$cargoMetadataJson = & cargo $cargoToolchainArgument metadata --format-version 1 --no-deps `
     --manifest-path (Join-Path $CrateDir 'Cargo.toml') 2>&1
 if ($LASTEXITCODE -ne 0) {
     throw "cargo metadata failed with exit code $LASTEXITCODE`n$($cargoMetadataJson -join "`n")"
@@ -305,13 +298,14 @@ foreach ($row in $rows) {
     }
 
     if (-not (Test-TripleInstalled $row.triple)) {
-        Write-Host "    target not installed; attempting '$rustupExecutable target add $($row.triple)'"
-        & $rustupExecutable target add $row.triple *> $null
+        Write-Host "    target not installed; attempting 'msrustup target add $($row.triple) --toolchain $($microsoftRustConfig.Channel)'"
+        & $msrustupExecutable target add $row.triple `
+            --toolchain $microsoftRustConfig.Channel *> $null
         if ($LASTEXITCODE -ne 0) {
-            throw "$rustupExecutable target add failed for $($row.triple) with exit code $LASTEXITCODE"
+            throw "msrustup target add failed for $($row.triple) with exit code $LASTEXITCODE"
         }
         if (-not (Test-TripleInstalled $row.triple)) {
-            throw "$rustupExecutable did not install required target '$($row.triple)'."
+            throw "msrustup did not install required target '$($row.triple)' for '$($microsoftRustConfig.Channel)'."
         }
     }
     $targetOut = Join-Path $OutputRoot $row.id
@@ -362,8 +356,8 @@ foreach ($row in $rows) {
                     '--config', 'profile.release.codegen-units=1',
                     '--config', 'profile.release.strip="symbols"'
                 )
-                if ($NoAuditable) { & cargo @buildArgs }
-                else              { & cargo auditable @buildArgs }
+                if ($NoAuditable) { & cargo $cargoToolchainArgument @buildArgs }
+                else              { & cargo $cargoToolchainArgument auditable @buildArgs }
                 if ($LASTEXITCODE -ne 0) {
                     throw "$builtWith build failed for $($row.triple) with exit code $LASTEXITCODE"
                 }
@@ -445,11 +439,11 @@ foreach ($row in $rows) {
         toolchain = [ordered]@{
             provider = 'microsoft'
             manager = [ordered]@{
-                executable = $rustupExecutable
+                executable = $msrustupExecutable
                 version    = $managerVersion
             }
             channel               = $microsoftRustConfig.Channel
-            active_toolchain      = $activeToolchain
+            selected_toolchain    = $microsoftRustConfig.Channel
             rustc_verbose_version = $rustcVerboseVersion
             rustc_release         = $rustcRelease
             cargo_version         = $cargoVersion

--- a/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/Build-NativeMatrix.ps1
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/Build-NativeMatrix.ps1
@@ -60,7 +60,8 @@ param(
     [string]   $CCompiler,
     [switch]   $SkipBuild,
     [switch]   $NoAuditable,
-    [switch]   $StaticOnly
+    [switch]   $StaticOnly,
+    [string]   $ToolchainConfigPath
 )
 
 Set-StrictMode -Version 3.0
@@ -71,6 +72,18 @@ $CrateDir    = Split-Path -Parent $PipelineDir
 $RepoRoot    = (Resolve-Path (Join-Path $CrateDir '..' '..' '..')).Path
 $MatrixPath  = Join-Path $PipelineDir 'build-matrix.json'
 $MetadataFilename = 'rust-driver-native-interface-metadata.json'
+
+. ([System.IO.Path]::Combine($RepoRoot, 'eng', 'scripts', 'shared', 'common.ps1'))
+
+if (-not $ToolchainConfigPath) {
+    $ToolchainConfigPath = [System.IO.Path]::Combine(
+        $RepoRoot,
+        'eng',
+        'templates',
+        'ms-rust-toolchain.toml'
+    )
+}
+$microsoftRustConfig = Get-MicrosoftRustToolchainConfiguration -Path $ToolchainConfigPath
 
 if (-not $OutputRoot) { $OutputRoot = Join-Path $PipelineDir 'artifacts' }
 New-Item -ItemType Directory -Force -Path $OutputRoot | Out-Null
@@ -84,20 +97,42 @@ if ($CCompiler -and $rows.Count -ne 1) {
 }
 
 $compilers = @{}
+$compilerCommands = @{}
 foreach ($row in $rows) {
     $compiler = if ($CCompiler) { $CCompiler } else { $row.c_compiler }
     if (-not $compiler) {
         throw "No C compiler is configured for target '$($row.id)'."
     }
-    if (-not (Get-Command $compiler -CommandType Application -ErrorAction SilentlyContinue)) {
+    $compilerCommand = Get-Command $compiler -CommandType Application -ErrorAction SilentlyContinue
+    if (-not $compilerCommand) {
         throw "C compiler '$compiler' is not available for target '$($row.id)'."
     }
     $compilers[$row.id] = $compiler
+    $compilerCommands[$row.id] = $compilerCommand
 }
 
-function Get-ToolVersion([string] $exe, [string[]] $verArgs) {
-    try { (& $exe @verArgs 2>&1 | Select-Object -First 1) -join ' ' }
-    catch { $null }
+function Invoke-RequiredToolOutput(
+    [string] $Executable,
+    [string[]] $Arguments,
+    [string] $Description
+) {
+    try {
+        $output = @(& $Executable @Arguments 2>&1)
+    }
+    catch {
+        throw "Unable to execute ${Description}: $($_.Exception.Message)"
+    }
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Description failed with exit code $LASTEXITCODE`n$($output -join "`n")"
+    }
+
+    $text = ($output | ForEach-Object { [string]$_ }) -join "`n"
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        throw "$Description returned no identity information."
+    }
+
+    return $text.Trim()
 }
 
 # Programmatically parse the `native-static-libs:` note out of a
@@ -174,8 +209,66 @@ function Resolve-ConsumerNativeStaticLibs(
 }
 
 function Test-TripleInstalled([string] $triple) {
-    (& rustup target list --installed 2>$null) -contains $triple
+    $installedTargets = @(
+        (& $rustupExecutable target list --installed 2>&1) |
+            Where-Object { $_ -match '\S' -and $_ -notmatch '^\s*(INFO|WARN)\b' } |
+            ForEach-Object { ([string]$_).Trim() }
+    )
+    if ($LASTEXITCODE -ne 0) {
+        throw "$rustupExecutable target list --installed failed with exit code $LASTEXITCODE."
+    }
+
+    return $installedTargets -contains $triple
 }
+
+$rustupExecutable = Get-RustupExecutable
+$rustupName = [System.IO.Path]::GetFileNameWithoutExtension($rustupExecutable)
+if ($rustupName -cne 'msrustup') {
+    throw "Microsoft Rust is required: RUSTUP_EXE must resolve to msrustup, found '$rustupExecutable'."
+}
+
+$managerVersion = Invoke-RequiredToolOutput `
+    -Executable $rustupExecutable `
+    -Arguments @('--version') `
+    -Description 'Microsoft Rust toolchain manager'
+$activeToolchainOutput = Invoke-RequiredToolOutput `
+    -Executable $rustupExecutable `
+    -Arguments @('show', 'active-toolchain') `
+    -Description 'Microsoft Rust active toolchain query'
+$activeToolchain = (
+    $activeToolchainOutput -split "`r?`n" |
+        Where-Object { $_ -match '\S' -and $_ -notmatch '^\s*(INFO|WARN)\b' } |
+        Select-Object -First 1
+)
+if (
+    -not $activeToolchain -or
+    -not (Test-MicrosoftRustActiveToolchain `
+        -ActiveToolchain $activeToolchain.Trim() `
+        -Channel $microsoftRustConfig.Channel)
+) {
+    throw "Active Rust toolchain '$activeToolchain' does not match pinned Microsoft channel '$($microsoftRustConfig.Channel)'."
+}
+$activeToolchain = $activeToolchain.Trim()
+
+$rustcVerboseVersion = Invoke-RequiredToolOutput `
+    -Executable 'rustc' `
+    -Arguments @('-Vv') `
+    -Description 'rustc -Vv'
+if ($rustcVerboseVersion -notmatch '(?im)^rustc\s+.*\bmicrosoft\b') {
+    throw "rustc -Vv does not identify a Microsoft Rust compiler; refusing a possible upstream fallback."
+}
+$rustcReleaseMatch = [regex]::Match(
+    $rustcVerboseVersion,
+    '(?m)^release:\s*(\S+)\s*$'
+)
+if (-not $rustcReleaseMatch.Success) {
+    throw "rustc -Vv did not report a release identity."
+}
+$rustcRelease = $rustcReleaseMatch.Groups[1].Value
+$cargoVersion = Invoke-RequiredToolOutput `
+    -Executable 'cargo' `
+    -Arguments @('--version') `
+    -Description 'cargo --version'
 
 $sourceCommit = (& git -C $RepoRoot rev-parse HEAD 2>$null)
 if ($LASTEXITCODE -ne 0) { throw 'Unable to resolve the source commit.' }
@@ -205,12 +298,20 @@ $summary = @()
 foreach ($row in $rows) {
     Write-Host "==> $($row.id) ($($row.triple))" -ForegroundColor Cyan
     $compiler = $compilers[$row.id]
+    $compilerCommand = $compilerCommands[$row.id]
+
+    if ($row.triple -notin $microsoftRustConfig.Targets) {
+        throw "[$($row.id)] target '$($row.triple)' is absent from the Microsoft Rust toolchain configuration."
+    }
 
     if (-not (Test-TripleInstalled $row.triple)) {
-        Write-Host "    target not installed; attempting 'rustup target add $($row.triple)'"
-        & rustup target add $row.triple *> $null
+        Write-Host "    target not installed; attempting '$rustupExecutable target add $($row.triple)'"
+        & $rustupExecutable target add $row.triple *> $null
         if ($LASTEXITCODE -ne 0) {
-            throw "rustup target add failed for $($row.triple) with exit code $LASTEXITCODE"
+            throw "$rustupExecutable target add failed for $($row.triple) with exit code $LASTEXITCODE"
+        }
+        if (-not (Test-TripleInstalled $row.triple)) {
+            throw "$rustupExecutable did not install required target '$($row.triple)'."
         }
     }
     $targetOut = Join-Path $OutputRoot $row.id
@@ -312,7 +413,7 @@ foreach ($row in $rows) {
     $headerSha = (Get-FileHash $headerSrc -Algorithm SHA256).Hash.ToLowerInvariant()
 
     $manifest = [ordered]@{
-        schema_version           = 3
+        schema_version           = 4
         artifact_id              = $row.id
         goos                     = $row.goos
         goarch                   = $row.goarch
@@ -341,11 +442,26 @@ foreach ($row in $rows) {
         }
         rustc_native_static_libs = $rustcSyslibs
         native_static_libs       = $syslibs
-        toolchains = [ordered]@{
-            rustc              = Get-ToolVersion 'rustc' @('--version')
-            cargo              = Get-ToolVersion 'cargo' @('--version')
-            c_compiler         = $compiler
-            c_compiler_version = Get-ToolVersion $compiler @('--version')
+        toolchain = [ordered]@{
+            provider = 'microsoft'
+            manager = [ordered]@{
+                executable = $rustupExecutable
+                version    = $managerVersion
+            }
+            channel               = $microsoftRustConfig.Channel
+            active_toolchain      = $activeToolchain
+            rustc_verbose_version = $rustcVerboseVersion
+            rustc_release         = $rustcRelease
+            cargo_version         = $cargoVersion
+            target                = $row.triple
+            linker = [ordered]@{
+                command    = $compiler
+                executable = $compilerCommand.Source
+                version    = Invoke-RequiredToolOutput `
+                    -Executable $compiler `
+                    -Arguments @('--version') `
+                    -Description "$compiler --version"
+            }
         }
         generated_utc = (Get-Date).ToUniversalTime().ToString('o')
     }

--- a/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/New-GoModules.ps1
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/New-GoModules.ps1
@@ -272,12 +272,12 @@ foreach ($row in $rows) {
         throw "[$($row.id)] metadata Microsoft Rust channel mismatch: expected '$($microsoftRustConfig.Channel)', found '$channel'."
     }
 
-    $activeToolchain = Get-RequiredMetadataString `
+    $selectedToolchain = Get-RequiredMetadataString `
         -TargetId $row.id `
         -Object $toolchain `
-        -Name 'active_toolchain'
-    if (-not (Test-MicrosoftRustActiveToolchain -ActiveToolchain $activeToolchain -Channel $channel)) {
-        throw "[$($row.id)] metadata active toolchain '$activeToolchain' does not match '$channel'."
+        -Name 'selected_toolchain'
+    if ($selectedToolchain -cne $channel) {
+        throw "[$($row.id)] metadata selected toolchain '$selectedToolchain' does not match '$channel'."
     }
 
     $rustcVerboseVersion = Get-RequiredMetadataString `
@@ -291,6 +291,21 @@ foreach ($row in $rows) {
         -TargetId $row.id `
         -Object $toolchain `
         -Name 'rustc_release'
+    $verboseReleaseMatches = [regex]::Matches(
+        $rustcVerboseVersion,
+        '(?m)^release:\s*(\S+)\s*$'
+    )
+    if ($verboseReleaseMatches.Count -ne 1) {
+        throw "[$($row.id)] metadata rustc identity must report exactly one release."
+    }
+    $verboseRustcRelease = $verboseReleaseMatches[0].Groups[1].Value
+    if ($verboseRustcRelease -cne $rustcRelease) {
+        throw "[$($row.id)] metadata rustc release '$rustcRelease' does not match rustc identity release '$verboseRustcRelease'."
+    }
+    $channelRelease = $channel.Substring('ms-prod-'.Length)
+    if ($rustcRelease -notmatch "^$([regex]::Escape($channelRelease))(?:\.|$)") {
+        throw "[$($row.id)] metadata Microsoft Rust release '$rustcRelease' does not match pinned channel '$channel'."
+    }
     $cargoVersion = Get-RequiredMetadataString `
         -TargetId $row.id `
         -Object $toolchain `
@@ -379,7 +394,7 @@ foreach ($row in $rows) {
         HeaderPath = $headerPath
         StaticLibraryPath = $staticLibraryPath
         Toolchain = [ordered]@{
-            active_toolchain      = $activeToolchain
+            selected_toolchain    = $selectedToolchain
             rustc_verbose_version = $rustcVerboseVersion
             target                = [string]$toolchain.target
             linker = [ordered]@{

--- a/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/New-GoModules.ps1
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/New-GoModules.ps1
@@ -48,7 +48,8 @@ param(
     [string]   $OutputRoot,
     [string[]] $TargetId,
     [switch]   $SkipNativeCopy,
-    [string]   $MatrixPath = (Join-Path $PSScriptRoot 'build-matrix.json')
+    [string]   $MatrixPath = (Join-Path $PSScriptRoot 'build-matrix.json'),
+    [string]   $ToolchainConfigPath
 )
 
 Set-StrictMode -Version 3.0
@@ -56,6 +57,20 @@ $ErrorActionPreference = 'Stop'
 
 $PipelineDir = $PSScriptRoot
 $MetadataFilename = 'rust-driver-native-interface-metadata.json'
+$CrateDir = Split-Path -Parent $PipelineDir
+$RepoRoot = (Resolve-Path (Join-Path $CrateDir '..' '..' '..')).Path
+. ([System.IO.Path]::Combine($RepoRoot, 'eng', 'scripts', 'shared', 'common.ps1'))
+
+if (-not $ToolchainConfigPath) {
+    $ToolchainConfigPath = [System.IO.Path]::Combine(
+        $RepoRoot,
+        'eng',
+        'templates',
+        'ms-rust-toolchain.toml'
+    )
+}
+$microsoftRustConfig = Get-MicrosoftRustToolchainConfiguration -Path $ToolchainConfigPath
+
 if (-not $ArtifactRoot) { $ArtifactRoot = Join-Path $PipelineDir 'artifacts' }
 if (-not $OutputRoot)   { $OutputRoot   = Join-Path $PipelineDir 'generated' 'azure-cosmos-driver' }
 
@@ -109,6 +124,28 @@ function Assert-MetadataValue {
     if ([string]$actual -cne [string]$Expected) {
         throw "[$TargetId] metadata '$Name' mismatch: expected '$Expected', found '$actual'."
     }
+}
+
+function Get-RequiredMetadataString {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TargetId,
+
+        [Parameter(Mandatory = $true)]
+        [object]$Object,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    if (
+        -not (Test-Property -Object $Object -Name $Name) -or
+        [string]::IsNullOrWhiteSpace([string]$Object.$Name)
+    ) {
+        throw "[$TargetId] metadata is missing non-empty '$Name'."
+    }
+
+    return [string]$Object.$Name
 }
 
 function Get-FileSha256 {
@@ -169,7 +206,7 @@ foreach ($row in $rows) {
     }
 
     $metadata = Get-Content $manifestPath -Raw | ConvertFrom-Json
-    Assert-MetadataValue -TargetId $row.id -Metadata $metadata -Name 'schema_version' -Expected 3
+    Assert-MetadataValue -TargetId $row.id -Metadata $metadata -Name 'schema_version' -Expected 4
     Assert-MetadataValue -TargetId $row.id -Metadata $metadata -Name 'artifact_id' -Expected $row.id
     Assert-MetadataValue -TargetId $row.id -Metadata $metadata -Name 'triple' -Expected $row.triple
     Assert-MetadataValue -TargetId $row.id -Metadata $metadata -Name 'goos' -Expected $row.goos
@@ -185,7 +222,8 @@ foreach ($row in $rows) {
         'rustc_native_static_libs',
         'native_static_libs',
         'static_library',
-        'header'
+        'header',
+        'toolchain'
     )) {
         if (-not (Test-Property -Object $metadata -Name $name)) {
             throw "[$($row.id)] metadata is missing '$name'."
@@ -197,6 +235,87 @@ foreach ($row in $rows) {
     if (-not $metadata.native_interface_version -or -not $metadata.rust_driver_version) {
         throw "[$($row.id)] metadata package versions must not be empty."
     }
+
+    $toolchain = $metadata.toolchain
+    $provider = Get-RequiredMetadataString `
+        -TargetId $row.id `
+        -Object $toolchain `
+        -Name 'provider'
+    if ($provider -cne 'microsoft') {
+        throw "[$($row.id)] metadata toolchain provider must be 'microsoft', found '$provider'."
+    }
+
+    if (-not (Test-Property -Object $toolchain -Name 'manager')) {
+        throw "[$($row.id)] metadata toolchain is missing 'manager'."
+    }
+    $managerExecutable = Get-RequiredMetadataString `
+        -TargetId $row.id `
+        -Object $toolchain.manager `
+        -Name 'executable'
+    $managerName = [System.IO.Path]::GetFileNameWithoutExtension($managerExecutable)
+    if ($managerName -cne 'msrustup') {
+        throw "[$($row.id)] metadata toolchain manager must be msrustup, found '$managerExecutable'."
+    }
+    $managerVersion = Get-RequiredMetadataString `
+        -TargetId $row.id `
+        -Object $toolchain.manager `
+        -Name 'version'
+
+    $channel = Get-RequiredMetadataString `
+        -TargetId $row.id `
+        -Object $toolchain `
+        -Name 'channel'
+    if ($channel -notmatch '^ms-prod-\d+(?:\.\d+)+$') {
+        throw "[$($row.id)] metadata Microsoft Rust channel '$channel' is not explicitly pinned."
+    }
+    if ($channel -cne $microsoftRustConfig.Channel) {
+        throw "[$($row.id)] metadata Microsoft Rust channel mismatch: expected '$($microsoftRustConfig.Channel)', found '$channel'."
+    }
+
+    $activeToolchain = Get-RequiredMetadataString `
+        -TargetId $row.id `
+        -Object $toolchain `
+        -Name 'active_toolchain'
+    if (-not (Test-MicrosoftRustActiveToolchain -ActiveToolchain $activeToolchain -Channel $channel)) {
+        throw "[$($row.id)] metadata active toolchain '$activeToolchain' does not match '$channel'."
+    }
+
+    $rustcVerboseVersion = Get-RequiredMetadataString `
+        -TargetId $row.id `
+        -Object $toolchain `
+        -Name 'rustc_verbose_version'
+    if ($rustcVerboseVersion -notmatch '(?im)^rustc\s+.*\bmicrosoft\b') {
+        throw "[$($row.id)] metadata rustc identity is not Microsoft Rust."
+    }
+    $rustcRelease = Get-RequiredMetadataString `
+        -TargetId $row.id `
+        -Object $toolchain `
+        -Name 'rustc_release'
+    $cargoVersion = Get-RequiredMetadataString `
+        -TargetId $row.id `
+        -Object $toolchain `
+        -Name 'cargo_version'
+    Assert-MetadataValue `
+        -TargetId $row.id `
+        -Metadata $toolchain `
+        -Name 'target' `
+        -Expected $row.triple
+
+    if (-not (Test-Property -Object $toolchain -Name 'linker')) {
+        throw "[$($row.id)] metadata toolchain is missing 'linker'."
+    }
+    $linkerCommand = Get-RequiredMetadataString `
+        -TargetId $row.id `
+        -Object $toolchain.linker `
+        -Name 'command'
+    $linkerExecutable = Get-RequiredMetadataString `
+        -TargetId $row.id `
+        -Object $toolchain.linker `
+        -Name 'executable'
+    $linkerVersion = Get-RequiredMetadataString `
+        -TargetId $row.id `
+        -Object $toolchain.linker `
+        -Name 'version'
 
     if (-not (Test-Property -Object $metadata.static_library -Name 'sha256')) {
         throw "[$($row.id)] metadata static library is missing 'sha256'."
@@ -231,6 +350,12 @@ foreach ($row in $rows) {
         source_commit = [string]$metadata.source_commit
         native_interface_version = [string]$metadata.native_interface_version
         rust_driver_version = [string]$metadata.rust_driver_version
+        rust_toolchain_provider = $provider
+        rust_toolchain_manager = $managerName
+        rust_toolchain_manager_version = $managerVersion
+        rust_toolchain_channel = $channel
+        rustc_release = $rustcRelease
+        cargo_version = $cargoVersion
     }
     if ($null -eq $releaseIdentity) {
         $releaseIdentity = $identity
@@ -253,6 +378,16 @@ foreach ($row in $rows) {
         Metadata = $metadata
         HeaderPath = $headerPath
         StaticLibraryPath = $staticLibraryPath
+        Toolchain = [ordered]@{
+            active_toolchain      = $activeToolchain
+            rustc_verbose_version = $rustcVerboseVersion
+            target                = [string]$toolchain.target
+            linker = [ordered]@{
+                command    = $linkerCommand
+                executable = $linkerExecutable
+                version    = $linkerVersion
+            }
+        }
     }
 }
 
@@ -349,20 +484,29 @@ $provenanceTargets = foreach ($row in $rows) {
         module_path           = [string]$row.module_path
         static_library_sha256 = ([string]$targetMetadata.static_library.sha256).ToLowerInvariant()
         header_sha256         = ([string]$targetMetadata.header.sha256).ToLowerInvariant()
+        toolchain              = $verifiedArtifacts[$row.id].Toolchain
     }
 }
 
 $provenance = [ordered]@{
-    schema_version           = 1
+    schema_version           = 2
     source_commit            = $releaseIdentity['source_commit']
     native_interface_crate   = [string]$matrix.native_interface_crate
     native_interface_version = $releaseIdentity['native_interface_version']
     rust_driver_crate        = [string]$matrix.rust_driver_crate
     rust_driver_version      = $releaseIdentity['rust_driver_version']
+    rust_toolchain = [ordered]@{
+        provider        = $releaseIdentity['rust_toolchain_provider']
+        manager         = $releaseIdentity['rust_toolchain_manager']
+        manager_version = $releaseIdentity['rust_toolchain_manager_version']
+        channel         = $releaseIdentity['rust_toolchain_channel']
+        rustc_release   = $releaseIdentity['rustc_release']
+        cargo_version   = $releaseIdentity['cargo_version']
+    }
     targets                  = @($provenanceTargets)
 }
 
-$provenanceJson = $provenance | ConvertTo-Json -Depth 6
+$provenanceJson = $provenance | ConvertTo-Json -Depth 8
 Write-GeneratedTextFile -Path (Join-Path $OutputRoot 'provenance.json') -Content $provenanceJson
 Write-Host "Wrote provenance.json (commit $($releaseIdentity['source_commit']), rust_driver v$($releaseIdentity['rust_driver_version']))"
 

--- a/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/README.md
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/README.md
@@ -15,6 +15,11 @@ not connected to a CI or release definition yet. After an owner registers it in
 the internal Azure SDK project, a successful manual main-branch build can open a
 draft pull request in `Azure/azure-cosmos-driver`.
 
+Production jobs install the centrally pinned Microsoft Rust toolchain from
+`eng/templates/ms-rust-toolchain.toml` through the internal `RustInstaller@1`
+feed. The native build rejects ordinary `rustup`, a different or unpinned
+channel, and targets that `msrustup` cannot install.
+
 ## What this pull request supports
 
 The active build targets are:
@@ -38,8 +43,10 @@ This prevents the final Go application from requiring a separately distributed
 | File | Purpose |
 | ---- | ------- |
 | `build-matrix.json` | Lists supported Rust targets and their Go module paths. |
+| `../../../../eng/templates/ms-rust-toolchain.toml` | Pins the Microsoft Rust release channel and required Rust targets. |
+| `../../../../eng/pipelines/templates/steps/use-ms-rust.yml` | Provides the opt-in internal Microsoft Rust installer path without changing ordinary Rust jobs. |
 | `New-NativeJobMatrix.ps1` | Converts the canonical target list into the standard Azure Pipelines matrix-generator format. |
-| `Build-NativeMatrix.ps1` | Builds each static library, records required system libraries, and writes release metadata. |
+| `Build-NativeMatrix.ps1` | Verifies Microsoft Rust, builds each static library, and writes schema 4 release metadata. |
 | `Test-NativeLink.ps1` | Cross-links a minimal Go/cgo program against each target archive before publication. |
 | `New-GoModules.ps1` | Creates the `Azure/azure-cosmos-driver` directory layout, Go module files, cgo linker files, headers, and static libraries. |
 | `Prepare-GoDriverPullRequest.ps1` | Verifies the artifact, synchronizes the downstream generated roots, validates the Go modules, and stages the changes. |
@@ -54,7 +61,7 @@ This prevents the final Go application from requiring a separately distributed
 ## Production flow
 
 ```text
-Pinned azure-sdk-for-rust commit
+Pinned azure-sdk-for-rust commit and Microsoft Rust channel
     |
     v
 Generate jobs from build-matrix.json using the shared matrix infrastructure
@@ -86,6 +93,12 @@ pipeline uses the repository's standard `1ES.PublishPipelineArtifact@1` wrapper
 with SBOM generation enabled rather than implementing a second, pipeline-local
 signature verifier.
 
+Each target artifact includes schema 4 metadata with the selected toolchain
+manager, active Microsoft Rust channel, manager and Cargo versions, complete
+`rustc -Vv` output, target triple, and linker command, resolved path, and version
+output. `New-GoModules.ps1` rejects missing or mixed toolchain identities before
+writing schema 2 `provenance.json`.
+
 The native-driver pipeline is not part of the automatic pull-request pipeline.
 Authorized reviewers can run its registered pipeline definition against a pull
 request with an `/azp run` comment.
@@ -110,6 +123,10 @@ Run the complete local test on Windows AMD64:
 ```powershell
 ./Invoke-LocalSupplyChain.ps1
 ```
+
+The local machine must already have access to the internal Microsoft Rust feed,
+the pinned channel installed through `msrustup`, and `RUSTUP_EXE=msrustup`.
+There is no fallback to an upstream Rust installation.
 
 The script:
 
@@ -169,9 +186,10 @@ the appropriate driver module, so users do not need a custom musl build tag.
   `1es-redirect.yml` selects the official 1ES template.
 - Confirm with the central security owners that the official 1ES template is the
   approved trust boundary for these static libraries.
-- Provision every cross-compiler named by the build matrix. In particular, the
-  managed Ubuntu image does not include the ARM64 musl compiler required by
-  `linux-arm64-musl`; this must be resolved before registering the pipeline.
+- Run the registered pipeline manually in the internal project and confirm that
+  `ms-prod-1.95` supplies all six required targets. The checked-in configuration
+  intentionally fails closed if the private feed does not yet provide one; local
+  tests do not establish target availability.
 - Confirm that the Azure SDK Automation GitHub App installation includes the
   private `Azure/azure-cosmos-driver` repository and that this pipeline may use
   the `AzureSDKEngKeyVault Secrets` service connection.

--- a/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/README.md
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/README.md
@@ -17,12 +17,13 @@ draft pull request in `Azure/azure-cosmos-driver`.
 
 Production jobs install the centrally pinned Microsoft Rust toolchain from
 `eng/templates/ms-rust-toolchain.toml` through the internal `RustInstaller@1`
-feed. The native build rejects ordinary `rustup`, a different or unpinned
+feed. The native build invokes Cargo and rustc with the explicit pinned
+toolchain selector and rejects an upstream compiler, a different or unpinned
 channel, and targets that `msrustup` cannot install.
 
-## What this pull request supports
+## Configured release matrix
 
-The active build targets are:
+The intended build targets are:
 
 - Windows AMD64
 - Linux AMD64 using glibc
@@ -30,6 +31,10 @@ The active build targets are:
 - Linux AMD64 using musl
 - Linux ARM64 using musl
 - macOS ARM64
+
+This matrix is configured but not yet claimed as available. A manual run in the
+internal Azure DevOps project must confirm that the private Microsoft Rust feed
+supplies every target; unsupported targets fail closed.
 
 Windows ARM64 and Intel macOS are outside the supported matrix. Dynamic libraries
 for .NET, Java, and Python are also outside this pull request.
@@ -94,7 +99,7 @@ with SBOM generation enabled rather than implementing a second, pipeline-local
 signature verifier.
 
 Each target artifact includes schema 4 metadata with the selected toolchain
-manager, active Microsoft Rust channel, manager and Cargo versions, complete
+manager, pinned Microsoft Rust channel, manager and Cargo versions, complete
 `rustc -Vv` output, target triple, and linker command, resolved path, and version
 output. `New-GoModules.ps1` rejects missing or mixed toolchain identities before
 writing schema 2 `provenance.json`.
@@ -125,8 +130,8 @@ Run the complete local test on Windows AMD64:
 ```
 
 The local machine must already have access to the internal Microsoft Rust feed,
-the pinned channel installed through `msrustup`, and `RUSTUP_EXE=msrustup`.
-There is no fallback to an upstream Rust installation.
+and the pinned channel installed through `msrustup`. Build commands select that
+channel explicitly; there is no fallback to an upstream Rust installation.
 
 The script:
 

--- a/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/Test-NativeLink.ps1
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/Test-NativeLink.ps1
@@ -50,14 +50,15 @@ foreach ($property in @(
     'libc',
     'triple',
     'rustc_native_static_libs',
-    'native_static_libs'
+    'native_static_libs',
+    'toolchain'
 )) {
     if ($metadata.PSObject.Properties.Name -notcontains $property) {
         throw "[$TargetId] metadata is missing '$property'."
     }
 }
-if ($metadata.schema_version -ne 3) {
-    throw "[$TargetId] metadata 'schema_version' does not match expected version 3."
+if ($metadata.schema_version -ne 4) {
+    throw "[$TargetId] metadata 'schema_version' does not match expected version 4."
 }
 $expectedIdentity = @{
     artifact_id = $target.id
@@ -70,6 +71,21 @@ foreach ($property in $expectedIdentity.Keys) {
     if ([string]$metadata.$property -cne [string]$expectedIdentity[$property]) {
         throw "[$TargetId] metadata '$property' does not match build-matrix.json."
     }
+}
+if ([string]$metadata.toolchain.provider -cne 'microsoft') {
+    throw "[$TargetId] metadata toolchain provider is not Microsoft Rust."
+}
+$manager = [System.IO.Path]::GetFileNameWithoutExtension(
+    [string]$metadata.toolchain.manager.executable
+)
+if ($manager -cne 'msrustup') {
+    throw "[$TargetId] metadata toolchain manager is not msrustup."
+}
+if ([string]$metadata.toolchain.channel -notmatch '^ms-prod-\d+(?:\.\d+)+$') {
+    throw "[$TargetId] metadata Microsoft Rust channel is not explicitly pinned."
+}
+if ([string]$metadata.toolchain.target -cne [string]$target.triple) {
+    throw "[$TargetId] metadata toolchain target does not match build-matrix.json."
 }
 
 $libraryPath = Join-Path $targetRoot $matrix.static_lib_filename

--- a/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/native-driver-build-job.yml
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/native-driver-build-job.yml
@@ -28,9 +28,7 @@ jobs:
         image: $(OSVmImage)
       os: ${{ parameters.OSName }}
     steps:
-      - template: /eng/pipelines/templates/steps/use-rust.yml@self
-        parameters:
-          Toolchain: active
+      - template: /eng/pipelines/templates/steps/use-ms-rust.yml@self
 
       - ${{ if eq(parameters.OSName, 'windows') }}:
         - pwsh: |

--- a/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/tests/Build-NativeMatrix.Tests.ps1
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/tests/Build-NativeMatrix.Tests.ps1
@@ -12,8 +12,6 @@ Describe 'Build-NativeMatrix target compiler configuration' {
         $RepositoryRoot = (Resolve-Path (Join-Path $PipelineDirectory '../../../..')).Path
         $OneEsRedirectPath = Join-Path $RepositoryRoot 'eng/pipelines/templates/stages/1es-redirect.yml'
         $UseRustTemplatePath = Join-Path $RepositoryRoot 'eng/pipelines/templates/steps/use-rust.yml'
-        $UseRustScriptPath = Join-Path $RepositoryRoot 'eng/scripts/Use-Rust.ps1'
-        $CargoScriptPath = Join-Path $RepositoryRoot 'eng/scripts/shared/Cargo.ps1'
         $MicrosoftRustTemplatePath = Join-Path $RepositoryRoot 'eng/pipelines/templates/steps/use-ms-rust.yml'
         $MicrosoftRustConfigPath = Join-Path $RepositoryRoot 'eng/templates/ms-rust-toolchain.toml'
         $Matrix = Get-Content $MatrixPath -Raw | ConvertFrom-Json
@@ -24,25 +22,17 @@ Describe 'Build-NativeMatrix target compiler configuration' {
         ).Groups[1].Value
         $CargoLinkerVariable = 'CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER'
         $CcVariable = 'CC_x86_64_pc_windows_gnu'
-        $OriginalRustupExe = $env:RUSTUP_EXE
         function msrustup {}
     }
 
-    AfterAll {
-        if ($null -eq $OriginalRustupExe) {
-            Remove-Item Env:RUSTUP_EXE -ErrorAction SilentlyContinue
-        }
-        else {
-            $env:RUSTUP_EXE = $OriginalRustupExe
-        }
-    }
-
     BeforeEach {
-        $env:RUSTUP_EXE = 'msrustup'
         $global:ObservedCargoLinker = $null
         $global:ObservedCc = $null
         $global:ObservedBuildCargoLinker = $null
         $global:ObservedBuildCc = $null
+        $global:ObservedCargoArguments = @()
+        $global:ObservedRustcArguments = @()
+        $global:MicrosoftRustManagerAvailable = $true
         $global:InstalledMicrosoftRustTargets = @(
             'x86_64-pc-windows-gnu'
             'x86_64-unknown-linux-musl'
@@ -50,6 +40,7 @@ Describe 'Build-NativeMatrix target compiler configuration' {
         $global:MicrosoftRustTargetAddExitCode = 0
         $global:InstallMicrosoftRustTarget = $true
         $global:UseUpstreamRustc = $false
+        $global:MicrosoftRustRelease = '1.95.0'
         $global:CompilerLibraryPath = Join-Path $TestDrive 'libgcc_eh.a'
         Set-Content $global:CompilerLibraryPath 'archive'
 
@@ -57,18 +48,21 @@ Describe 'Build-NativeMatrix target compiler configuration' {
             $global:LASTEXITCODE = 0
             '0123456789abcdef0123456789abcdef01234567'
         }
+        Mock Get-Command {
+            if ($global:MicrosoftRustManagerAvailable) {
+                [pscustomobject]@{
+                    Name = 'msrustup'
+                    Source = $null
+                }
+            }
+        } -ParameterFilter { $Name -eq 'msrustup' }
         Mock msrustup {
             switch ("$args") {
                 '--version' {
                     $global:LASTEXITCODE = 0
                     'msrustup 1.0.0'
                 }
-                'show active-toolchain' {
-                    $global:LASTEXITCODE = 0
-                    'INFO loading Microsoft Rust toolchain'
-                    "$MicrosoftRustChannel-x86_64-pc-windows-msvc (directory override)"
-                }
-                'target list --installed' {
+                "target list --installed --toolchain $MicrosoftRustChannel" {
                     $global:LASTEXITCODE = 0
                     $global:InstalledMicrosoftRustTargets
                 }
@@ -86,6 +80,7 @@ Describe 'Build-NativeMatrix target compiler configuration' {
             }
         }
         Mock rustc {
+            $global:ObservedRustcArguments = @($args)
             $global:LASTEXITCODE = 0
             if ($global:UseUpstreamRustc) {
                 return @(
@@ -99,12 +94,12 @@ Describe 'Build-NativeMatrix target compiler configuration' {
                 )
             }
             @(
-                'rustc 1.95.0 (microsoft 012345678 2026-08-01)'
+                "rustc $global:MicrosoftRustRelease (microsoft 012345678 2026-08-01)"
                 'binary: rustc'
                 'commit-hash: 0123456789abcdef0123456789abcdef01234567'
                 'commit-date: 2026-08-01'
                 'host: x86_64-pc-windows-msvc'
-                'release: 1.95.0'
+                "release: $global:MicrosoftRustRelease"
                 'LLVM version: 21.1.0'
             )
         }
@@ -118,8 +113,9 @@ Describe 'Build-NativeMatrix target compiler configuration' {
             }
         }
         Mock cargo {
+            $global:ObservedCargoArguments += ,@($args)
             $global:LASTEXITCODE = 0
-            switch ($args[0]) {
+            switch ($args[1]) {
                 'metadata' {
                     [ordered]@{
                         packages = @(
@@ -196,7 +192,7 @@ Describe 'Build-NativeMatrix target compiler configuration' {
             $metadata.toolchain.provider | Should -Be 'microsoft'
             $metadata.toolchain.manager.executable | Should -Be 'msrustup'
             $metadata.toolchain.channel | Should -Be $MicrosoftRustChannel
-            $metadata.toolchain.active_toolchain | Should -Match "^$([regex]::Escape($MicrosoftRustChannel))-"
+            $metadata.toolchain.selected_toolchain | Should -Be $MicrosoftRustChannel
             $metadata.toolchain.rustc_verbose_version | Should -Match 'release: 1\.95\.0'
             $metadata.toolchain.rustc_release | Should -Be '1.95.0'
             $metadata.toolchain.cargo_version | Should -Be 'cargo 1.0.0'
@@ -204,6 +200,13 @@ Describe 'Build-NativeMatrix target compiler configuration' {
             $metadata.toolchain.linker.command | Should -Be 'pwsh'
             $metadata.toolchain.linker.executable | Should -Not -BeNullOrEmpty
             $metadata.toolchain.linker.version | Should -Be 'PowerShell 7.0.0'
+            $global:ObservedRustcArguments | Should -Be @(
+                "+$MicrosoftRustChannel"
+                '-Vv'
+            )
+            foreach ($invocation in $global:ObservedCargoArguments) {
+                $invocation[0] | Should -Be "+$MicrosoftRustChannel"
+            }
         }
         finally {
             [Environment]::SetEnvironmentVariable($CargoLinkerVariable, $savedCargoLinker, 'Process')
@@ -263,7 +266,7 @@ Describe 'Build-NativeMatrix target compiler configuration' {
     }
 
     It 'rejects a missing Microsoft Rust manager selection' {
-        Remove-Item Env:RUSTUP_EXE
+        $global:MicrosoftRustManagerAvailable = $false
 
         {
             & $ScriptPath `
@@ -271,19 +274,7 @@ Describe 'Build-NativeMatrix target compiler configuration' {
                 -OutputRoot (Join-Path $TestDrive 'artifacts') `
                 -CCompiler 'pwsh' `
                 -SkipBuild
-        } | Should -Throw '*RUSTUP_EXE must resolve to msrustup*'
-    }
-
-    It 'rejects an upstream rustup fallback' {
-        $env:RUSTUP_EXE = 'rustup'
-
-        {
-            & $ScriptPath `
-                -TargetId 'windows-amd64' `
-                -OutputRoot (Join-Path $TestDrive 'artifacts') `
-                -CCompiler 'pwsh' `
-                -SkipBuild
-        } | Should -Throw "*found 'rustup'*"
+        } | Should -Throw '*msrustup is not installed or is not available on PATH*'
     }
 
     It 'rejects an upstream rustc fallback' {
@@ -296,6 +287,18 @@ Describe 'Build-NativeMatrix target compiler configuration' {
                 -CCompiler 'pwsh' `
                 -SkipBuild
         } | Should -Throw '*does not identify a Microsoft Rust compiler*'
+    }
+
+    It 'rejects a Microsoft compiler release that differs from the pinned channel' {
+        $global:MicrosoftRustRelease = '1.96.0'
+
+        {
+            & $ScriptPath `
+                -TargetId 'windows-amd64' `
+                -OutputRoot (Join-Path $TestDrive 'artifacts') `
+                -CCompiler 'pwsh' `
+                -SkipBuild
+        } | Should -Throw "*does not match pinned channel '$MicrosoftRustChannel'*"
     }
 
     It 'rejects an unpinned Microsoft Rust channel' {
@@ -399,8 +402,6 @@ targets = ["x86_64-pc-windows-gnu"]
     It 'keeps Microsoft Rust installation opt-in and centrally pinned' {
         $template = Get-Content $MicrosoftRustTemplatePath -Raw
         $useRustTemplate = Get-Content $UseRustTemplatePath -Raw
-        $useRustScript = Get-Content $UseRustScriptPath -Raw
-        $cargoScript = Get-Content $CargoScriptPath -Raw
 
         $template | Should -Match 'task:\s+RustInstaller@1'
         $template | Should -Match ([regex]::Escape(
@@ -409,7 +410,7 @@ targets = ["x86_64-pc-windows-gnu"]
         $template | Should -Match ([regex]::Escape(
             'eng/templates/ms-rust-toolchain.toml'
         ))
-        $template | Should -Match 'RUSTUP_EXE\]msrustup'
+        $template | Should -Not -Match 'RUSTUP_EXE'
         $template | Should -Match 'InstallToolchain:\s+false'
         $useRustTemplate | Should -Match '(?s)name:\s+InstallToolchain.*?default:\s+true'
         $MicrosoftRustChannel | Should -Match '^ms-prod-\d+(?:\.\d+)+$'
@@ -419,8 +420,6 @@ targets = ["x86_64-pc-windows-gnu"]
                 "`"$($target.triple)`""
             ))
         }
-        $cargoScript | Should -Match 'function Get-RustupExecutable'
-        $useRustScript | Should -Not -Match '(?m)Invoke-LoggedCommand\s+"rustup\s'
     }
 
     It 'provisions Linux compilers from Ubuntu or checksum-pinned Microsoft prior art' {

--- a/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/tests/Build-NativeMatrix.Tests.ps1
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/tests/Build-NativeMatrix.Tests.ps1
@@ -11,16 +11,45 @@ Describe 'Build-NativeMatrix target compiler configuration' {
         $BuildJobTemplatePath = Join-Path $PipelineDirectory 'native-driver-build-job.yml'
         $RepositoryRoot = (Resolve-Path (Join-Path $PipelineDirectory '../../../..')).Path
         $OneEsRedirectPath = Join-Path $RepositoryRoot 'eng/pipelines/templates/stages/1es-redirect.yml'
+        $UseRustTemplatePath = Join-Path $RepositoryRoot 'eng/pipelines/templates/steps/use-rust.yml'
+        $UseRustScriptPath = Join-Path $RepositoryRoot 'eng/scripts/Use-Rust.ps1'
+        $CargoScriptPath = Join-Path $RepositoryRoot 'eng/scripts/shared/Cargo.ps1'
+        $MicrosoftRustTemplatePath = Join-Path $RepositoryRoot 'eng/pipelines/templates/steps/use-ms-rust.yml'
+        $MicrosoftRustConfigPath = Join-Path $RepositoryRoot 'eng/templates/ms-rust-toolchain.toml'
         $Matrix = Get-Content $MatrixPath -Raw | ConvertFrom-Json
+        $MicrosoftRustConfig = Get-Content $MicrosoftRustConfigPath -Raw
+        $MicrosoftRustChannel = [regex]::Match(
+            $MicrosoftRustConfig,
+            '(?m)^\s*channel\s*=\s*"([^"]+)"\s*$'
+        ).Groups[1].Value
         $CargoLinkerVariable = 'CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER'
         $CcVariable = 'CC_x86_64_pc_windows_gnu'
+        $OriginalRustupExe = $env:RUSTUP_EXE
+        function msrustup {}
+    }
+
+    AfterAll {
+        if ($null -eq $OriginalRustupExe) {
+            Remove-Item Env:RUSTUP_EXE -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:RUSTUP_EXE = $OriginalRustupExe
+        }
     }
 
     BeforeEach {
+        $env:RUSTUP_EXE = 'msrustup'
         $global:ObservedCargoLinker = $null
         $global:ObservedCc = $null
         $global:ObservedBuildCargoLinker = $null
         $global:ObservedBuildCc = $null
+        $global:InstalledMicrosoftRustTargets = @(
+            'x86_64-pc-windows-gnu'
+            'x86_64-unknown-linux-musl'
+        )
+        $global:MicrosoftRustTargetAddExitCode = 0
+        $global:InstallMicrosoftRustTarget = $true
+        $global:UseUpstreamRustc = $false
         $global:CompilerLibraryPath = Join-Path $TestDrive 'libgcc_eh.a'
         Set-Content $global:CompilerLibraryPath 'archive'
 
@@ -28,11 +57,55 @@ Describe 'Build-NativeMatrix target compiler configuration' {
             $global:LASTEXITCODE = 0
             '0123456789abcdef0123456789abcdef01234567'
         }
-        Mock rustup {
+        Mock msrustup {
+            switch ("$args") {
+                '--version' {
+                    $global:LASTEXITCODE = 0
+                    'msrustup 1.0.0'
+                }
+                'show active-toolchain' {
+                    $global:LASTEXITCODE = 0
+                    'INFO loading Microsoft Rust toolchain'
+                    "$MicrosoftRustChannel-x86_64-pc-windows-msvc (directory override)"
+                }
+                'target list --installed' {
+                    $global:LASTEXITCODE = 0
+                    $global:InstalledMicrosoftRustTargets
+                }
+                default {
+                    if ($args[0] -eq 'target' -and $args[1] -eq 'add') {
+                        $global:LASTEXITCODE = $global:MicrosoftRustTargetAddExitCode
+                        if ($global:LASTEXITCODE -eq 0 -and $global:InstallMicrosoftRustTarget) {
+                            $global:InstalledMicrosoftRustTargets += $args[2]
+                        }
+                    }
+                    else {
+                        throw "Unexpected msrustup arguments: $args"
+                    }
+                }
+            }
+        }
+        Mock rustc {
             $global:LASTEXITCODE = 0
+            if ($global:UseUpstreamRustc) {
+                return @(
+                    'rustc 1.95.0 (012345678 2026-08-01)'
+                    'binary: rustc'
+                    'commit-hash: 0123456789abcdef0123456789abcdef01234567'
+                    'commit-date: 2026-08-01'
+                    'host: x86_64-pc-windows-msvc'
+                    'release: 1.95.0'
+                    'LLVM version: 21.1.0'
+                )
+            }
             @(
-                'x86_64-pc-windows-gnu'
-                'x86_64-unknown-linux-musl'
+                'rustc 1.95.0 (microsoft 012345678 2026-08-01)'
+                'binary: rustc'
+                'commit-hash: 0123456789abcdef0123456789abcdef01234567'
+                'commit-date: 2026-08-01'
+                'host: x86_64-pc-windows-msvc'
+                'release: 1.95.0'
+                'LLVM version: 21.1.0'
             )
         }
         Mock pwsh {
@@ -117,10 +190,20 @@ Describe 'Build-NativeMatrix target compiler configuration' {
             $metadataPath = Join-Path $TestDrive `
                 'artifacts/windows-amd64/rust-driver-native-interface-metadata.json'
             $metadata = Get-Content $metadataPath -Raw | ConvertFrom-Json
-            $metadata.schema_version | Should -Be 3
+            $metadata.schema_version | Should -Be 4
             @($metadata.rustc_native_static_libs) | Should -Be @('-lsystem')
             @($metadata.native_static_libs) | Should -Be @('-lsystem')
-            $metadata.toolchains.c_compiler | Should -Be 'pwsh'
+            $metadata.toolchain.provider | Should -Be 'microsoft'
+            $metadata.toolchain.manager.executable | Should -Be 'msrustup'
+            $metadata.toolchain.channel | Should -Be $MicrosoftRustChannel
+            $metadata.toolchain.active_toolchain | Should -Match "^$([regex]::Escape($MicrosoftRustChannel))-"
+            $metadata.toolchain.rustc_verbose_version | Should -Match 'release: 1\.95\.0'
+            $metadata.toolchain.rustc_release | Should -Be '1.95.0'
+            $metadata.toolchain.cargo_version | Should -Be 'cargo 1.0.0'
+            $metadata.toolchain.target | Should -Be 'x86_64-pc-windows-gnu'
+            $metadata.toolchain.linker.command | Should -Be 'pwsh'
+            $metadata.toolchain.linker.executable | Should -Not -BeNullOrEmpty
+            $metadata.toolchain.linker.version | Should -Be 'PowerShell 7.0.0'
         }
         finally {
             [Environment]::SetEnvironmentVariable($CargoLinkerVariable, $savedCargoLinker, 'Process')
@@ -179,6 +262,86 @@ Describe 'Build-NativeMatrix target compiler configuration' {
         Should -Invoke cargo -Exactly 0
     }
 
+    It 'rejects a missing Microsoft Rust manager selection' {
+        Remove-Item Env:RUSTUP_EXE
+
+        {
+            & $ScriptPath `
+                -TargetId 'windows-amd64' `
+                -OutputRoot (Join-Path $TestDrive 'artifacts') `
+                -CCompiler 'pwsh' `
+                -SkipBuild
+        } | Should -Throw '*RUSTUP_EXE must resolve to msrustup*'
+    }
+
+    It 'rejects an upstream rustup fallback' {
+        $env:RUSTUP_EXE = 'rustup'
+
+        {
+            & $ScriptPath `
+                -TargetId 'windows-amd64' `
+                -OutputRoot (Join-Path $TestDrive 'artifacts') `
+                -CCompiler 'pwsh' `
+                -SkipBuild
+        } | Should -Throw "*found 'rustup'*"
+    }
+
+    It 'rejects an upstream rustc fallback' {
+        $global:UseUpstreamRustc = $true
+
+        {
+            & $ScriptPath `
+                -TargetId 'windows-amd64' `
+                -OutputRoot (Join-Path $TestDrive 'artifacts') `
+                -CCompiler 'pwsh' `
+                -SkipBuild
+        } | Should -Throw '*does not identify a Microsoft Rust compiler*'
+    }
+
+    It 'rejects an unpinned Microsoft Rust channel' {
+        $toolchainConfig = Join-Path $TestDrive 'ms-rust-toolchain.toml'
+        Set-Content $toolchainConfig @'
+[toolchain]
+channel = "ms-prod"
+targets = ["x86_64-pc-windows-gnu"]
+'@
+
+        {
+            & $ScriptPath `
+                -TargetId 'windows-amd64' `
+                -OutputRoot (Join-Path $TestDrive 'artifacts') `
+                -CCompiler 'pwsh' `
+                -ToolchainConfigPath $toolchainConfig `
+                -SkipBuild
+        } | Should -Throw '*not an explicit pinned ms-prod channel*'
+    }
+
+    It 'fails closed when msrustup cannot install a required target' {
+        $global:InstalledMicrosoftRustTargets = @('x86_64-pc-windows-gnu')
+        $global:MicrosoftRustTargetAddExitCode = 1
+
+        {
+            & $ScriptPath `
+                -TargetId 'linux-amd64-musl' `
+                -OutputRoot (Join-Path $TestDrive 'artifacts') `
+                -CCompiler 'pwsh' `
+                -SkipBuild
+        } | Should -Throw '*msrustup target add failed for x86_64-unknown-linux-musl*'
+    }
+
+    It 'fails closed when a target remains unavailable after msrustup succeeds' {
+        $global:InstalledMicrosoftRustTargets = @('x86_64-pc-windows-gnu')
+        $global:InstallMicrosoftRustTarget = $false
+
+        {
+            & $ScriptPath `
+                -TargetId 'linux-amd64-musl' `
+                -OutputRoot (Join-Path $TestDrive 'artifacts') `
+                -CCompiler 'pwsh' `
+                -SkipBuild
+        } | Should -Throw "*did not install required target 'x86_64-unknown-linux-musl'*"
+    }
+
     It 'generates one shared job-matrix row for every active build target' {
         $outputPath = Join-Path $TestDrive 'native-driver-job-matrix.json'
         & $JobMatrixScriptPath -MatrixPath $MatrixPath -OutputPath $outputPath
@@ -225,12 +388,39 @@ Describe 'Build-NativeMatrix target compiler configuration' {
         $buildJobTemplate = Get-Content $BuildJobTemplatePath -Raw
         $buildJobTemplate | Should -Match 'name:\s+\$\(Pool\)'
         $buildJobTemplate | Should -Match ([regex]::Escape(
-            'template: /eng/pipelines/templates/steps/use-rust.yml@self'
+            'template: /eng/pipelines/templates/steps/use-ms-rust.yml@self'
         ))
         $buildJobTemplate | Should -Match ([regex]::Escape(
             "C:\msys64\mingw64\bin"
         ))
         $buildJobTemplate | Should -Match ([regex]::Escape('-StaticOnly'))
+    }
+
+    It 'keeps Microsoft Rust installation opt-in and centrally pinned' {
+        $template = Get-Content $MicrosoftRustTemplatePath -Raw
+        $useRustTemplate = Get-Content $UseRustTemplatePath -Raw
+        $useRustScript = Get-Content $UseRustScriptPath -Raw
+        $cargoScript = Get-Content $CargoScriptPath -Raw
+
+        $template | Should -Match 'task:\s+RustInstaller@1'
+        $template | Should -Match ([regex]::Escape(
+            'https://pkgs.dev.azure.com/azure-sdk/internal/_packaging/ms-rust-tools/nuget/v3/index.json'
+        ))
+        $template | Should -Match ([regex]::Escape(
+            'eng/templates/ms-rust-toolchain.toml'
+        ))
+        $template | Should -Match 'RUSTUP_EXE\]msrustup'
+        $template | Should -Match 'InstallToolchain:\s+false'
+        $useRustTemplate | Should -Match '(?s)name:\s+InstallToolchain.*?default:\s+true'
+        $MicrosoftRustChannel | Should -Match '^ms-prod-\d+(?:\.\d+)+$'
+        $MicrosoftRustConfig | Should -Not -Match '"rust-std"'
+        foreach ($target in $Matrix.targets) {
+            $MicrosoftRustConfig | Should -Match ([regex]::Escape(
+                "`"$($target.triple)`""
+            ))
+        }
+        $cargoScript | Should -Match 'function Get-RustupExecutable'
+        $useRustScript | Should -Not -Match '(?m)Invoke-LoggedCommand\s+"rustup\s'
     }
 
     It 'provisions Linux compilers from Ubuntu or checksum-pinned Microsoft prior art' {

--- a/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/tests/New-GoModules.Tests.ps1
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/tests/New-GoModules.Tests.ps1
@@ -7,6 +7,13 @@ BeforeAll {
     $ScriptPath = Join-Path $PipelineDirectory 'New-GoModules.ps1'
     $MatrixPath = Join-Path $PipelineDirectory 'build-matrix.json'
     $Matrix = Get-Content $MatrixPath -Raw | ConvertFrom-Json
+    $RepositoryRoot = (Resolve-Path (Join-Path $PipelineDirectory '../../../..')).Path
+    $MicrosoftRustConfigPath = Join-Path $RepositoryRoot 'eng/templates/ms-rust-toolchain.toml'
+    $MicrosoftRustConfig = Get-Content $MicrosoftRustConfigPath -Raw
+    $MicrosoftRustChannel = [regex]::Match(
+        $MicrosoftRustConfig,
+        '(?m)^\s*channel\s*=\s*"([^"]+)"\s*$'
+    ).Groups[1].Value
 
     function Write-TestFile {
         param(
@@ -45,7 +52,7 @@ BeforeAll {
             Write-TestFile -Path $libraryPath -Content "archive-$($row.id)"
 
             $metadata = [ordered]@{
-                schema_version = 3
+                schema_version = 4
                 artifact_id = $row.id
                 goos = $row.goos
                 goarch = $row.goarch
@@ -74,9 +81,35 @@ BeforeAll {
                 } else {
                     @('-lsystem')
                 }
+                toolchain = [ordered]@{
+                    provider = 'microsoft'
+                    manager = [ordered]@{
+                        executable = 'msrustup'
+                        version = 'msrustup 1.0.0'
+                    }
+                    channel = $MicrosoftRustChannel
+                    active_toolchain = "$MicrosoftRustChannel-test-host"
+                    rustc_verbose_version = @"
+rustc 1.95.0 (microsoft 012345678 2026-08-01)
+binary: rustc
+commit-hash: 0123456789abcdef0123456789abcdef01234567
+commit-date: 2026-08-01
+host: test-host
+release: 1.95.0
+LLVM version: 21.1.0
+"@
+                    rustc_release = '1.95.0'
+                    cargo_version = 'cargo 1.95.0'
+                    target = $row.triple
+                    linker = [ordered]@{
+                        command = $row.c_compiler
+                        executable = "/tools/$($row.c_compiler)"
+                        version = "$($row.c_compiler) 1.0.0"
+                    }
+                }
             }
             $metadataPath = Join-Path $targetRoot 'rust-driver-native-interface-metadata.json'
-            $metadata | ConvertTo-Json -Depth 6 | Set-Content $metadataPath -Encoding utf8
+            $metadata | ConvertTo-Json -Depth 8 | Set-Content $metadataPath -Encoding utf8
         }
     }
 
@@ -95,7 +128,7 @@ BeforeAll {
         $path = Join-Path $Root $TargetId 'rust-driver-native-interface-metadata.json'
         $metadata = Get-Content $path -Raw | ConvertFrom-Json
         & $Update $metadata
-        $metadata | ConvertTo-Json -Depth 6 | Set-Content $path -Encoding utf8
+        $metadata | ConvertTo-Json -Depth 8 | Set-Content $path -Encoding utf8
     }
 }
 
@@ -132,18 +165,30 @@ BeforeEach {
         Test-Path $provenancePath | Should -BeTrue
 
         $provenance = Get-Content $provenancePath -Raw | ConvertFrom-Json
-        $provenance.schema_version | Should -Be 1
+        $provenance.schema_version | Should -Be 2
         $provenance.source_commit | Should -Be '0123456789abcdef0123456789abcdef01234567'
         $provenance.rust_driver_crate | Should -Be $Matrix.rust_driver_crate
         $provenance.rust_driver_version | Should -Be '0.7.0'
         $provenance.native_interface_crate | Should -Be $Matrix.native_interface_crate
         $provenance.native_interface_version | Should -Be '0.1.0'
+        $provenance.rust_toolchain.provider | Should -Be 'microsoft'
+        $provenance.rust_toolchain.manager | Should -Be 'msrustup'
+        $provenance.rust_toolchain.manager_version | Should -Be 'msrustup 1.0.0'
+        $provenance.rust_toolchain.channel | Should -Be $MicrosoftRustChannel
+        $provenance.rust_toolchain.rustc_release | Should -Be '1.95.0'
+        $provenance.rust_toolchain.cargo_version | Should -Be 'cargo 1.95.0'
 
         @($provenance.targets).Count | Should -Be @($Matrix.targets).Count
         $windowsEntry = @($provenance.targets | Where-Object { $_.id -eq 'windows-amd64' })
         $windowsEntry.Count | Should -Be 1
         $windowsEntry[0].static_library_sha256 | Should -Match '^[0-9a-f]{64}$'
         $windowsEntry[0].header_sha256 | Should -Match '^[0-9a-f]{64}$'
+        $windowsEntry[0].toolchain.active_toolchain | Should -Be "$MicrosoftRustChannel-test-host"
+        $windowsEntry[0].toolchain.rustc_verbose_version | Should -Match 'release: 1\.95\.0'
+        $windowsEntry[0].toolchain.target | Should -Be 'x86_64-pc-windows-gnu'
+        $windowsEntry[0].toolchain.linker.command | Should -Be 'gcc'
+        $windowsEntry[0].toolchain.linker.executable | Should -Be '/tools/gcc'
+        $windowsEntry[0].toolchain.linker.version | Should -Be 'gcc 1.0.0'
     }
 
     It 'generates only the selected standalone musl module' {
@@ -198,6 +243,70 @@ BeforeEach {
 
         { & $ScriptPath -ArtifactRoot $ArtifactRoot -OutputRoot $OutputRoot } |
             Should -Throw "*release identity 'rust_driver_version' mismatch*"
+    }
+
+    It 'rejects metadata without Microsoft Rust provenance' {
+        Update-TestMetadata -Root $ArtifactRoot -TargetId 'windows-amd64' -Update {
+            param($metadata)
+            $metadata.PSObject.Properties.Remove('toolchain')
+        }
+
+        { & $ScriptPath -ArtifactRoot $ArtifactRoot -OutputRoot $OutputRoot } |
+            Should -Throw "*metadata is missing 'toolchain'*"
+    }
+
+    It 'rejects metadata produced through upstream rustup' {
+        Update-TestMetadata -Root $ArtifactRoot -TargetId 'windows-amd64' -Update {
+            param($metadata)
+            $metadata.toolchain.provider = 'upstream'
+            $metadata.toolchain.manager.executable = 'rustup'
+            $metadata.toolchain.channel = 'stable'
+            $metadata.toolchain.active_toolchain = 'stable-test-host'
+        }
+
+        { & $ScriptPath -ArtifactRoot $ArtifactRoot -OutputRoot $OutputRoot } |
+            Should -Throw "*toolchain provider must be 'microsoft'*"
+    }
+
+    It 'rejects metadata produced by an upstream rustc' {
+        Update-TestMetadata -Root $ArtifactRoot -TargetId 'windows-amd64' -Update {
+            param($metadata)
+            $metadata.toolchain.rustc_verbose_version = @'
+rustc 1.95.0 (012345678 2026-08-01)
+binary: rustc
+commit-hash: 0123456789abcdef0123456789abcdef01234567
+commit-date: 2026-08-01
+host: x86_64-pc-windows-msvc
+release: 1.95.0
+LLVM version: 21.1.0
+'@
+        }
+
+        { & $ScriptPath -ArtifactRoot $ArtifactRoot -OutputRoot $OutputRoot } |
+            Should -Throw '*rustc identity is not Microsoft Rust*'
+    }
+
+    It 'rejects an unpinned Microsoft Rust identity' {
+        Update-TestMetadata -Root $ArtifactRoot -TargetId 'windows-amd64' -Update {
+            param($metadata)
+            $metadata.toolchain.channel = 'ms-prod'
+            $metadata.toolchain.active_toolchain = 'ms-prod-test-host'
+        }
+
+        { & $ScriptPath -ArtifactRoot $ArtifactRoot -OutputRoot $OutputRoot } |
+            Should -Throw '*Microsoft Rust channel*not explicitly pinned*'
+    }
+
+    It 'rejects targets carrying mixed Microsoft Rust releases' {
+        Update-TestMetadata -Root $ArtifactRoot -TargetId 'linux-amd64-glibc' -Update {
+            param($metadata)
+            $metadata.toolchain.rustc_release = '1.95.1'
+            $metadata.toolchain.rustc_verbose_version = $metadata.toolchain.rustc_verbose_version `
+                -replace 'release: 1\.95\.0', 'release: 1.95.1'
+        }
+
+        { & $ScriptPath -ArtifactRoot $ArtifactRoot -OutputRoot $OutputRoot } |
+            Should -Throw "*release identity 'rustc_release' mismatch*"
     }
 
     It 'rejects a static archive whose bytes do not match metadata' {

--- a/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/tests/New-GoModules.Tests.ps1
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/tests/New-GoModules.Tests.ps1
@@ -88,7 +88,7 @@ BeforeAll {
                         version = 'msrustup 1.0.0'
                     }
                     channel = $MicrosoftRustChannel
-                    active_toolchain = "$MicrosoftRustChannel-test-host"
+                    selected_toolchain = $MicrosoftRustChannel
                     rustc_verbose_version = @"
 rustc 1.95.0 (microsoft 012345678 2026-08-01)
 binary: rustc
@@ -183,7 +183,7 @@ BeforeEach {
         $windowsEntry.Count | Should -Be 1
         $windowsEntry[0].static_library_sha256 | Should -Match '^[0-9a-f]{64}$'
         $windowsEntry[0].header_sha256 | Should -Match '^[0-9a-f]{64}$'
-        $windowsEntry[0].toolchain.active_toolchain | Should -Be "$MicrosoftRustChannel-test-host"
+        $windowsEntry[0].toolchain.selected_toolchain | Should -Be $MicrosoftRustChannel
         $windowsEntry[0].toolchain.rustc_verbose_version | Should -Match 'release: 1\.95\.0'
         $windowsEntry[0].toolchain.target | Should -Be 'x86_64-pc-windows-gnu'
         $windowsEntry[0].toolchain.linker.command | Should -Be 'gcc'
@@ -261,7 +261,7 @@ BeforeEach {
             $metadata.toolchain.provider = 'upstream'
             $metadata.toolchain.manager.executable = 'rustup'
             $metadata.toolchain.channel = 'stable'
-            $metadata.toolchain.active_toolchain = 'stable-test-host'
+            $metadata.toolchain.selected_toolchain = 'stable'
         }
 
         { & $ScriptPath -ArtifactRoot $ArtifactRoot -OutputRoot $OutputRoot } |
@@ -290,11 +290,37 @@ LLVM version: 21.1.0
         Update-TestMetadata -Root $ArtifactRoot -TargetId 'windows-amd64' -Update {
             param($metadata)
             $metadata.toolchain.channel = 'ms-prod'
-            $metadata.toolchain.active_toolchain = 'ms-prod-test-host'
+            $metadata.toolchain.selected_toolchain = 'ms-prod'
         }
 
         { & $ScriptPath -ArtifactRoot $ArtifactRoot -OutputRoot $OutputRoot } |
             Should -Throw '*Microsoft Rust channel*not explicitly pinned*'
+    }
+
+    It 'rejects a Microsoft compiler release that differs from the pinned channel' {
+        foreach ($row in $Matrix.targets) {
+            Update-TestMetadata -Root $ArtifactRoot -TargetId $row.id -Update {
+                param($metadata)
+                $metadata.toolchain.rustc_release = '1.96.0'
+                $metadata.toolchain.rustc_verbose_version = $metadata.toolchain.rustc_verbose_version `
+                    -replace 'rustc 1\.95\.0', 'rustc 1.96.0' `
+                    -replace 'release: 1\.95\.0', 'release: 1.96.0'
+            }
+        }
+
+        { & $ScriptPath -ArtifactRoot $ArtifactRoot -OutputRoot $OutputRoot } |
+            Should -Throw "*Microsoft Rust release '1.96.0' does not match pinned channel*"
+    }
+
+    It 'rejects a rustc identity that contradicts its release field' {
+        Update-TestMetadata -Root $ArtifactRoot -TargetId 'windows-amd64' -Update {
+            param($metadata)
+            $metadata.toolchain.rustc_verbose_version = $metadata.toolchain.rustc_verbose_version `
+                -replace 'release: 1\.95\.0', 'release: 1.95.1'
+        }
+
+        { & $ScriptPath -ArtifactRoot $ArtifactRoot -OutputRoot $OutputRoot } |
+            Should -Throw "*rustc release '1.95.0' does not match rustc identity release '1.95.1'*"
     }
 
     It 'rejects targets carrying mixed Microsoft Rust releases' {

--- a/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/tests/Test-NativeLink.Tests.ps1
+++ b/sdk/cosmos/azure_data_cosmos_driver_native/pipeline/tests/Test-NativeLink.Tests.ps1
@@ -45,7 +45,7 @@ Describe 'Test-NativeLink target validation' {
         })
         $MetadataPath = Join-Path $TargetRoot 'rust-driver-native-interface-metadata.json'
         Write-TestJson -Path $MetadataPath -Value ([ordered]@{
-            schema_version = 3
+            schema_version = 4
             artifact_id = 'test-target'
             goos = 'windows'
             goarch = 'amd64'
@@ -53,6 +53,14 @@ Describe 'Test-NativeLink target validation' {
             triple = 'x86_64-pc-windows-gnu'
             rustc_native_static_libs = @('-lsystem')
             native_static_libs = @('-lsystem')
+            toolchain = [ordered]@{
+                provider = 'microsoft'
+                manager = [ordered]@{
+                    executable = 'msrustup'
+                }
+                channel = 'ms-prod-1.95'
+                target = 'x86_64-pc-windows-gnu'
+            }
         })
 
         Mock go {
@@ -86,6 +94,24 @@ Describe 'Test-NativeLink target validation' {
                 -CCompiler 'pwsh' `
                 -MatrixPath $MatrixPath
         } | Should -Throw "*metadata 'goarch' does not match*"
+
+        Should -Invoke go -Exactly 0
+    }
+
+    It 'rejects upstream Rust metadata before invoking Go' {
+        $metadata = Get-Content $MetadataPath -Raw | ConvertFrom-Json
+        $metadata.toolchain.provider = 'upstream'
+        $metadata.toolchain.manager.executable = 'rustup'
+        $metadata.toolchain.channel = 'stable'
+        Write-TestJson -Path $MetadataPath -Value $metadata
+
+        {
+            & $ScriptPath `
+                -TargetId 'test-target' `
+                -ArtifactRoot $ArtifactRoot `
+                -CCompiler 'pwsh' `
+                -MatrixPath $MatrixPath
+        } | Should -Throw '*toolchain provider is not Microsoft Rust*'
 
         Should -Invoke go -Exactly 0
     }


### PR DESCRIPTION
Build the Cosmos native-driver release artifacts with the centrally pinned Microsoft Rust `ms-prod-1.95` toolchain while preserving upstream Rust behavior for existing crates and ordinary CI.

The change adds opt-in installation, fail-closed toolchain and target validation, and per-target plus consolidated build provenance. A manual internal Azure DevOps run is still required to confirm availability of all six configured targets.

Fixes #5237